### PR TITLE
attempt to name resolve Chris Manning

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -1092,8 +1092,6 @@ Andrew Y. Ng , Stanford University
 Anshul Kundaje , Stanford University
 Balaji Prabhakar , Stanford University
 Bill Dally , Stanford University
-Chris Manning , Stanford University
-Christopher Manning , Stanford University
 Christopher D. Manning , Stanford University
 Christopher Re , Stanford University
 Christopher Ré , Stanford University

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -1093,6 +1093,8 @@ Anshul Kundaje , Stanford University
 Balaji Prabhakar , Stanford University
 Bill Dally , Stanford University
 Chris Manning , Stanford University
+Christopher Manning , Stanford University
+Christopher D. Manning , Stanford University
 Christopher Re , Stanford University
 Christopher Ré , Stanford University
 Dan Boneh , Stanford University


### PR DESCRIPTION
"Chris Manning" is currently in there but doesn't seem to resolve against DBLP.  Fixing this will affect NLP rankings quite a bit.  I'm not sure how the name resolution works (either within DBLP or between DBLP and this system...)
