### PR TITLE
CMU tenure-track additions

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -132,6 +132,7 @@ Ariel D. Procaccia , Carnegie Mellon University
 Avrim Blum , Carnegie Mellon University
 Barnabás Póczos , Carnegie Mellon University
 Bernhard Haeupler , Carnegie Mellon University
+Bhiksha Raj , Carnegie Mellon University
 Bhiksha Ramakrishnan , Carnegie Mellon University
 Brad A. Myers , Carnegie Mellon University
 Brandon Lucia , Carnegie Mellon University
@@ -166,6 +167,7 @@ Gary K. Fedder , Carnegie Mellon University
 Gary L. Miller , Carnegie Mellon University
 Geoff F. Kaufman , Carnegie Mellon University
 Geoffrey J. Gordon , Carnegie Mellon University
+Graham Neubig , Carnegie Mellon University
 Guy E. Blelloch , Carnegie Mellon University
 Hartmut Geyer , Carnegie Mellon University
 Howie Choset , Carnegie Mellon University
@@ -242,6 +244,7 @@ Subra Suresh , Carnegie Mellon University
 Steven Rudich , Carnegie Mellon University
 Tai Sing Lee , Carnegie Mellon University
 Takeo Kanade , Carnegie Mellon University
+Taylor Berg-Kirkpatrick , Carnegie Mellon University
 Todd C. Mowry , Carnegie Mellon University
 Tom M. Mitchell , Carnegie Mellon University
 Travis D. Breaux , Carnegie Mellon University


### PR DESCRIPTION
(Taylor Berg-Kirkpatrick and Graham Neubig have recently joined as Assistant Professors. Bhiksha Raj is Associate.)

see also #8
