### PR TITLE
Added some missing Cornell CSL faculty.

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -317,12 +317,15 @@ Yechiam Yemini , Columbia University
 Adrian Sampson , Cornell University
 Andrew C. Myers , Cornell University
 Ari Juels , Cornell University
+Arpita Ghosh , Cornell University
 Ashutosh Saxena , Cornell University
 Bart Selman , Cornell University
 Carla P. Gomes , Cornell University
 Charles Van Loan , Cornell University
+Cristian Danescu-Niculescu-Mizil , Cornell University
 Christopher Batten , Cornell University
 Claire Cardie , Cornell University
+Dan Cosley , Cornell University
 Daniel P. Huttenlocher , Cornell University
 David Bindel , Cornell University
 David H. Albonesi , Cornell University
@@ -334,6 +337,7 @@ Donald P. Greenberg , Cornell University
 Elaine Shi , Cornell University
 Emin Gün Sirer , Cornell University
 Erik Andersen , Cornell University
+François Guimbretière , Cornell University
 Fred B. Schneider , Cornell University
 G. Edward Suh , Cornell University
 Greg Morrisett , Cornell University
@@ -353,6 +357,7 @@ Lillian Lee , Cornell University
 Mor Naaman , Cornell University
 Nate Foster , Cornell University
 J. Nathan Foster , Cornell University
+Nicola Dell , Cornell University
 Noah Snavely , Cornell University
 Rafael Pass , Cornell University
 Ramin Zabih , Cornell University
@@ -363,6 +368,7 @@ Ross Tate , Cornell University
 Salman Avestimehr , Cornell University
 Serge J. Belongie , Cornell University
 Steve Marschner , Cornell University
+Tanzeem Choudhury , Cornell University
 Thorsten Joachims , Cornell University
 Thomas Ristenpart , Cornell University
 Vitaly Shmatikov , Cornell University

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -321,9 +321,11 @@ Ashutosh Saxena , Cornell University
 Bart Selman , Cornell University
 Carla P. Gomes , Cornell University
 Charles Van Loan , Cornell University
+Christopher Batten , Cornell University
 Claire Cardie , Cornell University
 Daniel P. Huttenlocher , Cornell University
 David Bindel , Cornell University
+David H. Albonesi , Cornell University
 David M. Mimno , Cornell University
 David Steurer , Cornell University
 Deborah Estrin , Cornell University
@@ -333,12 +335,15 @@ Elaine Shi , Cornell University
 Emin Gün Sirer , Cornell University
 Erik Andersen , Cornell University
 Fred B. Schneider , Cornell University
+G. Edward Suh , Cornell University
 Greg Morrisett , Cornell University
 Hakim Weatherspoon , Cornell University
 Haym Hirsh , Cornell University
+Rajit Manohar , Cornell University
 J. Gregory Morrisett , Cornell University
 John E. Hopcroft , Cornell University
 Jon M. Kleinberg , Cornell University
+José Martinez , Cornell University
 Joseph Y. Halpern , Cornell University
 Karthik Sridharan , Cornell University
 Kavita Bala , Cornell University


### PR DESCRIPTION
Cornell faculty publishing in architecture tend to be in the CS "field" but in the ECE "department".
