### PR TITLE
Add Tel Aviv University faculty

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -18,3 +18,4 @@ TU Dresden,europe
 TU Darmstadt,europe
 Ecole Normale Superieure,europe
 DIKU,europe
+Tel Aviv University,europe

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -3641,3 +3641,49 @@ Mikkel Thorup , DIKU
 Katarzyna Wac , DIKU
 Pawel Winter , DIKU
 Christian Wulff-Nilsen , DIKU
+Yehuda Afek , Tel Aviv University
+Noga Alon , Tel Aviv University
+Arnon Avron , Tel Aviv University
+Amir Averbuch , Tel Aviv University
+Yossi Azar , Tel Aviv University
+Benny Chor , Tel Aviv University
+Amir Shpilka , Tel Aviv University
+Ran Canetti , Tel Aviv University
+Shiri Chechik , Tel Aviv University
+Daniel Cohen-Or , Tel Aviv University
+Nachum Dershowitz , Tel Aviv University
+Daniel Deutch , Tel Aviv University
+Michal Feldman , Tel Aviv University
+Amos Fiat , Tel Aviv University
+Amir Globerson , Tel Aviv University
+Iftach Haitner , Tel Aviv University
+Eran Halperin , Tel Aviv University
+Dan Halperin , Tel Aviv University
+Nathan Intrator , Tel Aviv University
+Haim Kaplan , Tel Aviv University
+Hanoch Levy , Tel Aviv University
+Yishay Mansour , Tel Aviv University
+Shahar Maoz , Tel Aviv University
+Yossi Matias , Tel Aviv University
+Tova Milo , Tel Aviv University
+Rotem Oshman , Tel Aviv University
+Alexander Moshe Rabinovich , Tel Aviv University
+Noam Rinetzky , Tel Aviv University
+Ronitt Rubinfeld , Tel Aviv University
+Eytan Ruppin , Tel Aviv University
+Shmuel Safra , Tel Aviv University
+Shmuel Sagiv , Tel Aviv University
+Ron Shamir , Tel Aviv University
+Roded Sharan , Tel Aviv University
+Micha Sharir , Tel Aviv University
+Nir Shavit , Tel Aviv University
+Amnon Ta-Shma , Tel Aviv University
+Michael Tarsi , Tel Aviv University
+Sivan Toledo , Tel Aviv University
+Boris A. Trakhtenbrot , Tel Aviv University
+Eran Tromer , Tel Aviv University
+Lior Wolf , Tel Aviv University
+Haim J. Wolfson , Tel Aviv University
+Amiram Yehudai , Tel Aviv University
+Yehezkel Yeshurun , Tel Aviv University
+Uri Zwick , Tel Aviv University


### PR DESCRIPTION
Based on https://en-exact-sciences.tau.ac.il/computer/faculty_members, with the required adjustments so that names match their DBLP author entries.
