### PR TITLE
Faculty affiliation @ RHUL

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -3641,6 +3641,13 @@ Mikkel Thorup , DIKU
 Katarzyna Wac , DIKU
 Pawel Winter , DIKU
 Christian Wulff-Nilsen , DIKU
+Martin R. Albrecht , Royal Holloway University of London
+Lorenzo Cavallaro , Royal Holloway University of London
+Carlos Cid , Royal Holloway University of London
+Jason Crampton , Royal Holloway University of London
+Johannes Kinder , Royal Holloway University of London
+Kenneth G. Paterson , Royal Holloway University of London
+Vladimir Vovk , Royal Holloway University of London
 Yehuda Afek , Tel Aviv University
 Noga Alon , Tel Aviv University
 Arnon Avron , Tel Aviv University


### PR DESCRIPTION
Update faculty affiliation at Royal Holloway University of London
