### PR TITLE
add more CS faculty members of Penn State U

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -998,7 +998,7 @@ Wang-Chien Lee , Pennsylvania State University
 Webb C. Miller , Pennsylvania State University
 Yanxi Liu , Pennsylvania State University
 Chao-Hsien Chu , Pennsylvania State University
-Lee Giles , Pennsylvania State University
+C. Lee Giles , Pennsylvania State University
 Vasant Honavar , Pennsylvania State University
 Dongwon Lee , Pennsylvania State University
 Zhenhui Jessie Li , Pennsylvania State University

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -997,6 +997,29 @@ Vijaykrishnan Narayanan , Pennsylvania State University
 Wang-Chien Lee , Pennsylvania State University
 Webb C. Miller , Pennsylvania State University
 Yanxi Liu , Pennsylvania State University
+Chao-Hsien Chu , Pennsylvania State University
+Lee Giles , Pennsylvania State University
+Vasant Honavar , Pennsylvania State University
+Dongwon Lee , Pennsylvania State University
+Zhenhui Jessie Li , Pennsylvania State University
+Prasenjit Mitra , Pennsylvania State University
+David Reitter , Pennsylvania State University
+Dashun Wang , Pennsylvania State University
+James Z. Wang , Pennsylvania State University
+John Yen , Pennsylvania State University
+Zihan Zhou , Pennsylvania State University
+David Reitter , Pennsylvania State University
+Guoray Cai , Pennsylvania State University
+John Carroll , Pennsylvania State University
+Eun Kyoung Choe , Pennsylvania State University
+Steven Haynes , Pennsylvania State University
+Mary Beth Rosson , Pennsylvania State University
+Luke Zhang , Pennsylvania State University
+Peng Liu , Pennsylvania State University 
+Anna Squicciarini , Pennsylvania State University
+Dinghao Wu , Pennsylvania State University
+Xinyu Xing , Pennsylvania State University
+Heng Xu , Pennsylvania State University
 Aarti Gupta , Princeton University
 Adam Finkelstein , Princeton University
 Andrea S. LaPaugh , Princeton University


### PR DESCRIPTION
Penn State faculty on several areas including AI, HCI, Security are actually all not at CSE department (now merged with EE department, focusing more on hardwares), many of them are associated College of Information Sciences and Technology. They include ACM SIGCHI Lifetime Achievement Award, John M. Carroll and ACM Fellow C. Lee Giles.
