### PR TITLE
Update faculty-affiliation.csv

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -4108,3 +4108,9 @@ Ian Utting , University of Kent
 Frank Wang , University of Kent
 Frank Zhigang Wang , University of Kent
 Peter H. Welch , University of Kent
+Xiaoming Fu , University of Gottingen
+Konrad Rieck , University of Gottingen
+Dieter Hogrefe , University of Gottingen
+Jens Grabowski , University of Gottingen
+Ramin Yahyapour , University of Gottingen
+Stephan Waack , University of Gottingen


### PR DESCRIPTION
Add several faculty members from University of Gottingen (Germany), Europe
