### PR TITLE
Update faculty-affiliations.csv

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -5437,3 +5437,55 @@ Steven W. Zucker , Yale University
 Vladimir Rokhlin , Yale University
 Yang Richard Yang , Yale University
 Zhong Shao , Yale University
+Krzysztof R. Apt , University of Warsaw
+Mikolaj Bojanczyk , University of Warsaw
+Lorenzo Clemente , University of Warsaw
+Marek Cygan , University of Warsaw
+Wojciech Czerwinski , University of Warsaw
+Robert Dabrowski , University of Warsaw
+Krzysztof Diks , University of Warsaw
+Norbert Dojer , University of Warsaw
+Barbara Dunin-Keplicz , University of Warsaw
+Stefan Dziembowski , University of Warsaw
+Marcin Dziubinski , University of Warsaw
+Konrad Iwanicki , University of Warsaw
+Andrzej Janusz , University of Warsaw
+Wojciech Jaworski , University of Warsaw
+Marcin Jakub Kaminski , University of Warsaw
+Tomasz Kazana , University of Warsaw
+Bartek Klin , University of Warsaw
+Eryk Kopczynski , University of Warsaw
+Lukasz Kowalik , University of Warsaw
+Miroslaw Kowaluk , University of Warsaw
+Slawomir Lasota , University of Warsaw
+Jan Madey , University of Warsaw
+Tomasz P. Michalak , University of Warsaw
+Marcin Mucha , University of Warsaw
+Filip Murlak , University of Warsaw
+Linh Anh Nguyen , University of Warsaw
+Hung Son Nguyen , University of Warsaw
+Damian Niwinski , University of Warsaw
+Pawel Parys , University of Warsaw
+Jakub Pawlewicz , University of Warsaw
+Marcin Peczarski , University of Warsaw
+Michal Pilipczuk , University of Warsaw
+Marcin Pilipczuk , University of Warsaw
+Wojciech Plandowski , University of Warsaw
+Jakub Radoszewski , University of Warsaw
+Wojciech Rytter , University of Warsaw
+Krzysztof Rzadca , University of Warsaw
+Piotr Sankowski , University of Warsaw
+Aleksy Schubert , University of Warsaw
+Oskar Skibski , University of Warsaw
+Michal Skrzypczak , University of Warsaw
+Jacek Sroka , University of Warsaw
+Krzysztof Stencel , University of Warsaw
+Andrzej Szalas , University of Warsaw
+Dominik Slezak , University of Warsaw
+Andrzej Tarlecki , University of Warsaw
+Szymon Torunczyk , University of Warsaw
+Jerzy Tyszkiewicz , University of Warsaw
+Pawel Urzyczyn , University of Warsaw
+Tomasz Walen , University of Warsaw
+Piotr Wasilewski , University of Warsaw
+Anna Zych , University of Warsaw


### PR DESCRIPTION
added faculty from the University of Warsaw. The list includes all the faculty members with a position of an assistant professor ("adiunkt") or higher. I excluded faculty members whose main focus is computational biology since this area seems to be not covered by this ranking.
