### PR TITLE
Added TVCG/IEEE Vis

### DIFF
--- a/util/csrankings.py
+++ b/util/csrankings.py
@@ -59,7 +59,7 @@ areadict = {
     'ai' : ['AAAI', 'AAAI/IAAI', 'IJCAI'],
     # AAAI listed to account for AAAI/IAAI joint conference
     'database' : ['PODS', 'VLDB', 'PVLDB', 'SIGMOD Conference'],
-    'graphics' : ['ACM Trans. Graph.', 'SIGGRAPH'],
+    'graphics' : ['ACM Trans. Graph.', 'SIGGRAPH','IEEE Trans. Vis. Comput. Graph.','IEEE Visualization'],
     'metrics' : ['SIGMETRICS','SIGMETRICS/Performance','IMC','Internet Measurement Conference'],
     # Two variants for each, as in DBLP.
     'web' : ['WWW', 'SIGIR'],


### PR DESCRIPTION
IEEE TVCG-VIS/VR probably should be included in the publication list, since IEEE
VIS and IEEE VR are large specialty conferences that each have about 1,000 and 500
attendees annually and their proceedings are published as special issues of IEEE TVCG.   There are more than 50 top institutions around the world that have published regularly in IEEE VIS and IEEE VR with IEEE TVCG since 2000.
This arrangement is identical to ACM TOG/SIGGRAPH, which you’ve listed
under Computer Graphics. The CS attendance and participation level at these conferences surpass many system/AI/theory conferences listed under csrankings.org.
