### PR TITLE
Added University of Zurich faculty (according to website)

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -6445,6 +6445,20 @@ Stephen J. Wright , University of Wisconsin - Madison
 Suman Banerjee , University of Wisconsin - Madison
 Thomas W. Reps , University of Wisconsin - Madison
 Xiaojin Zhu , University of Wisconsin - Madison
+Abraham Bernstein , University of Zurich
+Michael H. Böhlen , University of Zurich
+Thomas Fritz , University of Zurich
+Harald C. Gall , University of Zurich
+Martin Glinz , University of Zurich
+Lorenz Hilty , University of Zurich
+Daning Hu , University of Zurich
+Elaine M. Huang , University of Zurich
+Renato Pajarola , University of Zurich
+Davide Scaramuzza , University of Zurich
+Gerhard Schwabe , University of Zurich
+Sven Seuken , University of Zurich
+Burkhard Stiller , University of Zurich
+Chat Wacharamanotham , University of Zurich
 A. E. Eiben , VU Amsterdam
 A. Th. Schreiber , VU Amsterdam
 Alban Ponse , VU Amsterdam


### PR DESCRIPTION
Added University of Zurich faculty according to 'Professors' list in http://www.ifi.uzh.ch/en/ifi/people/ifi.html
