### PR TITLE
removed ambiguous name.

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -5411,7 +5411,6 @@ Frederick C. Harris Jr. , University of Nevada
 George Bebis , University of Nevada
 Hung Manh La , University of Nevada
 Kostas Alexis , University of Nevada
-Lei Yang , University of Nevada
 Mehmet Hadi Gunes , University of Nevada
 Mehmet Hadi Günes , University of Nevada
 Mircea Nicolescu , University of Nevada


### PR DESCRIPTION
Was unable to disambiguate the name of Lei Yang which seems to map to multiple authors with the same name. It currently over reports the ranking of our department so I removed it for now. I put in a request with DBLP to unmerge this author.
