### PR TITLE
Add Harvard DBMI faculty

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -1431,9 +1431,12 @@ Umakishore Ramachandran , Georgia Institute of Technology
 Vijay V. Vazirani , Georgia Institute of Technology
 Wenke Lee , Georgia Institute of Technology
 William R. Harris , Georgia Institute of Technology
+Alexa McCray, Harvard University
 Alexander M. Rush , Harvard University
 Barbara J. Grosz , Harvard University
 Boaz Barak , Harvard University
+Chirag Patel, Harvard University
+Chirag J. Patel, Harvard University
 David C. Parkes , Harvard University
 David Cox , Harvard University
 David M. Brooks , Harvard University
@@ -1443,6 +1446,8 @@ Finale Doshi-Velez , Harvard University
 H. T. Kung , Harvard University
 Hanspeter Pfister , Harvard University
 Harry R. Lewis , Harvard University
+Isaac Kohane, Harvard University
+Isaac S. Kohane, Harvard University
 James W. Mickens , Harvard University
 Jelani Nelson , Harvard University
 Jim Waldo , Harvard University
@@ -1458,6 +1463,11 @@ Michael M. Mitzenmacher , Harvard University
 Michael Mitzenmacher , Harvard University
 Michael O. Rabin , Harvard University
 Michael Oser Rabin , Harvard University
+Nils Gehlenborg, Harvard University
+Peter Kharchenko, Harvard University
+Peter V. Kharchenko, Harvard University
+Peter Park, Harvard University
+Peter J. Park, Harvard University
 Radhika Nagpal , Harvard University
 Ryan P. Adams , Harvard University
 Ryan Prescott Adams , Harvard University


### PR DESCRIPTION
Added faculty in the Harvard Department of Biomedical Informatics. 
