### PR TITLE
Added Emory University faculty

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -994,6 +994,29 @@ Theophilus Benson , Duke University
 Vincent Conitzer , Duke University
 Xiaobai Sun , Duke University
 Xiaowei Yang , Duke University
+Eugene Agichtein,Emory University
+Vaidy S. Sunderam,Emory University
+Ymir Vigfusson,Emory University
+Michele Benzi,Emory University
+Li Xiong,Emory University
+Gari D. Clifford,Emory University
+Shamim Nemati,Emory University
+Joyce C. Ho,Emory University
+Michelangelo Grigni,Emory University
+Alessandro Veneziani,Emory University
+Lars Ruthotto,Emory University
+James G. Nagy,Emory University
+Lee A. D. Cooper,Emory University
+Andrew R. Post,Emory University
+James J. Lu,Emory University
+Zhaohui S. Qin,Emory University
+Davide Fossati,Emory University
+Shun Yan Cheung,Emory University
+Ronald J. Gould,Emory University
+Dwight Duffus,Emory University
+Vojtech Rödl,Emory University
+Hao Huang,Emory University
+Avani Wildani,Emory University
 Ailamaki Natassa , EPFL
 Alain Wegmann , EPFL
 Amin Shokrollahi , EPFL


### PR DESCRIPTION
Added Emory CSI faculty:
http://csi.mathcs.emory.edu/
that are core members of the Computer Science & Informatics (CSI) graduate program.
