### PR TITLE
Updated Jenkins affiliation

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -322,7 +322,6 @@ Andries van Dam , Brown University
 Andy van Dam , Brown University
 Anna Lysyanskaya , Brown University
 Benjamin J. Raphael , Brown University
-Chad Jenkins , Brown University
 David H. Laidlaw , Brown University
 Eli Upfal , Brown University
 Erik B. Sudderth , Brown University
@@ -333,7 +332,6 @@ John E. Savage , Brown University
 John F. Hughes , Brown University
 Maurice Herlihy , Brown University
 Michael L. Littman , Brown University
-Odest Chadwicke Jenkins , Brown University
 Paul Valiant , Brown University
 Pedro F. Felzenszwalb , Brown University
 Pedro Felipe Felzenszwalb , Brown University
@@ -5313,6 +5311,8 @@ Barzan Mozafari , University of Michigan
 Benjamin Kuipers , University of Michigan
 Brian D. Noble , University of Michigan
 Brian Noble , University of Michigan
+Chad Jenkins , University of Michigan
+Odest Chadwicke Jenkins , University of Michigan
 Chris Peikert , University of Michigan
 Danai Koutra , University of Michigan
 Daniel E. Atkins , University of Michigan


### PR DESCRIPTION
Updated affiliation for Odest Chadwicke Jenkins (Chad Jenkins) to the University of Michigan
