### PR TITLE
Links to homepages contain spaces in the CSV file

### DIFF
--- a/csrankings.ts
+++ b/csrankings.ts
@@ -351,7 +351,9 @@ class CSRankings {
 		const data : any = results.data;
 		const d = data as Array<HomePage>;
 		for (let namePage of d) {
-		    this.homepages[namePage.name] = namePage.homepage;
+			if (typeof namePage.homepage === 'undefined')
+        			continue
+		  	this.homepages[namePage.name.trim()] = namePage.homepage.trim();
 		}
 		setTimeout(cont, 0);
 	    }


### PR DESCRIPTION
The names and URLs must be trimmed from whitespace in order for the lookup based on the name to work. To verify the bug search for " , " in the homepage.csv file and then find that name in csrankings.org and it will not have the associated homepage from the csv file linked there.
