### PR TITLE
add CU Boulder faculty

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -1685,6 +1685,7 @@ Matthew A. Hammer , University of Colorado Boulder
 Michael Eisenberg , University of Colorado Boulder
 Michael C. Mozer , University of Colorado Boulder
 Nikolaus Correll , University of Colorado Boulder
+Pavol Cerný , University of Colorado Boulder
 Qin Lv , University of Colorado Boulder
 Rafael M. Frongillo , University of Colorado Boulder
 Richard Han , University of Colorado Boulder


### PR DESCRIPTION
Ok I'm trying this again. The new policy seems to allow it now:

https://github.com/emeryberger/CSrankings/issues/39#issuecomment-246198100

Just for reference, Pavol Cerny is ECEE faculty, but has a courtesy appointment in CS and can advise CS students (like me, for instance).
http://www.colorado.edu/cs/our-people
