### PR TITLE
Added GMU faculty with CS adjunct appointments

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -1347,6 +1347,9 @@ Thomas D. LaToza , George Mason University
 Xinyuan Wang , George Mason University
 Yotam I. Gingold , George Mason University
 Zoran Duric , George Mason University
+Houman Homayoun , George Mason University
+Qi Wei , George Mason University
+Kai Zeng , George Mason University
 Abdou S. Youssef , George Washington University
 Abdou Youssef , George Washington University
 Bhagirath Narahari , George Washington University


### PR DESCRIPTION
These faculty can advise CS PhD students.
