### PR TITLE
Added missing faculty to UCSC

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -4437,22 +4437,34 @@ Alex Pang , University of California - Santa Cruz
 Alex T. Pang , University of California - Santa Cruz
 Alexander Wolf , University of California - Santa Cruz
 Allen Van Gelder , University of California - Santa Cruz
-Ashutosh Raina , University of California - Santa Cruz
+Anujan Varma , University of California - Santa Cruz
 C. Seshadhri , University of California - Santa Cruz
+Carlos Maltzahn , University of California - Santa Cruz
 Charles E. McDowell , University of California - Santa Cruz
 Charlie McDowell , University of California - Santa Cruz
 Cormac Flanagan , University of California - Santa Cruz
+Daniel Friedman , University of California - Santa Cruz
 Darrell D. E. Long , University of California - Santa Cruz
+David Haussler , University of California - Santa Cruz
 David P. Helmbold , University of California - Santa Cruz
 Dimitris Achlioptas , University of California - Santa Cruz
 Ethan L. Miller , University of California - Santa Cruz
+Hamid R. Sadjadpour , University of California - Santa Cruz
+J. J. Garcia-Luna-Aceves , University of California - Santa Cruz
 James Davis , University of California - Santa Cruz
+Jim Whitehead , University of California - Santa Cruz
+Katia Obraczka , University of California - Santa Cruz
+Kevin Karplus , University of California - Santa Cruz
 Lise Getoor , University of California - Santa Cruz
 Luca de Alfaro , University of California - Santa Cruz
 Manfred K. Warmuth , University of California - Santa Cruz
 Marilyn Walker , University of California - Santa Cruz
+Michael Mateas , University of California - Santa Cruz
+Noah Wardrip-Fruin , University of California - Santa Cruz
+Patrick Mantey , University of California - Santa Cruz
 Peter Alvaro , University of California - Santa Cruz
 Phokion G. Kolaitis , University of California - Santa Cruz
+Ram Akella , University of California - Santa Cruz
 S. V. N. Vishwanathan , University of California - Santa Cruz
 Scott Brandt , University of California - Santa Cruz
 Seshadhri Comandur , University of California - Santa Cruz
@@ -4461,6 +4473,7 @@ Thomas Schwarz , University of California - Santa Cruz
 Vishy Vishwanathan , University of California - Santa Cruz
 Wang Chiew Tan , University of California - Santa Cruz
 Wang-Chiew Tan , University of California - Santa Cruz
+Yi Zhang , University of California - Santa Cruz
 Alan Blackwell , University of Cambridge
 Alan F. Blackwell , University of Cambridge
 Alan Mycroft , University of Cambridge


### PR DESCRIPTION
At UCSC, faculty members in the CE, CM and BME department can advise CS PhD students and they are actively involved in research (e.g. bioinformatics).
