### PR TITLE
Added VCU faculty and the homepages

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -7028,6 +7028,22 @@ Winston Seah , Victoria University of Wellington
 Xiaoying Gao , Victoria University of Wellington
 Yi Mei , Victoria University of Wellington
 Zohar Levi , Victoria University of Wellington
+Tomasz Arodz , Virginia Commonwealth University
+Eyuphan Bulut , Virginia Commonwealth University
+Alberto Cano 0001 , Virginia Commonwealth University
+Wei Cheng , Virginia Commonwealth University
+Krzysztof J. Cios , Virginia Commonwealth University
+Kostadin Damevski , Virginia Commonwealth University
+Thang N. Dinh , Virginia Commonwealth University
+Carol J. Fung , Virginia Commonwealth University
+Sevag Gharibian , Virginia Commonwealth University
+Preetam Ghosh , Virginia Commonwealth University
+Vojislav Kecman , Virginia Commonwealth University
+Bartosz Krawczyk , Virginia Commonwealth University
+Lukasz Kurgan , Virginia Commonwealth University
+Milos Manic , Virginia Commonwealth University
+Bridget T. McInnes , Virginia Commonwealth University
+Hong-Sheng Zhou , Virginia Commonwealth University
 Adrian Sandu , Virginia Tech
 Alexey Onufriev , Virginia Tech
 Ali Raza Butt , Virginia Tech

--- a/homepages.csv
+++ b/homepages.csv
@@ -7279,3 +7279,19 @@ Lei Yu 0001 , http://www.google.com/search?ie=UTF-8&oe=UTF-8&sourceid=navclient&
 Dmitry V. Ponomarev , http://www.google.com/search?ie=UTF-8&oe=UTF-8&sourceid=navclient&gfns=1&q=Dmitry%20V.%20Ponomarev%20Binghamton%20University
 Kyoung-Don Kang , https://www.binghamton.edu/cs/people/kang.html
 Michal Cutler , http://www.google.com/search?ie=UTF-8&oe=UTF-8&sourceid=navclient&gfns=1&q=Michal%20Cutler%20Binghamton%20University
+Tomasz Arodz , http://www.people.vcu.edu/~tarodz
+Eyuphan Bulut , http://www.people.vcu.edu/~ebulut/
+Alberto Cano 0001 , http://www.people.vcu.edu/~acano/
+Wei Cheng , http://www.people.vcu.edu/~wcheng3/
+Krzysztof J. Cios , http://cioslab.vcu.edu/index.html
+Kostadin Damevski , http://damevski.github.io/
+Thang N. Dinh , http://www.people.vcu.edu/~tndinh/
+Carol J. Fung , http://www.people.vcu.edu/~cfung/
+Sevag Gharibian , http://www.people.vcu.edu/~sgharibian/
+Preetam Ghosh , http://www.people.vcu.edu/~pghosh/index.html
+Vojislav Kecman , http://www.people.vcu.edu/~vkecman/
+Bartosz Krawczyk , http://computer-science.egr.vcu.edu/faculty/bartosz-krawczyk-ph-d/
+Lukasz Kurgan , http://computer-science.egr.vcu.edu/faculty/lukasz-kurgan-ph-d/
+Milos Manic , http://www.people.vcu.edu/~mmanic/
+Bridget T. McInnes , http://www.people.vcu.edu/~btmcinnes/
+Hong-Sheng Zhou , http://www.people.vcu.edu/~hszhou/


### PR DESCRIPTION
Added VCU CS faculty from the department website
http://computer-science.egr.vcu.edu/faculty/
Only added faculty who advise CS PhD students.
