### PR TITLE
update Xiuzhen Cheng's name for GW

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -1397,6 +1397,7 @@ Rahul Simha , George Washington University
 Shmuel Rotenstreich , George Washington University
 Timothy Wood , George Washington University
 Xiuzhen (Susan) Cheng , George Washington University
+Xiuzhen Cheng , George Washington University
 Adam O'Neill , Georgetown University
 Bala Kalyanasundaram , Georgetown University
 Calvin C. Newport , Georgetown University


### PR DESCRIPTION
http://dblp.uni-trier.de/pers/hd/c/Cheng:Xiuzhen
https://www.seas.gwu.edu/~cheng/

Her INFOCOM papers don't seem to be being included in the GW counts, probably since the existing name doesn't match DBLP.
