### PR TITLE
Adding correct DBLP entry for Prof. Wu-chun Feng (VT)

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -7092,7 +7092,7 @@ Steve H. Harrison , Virginia Tech
 Steve Harrison , Virginia Tech
 T. M. Murali , Virginia Tech
 Wenjing Lou , Virginia Tech
-Wu Feng 0001 , Virginia Tech
+Wu-chun Feng , Virginia Tech
 Yang Cao , Virginia Tech
 Yong Cao , Virginia Tech
 Adam Hahn , Washington State University


### PR DESCRIPTION
The existing faculty-affiliations.csv file links to an incorrect entry for Prof. Wu-chun Feng. The edit made should link to the correct entry.