### PR TITLE
add National University of Singapore (NUS)

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -16,6 +16,7 @@ Massey University,australasia
 Max Planck Institute,europe
 McGill University,canada
 Monash University,australasia
+National University of Singapore, australasia
 Polytechnic University of Catalonia,europe
 RWTH Aachen,europe
 Simon Fraser University,canada

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -7358,3 +7358,69 @@ Jia Rao , University of Texas at Arlington
 Song Jiang , University of Texas at Arlington
 Ramez Elmasri , University of Texas at Arlington 
 Hong Jiang , University of Texas at Arlington
+Kian-Lee Tan, National University of Singapore
+Wei Tsang Ooi, National University of Singapore
+Tulika Mitra, National University of Singapore
+Wynne Hsu, National University of Singapore
+Hugh Anderson, National University of Singapore
+Divesh Aggarwal, National University of Singapore
+Anand Bhojan, National University of Singapore
+Stéphane Bressan, National University of Singapore
+Michael Scott Brown, National University of Singapore
+Chee Yong Chan, National University of Singapore
+Mun Choon Chan, National University of Singapore
+Ee-Chien Chang, National University of Singapore
+Wei-Ngan Chin, National University of Singapore
+Tat-Seng Chua, National University of Singapore
+Jin Song Dong, National University of Singapore
+Seth Gilbert, National University of Singapore
+Martin Henz, National University of Singapore
+Aquinas Hobor, National University of Singapore
+David Hsu, National University of Singapore
+Bingsheng He, National University of Singapore
+Joxan Jaffar, National University of Singapore
+Sanjay Jain, National University of Singapore
+Rahul Jain 0001, National University of Singapore
+Mohan S. Kankanhalli, National University of Singapore
+Siau-Cheng Khoo, National University of Singapore
+Min-Suk Kang, National University of Singapore
+Mong-Li Lee, National University of Singapore
+Wee Sun Lee, National University of Singapore
+Tze-Yun Leong, National University of Singapore
+Hon Wai Leong, National University of Singapore
+Ben Leong, National University of Singapore
+Zhenkai Liang, National University of Singapore
+Brian Y. Lim, National University of Singapore
+Tok Wang Ling, National University of Singapore
+Kian Hsiang Low, National University of Singapore
+Wee Kheng Leow, National University of Singapore
+Richard MA, National University of Singapore
+Richard T. B. Ma, National University of Singapore
+Teck Khim Ng, National University of Singapore
+Hwee Tou Ng, National University of Singapore
+See-Kiong Ng, National University of Singapore
+Beng Chin Ooi, National University of Singapore
+Wei Tsang Ooi, National University of Singapore
+Li-Shiuan Peh, National University of Singapore
+Damith C. Rajapakse, National University of Singapore
+David S. Rosenblum, National University of Singapore
+Abhik Roychoudhury, National University of Singapore
+Prateek Saxena, National University of Singapore
+Terence Sim, National University of Singapore
+Frank Stephan, National University of Singapore
+Wing-Kin Sung, National University of Singapore
+Gary S. H. Tan, National University of Singapore
+Colin Keng-Yan Tan, National University of Singapore
+Tiow Seng Tan, National University of Singapore
+Sun-Teck Tan, National University of Singapore
+Y. C. Tay, National University of Singapore
+Yong Meng Teo, National University of Singapore
+Anthony K. H. Tung, National University of Singapore
+Limsoon Wong, National University of Singapore
+Weng-Fai Wong, National University of Singapore
+Roland H. C. Yap, National University of Singapore
+KangKang Yin, National University of Singapore
+Haifeng Yu, National University of Singapore
+Shengdong Zhao, National University of Singapore
+Roger Zimmermann, National University of Singapore
+Yair Zick, National University of Singapore


### PR DESCRIPTION
Added the National University of Singapore(NUS) in australasia region, along with the list of full-time faculty members in Department of Computer Science, School of Computing, NUS.