### PR TITLE
Adding Dan Lee

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -5968,6 +5968,7 @@ Benjamin C. Pierce , University of Pennsylvania
 Boon Thau Loo , University of Pennsylvania
 Camillo J. Taylor , University of Pennsylvania
 Chris Callison-Burch , University of Pennsylvania
+Daniel D. Lee , University of Pennsylvania
 Insup Lee , University of Pennsylvania
 Jean Gallier , University of Pennsylvania
 Jean H. Gallier , University of Pennsylvania


### PR DESCRIPTION
Adding Dan Lee, a machine learning researcher who is secondary in the CS department (has advising privileges)