### PR TITLE
Adding several secondary CIS faculty at Penn

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -5968,11 +5968,13 @@ Benjamin C. Pierce , University of Pennsylvania
 Boon Thau Loo , University of Pennsylvania
 Camillo J. Taylor , University of Pennsylvania
 Chris Callison-Burch , University of Pennsylvania
+Daniel E. Koditschek , University of Pennsylvania
 Insup Lee , University of Pennsylvania
 Jean Gallier , University of Pennsylvania
 Jean H. Gallier , University of Pennsylvania
 Jianbo Shi , University of Pennsylvania
 Joseph Devietti , University of Pennsylvania
+Katherine J. Kuchenbecker , University of Pennsylvania
 Konstantinos Daniilidis , University of Pennsylvania
 Kostas Daniilidis , University of Pennsylvania
 Lyle H. Ungar , University of Pennsylvania
@@ -5997,6 +5999,7 @@ Susan B. Davidson , University of Pennsylvania
 Val Breazu-Tannen , University of Pennsylvania
 Val Tannen , University of Pennsylvania
 Valeriu Breazu , University of Pennsylvania
+Vijay Kumar 0001 , University of Pennsylvania
 Zachary G. Ives , University of Pennsylvania
 Adam J. Lee , University of Pittsburgh
 Alexandros Labrinidis , University of Pittsburgh


### PR DESCRIPTION
All are members of the graduate group (can advise CS students)