### PR TITLE
Yue Zhang 0009

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -2710,7 +2710,7 @@ Weng-Keen Wong , Oregon State University
 Xiaoli Fern , Oregon State University
 Xiaoli Z. Fern , Oregon State University
 Xiaoli Zhang Fern , Oregon State University
-Yue Zhang , Oregon State University
+Yue Zhang 0009 , Oregon State University
 Adam D. Smith , Pennsylvania State University
 Anand Sivasubramaniam , Pennsylvania State University
 Bhuvan Urgaonkar , Pennsylvania State University


### PR DESCRIPTION
the csv is intending to list http://eecs.oregonstate.edu/people/zhang-yue 
who is http://dblp.uni-trier.de/pers/hd/z/Zhang_0009:Yue

as opposed to the DBLP disambiguation page: http://dblp.uni-trier.de/pers/hd/z/Zhang:Yue

I noticed false positive pubs attributed to the OSU Yue Zhang via the SUTD Yue Zhang  http://people.sutd.edu.sg/~yue_zhang/