### PR TITLE
Add UW-Madison affiliate faculty

### DIFF
--- a/dblp-aliases.csv
+++ b/dblp-aliases.csv
@@ -29338,3 +29338,16 @@ Erik G. Miller,Erik G. Learned-Miller
 Mehmet Can Vuran,Mehmet C. Vuran
 Russ Greiner,Russell Greiner
 K. Gopinath,Kanchi Gopinath
+Anthony Gitter
+Alberto Del Pia
+Mark Craven
+Colin N. Dewey
+Jeffrey T. Linderoth,Jeff Linderoth
+Robert D. Nowak
+David Page, C. David Page Jr.
+Garvesh Raskutti
+Martina A. Rau
+Sushmita Roy
+Vikas Singh
+Grace Wahba
+Rebecca Willett,Rebecca M. Willett

--- a/dblp-aliases.csv
+++ b/dblp-aliases.csv
@@ -29338,16 +29338,3 @@ Erik G. Miller,Erik G. Learned-Miller
 Mehmet Can Vuran,Mehmet C. Vuran
 Russ Greiner,Russell Greiner
 K. Gopinath,Kanchi Gopinath
-Anthony Gitter
-Alberto Del Pia
-Mark Craven
-Colin N. Dewey
-Jeffrey T. Linderoth,Jeff Linderoth
-Robert D. Nowak
-David Page, C. David Page Jr.
-Garvesh Raskutti
-Martina A. Rau
-Sushmita Roy
-Vikas Singh
-Grace Wahba
-Rebecca Willett,Rebecca M. Willett

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -6962,18 +6962,23 @@ Amos Ron , University of Wisconsin - Madison
 AnHai Doan , University of Wisconsin - Madison
 Andrea C. Arpaci-Dusseau , University of Wisconsin - Madison
 Andrea C. Dusseau , University of Wisconsin - Madison
+Anthony Gitter , University of Wisconsin - Madison
+Alberto Del Pia , University of Wisconsin - Madison
 Aws Albarghouthi , University of Wisconsin - Madison
 Barton P. Miller , University of Wisconsin - Madison
 Ben Liblit , University of Wisconsin - Madison
 Bilge Mutlu , University of Wisconsin - Madison
 Charles R. Dyer , University of Wisconsin - Madison
 David A. Wood , University of Wisconsin - Madison
+C. David Page Jr. , University of Wisconsin - Madison
 Deborah Joseph , University of Wisconsin - Madison
 Dieter van Melkebeek , University of Wisconsin - Madison
-Eftichis Sifakis , University of Wisconsin - Madison
 Eftychios Sifakis , University of Wisconsin - Madison
 Eric Bach , University of Wisconsin - Madison
+Garvesh Raskutti , University of Wisconsin - Madison
+Grace Wahba , University of Wisconsin - Madison
 Gurindar S. Sohi , University of Wisconsin - Madison
+Jeff T. Linderoth , University of Wisconsin - Madison
 Jignesh M. Patel , University of Wisconsin - Madison
 Jin-Yi Cai , University of Wisconsin - Madison
 Jin-yi Cai , University of Wisconsin - Madison
@@ -6982,6 +6987,8 @@ Karthikeyan Sankaralingam , University of Wisconsin - Madison
 Karu Sankaralingam , University of Wisconsin - Madison
 Loris D'Antoni , University of Wisconsin - Madison
 Mark D. Hill , University of Wisconsin - Madison
+Mark Craven , University of Wisconsin - Madison
+Martina A. Rau , University of Wisconsin - Madison
 Michael C. Ferris , University of Wisconsin - Madison
 Michael Gleicher , University of Wisconsin - Madison
 Michael M. Swift , University of Wisconsin - Madison
@@ -6991,11 +6998,15 @@ Paraschos Koutris , University of Wisconsin - Madison
 Paul Barford , University of Wisconsin - Madison
 Remzi H. Arpaci , University of Wisconsin - Madison
 Remzi H. Arpaci-Dusseau , University of Wisconsin - Madison
+Rebecca Willett , University of Wisconsin - Madison
+Robert D. Nowak , University of Wisconsin - Madison
 Shuchi Chawla , University of Wisconsin - Madison
 Somesh Jha , University of Wisconsin - Madison
 Stephen J. Wright , University of Wisconsin - Madison
 Suman Banerjee , University of Wisconsin - Madison
+Sushmita Roy , University of Wisconsin - Madison
 Thomas W. Reps , University of Wisconsin - Madison
+Vikas Singh , University of Wisconsin - Madison
 Xiaojin Zhu , University of Wisconsin - Madison
 Abraham Bernstein , University of Zurich
 Burkhard Stiller , University of Zurich

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -6998,7 +6998,7 @@ Paraschos Koutris , University of Wisconsin - Madison
 Paul Barford , University of Wisconsin - Madison
 Remzi H. Arpaci , University of Wisconsin - Madison
 Remzi H. Arpaci-Dusseau , University of Wisconsin - Madison
-Rebecca Willett , University of Wisconsin - Madison
+Rebecca M. Willett , University of Wisconsin - Madison
 Robert D. Nowak , University of Wisconsin - Madison
 Shuchi Chawla , University of Wisconsin - Madison
 Somesh Jha , University of Wisconsin - Madison


### PR DESCRIPTION
I am adding a few CS affiliate faculty from UW-Madison. I got them from the affiliate faculty page (http://www.cs.wisc.edu/people/affiliate-faculty). Most, if not all, are actively advising or co-advising CS students at UW-Madison. 

I verified that the names match their dblp entry. 