### PR TITLE
Fixes to Stony Brook faculty 

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -3370,7 +3370,6 @@ Barbara M. Chapman , Stony Brook University
 Barbara Mary Chapman , Stony Brook University
 C. R. Ramakrishnan , Stony Brook University
 Cartic R. Ramakrishnan , Stony Brook University
-Cartic Ramakrishnan , Stony Brook University
 Dimitris Samaras , Stony Brook University
 Erez Zadok , Stony Brook University
 Eugene W. Stark , Stony Brook University

--- a/homepages.csv
+++ b/homepages.csv
@@ -1096,8 +1096,7 @@ Carroll Morgan,http://www.cse.unsw.edu.au/~carrollm/
 Carsten Rother,http://cvlab-dresden.de/
 Carsten Rudolph,http://monash.edu/research/explore/en/persons/carsten-rudolph(83382c2b-4d88-4bb8-ba88-2d20af2b906c).html
 Carsten Steger,http://iuks.informatik.tu-muenchen.de/members/steger
-Cartic R. Ramakrishnan,https://www.cs.stonybrook.edu/people/faculty/IVRamakrishnan
-Cartic Ramakrishnan,https://www.cs.stonybrook.edu/people/faculty/IVRamakrishnan
+Cartic R. Ramakrishnan,http://www3.cs.stonybrook.edu/~cram/
 Cas Cremers,https://www.cs.ox.ac.uk/people/cas.cremers/
 Cas J. F. Cremers,https://www.cs.ox.ac.uk/people/cas.cremers/
 Casimir A. Kulikowski,https://www.cs.rutgers.edu/~kulikows/


### PR DESCRIPTION
Removed Cartic Ramakrishnan from Stony Brook (he is at IBM) and fixed the webpage of Cartic R. Ramakrishnan.