### PR TITLE
Update faculty-affiliations.csv

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -5065,7 +5065,6 @@ John R. Longley , University of Edinburgh
 Jon Oberlander , University of Edinburgh
 Julian C. Bradfield , University of Edinburgh
 K. Kalorkoti , University of Edinburgh
-Kami E. Vaniea , University of Edinburgh
 Kami Vaniea , University of Edinburgh
 Kenneth Heafield , University of Edinburgh
 Kousha Etessami , University of Edinburgh


### PR DESCRIPTION
"Kami E. Vaniea" and "Kami Vaniea" are the same person, me. I removed "Kami E. Vaniea" as the majority of my papers omit the middle initial.