### PR TITLE
Fixed bug for opening links in a new window

### DIFF
--- a/csrankings.js
+++ b/csrankings.js
@@ -576,7 +576,7 @@ var CSRankings = (function () {
                     + encodeURI(CSRankings.homepages[name_5]) + '" '
                     + 'onclick="trackOutboundLink(\''
                     + encodeURI(CSRankings.homepages[name_5])
-                    + '\', true); return false;"'
+                    + '\'); return false;"'
                     + '>'
                     + name_5
                     + '</a>&nbsp;'
@@ -590,7 +590,7 @@ var CSRankings = (function () {
                     + '" '
                     + 'onclick="trackOutboundLink(\''
                     + CSRankings.translateNameToDBLP(name_5)
-                    + '\', true); return false;"'
+                    + '\'); return false;"'
                     + '>'
                     + facultycount[name_5 + dept]
                     + '</a>'

--- a/csrankings.js
+++ b/csrankings.js
@@ -576,7 +576,7 @@ var CSRankings = (function () {
                     + encodeURI(CSRankings.homepages[name_5]) + '" '
                     + 'onclick="trackOutboundLink(\''
                     + encodeURI(CSRankings.homepages[name_5])
-                    + '\'); return false;"'
+                    + '\', true); return false;"'
                     + '>'
                     + name_5
                     + '</a>&nbsp;'
@@ -590,7 +590,7 @@ var CSRankings = (function () {
                     + '" '
                     + 'onclick="trackOutboundLink(\''
                     + CSRankings.translateNameToDBLP(name_5)
-                    + '\'); return false;"'
+                    + '\', true); return false;"'
                     + '>'
                     + facultycount[name_5 + dept]
                     + '</a>'

--- a/csrankings.ts
+++ b/csrankings.ts
@@ -753,7 +753,7 @@ class CSRankings {
 		    + encodeURI(CSRankings.homepages[name]) + '" '
 		    + 'onclick="trackOutboundLink(\''
 		    + encodeURI(CSRankings.homepages[name])
-		    + '\'); return false;"'
+		    + '\', true); return false;"'
 		    + '>' 
 		    + name
 		    + '</a>&nbsp;'
@@ -767,7 +767,7 @@ class CSRankings {
 		    + '" '
 		    + 'onclick="trackOutboundLink(\''
 		    + CSRankings.translateNameToDBLP(name)
-		    + '\'); return false;"'
+		    + '\', true); return false;"'
 		    + '>'
 		    + facultycount[name+dept]
 		    + '</a>'

--- a/index.html
+++ b/index.html
@@ -24,16 +24,30 @@
     </script>
     <script>
       /**
-      * Function that tracks a click on an outbound link in Analytics.
-      * This function takes a valid URL string as an argument, and uses that URL string
-      * as the event label. Setting the transport method to 'beacon' lets the hit be sent
+      * Track clicks to a link. If new_window is true the google analytics request
+      * will be made synchronously, because browsers block new windows from opening unless
+      * it is done DURING an on click event. If new_window is false, the request will
+      * be made asynchronously, and the current window url will be changed.
+      *
+      * Setting the transport method to 'beacon' lets the hit be sent
       * using 'navigator.sendBeacon' in browser that support it.
       */
-      var trackOutboundLink = function(url) {
-      ga('send', 'event', 'outbound', 'click', url, {
-      'transport': 'beacon',
-      'hitCallback': function(){document.location = url;}
-      });
+      var trackOutboundLink = function(url, new_window) {
+        /* Setting a default value for backward compatibility */
+        if (new_window === undefined) {
+          new_window = false;
+        }
+        ga('send', 'event', 'outbound', 'click', url, {'transport': 'beacon',
+        'hitCallback':
+          function () {
+            if (!new_window) {
+              document.location = url;
+            }
+          }
+        });
+        if (new_window){
+          window.open(url);
+        }
       }
     </script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.4.4/d3.min.js"></script>


### PR DESCRIPTION
The links to a faculty member's homepage and to his/her DBLP entry do not open in new windows though `target="_blank" ` is specified in the links. 

This PR fixes the bug using the method suggested in https://www.cocept.io/blog/development/outbound-links-new-window-analytics/.