### PR TITLE
Update faculty-affiliations.csv

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -6400,6 +6400,7 @@ Rajeev Alur , University of Pennsylvania
 Sampath Kannan , University of Pennsylvania
 Sanjeev Khanna , University of Pennsylvania
 Sasha Rakhlin , University of Pennsylvania
+Vincent Liu , University of Pennsylvania
 Shivani Agarwal 0001 , University of Pennsylvania
 Stephanie Weirich , University of Pennsylvania
 Steve Zdancewic , University of Pennsylvania


### PR DESCRIPTION
Adding Vincent Liu, who started as an assistant professor at Penn CIS in January.