### PR TITLE
Updated several faculty at UWaterloo

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -7382,8 +7382,7 @@ Alex López-Ortiz , University of Waterloo
 Anna Lubiw , University of Waterloo
 Arne Storjohann , University of Waterloo
 Bernard Wong , University of Waterloo
-C. Justin Wan , University of Waterloo
-Charles A. Clarke , University of Waterloo
+Charles L. A. Clarke , University of Waterloo
 Christopher Batty , University of Waterloo
 Chrysanne Di Marco , University of Waterloo
 Chrysanne DiMarco , University of Waterloo
@@ -7407,7 +7406,6 @@ Grant E. Weddell , University of Waterloo
 Gregor Richards , University of Waterloo
 Ian Goldberg , University of Waterloo
 Ian McKillop , University of Waterloo
-Ian Michael Terry , University of Waterloo
 Ihab F. Ilyas , University of Waterloo
 Ihab Francis Ilyas , University of Waterloo
 J. Ian Munro , University of Waterloo
@@ -7419,6 +7417,7 @@ Jimmy J. Lin , University of Waterloo
 Joanne M. Atlee , University of Waterloo
 John Watrous , University of Waterloo
 Jonathan F. Buss , University of Waterloo
+Justin W. L. Wan , University of Waterloo
 Kate Larson , University of Waterloo
 Kenneth Salem , University of Waterloo
 Khuzaima Daudjee , University of Waterloo
@@ -7426,19 +7425,17 @@ Lap Chi Lau , University of Waterloo
 Lila Kari , University of Waterloo
 Lila Santean , University of Waterloo
 M. Tamer Özsu , University of Waterloo
-Maaz Bin Ahmad , University of Waterloo
-Maaz Bin Ahmed , University of Waterloo
 Mark Giesbrecht , University of Waterloo
 Martin Karsten , University of Waterloo
 Michael W. Godfrey , University of Waterloo
-Ming Li , University of Waterloo
+Ming Li 0001 , University of Waterloo
 Nancy A. Day , University of Waterloo
 Naomi Nishimura , University of Waterloo
 Ondrej Lhoták , University of Waterloo
 Pascal Poupart , University of Waterloo
 Peter A. Buhr , University of Waterloo
 Peter A. Forsyth , University of Waterloo
-Peter J. L. van Beek , University of Waterloo
+Peter van Beek , University of Waterloo
 Prabhakar Ragde , University of Waterloo
 Raouf Boutaba , University of Waterloo
 Richard Cleve , University of Waterloo

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -3345,7 +3345,6 @@ Matt Huenerfauth , Rochester Institute of Technology
 Matthew Fluet , Rochester Institute of Technology
 Matthew T. Fluet , Rochester Institute of Technology
 Mehdi Mirakhorli , Rochester Institute of Technology
-Meiyappan Nagappan , Rochester Institute of Technology
 Michael Yacci , Rochester Institute of Technology
 Minseok Kwon , Rochester Institute of Technology
 Mohan Kumar , Rochester Institute of Technology

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -7381,6 +7381,7 @@ Alejandro López-Ortiz , University of Waterloo
 Alex López-Ortiz , University of Waterloo
 Anna Lubiw , University of Waterloo
 Arne Storjohann , University of Waterloo
+Bin Ma , University of Waterloo
 Bernard Wong , University of Waterloo
 Charles L. A. Clarke , University of Waterloo
 Christopher Batty , University of Waterloo
@@ -7398,6 +7399,7 @@ Edith Law , University of Waterloo
 Edward Chan , University of Waterloo
 Edward Lank , University of Waterloo
 Eric Blais , University of Waterloo
+Florian Kerschbaum , University of Waterloo
 George Labahn , University of Waterloo
 Gladimir Baranoski , University of Waterloo
 Gladimir V. G. Baranoski , University of Waterloo
@@ -7427,6 +7429,7 @@ Lila Santean , University of Waterloo
 M. Tamer Özsu , University of Waterloo
 Mark Giesbrecht , University of Waterloo
 Martin Karsten , University of Waterloo
+Meiyappan Nagappan , University of Waterloo
 Michael W. Godfrey , University of Waterloo
 Ming Li 0001 , University of Waterloo
 Nancy A. Day , University of Waterloo
@@ -7442,6 +7445,7 @@ Richard Cleve , University of Waterloo
 Richard J. Trefler , University of Waterloo
 Richard Mann , University of Waterloo
 Robin Cohen , University of Waterloo
+Samer Al-Kiswany , University of Waterloo 
 Semih Salihoglu , University of Waterloo
 Sergey Gorbunov , University of Waterloo
 Shai Ben-David , University of Waterloo


### PR DESCRIPTION
There is no faculty by the name "Maaz Bin Ahmed" at University of Waterloo. 
There is no faculty by the name "Ian Michael Terry" at University of Waterloo.
The correct dblp profile name of "Peter J. L. van Beek" is "Peter van Beek" .
The correct dblp profile name of "Charles A. Clarke" is "Charles L. A. Clarke". 
The correct dblp profile for "Ming Li" is "Ming Li 0001". 
The correcr dblp profile for "C. Justin Wan" is "Justin W. L. Wan"