### PR TITLE
Updated few faculty members at UBC and one at Waterloo

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -4480,7 +4480,6 @@ Bill Aiello , University of British Columbia
 Chen Greif , University of British Columbia
 Cristina Conati , University of British Columbia
 David G. Kirkpatrick , University of British Columbia
-David G. Lowe , University of British Columbia
 David Poole , University of British Columbia
 Dinesh K. Pai , University of British Columbia
 Gail C. Murphy , University of British Columbia
@@ -4488,6 +4487,7 @@ Giuseppe Carenini , University of British Columbia
 Gregor Kiczales , University of British Columbia
 Holger H. Hoos , University of British Columbia
 Holger Hoos , University of British Columbia
+Hu Fu, University of British Columbia
 Ian M. Mitchell , University of British Columbia
 Ian Mitchell , University of British Columbia
 Ivan Beschastnikh , University of British Columbia
@@ -4516,7 +4516,7 @@ Tamara Munzner , University of British Columbia
 Uri M. Ascher , University of British Columbia
 V. S. Lakshmanan , University of British Columbia
 William Aiello , University of British Columbia
-William Evans , University of British Columbia
+William S. Evans , University of British Columbia
 Wolfgang Heidrich , University of British Columbia
 Anthony Tang , University of Calgary
 Ben Stephenson , University of Calgary
@@ -7421,7 +7421,6 @@ Jonathan F. Buss , University of Waterloo
 Justin W. L. Wan , University of Waterloo
 Kate Larson , University of Waterloo
 Kenneth Salem , University of Waterloo
-Khuzaima Daudjee , University of Waterloo
 Lap Chi Lau , University of Waterloo
 Lila Kari , University of Waterloo
 Lila Santean , University of Waterloo


### PR DESCRIPTION
Removed David G. Lowe as his webpage (http://www.cs.ubc.ca/~lowe/) says that he's joined Google.
The correct dblp entry for "William Evans" is "William S. Evans".
Added Hu Fu at UBC (https://www.cs.ubc.ca/our-department/people/faculty).
Removed Khuzaima Daudjee at University of Waterloo as he is not listed as tenure-track faculty, but a lecturer (https://cs.uwaterloo.ca/about/people/group/41).