### PR TITLE
Updated several faculty at UToronto

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -7062,13 +7062,11 @@ Bianca Schröder , University of Toronto
 Bogdan Simion , University of Toronto
 Charles Rackoff , University of Toronto
 Christina C. Christara , University of Toronto
-Craig Boutilier , University of Toronto
-Dan Heap , University of Toronto
 Daniel J. Wigdor , University of Toronto
 Daniel Wigdor , University of Toronto
 David J. Fleet , University of Toronto
 David K. Duvenaud , University of Toronto
-David Levin , University of Toronto
+David I. W. Levin , University of Toronto
 David Liu , University of Toronto
 Derek G. Corneil , University of Toronto
 Derek Gordon Corneil , University of Toronto
@@ -7087,18 +7085,15 @@ Graeme Hirst , University of Toronto
 Hector J. Levesque , University of Toronto
 Jaqueline Smith , University of Toronto
 Jennifer Campbell , University of Toronto
-Jim Clarke , University of Toronto
 John Mylopoulos , University of Toronto
 Karan Singh , University of Toronto
 Karen L. Reid , University of Toronto
-Kelly Gotlieb , University of Toronto
-Ken Jackson , University of Toronto
+Kenneth R. Jackson , University of Toronto
 Khai N. Truong , University of Toronto
 Kiriakos N. Kutulakos , University of Toronto
 Kyros Kutulakos , University of Toronto
 Marsha Chechik , University of Toronto
 Michael Brudno , University of Toronto
-Michael Guerzhoy , University of Toronto
 Michael Molloy , University of Toronto
 Michael S. O. Molloy , University of Toronto
 Michelle Craig , University of Toronto


### PR DESCRIPTION
Craig Boutilier has been removed since his webpage (http://www.cs.toronto.edu/~cebly/) states that he has joined Google. 
Dan Heap has been removed as he is not a tenure-track faculty member at UToronto. 
The correct dblp entry for "David Levin" is "David I. W. Levin".
Jim Clarke has been removed as he is not a tenure-track faculty member at UToronto. 
There is no faculty member by the name "Kelly Gotlieb" at UToronto.
The correct  dblp entry for "Kenneth Jackson" is "Kenneth R. Jackson".
Michael Guerzhoy has been removed as he is not a tenure-track faculty member at UToronto.