### PR TITLE
Updated few faculty members at McGill University

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -2204,7 +2204,6 @@ Derek Ruths , McGill University
 Doina Precup , McGill University
 Gregory Dudek , McGill University
 Hamed Hatami , McGill University
-Hans Vangheluwe , McGill University
 Jackie Chi Kit Cheung , McGill University
 Joelle Pineau , McGill University
 Jérôme Waldispühl , McGill University
@@ -2220,10 +2219,9 @@ Muthucumaru Maheswaran , McGill University
 Nathan Friedman , McGill University
 Paul G. Kry , McGill University
 Prakash Panangaden , McGill University
-Wenbo He , McGill University
 Xiao-Wen Chang , McGill University
 Xue Liu , McGill University
-Yang Cai , McGill University
+Yang Cai 0001 , McGill University
 Abdol-Hossein Esfahanian , Michigan State University
 Alex Liu , Michigan State University
 Anil K. Jain , Michigan State University


### PR DESCRIPTION
Removed Hans Vangheluwe as he is listed as an Adjunct Professor at McGill University.
Removed Wenbo He as she is listed as an Adjunct Professor at McGill University.
The correct dblp entry for Yang Cai is Yang Cai 0001.