### PR TITLE
Updated several faculty members at SFU

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -3747,9 +3747,11 @@ Anoop Sarkar , Simon Fraser University
 Arrvindh Shriraman , Simon Fraser University
 Binay Bhattacharya , Simon Fraser University
 Binay K. Bhattacharya , Simon Fraser University
-Brian Funt , Simon Fraser University
+Brian V. Funt , Simon Fraser University
+David G. Mitchell , Simon Fraser University
 Eugenia Ternovska , Simon Fraser University
 Eugenia Ternovskaia , Simon Fraser University
+Fred Popowich , Simon Fraser University
 Ghassan Hamarneh , Simon Fraser University
 Greg Mori , Simon Fraser University
 Hao (Richard) Zhang , Simon Fraser University
@@ -3758,6 +3760,8 @@ James P. Delgrande , Simon Fraser University
 Jian Pei , Simon Fraser University
 Jiangchuan Liu , Simon Fraser University
 Jiannan Wang , Simon Fraser University
+Joseph G. Peters , Simon Fraser University
+Kay C. Wiese , Simon Fraser University
 Ke Wang , Simon Fraser University
 Leonid Chindelevitch , Simon Fraser University
 Mark S. Drew , Simon Fraser University
@@ -3770,12 +3774,16 @@ Parmit K. Chilana , Simon Fraser University
 Pavol Hell , Simon Fraser University
 Petra Berenbrink , Simon Fraser University
 Ping Tan , Simon Fraser University
+Qian-Ping Gu , Simon Fraser University
+Ramesh Krishnamurti , Simon Fraser University
 Richard T. Vaughan , Simon Fraser University
 Robert D. Cameron , Simon Fraser University
+Ryan C. N. D'Arcy , Simon Fraser University
 Thomas C. Shermer , Simon Fraser University
 Uwe Glässer , Simon Fraser University
 Valentine Kabanets , Simon Fraser University
 William N. Sumner , Simon Fraser University
+Wo-Shun Luk , Simon Fraser University
 Ze-Nian Li , Simon Fraser University
 Alex Aiken , Stanford University
 Alexander Aiken , Stanford University


### PR DESCRIPTION
The correct dblp entry for Brian Funt is Brian V. Funt.
Added Ryan C. N. D'Arcy at Simon Fraser University. 
Added Qian-Ping Gu at Simon Fraser University.
Added Ramesh Krishnamurti at Simon Fraser University.
Added Wo-Shun Luk at Simon Fraser University.
Added David G. Mitchell at Simon Fraser University.
Added Joseph G. Peters at Simon Fraser University.
Added Fred Popowich at Simon Fraser University.
Added Kay C. Wiese , at Simon Fraser University.