### PR TITLE
Add Chulalongkorn University

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -3,6 +3,7 @@ Aarhus University,europe
 Australian National University,australasia
 Bar-Ilan University,europe
 Carleton University,canada
+Chulalongkorn University,australasia
 Concordia University,canada
 DIKU,europe
 EPFL,europe

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -737,6 +737,55 @@ Yiming Yang , Carnegie Mellon University
 Yong-Lae Park , Carnegie Mellon University
 Yuvraj Agarwal , Carnegie Mellon University
 Ziv Bar-Joseph , Carnegie Mellon University
+Arthit Thongtak , Chulalongkorn Uniersity
+Arthorn Luangsodsai , Chulalongkorn University
+Athasit Surarerks , Chulalongkorn Uniersity
+Atiwong Suchato , Chulalongkorn Uniersity
+Attawith Sudsang , Chulalongkorn Uniersity
+Boonchai Sowanwanichkul , Chulalongkorn Uniersity
+Boonserm Kijsirikul , Chulalongkorn Uniersity
+Chatchawit Aporntewan , Chulalongkorn University
+Chidchanok Lursinsap , Chulalongkorn University
+Chotirat (Ann) Ratanamahatana , Chulalongkorn Uniersity
+Dittaya Wanvarie , Chulalongkorn University
+Duangdao Wichadakul , Chulalongkorn Uniersity
+Jaruloj Eamsiri Chongstitvatana , Chulalongkorn University
+Kitiporn Plaimas , Chulalongkorn University
+Krerk Piromsopa , Chulalongkorn Uniersity
+Krung Sinapiromsaran , Chulalongkorn University
+Kultida Rojviboonchai , Chulalongkorn Uniersity
+Kunwadee Sripanidkulchai , Chulalongkorn Uniersity
+Nagul Cooharojananone , Chulalongkorn University
+Nakornthip Prompoon , Chulalongkorn Uniersity
+Natawut Nupairoj , Chulalongkorn Uniersity
+Nattee Niparnan , Chulalongkorn Uniersity
+Nongluk Covavisaruch , Chulalongkorn Uniersity
+Nuttapong Chentanez , Chulalongkorn Uniersity
+Pattarasinee Bhattarakosol , Chulalongkorn University
+Peerapon Vateekul , Chulalongkorn Uniersity
+Peraphon Sophatsathit , Chulalongkorn University
+Pitchaya Sitthi-amorn , Chulalongkorn Uniersity
+Pizzanu Kanongchaiyos , Chulalongkorn Uniersity
+Pornsiri Muenchaisri , Chulalongkorn Uniersity
+Prabhas Chongstitvatana , Chulalongkorn Uniersity
+Proadpran Punyabukkana , Chulalongkorn Uniersity
+Rajalida Lipikorn , Chulalongkorn University
+Saranya Maneeroj , Chulalongkorn University
+Somchai Prasitjutrakul , Chulalongkorn Uniersity
+Somjai Boonsiri , Chulalongkorn University
+Suchada Siripant , Chulalongkorn University
+Suebskul Phiphobmongkol , Chulalongkorn Uniersity
+Sukree Sinthupinyo , Chulalongkorn Uniersity
+Suphakant Phimoltares , Chulalongkorn University
+Taratip Suwannasart , Chulalongkorn Uniersity
+Thanarat H. Chalidabhongse , Chulalongkorn Uniersity
+Thongchai Rojkangsadan , Chulalongkorn Uniersity
+Twittie Senivongse , Chulalongkorn Uniersity
+Veera Muangsin , Chulalongkorn Uniersity
+Vishnu Kotrajaras , Chulalongkorn Uniersity
+Wanchai Rivepiboon , Chulalongkorn Uniersity
+Wiwat Vatanawood , Chulalongkorn Uniersity
+Yachai Limpiyakorn , Chulalongkorn Uniersity
 Alexander Herzog , Clemson University
 Amy W. Apon , Clemson University
 Andrew Robb , Clemson University

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -737,55 +737,22 @@ Yiming Yang , Carnegie Mellon University
 Yong-Lae Park , Carnegie Mellon University
 Yuvraj Agarwal , Carnegie Mellon University
 Ziv Bar-Joseph , Carnegie Mellon University
-Arthit Thongtak , Chulalongkorn Uniersity
 Arthorn Luangsodsai , Chulalongkorn University
-Athasit Surarerks , Chulalongkorn Uniersity
-Atiwong Suchato , Chulalongkorn Uniersity
-Attawith Sudsang , Chulalongkorn Uniersity
-Boonchai Sowanwanichkul , Chulalongkorn Uniersity
-Boonserm Kijsirikul , Chulalongkorn Uniersity
 Chatchawit Aporntewan , Chulalongkorn University
 Chidchanok Lursinsap , Chulalongkorn University
-Chotirat (Ann) Ratanamahatana , Chulalongkorn Uniersity
 Dittaya Wanvarie , Chulalongkorn University
-Duangdao Wichadakul , Chulalongkorn Uniersity
 Jaruloj Eamsiri Chongstitvatana , Chulalongkorn University
 Kitiporn Plaimas , Chulalongkorn University
-Krerk Piromsopa , Chulalongkorn Uniersity
 Krung Sinapiromsaran , Chulalongkorn University
-Kultida Rojviboonchai , Chulalongkorn Uniersity
-Kunwadee Sripanidkulchai , Chulalongkorn Uniersity
 Nagul Cooharojananone , Chulalongkorn University
-Nakornthip Prompoon , Chulalongkorn Uniersity
-Natawut Nupairoj , Chulalongkorn Uniersity
-Nattee Niparnan , Chulalongkorn Uniersity
-Nongluk Covavisaruch , Chulalongkorn Uniersity
-Nuttapong Chentanez , Chulalongkorn Uniersity
 Pattarasinee Bhattarakosol , Chulalongkorn University
-Peerapon Vateekul , Chulalongkorn Uniersity
 Peraphon Sophatsathit , Chulalongkorn University
-Pitchaya Sitthi-amorn , Chulalongkorn Uniersity
-Pizzanu Kanongchaiyos , Chulalongkorn Uniersity
 Pornsiri Muenchaisri , Chulalongkorn Uniersity
-Prabhas Chongstitvatana , Chulalongkorn Uniersity
-Proadpran Punyabukkana , Chulalongkorn Uniersity
 Rajalida Lipikorn , Chulalongkorn University
 Saranya Maneeroj , Chulalongkorn University
-Somchai Prasitjutrakul , Chulalongkorn Uniersity
 Somjai Boonsiri , Chulalongkorn University
 Suchada Siripant , Chulalongkorn University
-Suebskul Phiphobmongkol , Chulalongkorn Uniersity
-Sukree Sinthupinyo , Chulalongkorn Uniersity
 Suphakant Phimoltares , Chulalongkorn University
-Taratip Suwannasart , Chulalongkorn Uniersity
-Thanarat H. Chalidabhongse , Chulalongkorn Uniersity
-Thongchai Rojkangsadan , Chulalongkorn Uniersity
-Twittie Senivongse , Chulalongkorn Uniersity
-Veera Muangsin , Chulalongkorn Uniersity
-Vishnu Kotrajaras , Chulalongkorn Uniersity
-Wanchai Rivepiboon , Chulalongkorn Uniersity
-Wiwat Vatanawood , Chulalongkorn Uniersity
-Yachai Limpiyakorn , Chulalongkorn Uniersity
 Alexander Herzog , Clemson University
 Amy W. Apon , Clemson University
 Andrew Robb , Clemson University


### PR DESCRIPTION
Add Chulalongkorn University. Faculty staffs from two departments below are added.

   1. The Department of Computer Engineering, Faculty of Engineering, CU
   2. The Department of Mathematics and Computer Science, Faculty of Science, CU