### PR TITLE
added Lund University, Sweden, Europe

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -30,6 +30,7 @@ IIT Kharagpur,australasia
 IIT Madras,australasia
 IIT Roorkee,australasia
 IST Austria,europe
+Lund University,europe
 Massey University,australasia
 Max Planck Institute,europe
 McGill University,canada

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -8748,6 +8748,5 @@ Jörn Janneck, Lund University
 Klas Nilsson, Lund University
 Martina Maggio, Lund University
 Karl-Erik Årzen, Lund University
-Johan Eker, Lund University
 Anders Robertsson, Lund University
 Maria Kihl, Lund University

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -8736,3 +8736,18 @@ Vladimir Rokhlin , Yale University
 Wenjun Hu , Yale University
 Yang Richard Yang , Yale University
 Zhong Shao , Yale University
+Per Runeson, Lund University
+Martin Höst, Lund University
+Björn Regnell, Lund University
+Christin Lindholm, Lund University
+Thore Husfeldt, Lund University
+Krzysztof Kuchcinski, Lund University
+Per Andersson, Lund University
+Flavius Gruian, Lund University
+Jörn Janneck, Lund University
+Klas Nilsson, Lund University
+Martina Maggio, Lund University
+Karl-Erik Årzen, Lund University
+Johan Eker, Lund University
+Anders Robertsson, Lund University
+Maria Kihl, Lund University


### PR DESCRIPTION
Faculty members from three different departments (all supervising PhD students in CS):
- Department of Computer Science (http://cs.lth.se/computer-science)
- Department of Electrical and Information Technology (http://www.eit.lth.se/)
- Department of Automatic Control (http://control.lth.se/)