### PR TITLE
More CS field members at Cornell

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -1053,6 +1053,7 @@ Haym Hirsh , Cornell University
 Immanuel Trummer , Cornell University
 J. Gregory Morrisett , Cornell University
 J. Nathan Foster , Cornell University
+Jayadev Acharya , Cornell University
 John E. Hopcroft , Cornell University
 Jon M. Kleinberg , Cornell University
 Joseph Y. Halpern , Cornell University
@@ -1080,6 +1081,7 @@ Ronald J. Brachman , Cornell University
 Ross A. Knepper , Cornell University
 Ross Tate , Cornell University
 Salman Avestimehr , Cornell University
+Siddhartha Banerjee , Cornell University
 Serge J. Belongie , Cornell University
 Stephen R. Marschner , Cornell University
 Steve Marschner , Cornell University
@@ -1089,6 +1091,20 @@ Thorsten Joachims , Cornell University
 Vitaly Shmatikov , Cornell University
 Yoav Artzi , Cornell University
 Éva Tardos , Cornell University
+Tsuhan Chen , Cornell University
+Tsu-Han Chen , Cornell University
+Malte Jung , Cornell University
+Malte F. Jung , Cornell University
+Alon Keinan , Cornell University
+Hadas Kress-Gazit , Cornell University
+David Mimno , Cornell University
+Mor Naaman , Cornell University
+Kirstin Peterson , Cornell University
+Phoebe Sengers , Cornell University
+David Shmoys , Cornell University
+David P. Williamson , Cornell University
+Andrew Gordon Wilson , Cornell University
+Zhiru Zhang , Cornell University
 Aasa Feragen , DIKU
 Andrzej Filinski , DIKU
 Christian Igel , DIKU

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -1015,8 +1015,10 @@ Volker Haarslev , Concordia University
 Weiyi Shang , Concordia University
 Yuhong Yan , Concordia University
 Adrian Sampson , Cornell University
+Alon Keinan , Cornell University
 Amir Salman Avestimehr , Cornell University
 Andrew C. Myers , Cornell University
+Andrew Gordon Wilson , Cornell University
 Anil Damle , Cornell University
 Ari Juels , Cornell University
 Arpita Ghosh , Cornell University
@@ -1035,6 +1037,9 @@ Daniel P. Huttenlocher , Cornell University
 David Bindel , Cornell University
 David H. Albonesi , Cornell University
 David M. Mimno , Cornell University
+David Mimno , Cornell University
+David P. Williamson , Cornell University
+David Shmoys , Cornell University
 David Steurer , Cornell University
 Deborah Estrin , Cornell University
 Dexter Campbell Kozen , Cornell University
@@ -1048,6 +1053,7 @@ François Guimbretière , Cornell University
 Fred B. Schneider , Cornell University
 G. Edward Suh , Cornell University
 Greg Morrisett , Cornell University
+Hadas Kress-Gazit , Cornell University
 Hakim Weatherspoon , Cornell University
 Haym Hirsh , Cornell University
 Immanuel Trummer , Cornell University
@@ -1063,13 +1069,18 @@ Kavita Bala , Cornell University
 Ken Birman , Cornell University
 Kenneth P. Birman , Cornell University
 Kilian Q. Weinberger , Cornell University
+Kirstin Peterson , Cornell University
 Lillian Lee , Cornell University
 Lorenzo Alvisi , Cornell University
+Malte F. Jung , Cornell University
+Malte Jung , Cornell University
+Mor Naaman , Cornell University
 Mor Naaman , Cornell University
 Nate Foster , Cornell University
 Nicola Dell , Cornell University
 Nicola Lee Dell , Cornell University
 Noah Snavely , Cornell University
+Phoebe Sengers , Cornell University
 Rachit Agarwal 0001 , Cornell University
 Rafael Pass , Cornell University
 Ramin Zabih , Cornell University
@@ -1081,30 +1092,19 @@ Ronald J. Brachman , Cornell University
 Ross A. Knepper , Cornell University
 Ross Tate , Cornell University
 Salman Avestimehr , Cornell University
-Siddhartha Banerjee , Cornell University
 Serge J. Belongie , Cornell University
+Siddhartha Banerjee , Cornell University
 Stephen R. Marschner , Cornell University
 Steve Marschner , Cornell University
 Tanzeem Choudhury , Cornell University
 Thomas Ristenpart , Cornell University
 Thorsten Joachims , Cornell University
+Tsu-Han Chen , Cornell University
+Tsuhan Chen , Cornell University
 Vitaly Shmatikov , Cornell University
 Yoav Artzi , Cornell University
-Éva Tardos , Cornell University
-Tsuhan Chen , Cornell University
-Tsu-Han Chen , Cornell University
-Malte Jung , Cornell University
-Malte F. Jung , Cornell University
-Alon Keinan , Cornell University
-Hadas Kress-Gazit , Cornell University
-David Mimno , Cornell University
-Mor Naaman , Cornell University
-Kirstin Peterson , Cornell University
-Phoebe Sengers , Cornell University
-David Shmoys , Cornell University
-David P. Williamson , Cornell University
-Andrew Gordon Wilson , Cornell University
 Zhiru Zhang , Cornell University
+Éva Tardos , Cornell University
 Aasa Feragen , DIKU
 Andrzej Filinski , DIKU
 Christian Igel , DIKU


### PR DESCRIPTION
These are all people who can advise CS graduate students and who publish in CS venues.