### PR TITLE
Added faculty members at ITU Copenhagen

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -2451,6 +2451,32 @@ Xia Ning , Indiana University-Purdue University Indianapolis
 Xukai Zou , Indiana University-Purdue University Indianapolis
 Yao Liang , Indiana University-Purdue University Indianapolis
 Yuni Xia , Indiana University-Purdue University Indianapolis
+Alessandro Bruni , IT University of Copenhagen
+Andres Faina , IT University of Copenhagen
+Paolo Tell , IT University of Copenhagen
+Patrick Bahr , IT University of Copenhagen
+Zeljko Agic , IT University of Copenhagen
+Natalie Schluter , IT University of Copenhagen
+Björn Thór Jónsson , IT University of Copenhagen
+Carsten Schürmann , IT University of Copenhagen
+Claus Brabrand , IT University of Copenhagen
+Jes Frellsen , IT University of Copenhagen
+Jesper Bengtson , IT University of Copenhagen
+Riko Jacob , IT University of Copenhagen
+Rune Møller Jensen , IT University of Copenhagen
+Thomas Hildebrandt , IT University of Copenhagen
+Thore Husfeldt , IT University of Copenhagen
+Troels Bjerre Lund , IT University of Copenhagen
+Yvonne Dittrich , IT University of Copenhagen
+Dan Witzner Hansen , IT University of Copenhagen
+Marco Carbone , IT University of Copenhagen
+Rasmus Ejlers Møgelberg , IT University of Copenhagen
+Søren Debois , IT University of Copenhagen
+Andrzej Wasowski , IT University of Copenhagen
+Kasper Støy , IT University of Copenhagen
+Philippe Bonnet , IT University of Copenhagen
+Rasmus Pagh , IT University of Copenhagen
+Søren Lauesen , IT University of Copenhagen
 Abhishek Jain , Johns Hopkins University
 Alexis Battle , Johns Hopkins University
 Aviel D. Rubin , Johns Hopkins University
@@ -2512,7 +2538,6 @@ Martin Höst , Lund University
 Martina Maggio , Lund University
 Per Andersson , Lund University
 Per Runeson , Lund University
-Thore Husfeldt , Lund University
 Adam Chlipala , Massachusetts Institute of Technology
 Alan S. Willsky , Massachusetts Institute of Technology
 Albert R. Meyer , Massachusetts Institute of Technology


### PR DESCRIPTION
Data is current as of today. Also moved one faculty member, Thore Husfeldt, with a dual affiliation to Lund University (20%) and ITU Copenhagen (80%) to the latter. Please correct if he should be listed for both universities.