### PR TITLE
added IIT Gandhinagar affiliations

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -24,6 +24,7 @@ IIIT Hyderabad,australasia
 IISc Bangalore,australasia
 IIT Bombay,australasia
 IIT Delhi,australasia
+IIT Gandhinagar,australasia
 IIT Hyderabad,australasia
 IIT Kanpur,australasia
 IIT Kharagpur,australasia

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -2053,6 +2053,15 @@ Subodh Kumar , IIT Delhi
 Subodh Sharma , IIT Delhi
 Subodh Vishnu Sharma , IIT Delhi
 Vinay J. Ribeiro , IIT Delhi
+Bireswar Das , IIT Gandhinagar
+Neeldhara Misra , IIT Gandhinagar
+Manoj Gupta , IIT Gandhinagar
+Anirban Dasgupta 0001 , IIT Gandhinagar
+Souradyuti Paul , IIT Gandhinagar
+Shanmuganathan Raman , IIT Gandhinagar
+Krishna P. Miyapuram , IIT Gandhinagar
+Manu Awasthi , IIT Gandhinagar
+Dinesh Garg , IIT Gandhinagar
 A. Antony Franklin , IIT Hyderabad
 Bheemarjuna Reddy Tamma , IIT Hyderabad
 C. Krishna Mohan , IIT Hyderabad


### PR DESCRIPTION
Added IIT Gandhinagar in the country-info.csv, as well as the names of 9 faculty with their affiliations in the faculty-affiliations.csv.