### PR TITLE
Removed faculty from BITS Pilani and IIT Roorkee who had incorrect DBLP entry

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -2207,7 +2207,6 @@ Partha Pratim Roy , IIT Roorkee
 Rajdeep Niyogi , IIT Roorkee
 Raman Balasubramanian , IIT Roorkee
 Ranita Biswas , IIT Roorkee
-Sandeep Kumar , IIT Roorkee
 Subhankar Mishra , IIT Roorkee
 Sudip Roy 0001 , IIT Roorkee
 Sugata Gangopadhyay , IIT Roorkee

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -288,7 +288,6 @@ Yuchao Dai , Australian National University
 Yuerui Lu , Australian National University
 Abhishek Mishra , BITS Pilani
 Amit Dua , BITS Pilani
-Arun Chauhan , BITS Pilani
 Ashutosh Bhatia , BITS Pilani
 Avinash Gautam , BITS Pilani
 J. P. Misra , BITS Pilani
@@ -305,7 +304,6 @@ Sundar Balasubramaniam , BITS Pilani
 Sundaresan Raman , BITS Pilani
 Vandana Agarwal , BITS Pilani
 Virendra Singh Shekhawat , BITS Pilani
-Vishal Gupta , BITS Pilani
 Yashvardhan Sharma , BITS Pilani
 Amihood Amir , Bar-Ilan University
 Amir Herzberg , Bar-Ilan University


### PR DESCRIPTION
This is the list of faculty which were removed. 
* Arun Chauhan, BITS Pilani
* Vishal Gupta,  BITS Pilani
* Sandeep Kumar, IIT Roorkee