### PR TITLE
added alias for Minh

### DIFF
--- a/dblp-aliases.csv
+++ b/dblp-aliases.csv
@@ -21318,6 +21318,7 @@ Mingzheng Wang,Ming-Zheng Wang
 Mingzhou Song,Mingzhou (Joe) Song
 Minh D. Dao,Minh Dao
 Minh Ha Quang,Ha Quang Minh
+Minh Hoai,Minh Hoai Nguyen
 Minhaz F. Zibran,Minhaz Fahim Zibran
 Minhtuan Pham,Minh Tuan Pham
 Minyar Sassi,Minyar Sassi Hidri

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -4255,6 +4255,7 @@ Michael Ferdman , Stony Brook University
 Michael Kifer , Stony Brook University
 Michalis Polychronakis , Stony Brook University
 Minh Hoai Nguyen , Stony Brook University
+Minh Hoai , Stony Brook University
 Nick Nikiforakis , Stony Brook University
 Nima Honarmand , Stony Brook University
 Niranjan Balasubramanian , Stony Brook University


### PR DESCRIPTION
Minh Hoai Nguyen has been publishing as Minh Hoai lately.
(See note on his webpage http://www3.cs.stonybrook.edu/~minhhoai/)

So I added the alias to correctly count all his papers.