### PR TITLE
fixed two names

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -1820,7 +1820,6 @@ Umakishore Ramachandran , Georgia Institute of Technology
 Vijay V. Vazirani , Georgia Institute of Technology
 Wenke Lee , Georgia Institute of Technology
 William R. Harris , Georgia Institute of Technology
-Ümit V. Çatalyürek , Georgia Institute of Technology
 Alexander M. Rush , Harvard University
 Barbara J. Grosz , Harvard University
 Boaz Barak , Harvard University
@@ -2079,8 +2078,6 @@ Jagarlapudi Saketha Nath , IIT Bombay
 Kameswari Chebrolu , IIT Bombay
 Kavi Arya , IIT Bombay
 Krithi Ramamritham , IIT Bombay
-Manoj M. Prabhakaran , IIT Bombay
-Manoj Prabhakaran , IIT Bombay
 Milind A. Sohoni , IIT Bombay
 Mythili Vutukuru , IIT Bombay
 Nandlal L. Sarda , IIT Bombay
@@ -6669,6 +6666,8 @@ Luke N. Olson , University of Illinois at Urbana-Champaign
 Luke Olson , University of Illinois at Urbana-Champaign
 Mahesh Viswanathan 0001 , University of Illinois at Urbana-Champaign
 Mani Golparvar Fard , University of Illinois at Urbana-Champaign
+Manoj M. Prabhakaran , University of Illinois at Urbana-Champaign
+Manoj Prabhakaran , University of Illinois at Urbana-Champaign
 Marc Snir , University of Illinois at Urbana-Champaign
 Marco Caccamo , University of Illinois at Urbana-Champaign
 Mark A. Hasegawa-Johnson , University of Illinois at Urbana-Champaign
@@ -7066,12 +7065,12 @@ Weibo Gong , University of Massachusetts Amherst
 Yuriy Brun , University of Massachusetts Amherst
 Bill Campbell , University of Massachusetts Boston
 Bo Sheng , University of Massachusetts Boston
-Craig Yu , University of Massachusetts Boston
+Lap-Fai Yu , University of Massachusetts Boston
 Dan Simovici , University of Massachusetts Boston
 Duc Tran , University of Massachusetts Boston
 Elizabeth O'Neil , University of Massachusetts Boston
 Gabriel Ghinita , University of Massachusetts Boston
-Jun Suzuki , University of Massachusetts Boston
+Junichi Suzuki , University of Massachusetts Boston
 Kenneth Fletcher , University of Massachusetts Boston
 Marc Pomplun , University of Massachusetts Boston
 Ming Ouyang , University of Massachusetts Boston


### PR DESCRIPTION
Correct two names (UMass Boston) with the ones listed in DBLP.