### PR TITLE
Update faculty-affiliations.csv

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -675,7 +675,7 @@ Mengchi Liu , Carleton University
 Michel Barbeau , Carleton University
 Michiel H. M. Smid , Carleton University
 Nicola Santoro , Carleton University
-Oliver Matias van Kaick , Carleton University
+Oliver van Kaick , Carleton University
 Pat Morin , Carleton University
 Paul C. van Oorschot , Carleton University
 Prosenjit Bose , Carleton University


### PR DESCRIPTION
Changed the name of one faculty to the form that appears in his papers. It seems that with the full name, no data is being retrieved.