### PR TITLE
Add University of York academics from Real-time Group

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -90,6 +90,7 @@ University of Warsaw,europe
 University of Waterloo,canada
 University of Western Australia,australasia
 University of Wroclaw,europe
+University of York,europe
 University of Zurich,europe
 UNSW,australasia
 Victoria University of Wellington,australasia

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -9002,6 +9002,12 @@ Piotr Witkowski 0001 , University of Wroclaw
 Tomasz Gogacz , University of Wroclaw
 Tomasz Jurdzinski , University of Wroclaw
 Witold Charatonik , University of Wroclaw
+Alan Burns , University of York
+Robert I. Davis , University of York
+Iain Bate , University of York
+Andy J. Wellings , University of York
+Leandro Soares Indrusiak , University of York
+Neil C. Audsley , University of York
 Abraham Bernstein , University of Zurich
 Burkhard Stiller , University of Zurich
 Chat Wacharamanotham , University of Zurich

--- a/homepages.csv
+++ b/homepages.csv
@@ -1,4 +1,3 @@
-name,homepage
 A. Aldo Faisal,http://www.imperial.ac.uk/people/a.faisal/
 A. Antony Franklin,http://www.iith.ac.in/~antony/
 A. C. W. Finkelstein,http://www0.cs.ucl.ac.uk/staff/A.Finkelstein/
@@ -122,6 +121,7 @@ Aggeliki Arapoyanni,http://en.pharm.uoa.gr/personnel/faculty-members/pharmaceuti
 Aggelos K. Katsaggelos,http://www.mccormick.northwestern.edu/research-faculty/directory/profiles/katsaggelos-aggelos.html/
 Aggelos Kiayias,http://www.cse.uconn.edu/~akiayias/Home_of_Aggelos_Kiayias/Home_of_Aggelos_Kiayias.html/
 Agnes Hui Chan,http://www.ccs.neu.edu/home/ahchan/
+Ágoston E. Eiben,http://www.cs.vu.nl/~gusz/
 Agustin Fernández,http://engineering.academickeys.com/browse_whoswho_by_institution/Polytechnic_University_of_Catalonia?&start=104/
 Agustín Gravano,http://habla.dc.uba.ar/gravano/
 Ah-Hwee Tan,http://www.ntu.edu.sg/home/asahtan/
@@ -152,6 +152,7 @@ Ajit Rajwade,https://www.cse.iitb.ac.in/~ajitvr/
 Ajitha Rajan,http://homepages.inf.ed.ac.uk/arajan/
 Akash Kumar 0001,https://www.cfaed.tu-dresden.de/pd-about/
 Akira Kawaguchi,https://www.ccny.cuny.edu/profiles/akira-kawaguchi/
+Ákos Lédeczi,http://www.isis.vanderbilt.edu/akos/
 Akshay Krishnamurthy,https://www.cics.umass.edu/~akshay/
 Al Biles,http://igm.rit.edu/~jabics/
 Al Davis,http://www.cs.utah.edu/~ald/
@@ -164,6 +165,7 @@ Alan Blackwell,http://www.cl.cam.ac.uk/~afb21/
 Alan Blair,http://www.cse.unsw.edu.au/~blair/
 Alan Borning,http://www.cs.washington.edu/people/faculty/borning/
 Alan Bundy,https://sweb.inf.ed.ac.uk/bundy/
+Alan Burns,https://www-users.cs.york.ac.uk/~burns/
 Alan C. Wright,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=110200/
 Alan Christopher Williams,http://homepages.inf.ed.ac.uk/ckiw/
 Alan Cline,https://www.cs.utexas.edu/directory/alan-cline/
@@ -316,11 +318,11 @@ Alexandra Kolla,http://akolla.cs.illinois.edu/
 Alexandra Meliou,http://people.cs.umass.edu/~ameli/
 Alexandra Silva,http://www.alexandrasilva.org/
 Alexandre Bergel,https://www.dcc.uchile.cl/alexandre_bergel
+Alexandre d'Aspremont,http://www.di.ens.fr/~aspremon/
 Alexandre M. Bayen,http://www.ce.berkeley.edu/people/faculty/bayen/
 Alexandre Megretski,https://lids.mit.edu/people/facultypi/alexandre-megretski/
 Alexandre P. Francisco,https://web.ist.utl.pt/aplf/
 Alexandre Paulo Francisco,https://sotis.tecnico.ulisboa.pt/researcher/ist14152
-Alexandre d'Aspremont,http://www.di.ens.fr/~aspremon/
 Alexandros Eleftheriadis,http://itmb.di.uoa.gr/education/didaskontesEng/edu_didakt7.html/
 Alexandros G. Dimakis,http://users.ece.utexas.edu/~dimakis/
 Alexandros Kapravelos,https://www.kapravelos.com/
@@ -416,6 +418,7 @@ Ameet Talwalkar,http://www.cs.ucla.edu/~ameet/
 Amelia C. Regan,http://www.faculty.uci.edu/profile.cfm?faculty_id=3266/
 Amelia G. Nobile,http://www.unisa.it/docenti/ameliagiuseppinanobile/index/
 Amelia Regan,http://www.faculty.uci.edu/profile.cfm?faculty_id=3266/
+Amélie Marian,https://www.cs.rutgers.edu/~amelie/
 Amey Karkare,http://www.cse.iitk.ac.in/users/karkare/
 Ami Wiesel,http://www.cs.huji.ac.il/~amiw/
 Amihai Motro,http://cs.gmu.edu/~ami/
@@ -469,10 +472,8 @@ Amy Ogan,https://www.hcii.cmu.edu/people/amy-ogan/
 Amy S. Bruckman,http://www.cc.gatech.edu/fac/Amy.Bruckman/
 Amy Voida,http://www.colorado.edu/cmci/people/information-science/amy-voida
 Amy W. Apon,https://people.cs.clemson.edu/~aapon/
-Amélie Marian,https://www.cs.rutgers.edu/~amelie/
 An-I Andy Wang,http://www.cs.fsu.edu/~awang/
 An-I Wang,http://www.cs.fsu.edu/~awang/
-AnHai Doan,http://pages.cs.wisc.edu/~anhai/
 Ana Busic,http://www.di.ens.fr/~busic/
 Ana Claudia Arias,https://www2.eecs.berkeley.edu/Faculty/Homepages/acarias.html/
 Ana Milanova,http://www.cs.rpi.edu/~milanova/
@@ -503,6 +504,10 @@ Anca Dragan,https://people.eecs.berkeley.edu/~anca/
 Anders Møller,https://cs.au.dk/~amoeller/
 Anders Robertsson,http://www.control.lth.se/Staff/AndersRobertsson.html
 Andras Farago,http://www.utdallas.edu/~farago/
+András Faragó,http://www.utdallas.edu/~farago/
+André Nies,https://www.cs.auckland.ac.nz/~nies/
+André Platzer,http://symbolaris.com/
+André van der Hoek,http://www.ics.uci.edu/~andre/
 Andrea Bonarini,http://home.deib.polimi.it/bonarini/
 Andrea C. Arpaci-Dusseau,http://pages.cs.wisc.edu/~dusseau/
 Andrea C. Dusseau,http://pages.cs.wisc.edu/~dusseau/
@@ -515,6 +520,7 @@ Andrea Lockerd Thomaz,http://www.cc.gatech.edu/~athomaz/
 Andrea S. LaPaugh,https://www.cs.princeton.edu/~aslp/
 Andrea Tagliasacchi,http://gfx.uvic.ca/
 Andrea Thomaz,http://www.cc.gatech.edu/~athomaz/
+Andréa W. Richa,http://www.public.asu.edu/~aricha/
 Andreas Fell,https://cs.anu.edu.au/people/andreas-fell/
 Andreas Haeberlen,http://www.cis.upenn.edu/~ahae/
 Andreas Klappenecker,http://faculty.cs.tamu.edu/klappi/
@@ -599,23 +605,19 @@ Andrzej Szalas,https://www.researchgate.net/profile/Andrzej_Szalas/citations?sor
 Andrzej Tarlecki,http://www.mimuw.edu.pl/~tarlecki/
 Andrzej Wasowski,http://www.itu.dk/people/wasowski/
 Andrzej Wichert,http://loop.frontiersin.org/people/200500/overview
-András Faragó,http://www.utdallas.edu/~farago/
-André Nies,https://www.cs.auckland.ac.nz/~nies/
-André Platzer,http://symbolaris.com/
-André van der Hoek,http://www.ics.uci.edu/~andre/
-Andréa W. Richa,http://www.public.asu.edu/~aricha/
 Anduo Wang,http://anduowang.github.io/
 Andy Cockburn,http://www.cosc.canterbury.ac.nz/andrew.cockburn/
 Andy D. Pimentel,https://staff.science.uva.nl/a.d.pimentel/
 Andy Gill,http://www.ittc.ku.edu/csdl/fpg/people/andygill/
 Andy Gordon,https://www.inf.ed.ac.uk/people/staff/Andrew_Gordon.html/
 Andy Hopper,https://www.cl.cam.ac.uk/~ah12/
+Andy J. Wellings,http://www-users.cs.york.ac.uk/~andy/
 Andy King,https://www.cs.kent.ac.uk/people/staff/amk/
 Andy Nealen,http://engineering.nyu.edu/people/andy-nealen/
 Andy Pavlo,http://www.cs.cmu.edu/~pavlo/
 Andy Tanenbaum,http://www.cs.vu.nl/~ast/
-Andy Zaidman,http://www.st.ewi.tudelft.nl/~zaidman/
 Andy van Dam,http://cs.brown.edu/~avd/
+Andy Zaidman,http://www.st.ewi.tudelft.nl/~zaidman/
 Angela Arapoyanni,http://www.di.uoa.gr/eng/staff/1012/
 Angela Demke Brown,http://www.cs.toronto.edu/~demke/
 Angela Finlayson,https://www.engineering.unsw.edu.au/computer-science-engineering/staff/angela-finlayson/
@@ -627,6 +629,7 @@ Angelos D. Keromytis,http://www.cs.columbia.edu/~angelos/
 Angelos Stavrou,https://cs.gmu.edu/~astavrou/
 Angus Forbes,http://angusforbes.com/
 Angus Graeme Forbes,http://angusforbes.com/
+AnHai Doan,http://pages.cs.wisc.edu/~anhai/
 Ani Nenkova,http://www.cis.upenn.edu/~nenkova/
 Aniket Kate,https://www.cs.purdue.edu/homes/akate/
 Aniket Kittur,https://www.hcii.cmu.edu/people/aniket-kittur/
@@ -721,8 +724,8 @@ Anthony Wirth,http://people.eng.unimelb.edu.au/awirth/
 Antoaneta Serguieva,http://www0.cs.ucl.ac.uk/people/A.Serguieva.html/
 Antoine Deza,http://www.cas.mcmaster.ca/~deza/
 Anton Eliëns,http://vu-nl.academia.edu/AntonEli%C3%ABns/
-Anton Wijs,https://www.win.tue.nl/~awijs/
 Anton van den Hengel,https://cs.adelaide.edu.au/~hengel/
+Anton Wijs,https://www.win.tue.nl/~awijs/
 Antonella Di Lillo,http://www.brandeis.edu/facultyguide/person.html?emplid=4b4fcfe64c1c153c08a131c97077c1726072e6c9/
 Antonette Mendoza,http://www.msi.unimelb.edu.au/people/antonette-mendoza/
 Antonia Zhai,http://www-users.cs.umn.edu/~zhai/
@@ -733,20 +736,20 @@ Antonio Cortes Rossello,https://www.upc.edu/?set_language=en/
 Antonio Della Cioppa,http://docenti.unisa.it/004367/home/
 Antonio Filieri,http://www.antonio.filieri.name/
 Antonio González 0001,http://people.ac.upc.es/antonio/
+António Grilo,http://www.demi.fct.unl.pt/en/pessoas/docentes/antonio-carlos-barbara-grilo
 Antonio Juan Hormigo,http://www.upc.edu/?set_language=en/
+António Manuel Ferreira Rito da Silva,https://fenix.tecnico.ulisboa.pt/homepage/ist12628
+António Manuel Grilo,https://www.l2f.inesc-id.pt/wiki/index.php/Ant%C3%B3nio_Serralheiro
+António Menezes Leitão,http://www.fd.ulisboa.pt/professors/teaching-staff/
 Antonio Nicolosi,http://www.cs.stevens.edu/~nicolosi/
 Antonio R. Miele,http://home.deib.polimi.it/miele/
+António Rito Silva,https://fenix.tecnico.ulisboa.pt/homepage/ist12628
 Antonio Torralba,http://web.mit.edu/torralba/www/
 Antonio Tricoli,https://researchers.anu.edu.au/researchers/tricoli-a?term=antonio/
 Antonis Dimakis,http://nes.aueb.gr/dimakis.html
 Antonis M. Paschalis,http://www.di.uoa.gr/eng/staff/999/
 Antony Hosking,https://cecs.anu.edu.au/people/tony-hosking/
 Antony L. Hosking,https://cs.anu.edu.au/people/tony-hosking/
-António Grilo,http://www.demi.fct.unl.pt/en/pessoas/docentes/antonio-carlos-barbara-grilo
-António Manuel Ferreira Rito da Silva,https://fenix.tecnico.ulisboa.pt/homepage/ist12628
-António Manuel Grilo,https://www.l2f.inesc-id.pt/wiki/index.php/Ant%C3%B3nio_Serralheiro
-António Menezes Leitão,http://www.fd.ulisboa.pt/professors/teaching-staff/
-António Rito Silva,https://fenix.tecnico.ulisboa.pt/homepage/ist12628
 Anuj Dawar,http://www.cl.cam.ac.uk/~ad260/
 Anup Basu,https://webdocs.cs.ualberta.ca/~anup/
 Anup Rao,http://homes.cs.washington.edu/~anuprao/
@@ -1013,9 +1016,10 @@ Benny Chor,http://www.tau.ac.il/~bchor/
 Benny George Kenkireth,http://www.iitg.ernet.in/ben/
 Benny Kimelfeld,http://www.cs.technion.ac.il/people/bennyk/
 Benny Pinkas,http://www.pinkas.net/
-Benoit M. Dawant,http://engineering.vanderbilt.edu/bio/benoit-dawant/
 Benoît Libert,http://perso.ens-lyon.fr/benoit.libert/
+Benoit M. Dawant,http://engineering.vanderbilt.edu/bio/benoit-dawant/
 Benyuan Liu,http://www.cs.uml.edu/~bliu/
+Berç Rustem,http://www.doc.ic.ac.uk/~br/
 Bernard Chazelle,https://www.cs.princeton.edu/~chazelle/
 Bernard Fortz,http://homepages.ulb.ac.be/~bfortz/
 Bernard Gendron,https://www.iro.umontreal.ca/~gendron/
@@ -1039,8 +1043,8 @@ Bernhard Hengst,http://www.cse.unsw.com/~bernhardh/
 Bernhard Kainz,http://www.imperial.ac.uk/people/b.kainz/
 Bernhard Pfahringer,http://www.cs.waikato.ac.nz/~bernhard/
 Bernhard Rumpe,http://www.se-rwth.de/~rumpe/
-Bernhard Scholz,http://web.it.usyd.edu.au/~scholz/
 Bernhard Schölkopf,http://www.kyb.mpg.de/~bs
+Bernhard Scholz,http://web.it.usyd.edu.au/~scholz/
 Bernt Schiele,https://www.mpi-inf.mpg.de/departments/computer-vision-and-multimodal-computing/people/bernt-schiele/
 Bert C. Huang,http://berthuang.com/
 Bert Huang,http://berthuang.com/
@@ -1049,7 +1053,6 @@ Berthold K. P. Horn,http://people.csail.mit.edu/bkph/
 Berthold Klaus Paul Horn,https://www.amazon.com/Vision-Electrical-Engineering-Computer-Science/dp/0262081598/
 Bertram Ludäscher,https://ischool.illinois.edu/people/faculty/ludaesch/
 Beryl Plimmer,https://www.cs.auckland.ac.nz/people/b-plimmer/
-Berç Rustem,http://www.doc.ic.ac.uk/~br/
 Beth A. Plale,http://www.cs.indiana.edu/~plale/
 Beth Plale,http://www.cs.indiana.edu/~plale/
 Betsy James DiSalvo,http://betsydisalvo.com/
@@ -1075,8 +1078,8 @@ Bhojan Anand,http://www.comp.nus.edu.sg/~bhojan/
 Bhubaneswar Mishra,https://cs.nyu.edu/mishra/
 Bhujanga Chakrabarti,http://sms.victoria.ac.nz/Main/BhujangaChakrabarti/
 Bhuvan Urgaonkar,http://www.cse.psu.edu/~buu1/
-Bianca Schroeder,http://www.cs.toronto.edu/~bianca/
 Bianca Schröder,http://www.cs.toronto.edu/~bianca/
+Bianca Schroeder,http://www.cs.toronto.edu/~bianca/
 Bilal Khan,https://www.gc.cuny.edu/Page-Elements/Academics-Research-Centers-Initiatives/Doctoral-Programs/Computer-Science/Faculty-Bios/Bilal-Khan/
 Bilge Mutlu,http://pages.cs.wisc.edu/~bilge/
 Bill Aiello,https://www.cs.ubc.ca/people/bill-aiello/
@@ -1387,8 +1390,10 @@ Cauligi S. Raghavendra,http://ceng.usc.edu/~raghu/
 Ce Zhang,https://www.inf.ethz.ch/personal/ce.zhang/
 Cecilia Mascolo,http://www.cl.cam.ac.uk/~cm542/
 Cees Witteveen,http://www.st.ewi.tudelft.nl/~witt/
+Céline Chevalier,http://www.di.ens.fr/~ccheval/
 Cem Yuksel,http://www.cemyuksel.com/
 Cenk S. Sahinalp,https://www.soic.indiana.edu/all-people/profile.html?profile_id=291/
+César Sánchez,http://software.imdea.org/~cesar/
 Cesare Alippi,http://home.deib.polimi.it/alippi/
 Cesare Enrico,http://www.polimi.it/en/english-version/
 Cesare Pautasso,http://search.usi.ch/persone/ea9b8e9c9be1b5ed3f03aff779452080/Pautasso-Cesare
@@ -1474,9 +1479,9 @@ Chen Greif,https://www.cs.ubc.ca/~greif/
 Chen Li 0001,https://chenli.ics.uci.edu/
 Chen Qian,http://www.cs.uky.edu/~qian/
 Chen-Ching Liu,https://school.eecs.wsu.edu/people/faculty/chen-ching-liu/
-ChengXiang Zhai,http://czhai.cs.illinois.edu/
 Chengjun Liu,http://cs.njit.edu/liu/
 Chengkai Li,http://ranger.uta.edu/~cli/
+ChengXiang Zhai,http://czhai.cs.illinois.edu/
 Chengxiang Zhai,http://czhai.cs.illinois.edu/
 Chengyu Song,http://www.cc.gatech.edu/grads/c/csong43/
 Chengzheng Sun,http://www.ntu.edu.sg/home/czsun/
@@ -1560,8 +1565,8 @@ Christian Kästner,https://www.cs.cmu.edu/~ckaestne/
 Christian Lengauer,http://www.infosun.fmi.uni-passau.de/cl/staff/lengauer/
 Christian N. S. Pedersen,http://users-birc.au.dk/cstorm/
 Christian Nørgaard Storm Pedersen,http://users-birc.au.dk/cstorm/
-Christian Poellabauer,http://www3.nd.edu/~cpoellab/
 Christian Pérez,http://www.ens-lyon.fr/annuaire/m-perez-christian-144203.kjsp?RH=ENS-LYON/
+Christian Poellabauer,http://www3.nd.edu/~cpoellab/
 Christian R. Shelton,http://www.cs.ucr.edu/~cshelton/
 Christian Richardt,http://richardt.name/
 Christian S. Collberg,http://www.cs.arizona.edu/people/collberg/
@@ -1575,8 +1580,8 @@ Christina Gardner-McCune,https://www.cise.ufl.edu/people/faculty/gmccune/
 Christina Lioma,http://www.diku.dk/~c.lioma/
 Christo Wilson,http://www.ccs.neu.edu/home/cbw/
 Christof Fetzer,https://tu-dresden.de/die_tu_dresden/fakultaeten/fakultaet_informatik/sysa/se/team/people/c_fetzer/
-Christof Huebner,http://www.ecm.uwa.edu.au/research/engineering-communities-environment/energy-saving-houses/investigatorsandpartners/
 Christof Hübner,http://www.ecm.uwa.edu.au/contact/profiles?type=profile&dn=cn%3DChristof%20Hubner%2Cou%3DSchool%20of%20Computer%20Science%20and%20Software%20Engineering%2Cou%3DFaculty%20of%20Engineering%5C2C%20Computing%20and%20Mathematics%2Cou%3DFaculties%2Co%3DThe%20University%20of%20Western%20Australia/
+Christof Huebner,http://www.ecm.uwa.edu.au/research/engineering-communities-environment/energy-saving-houses/investigatorsandpartners/
 Christof Lutteroth,https://www.cs.auckland.ac.nz/~lutteroth/
 Christoforos E. Kozyrakis,http://csl.stanford.edu/~christos/
 Christoph Bregler,http://bregler.com/
@@ -1630,8 +1635,8 @@ Christopher Mears,http://monash.edu/research/explore/en/persons/christopher-mear
 Christopher R. Johnson 0001,http://www.cs.utah.edu/~crj/
 Christopher Raphael,https://www.soic.indiana.edu/all-people/profile.html?profile_id=279/
 Christopher Rasmussen,https://www.eecis.udel.edu/~cer/
-Christopher Riesbeck,http://www.cs.northwestern.edu/~riesbeck/
 Christopher Ré,http://cs.stanford.edu/people/chrismre/
+Christopher Riesbeck,http://www.cs.northwestern.edu/~riesbeck/
 Christopher Scaffidi,http://web.engr.oregonstate.edu/~cscaffid/
 Christopher Stewart,http://web.cse.ohio-state.edu/~cstewart/
 Christopher Umans,http://www.cs.caltech.edu/~umans/
@@ -1649,9 +1654,9 @@ Chuck Hansen,https://www.cs.utah.edu/~hansen/
 Chun Tung Chou,http://www.cse.unsw.edu.au/~ctchou/
 Chun-Hsi Huang,http://www.engr.uconn.edu/~huang/
 Chung-Chieh Jay Kuo,http://ee.usc.edu/faculty_staff/faculty_directory/kuo.htm/
+Chung-chieh Shan,http://homes.soic.indiana.edu/ccshan/
 Chung-Hsing Yeh,http://monash.edu/research/explore/en/persons/chunghsing-yeh(1e5209c5-9c51-43ec-aefc-e87b62715579).html/
 Chung-Kuan Cheng,http://cseweb.ucsd.edu/~kuan/
-Chung-chieh Shan,http://homes.soic.indiana.edu/ccshan/
 Chunhua Shen,http://cs.adelaide.edu.au/~chhshen/
 Chunlei Liu,https://www2.eecs.berkeley.edu/Faculty/Homepages/chunleiliu.html/
 Chunming Qiao,http://www.cse.buffalo.edu/~qiao/
@@ -1683,6 +1688,7 @@ Claude Crépeau,http://www.cs.mcgill.ca/~crepeau/
 Claude Frasson,http://www.iro.umontreal.ca/~frasson/
 Claude Sammut,http://www.cse.unsw.com/~claude/
 Claude-Pierre Jeannerod,http://perso.ens-lyon.fr/nathalie.revol/
+Cláudia Antunes,http://web.ist.utl.pt/claudia.antunes/
 Claudia Eckert,https://www.sec.in.tum.de/claudia-eckert/
 Claudia Hauff,http://www.wis.ewi.tudelft.nl/hauff/
 Claudia Neuhauser,http://cbs.umn.edu/contacts/claudia-neuhauser/
@@ -1692,11 +1698,13 @@ Claudio E. Righetti,http://www-2.dc.uba.ar/profesores/righetti/
 Claudio Gutierrez,https://www.dcc.uchile.cl/cgutierr
 Claudio Gutiérrez,http://www.uchile.cl/portal/presentacion/senado-universitario/97591/claudio-gutierrez
 Claudio Orlandi,http://www.cs.au.dk/~orlandi/
+Cláudio T. Silva,https://vgc.poly.edu/~csilva/
 Claus Brabrand,http://itu.dk/people/brabrand/
 Clay Shields,http://people.cs.georgetown.edu/~clay/
 Clayton H. Lewis,https://www.colorado.edu/cs/users/clayton/
 Clelia De Felice,http://www.di.unisa.it/professori/defelice/
 Clelia de Felice,http://old.di.unisa.it/professori/defelice/
+Clément Pernet,http://lig-membres.imag.fr/pernet/
 Clement T. Yu,https://www.cs.uic.edu/~yu/
 Cliff Stein,http://www.columbia.edu/~cs2035/
 Cliff Zou,http://www.cs.ucf.edu/~czou/
@@ -1704,9 +1712,6 @@ Clifford A. Shaffer,http://www.cs.vt.edu/~shaffer/
 Clifford Stein,http://www.columbia.edu/~cs2035/
 Clyde Lee Giles,https://clgiles.ist.psu.edu/
 Clyde P. Kruskal,https://www.cs.umd.edu/people/ckruskal/
-Cláudia Antunes,http://web.ist.utl.pt/claudia.antunes/
-Cláudio T. Silva,https://vgc.poly.edu/~csilva/
-Clément Pernet,http://lig-membres.imag.fr/pernet/
 Cody Dunne,http://www.ccs.neu.edu/home/cody/
 Colin G. Johnson,https://www.cs.kent.ac.uk/people/staff/cgj/
 Colin Graeme Johnson,http://philpapers.org/profile/83435/
@@ -1775,8 +1780,6 @@ Cynthia Matuszek,http://www.csee.umbc.edu/~cmat/
 Cynthia Sturton,http://cs.unc.edu/~csturton/
 Cynthia Taylor,https://www.cs.uic.edu/~cynthiat/
 Cyrus Shahabi,http://infolab.usc.edu/Shahabi/
-Céline Chevalier,http://www.di.ens.fr/~ccheval/
-César Sánchez,http://software.imdea.org/~cesar/
 D. C. Douglas Hung,http://cs.njit.edu/people/hung.php/
 D. F. Wong,https://www.ece.illinois.edu/directory/profile/mdfwong/
 D. Janaki Ram,http://dos.iitm.ac.in/djwebsite/
@@ -2153,8 +2156,6 @@ Davood Rafiei,https://webdocs.cs.ualberta.ca/~drafiei/
 Dawn Song,http://www.cs.berkeley.edu/~dawnsong/
 Dawn Xiaodong Song,http://www.cs.berkeley.edu/~dawnsong/
 Dawson R. Engler,http://web.stanford.edu/~engler/
-DeLiang L. Wang,http://web.cse.ohio-state.edu/~dwang/
-DeLiang Wang,http://web.cse.ohio-state.edu/~dwang/
 Dean C. Barratt,http://cmic.cs.ucl.ac.uk/staff/dean_barratt/
 Dean Hendrix,http://www.auburn.edu/~hendrtd/
 Dean M. Tullsen,https://cseweb.ucsd.edu/~tullsen/
@@ -2188,6 +2189,8 @@ Dejing Dou,http://ix.cs.uoregon.edu/~dou/
 Dekai Wu,http://www.cs.ust.hk/~dekai/
 Delaram Kahrobaei,https://wfs.gc.cuny.edu/DKahrobaei/www/
 Delfina Malandrino,http://www.di.unisa.it/~delmal/
+DeLiang L. Wang,http://web.cse.ohio-state.edu/~dwang/
+DeLiang Wang,http://web.cse.ohio-state.edu/~dwang/
 Demetri Terzopoulos,http://www.cs.ucla.edu/~dt/
 Demetrios Achlioptas,https://users.soe.ucsc.edu/~optas/
 Deming Chen,https://www.ece.illinois.edu/directory/profile/dchen/
@@ -2244,8 +2247,8 @@ Dick H. J. Epema,http://www.ds.ewi.tudelft.nl/epema/
 Diego Fernández Slezak,https://liaa.dc.uba.ar/profile/70
 Diego Garbervetsky,http://lafhis.dc.uba.ar/en/~diegog
 Dieter Fox,http://homes.cs.washington.edu/~fox/
-Dieter W. Fellner,http://www.gris.tu-darmstadt.de/home/members/fellner/index.en.htm/
 Dieter van Melkebeek,http://pages.cs.wisc.edu/~dieter/
+Dieter W. Fellner,http://www.gris.tu-darmstadt.de/home/members/fellner/index.en.htm/
 Dietmar Berwanger,http://www.lsv.ens-cachan.fr/~dwb/
 Dietmar Pfahl,http://sep.cs.ut.ee/
 Diganta Goswami,https://www.iitg.ernet.in/dgoswami/
@@ -2437,9 +2440,9 @@ Eduard Ayguadé,http://people.ac.upc.edu/eduard/
 Eduard Ayguadé Parra,http://people.ac.upc.edu/eduard/
 Eduard Dragut,https://cis.temple.edu/~edragut/
 Eduardo Cotilla Sanchez,http://eecs.oregonstate.edu/people/cotilla-sanchez-eduardo/
+Eduardo del Castillo-Sánchez,https://people.epfl.ch/eduardo.sanchez/
 Eduardo Torres-Jara,http://www.wpi.edu/academics/facultydir/etj.html
 Eduardo Velloso,http://www.eduardovelloso.com/
-Eduardo del Castillo-Sánchez,https://people.epfl.ch/eduardo.sanchez/
 Edward A. Fox,http://fox.cs.vt.edu/foxinfo.html/
 Edward A. Lee,https://www2.eecs.berkeley.edu/Faculty/Homepages/lee.html/
 Edward Chan,https://cs.uwaterloo.ca/faculty-staff/contacts/edward-chan/
@@ -2594,6 +2597,7 @@ Eric Bach,http://pages.cs.wisc.edu/~bach/bach.html/
 Eric Blais,https://cs.uwaterloo.ca/~eblais/
 Eric C. McCreath,https://cs.anu.edu.au/~Eric.McCreath/
 Eric C. R. Hehner,http://www.cs.utoronto.ca/~hehner/
+Éric Colin de Verdière,http://www.di.ens.fr/~colin/
 Eric Fleury,http://perso.ens-lyon.fr/eric.fleury/
 Eric Fosler,http://web.cse.ohio-state.edu/~fosler/
 Eric Fosler-Lussier,http://web.cse.ohio-state.edu/~fosler/
@@ -2614,6 +2618,8 @@ Eric Pauwels,https://www.cwi.nl/people/1302
 Eric Po Xing,http://www.cs.cmu.edu/~epxing/
 Eric Price,http://www.cs.utexas.edu/~ecprice/
 Eric Roberts,http://cs.stanford.edu/people/eroberts/
+Éric Schost,https://cs.uwaterloo.ca/~eschost/
+Éric Tanter,https://www.dcc.uchile.cl/eric_tanter
 Eric Thierry,http://perso.ens-lyon.fr/eric.thierry/
 Eric Torng,http://www.cse.msu.edu/~torng/
 Eric Van Wyk,http://www-users.cs.umn.edu/~evw/
@@ -2655,6 +2661,7 @@ Esteban Feuerstein,http://www-2.dc.uba.ar/profesores/feuerstein/
 Esther Salami San Juan,https://icarus.upc.edu/en/staff-and-collaborators/staff/
 Ethan Katz-Bassett,http://www-bcf.usc.edu/~katzbass/
 Ethan L. Miller,https://users.soe.ucsc.edu/~elm/
+Étienne Lozes,http://www.lsv.ens-cachan.fr/~lozes/
 Etienne Vouga,http://www.cs.utexas.edu/users/evouga/
 Eugene Agichtein,http://www.mathcs.emory.edu/~eugene/
 Eugene Charniak,https://cs.brown.edu/~ec/
@@ -2676,6 +2683,7 @@ Eva Darulova,http://www.mpi-sws.org/~eva/
 Eva Heinrich,http://www.massey.ac.nz/massey/learning/colleges/college-of-sciences/staff-profile.cfm?stref=474230/
 Eva Marín-Tordera,https://craax.upc.edu/eva/
 Eva Rodriguez,http://www.crcsi.com.au/about/our-people/eva-rodriguez-rodriguez/
+Éva Tardos,http://www.cs.cornell.edu/~eva/
 Evan Barba,http://explore.georgetown.edu/people/eb892/
 Evan Drumwright,https://www.seas.gwu.edu/evan-drumwright/
 Evan Franklin,https://cecs.anu.edu.au/people/evan-franklin/
@@ -2692,13 +2700,14 @@ Evgenia Smirni,http://www.cs.wm.edu/~esmirni/
 Evimaria Terzi,http://www.cs.bu.edu/~evimaria/
 Ewan D. Tempero,https://www.cs.auckland.ac.nz/~ewan/
 Ewan Klein,https://www.inf.ed.ac.uk/people/staff/Ewan_Klein.html/
-Eyal Kushilevitz,http://www.cs.technion.ac.il/~eyalk/
 Eyal de Lara,http://www.cs.toronto.edu/~delara/
+Eyal Kushilevitz,http://www.cs.technion.ac.il/~eyalk/
 Eytan Ruppin,https://www.cs.umd.edu/people/ruppinumiacsumdedu/
 Eyuphan Bulut,http://www.people.vcu.edu/~ebulut/
 F. Y. Young,http://www.cse.cuhk.edu.hk/~fyyoung/
 Fabian Bastin,http://www.iro.umontreal.ca/~bastin/
 Fabian E. Bustamante,http://www.cs.northwestern.edu/~fabianb/
+Fabián E. Bustamante,http://www.cs.northwestern.edu/~fabianb/
 Fabian Monrose,https://www.cs.unc.edu/~fabian/
 Fabian R. Wirth,http://www.fim.uni-passau.de/en/dynamical-systems/publications/prof-dr-fabian-wirth/
 Fabian Wirth,http://www.fim.uni-passau.de/en/dynamical-systems/
@@ -2709,7 +2718,6 @@ Fabio Nemetz,http://www.bath.ac.uk/comp-sci/contacts/
 Fabio Salice,http://home.deib.polimi.it/salice/
 Fabio T. Ramos,http://sydney.edu.au/engineering/people/fabio.ramos.php/
 Fabio Tozeto Ramos,http://www-personal.acfr.usyd.edu.au/f.ramos/Fabio_Ramos_Homepage/Home.html/
-Fabián E. Bustamante,http://www.cs.northwestern.edu/~fabianb/
 Fabrizio Ferrandi,http://home.deib.polimi.it/ferrandi/
 Fabrizio Maria Maggi,https://www.etis.ee/Portal/Persons/Display/a37d438b-3add-4c4f-8e49-dfacab570f23/
 Facundo Mémoli,https://people.math.osu.edu/memoli.2/
@@ -2820,7 +2828,14 @@ Francisco Jordan Fernandez,http://directori.upc.edu/directori/dadesPersona.jsp?i
 Francisco S. Melo,http://orcid.org/0000-0001-5705-7372
 Franck Leprévost,http://wwwen.uni.lu/snt/people/franck_leprevost/
 Franco P. Preparata,http://cs.brown.edu/~franco/
+François Baccelli,http://www.di.ens.fr/~baccelli/
 Francois Berenger,http://www.di.ens.fr/AntiqueTeam.html.fr/
+François Guimbretière,https://www.cs.cornell.edu/~francois/
+François Gygi,http://faculty.engineering.ucdavis.edu/gygi/
+François Lauze,http://image.diku.dk/francois/
+François Major,http://www.iro.umontreal.ca/~major/
+François Pitt,http://www.cs.toronto.edu/~fpitt/
+Frank de Boer,http://homepages.cwi.nl/~frb/
 Frank Dehne,https://carleton.ca/scs/people/frank-dehne/
 Frank Dellaert,http://www.cc.gatech.edu/home/dellaert/
 Frank H. Collins,http://biology.nd.edu/people/frank-h-collins/
@@ -2838,22 +2853,15 @@ Frank Stajano,http://www.cl.cam.ac.uk/~fms27/
 Frank Stephan,https://www.comp.nus.edu.sg/~fstephan/
 Frank Tip,http://www.franktip.org/
 Frank Vahid,http://www.cs.ucr.edu/~vahid/
+Frank van Harmelen,http://www.cs.vu.nl/~frankh/
 Frank Vetere,http://people.eng.unimelb.edu.au/fv/
 Frank Wang,https://www.cs.kent.ac.uk/people/staff/fzw/
 Frank Y. Shih,https://web.njit.edu/~shih/
 Frank Yeong-Chyang Shih,https://web.njit.edu/~shih/
 Frank Zhigang Wang,https://www.cs.kent.ac.uk/people/staff/fzw/
-Frank de Boer,http://homepages.cwi.nl/~frb/
-Frank van Harmelen,http://www.cs.vu.nl/~frankh/
 Franya Franek,http://www.cas.mcmaster.ca/~franek/
 Franz Baader,https://lat.inf.tu-dresden.de/~baader/
 Franziska Roesner,http://www.franziroesner.com/
-François Baccelli,http://www.di.ens.fr/~baccelli/
-François Guimbretière,https://www.cs.cornell.edu/~francois/
-François Gygi,http://faculty.engineering.ucdavis.edu/gygi/
-François Lauze,http://image.diku.dk/francois/
-François Major,http://www.iro.umontreal.ca/~major/
-François Pitt,http://www.cs.toronto.edu/~fpitt/
 Frazer K. Noble,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=803250/
 Fred B. Schneider,https://www.cs.cornell.edu/fbs/
 Fred Brown,https://cs.adelaide.edu.au/~fred/
@@ -2862,21 +2870,21 @@ Fred G. Martin,http://www.cs.uml.edu/~fredm/
 Fred Martin,http://www.cs.uml.edu/~fredm/
 Fred Popowich,https://www.sfu.ca/~popowich/public/Home.html/
 Fred R. M. Barnes,https://www.cs.kent.ac.uk/~frmb/
+Frédéric Blanqui,http://www.lsv.ens-cachan.fr/People/
 Frederic Desprez,http://www.inria.fr/institut/organisation/adjoints-au-directeur-scientifique/frederic-desprez/
+Frédéric Desprez,http://www.inria.fr/institut/organisation/adjoints-au-directeur-scientifique/frederic-desprez/
+Frédéric Gibou,https://engineering.ucsb.edu/~fgibou/
+Frédéric Prost,http://perso.ens-lyon.fr/frederic.prost/
+Frédéric Suter,http://www.ens-lyon.fr/annuaire/m-suter-frederic-136989.kjsp?RH=ENS-LYON/
 Frederic T. Chong,http://www.cs.ucsb.edu/~chong/
 Frederick C. Harris Jr.,https://www.cse.unr.edu/~fredh/
 Frederick H. Lochovsky,https://www.cse.ust.hk/~fred/
 Frederick P. Brooks Jr.,https://www.cs.unc.edu/~brooks/
 Frederick R. M. Barnes,https://www.cs.kent.ac.uk/~frmb/
+Frédo Durand,http://people.csail.mit.edu/fredo/
 Fredrik Milani,http://www.ut.ee/en/fredrik-payman-milani/
 Friedmann Mattern,http://people.inf.ethz.ch/mattern/
 Fritz Henglein,http://www.diku.dk/~henglein/
-Frédo Durand,http://people.csail.mit.edu/fredo/
-Frédéric Blanqui,http://www.lsv.ens-cachan.fr/People/
-Frédéric Desprez,http://www.inria.fr/institut/organisation/adjoints-au-directeur-scientifique/frederic-desprez/
-Frédéric Gibou,https://engineering.ucsb.edu/~fgibou/
-Frédéric Prost,http://perso.ens-lyon.fr/frederic.prost/
-Frédéric Suter,http://www.ens-lyon.fr/annuaire/m-suter-frederic-136989.kjsp?RH=ENS-LYON/
 Fuhua (Frank) Cheng,http://www.cs.uky.edu/~cheng/
 Fuhua Cheng,http://www.cs.uky.edu/~cheng/
 Funda Ergün,http://homes.soic.indiana.edu/fergun/
@@ -2893,6 +2901,7 @@ Gabe Sibley,https://www.colorado.edu/cs/users/gasi6462/
 Gabor C. Temes,http://eecs.oregonstate.edu/people/temes-gabor/
 Gabor Fichtinger,http://www.cs.queensu.ca/~gabor/
 Gabor Karsai,http://engineering.vanderbilt.edu/bio/gabor-karsai/
+Gábor N. Sárközy,http://www.cs.wpi.edu/~gsarkozy/
 Gabor T. Herman,http://www.dig.cs.gc.cuny.edu/~gabor/
 Gabriel Ghinita,http://www.cs.umb.edu/~gghinita/
 Gabriel J. Brostow,http://www0.cs.ucl.ac.uk/staff/g.brostow/
@@ -3021,8 +3030,9 @@ Gerald Penn,http://www.cs.toronto.edu/~gpenn/
 Gerald Tripp,https://www.cs.kent.ac.uk/people/staff/gewt/
 Gerald Weber,https://www.cs.auckland.ac.nz/~gerald/
 Gerard Borg,https://researchers.anu.edu.au/researchers/borg-gg/
-Gerard R. Richter,http://www.cs.rutgers.edu/~richter/
 Gerard de Melo,http://gerard.demelo.org/
+Gérard G. Medioni,http://iris.usc.edu/people/medioni/
+Gerard R. Richter,http://www.cs.rutgers.edu/~richter/
 Gerardo Pelosi,http://home.deib.polimi.it/pelosi/
 Gerd Hirzinger,http://www6.in.tum.de/Main/Hirzinge/
 Gergely Zaruba,http://crystal.uta.edu/~zaruba/
@@ -3104,9 +3114,9 @@ Goce Trajcevski,http://www.ece.northwestern.edu/~goce/
 Godmar Back,https://people.cs.vt.edu/~gback/
 Godmar V. Back,https://people.cs.vt.edu/~gback/
 Gokhan Memik,http://www.ece.northwestern.edu/~memik/
-Gong Gu,http://web.eecs.utk.edu/~ggu1/
 Gonçalo Nuno Gomes Tavares,https://fenix.tecnico.ulisboa.pt/homepage/ist13269
 Gonçalo Tavares,http://www.fmh.ulisboa.pt/pt/contactos/docentes/item/648-goncalo-manuel-albuquerque-tavares
+Gong Gu,http://web.eecs.utk.edu/~ggu1/
 Gopal Gupta,http://www.utdallas.edu/~gupta/
 Gopalakrishnan Srinivasaraghavan,https://chessprogramming.wikispaces.com/Gopalakrishnan+Srinivasaraghavan/
 Gopalan Nadathur,http://www-users.cs.umn.edu/~gopalan/
@@ -3116,6 +3126,7 @@ Gordon L. Kindlmann,http://people.cs.uchicago.edu/~glk/
 Gordon S. Novak,https://www.cs.utexas.edu/users/novak/
 Gordon S. Novak Jr.,https://www.cs.utexas.edu/users/novak/
 Gordon V. Cormack,http://cormack.uwaterloo.ca/
+Gösta Grahne,http://www.cs.concordia.ca/~grahne
 Gourab Sen Gupta,http://seat.massey.ac.nz/g.sengupta/
 Govindarajulu Regeti,https://iiit.ac.in/people/faculty/gregeti/
 Grace Hui Yang,http://infosense.cs.georgetown.edu/grace/
@@ -3183,6 +3194,7 @@ Guillaume Hanrot,http://perso.ens-lyon.fr/guillaume.hanrot/
 Gul A. Agha,https://cs.illinois.edu/directory/profile/agha/
 Gul Agha,https://cs.illinois.edu/directory/profile/agha/
 Gunnar Rätsch,http://bmi.inf.ethz.ch/personnel/gunnar-ratsch/
+Günther Ruhe,http://ruhe.cpsc.ucalgary.ca/
 Guo-Hui Lin,https://webdocs.cs.ualberta.ca/~ghlin/
 Guo-Jun Qi,http://www.eecs.ucf.edu/~gqi/
 Guodong Shi,https://cecs.anu.edu.au/people/guodong-shi/
@@ -3207,10 +3219,6 @@ Guy McCusker,http://www.cs.bath.ac.uk/~gam23/
 Guy Van den Broeck,http://web.cs.ucla.edu/~guyvdb/
 Gwenaël Joret,http://www.ulb.ac.be/di/algo/gjoret/
 Gymama E. Slaughter,http://www.csee.umbc.edu/people/faculty/gymama-slaughter/
-Gábor N. Sárközy,http://www.cs.wpi.edu/~gsarkozy/
-Gérard G. Medioni,http://iris.usc.edu/people/medioni/
-Gösta Grahne,http://www.cs.concordia.ca/~grahne
-Günther Ruhe,http://ruhe.cpsc.ucalgary.ca/
 H. L. Graham,https://history.ucsd.edu/people/faculty/graham.html/
 H. M. M. van de Wetering,https://www.tue.nl/en/university/departments/mathematics-and-computer-science/the-department/staff/detail/ep/e/d/ep-uid/19890069/
 H. T. Kung,https://www.eecs.harvard.edu/htk/
@@ -3274,17 +3282,17 @@ Hanoch Levy,http://www.math.tau.ac.il/~hanoch/
 Hanqiu Sun,http://www.cse.cuhk.edu.hk/~hanqiu/
 Hans Akkermans,http://www.cs.vu.nl/~hansa/
 Hans Burg,http://www.cs.vu.nl/en/research/information-management-software-engineering/people/dr-hans-burg/index.aspx/
+Hans de Nivelle,http://www.ii.uni.wroc.pl/~nivelle/
 Hans Jörg Müller,http://pure.au.dk/portal/en/persons/id(3e718f2c-7cc4-4cc5-8f05-87e65963d7c1).html/
 Hans Michael Gerndt,http://wwwi10.lrr.in.tum.de/~gerndt/home/
 Hans P. Reiser,http://www.fim.uni-passau.de/en/sis/
 Hans Peter Reiser,http://www.fim.uni-passau.de/en/sis/
 Hans Tonino,http://www.alg.ewi.tudelft.nl/tonino/
+Hans van Vliet,http://www.cs.vu.nl/~hans/
 Hans Vangheluwe,http://cs.mcgill.ca/~hv/
 Hans W. Guesgen,http://seat.massey.ac.nz/h.w.guesgen/
 Hans Werner Guesgen,http://seat.massey.ac.nz/h.w.guesgen/
 Hans Zantema,http://www.win.tue.nl/~hzantema/
-Hans de Nivelle,http://www.ii.uni.wroc.pl/~nivelle/
-Hans van Vliet,http://www.cs.vu.nl/~hans/
 Hans-Arno Jacobsen,https://www.professoren.tum.de/en/jacobsen-hans-arno/
 Hans-Joachim Bungartz,http://www5.in.tum.de/wiki/index.php/Univ.-Prof._Dr._Hans-Joachim_Bungartz/
 Hans-Peter Bischof,https://www.cs.rit.edu/~hpb/
@@ -3312,6 +3320,7 @@ Harald Søndergaard,http://findanexpert.unimelb.edu.au/display/person13416/
 Hari Balakrishnan,http://nms.lcs.mit.edu/~hari/
 Hari Sundar,http://www.cs.utah.edu/~hari/
 Harish Karnick,http://www.iitk.ac.in/new/dr-harish-karnick/
+Härmel Nestra,http://www.ut.ee/en/harmel-nestra/
 Harold Abelson,http://groups.csail.mit.edu/mac/users/hal/hal.html/
 Harriet J. Fell,http://www.ccs.neu.edu/home/fell/
 Harry Buhrman,https://www.cwi.nl/people/552
@@ -3340,8 +3349,10 @@ Haym Hirsh,http://infosci.cornell.edu/faculty/haym-hirsh/
 He Sun 0001,http://seis.bris.ac.uk/~hs15417/
 He Wang,https://www.cs.purdue.edu/people/faculty/hw/
 Heather Zheng,http://www.cs.ucsb.edu/~htzheng/
+Héctor Corrada Bravo,https://www.cs.umd.edu/people/hcorrada/
 Hector Garcia-Molina,http://infolab.stanford.edu/people/hector.html/
 Hector J. Levesque,https://www.cs.toronto.edu/~hector/
+Héctor Pulgar-Painemal,https://www.eecs.utk.edu/people/faculty/hpulgar/
 Heechul Yun,http://www.ittc.ku.edu/~heechul/
 Heidi Tscherning,http://www.cis.unimelb.edu.au/people/
 Heiki-Jaan Kaalep,http://www.ut.ee/en/heiki-jaan-kaalep/
@@ -3355,6 +3366,7 @@ Helena Galhardas,http://web.ist.utl.pt/helena.galhardas/
 Helena Sarmento,http://lisboa.academia.edu/HelenaSarmento
 Helena Sofia Andrade N. P. Pinto,http://ontol.inesc-id.pt/~sofia/
 Helena Sofia Pinto,http://ontol.inesc-id.pt/~sofia/
+Hélène Coullon,http://avalon.ens-lyon.fr/members/hcoullon/
 Helger Lipmaa,http://kodu.ut.ee/~lipmaa/
 Helle Hein,http://www.ut.ee/en/kontakt/arvutiteaduse-instituut/
 Helmut Krcmar,http://www.professoren.tum.de/en/krcmar-helmut/
@@ -3395,10 +3407,10 @@ Herbert Bos,http://www.cs.vu.nl/~herbertb/
 Herbert Edelsbrunner,https://ist.ac.at/research/research-groups/edelsbrunner-group/
 Herbert Wiklicky,http://www.doc.ic.ac.uk/~herbert/
 Herman J. Haverkort,http://www.win.tue.nl/~hermanh/
+Hermann de Meer,http://www.fim.uni-passau.de/en/computer-networks/
 Hermann Haertig,http://os.inf.tu-dresden.de/~haertig/
 Hermann Härtig,http://os.inf.tu-dresden.de/~haertig/
 Hermann Ney,http://www-i6.informatik.rwth-aachen.de/web/Staff/ney/
-Hermann de Meer,http://www.fim.uni-passau.de/en/computer-networks/
 Hernán C. Melgratti,http://lafhis.dc.uba.ar/en/~melgratti
 Hernán Wilkinson,https://www.dc.uba.ar/rrhh/profesores/wilkinson
 Hezy Yeshurun,https://www.cs.tau.ac.il/~hezy/
@@ -3430,10 +3442,10 @@ Hongseok Yang,http://www.cs.ox.ac.uk/people/hongseok.yang/Public/Home.html/
 Hongwei Xi,https://www.cs.bu.edu/~hwxi/
 Hongxin Hu,https://people.cs.clemson.edu/~hongxih/
 Hongyuan Zha,http://www.cc.gatech.edu/~zha/
+Horácio C. Neto,https://tecnico.ulisboa.pt/pt/tag/horacio-neto/
 Horst Lazarek,http://forschungsinfo.tu-dresden.de/detail/professur/266/
 Horst Lichter,https://www.swc.rwth-aachen.de/
 Horst Reichel,https://wwwtcs.inf.tu-dresden.de/~reichel/
-Horácio C. Neto,https://tecnico.ulisboa.pt/pt/tag/horacio-neto/
 Hosagrahar Visvesvaraya Jagadish,http://web.eecs.umich.edu/~jag/
 Hossam S. Hassanein,http://research.cs.queensu.ca/home/hossam/
 Hossein Hojjat,https://cs.rit.edu/~hh/
@@ -3477,6 +3489,7 @@ Hung Q. Ngo 0001,http://www.cse.buffalo.edu/~hungngo/
 Hung Quang Ngo,http://www.cse.buffalo.edu/~hungngo/
 Hung Son Nguyen,http://www.mimuw.edu.pl/~son/
 Hung-Wei Tseng,http://cseweb.ucsd.edu/~h1tseng/
+Hüseyin Koçak,http://www.math.miami.edu/~hk/
 Husheng Li,http://web.eecs.utk.edu/~husheng/
 Huub H. C. Bakker,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=944130/
 Huub van de Wetering,https://www.tue.nl/en/university/departments/mathematics-and-computer-science/the-department/staff/detail/ep/e/d/ep-uid/19890069/
@@ -3490,15 +3503,11 @@ Hye-Young Helen Paik,http://www.cse.unsw.edu.au/~hpaik/
 Hye-Young Paik,http://www.cse.unsw.edu.au/~hpaik/
 Hyeong-Ah Choi,https://www.seas.gwu.edu/~hchoi/
 Hyesoon Kim,http://www.cc.gatech.edu/~hyesoon/
-Härmel Nestra,http://www.ut.ee/en/harmel-nestra/
-Héctor Corrada Bravo,https://www.cs.umd.edu/people/hcorrada/
-Héctor Pulgar-Painemal,https://www.eecs.utk.edu/people/faculty/hpulgar/
-Hélène Coullon,http://avalon.ens-lyon.fr/members/hcoullon/
-Hüseyin Koçak,http://www.math.miami.edu/~hk/
 I-Ling Yen,http://www.utdallas.edu/~ilyen/
 I-Ting Angelina Lee,http://www.cse.wustl.edu/~angelee/
 I. Emre Telatar,https://people.epfl.ch/emre.telatar/
 I. V. Ramakrishnan,https://www.cs.stonybrook.edu/people/faculty/IVRamakrishnan/
+Iain Bate,http://www-users.cs.york.ac.uk/~ijb/
 Iain C. C. Phillips,http://www.imperial.ac.uk/collegedirectory/index.asp?PeopleID=941691/
 Iain Murray,http://homepages.inf.ed.ac.uk/imurray2/
 Iain Phillips,http://www.imperial.ac.uk/people/i.phillips/
@@ -3570,6 +3579,7 @@ Indrakshi Ray,http://www.cs.colostate.edu/~iray/
 Indranil Gupta,http://indy.cs.illinois.edu/
 Indranil Saha,http://cse.iitk.ac.in/users/isaha/
 Indranil Sengupta 0001,http://www.facweb.iitkgp.ernet.in/~isg/
+Inês Lynce,https://fenix.tecnico.ulisboa.pt/homepage/ist14029
 Ing-Ray Chen,http://people.cs.vt.edu/~irchen/
 Ingemar J. Cox,http://mediafutures.cs.ucl.ac.uk/people/IngemarCox/
 Ingemar Johansson Cox,http://www0.cs.ucl.ac.uk/people/I.Cox.html/
@@ -3580,7 +3590,6 @@ Ingrid Zukerman,http://users.monash.edu/~ingrid/
 Injong Rhee,http://www4.ncsu.edu/~rhee/
 Inna Pivkina,http://www.cs.nmsu.edu/~ipivkina/
 Insup Lee,http://www.cis.upenn.edu/~lee/
-Inês Lynce,https://fenix.tecnico.ulisboa.pt/homepage/ist14029
 Ioanis Nikolaidis,http://webdocs.cs.ualberta.ca/~yannis/
 Ioannis Emiris,http://cgi.di.uoa.gr/~emiris/index-eng.html/
 Ioannis Kontoyiannis,http://pages.cs.aueb.gr/~yiannisk/
@@ -3624,6 +3633,7 @@ Ivan Damgård,http://pure.au.dk/portal/en/persons/id(70603eb5-52fd-41e3-8752-15d
 Ivan Flechais,https://www.cs.ox.ac.uk/people/ivan.flechais/
 Ivan Hal Sudborough,https://explorer.utdallas.edu/editprofile.php?pid=13187/
 Ivan Herman,http://homepages.cwi.nl/~ivan/
+Iván Herman,http://homepages.cwi.nl/~ivan/
 Ivan Laptev,https://www.di.ens.fr/~laptev/
 Ivan Martinovic,https://www.cs.ox.ac.uk/people/ivan.martinovic/
 Ivan Visconti,http://docenti.unisa.it/004312/home/
@@ -3632,7 +3642,6 @@ Ivano Malavolta,http://www.ivanomalavolta.com/
 Ivo F. Sbalzarini,http://mosaic.mpi-cbg.de/?q=people/ivo_sbalzarini/
 Ivona Bezáková,https://www.cs.rit.edu/~ib/
 Ivor P. Page,http://www.utdallas.edu/~ivor/
-Iván Herman,http://homepages.cwi.nl/~ivan/
 Izidor Gertner,https://www.ccny.cuny.edu/profiles/izidor-gertner/
 J. Alex Halderman,https://jhalderm.com/
 J. Andrew Bagnell,http://www.ri.cmu.edu/person.html?person_id=689/
@@ -3676,8 +3685,8 @@ Jack Poulson,http://www.cc.gatech.edu/people/jack-poulson/
 Jack Sampson,http://www.cse.psu.edu/~jms1257/
 Jack Snoeyink,http://www.cs.unc.edu/~snoeyink/
 Jack Tumblin,http://www.cs.northwestern.edu/~jet/
-Jack W. Davidson,https://www.cs.virginia.edu/people/faculty/davidson.html/
 Jack van Wijk,http://www.win.tue.nl/~vanwijk/
+Jack W. Davidson,https://www.cs.virginia.edu/people/faculty/davidson.html/
 Jackie Chi Kit Cheung,http://cs.mcgill.ca/~jcheung/
 Jacob D. Abernethy,http://web.eecs.umich.edu/~jabernet/
 Jacob Eisenstein,http://www.cc.gatech.edu/~jeisenst/
@@ -3824,17 +3833,17 @@ Jan Madey,http://www.eunis.org/organization/jan-madey-bio/
 Jan O. Borchers,https://hci.rwth-aachen.de/borchers/
 Jan Oliver Borchers,https://hci.rwth-aachen.de/borchers/
 Jan Otop,http://popl16.sigplan.org/profile/janotop
-Jan P. H. van Santen,http://cslu.ohsu.edu/~vansanten/
 Jan P. de Ruiter,https://ase.tufts.edu/psychology/people/de_ruiter/
+Jan P. H. van Santen,http://cslu.ohsu.edu/~vansanten/
 Jan Peter de Ruiter,http://www.uni-bielefeld.de/lili/personen/jruiter/
 Jan Peters 0001,http://www.kyb.mpg.de/~jrpeters/
 Jan Prins,http://www.cs.unc.edu/~prins/
 Jan Rutten,http://homepages.cwi.nl/~janr/
 Jan Schröder,https://findanexpert.unimelb.edu.au/display/person304961/
 Jan Treur,http://www.cs.vu.nl/~treur/
-Jan Vitek,http://janvitek.org/
-Jan van Eijck,http://homepages.cwi.nl/~jve/
 Jan van den Berg,http://www.tbm.tudelft.nl/en/about-faculty/departments/engineering-systems-and-services/ict-section/staff/jan-van-den-berg/
+Jan van Eijck,http://homepages.cwi.nl/~jve/
+Jan Vitek,http://janvitek.org/
 Jan-Michael Frahm,http://frahm.web.unc.edu/
 Jan-Willem van de Meent,http://www.robots.ox.ac.uk/~jwvdm/
 Jana Kosecka,https://cs.gmu.edu/~kosecka/
@@ -3896,7 +3905,6 @@ Jay Aslam,http://www.ccs.neu.edu/home/jaa/
 Jay Jackson,http://www.rit.edu/gccis/igm/jay-jackson/
 Jay Ligatti,http://www.cse.usf.edu/~ligatti/
 Jay McCarthy,https://jeapostrophe.github.io/home/
-JayPrakash Lalchandani,http://www.iiitb.ac.in/faculty_page.php?name=JayprakashTLalchandani/
 Jaya Sreevalsan Nair,http://www.iiitb.ac.in/faculty_page.php?name=JayaSreevalsanNair/
 Jayadev Acharya,http://people.ece.cornell.edu/acharya/
 Jayadev Misra,http://www.cs.utexas.edu/~misra/
@@ -3906,6 +3914,7 @@ Jayanta Mukherjee 0001,http://dblp2.uni-trier.de/pers/hd/m/Mukhopadhyay:Jayanta/
 Jayanta Mukhopadhyay,http://www.facweb.iitkgp.ernet.in/~jay/
 Jayanthi Sivaswamy,https://www.iiit.ac.in/people/faculty/jsivaswamy/
 Jayne Wu,http://www.eecs.utk.edu/people/faculty/jwu10/
+JayPrakash Lalchandani,http://www.iiitb.ac.in/faculty_page.php?name=JayprakashTLalchandani/
 Jean C. Walrand,https://www2.eecs.berkeley.edu/Faculty/Homepages/walrand.html/
 Jean Cardinal,http://www.ulb.ac.be/di/algo/jcardin/
 Jean Gallier,http://www.cis.upenn.edu/~jean/home.html/
@@ -3995,6 +4004,7 @@ Jens Krinke,http://www0.cs.ucl.ac.uk/staff/J.Krinke/
 Jens Palsberg,http://www.cs.ucla.edu/~palsberg/
 Jeremiah Blocki,https://www.cs.purdue.edu/homes/jblocki/
 Jeremy Aarons,http://monash.academia.edu/JeremyAarons/
+Jérémy Barbay,http://www.dcc.uchile.cl/~jbarbay/
 Jeremy Buhler,http://www.cse.wustl.edu/~jbuhler/
 Jeremy D. Buhler,http://www.cse.wustl.edu/~jbuhler/
 Jeremy Dawson,http://users.cecs.anu.edu.au/~jeremy/
@@ -4010,16 +4020,18 @@ Jeremy Z. Kolter,http://www.zicokolter.com/
 Jernej Barbic,http://www-bcf.usc.edu/~jbarbic/
 Jeroen J. A. Keiren,http://www.jeroenkeiren.nl/
 Jeroen Keiren,https://www.jeroenkeiren.nl/teaching/in4387/
+Jérôme Feret,http://www.di.ens.fr/~feret/
+Jérôme Waldispühl,http://www.cs.mcgill.ca/~jeromew/
+Jerónimo Castrillón,https://www.cfaed.tu-dresden.de/ccc-staff-castrillon/
+Jerónimo Castrillón Mazo,https://www.cfaed.tu-dresden.de/ccc-staff-castrillon/
 Jerry Alan Fails,http://cs.boisestate.edu/~jfails/
+Jerry den Hartog,https://www.tue.nl/en/university/departments/mathematics-and-computer-science/the-department/staff/detail/ep/e/d/ep-uid/20012328/
 Jerry Spinrad,http://engineering.vanderbilt.edu/bio/jeremy-spinrad/
 Jerry Tessendorf,http://people.clemson.edu/~jtessen/
-Jerry den Hartog,https://www.tue.nl/en/university/departments/mathematics-and-computer-science/the-department/staff/detail/ep/e/d/ep-uid/20012328/
 Jerzy Marcinkowski,https://www.ii.uni.wroc.pl/~jma/
 Jerzy Tyszkiewicz,http://www.mimuw.edu.pl/~jty/
 Jerzy W. Grzymala-Busse,http://people.eecs.ku.edu/~jerzy/
 Jerzy W. Jaromczyk,http://www.cs.uky.edu/~jurek/
-Jerónimo Castrillón,https://www.cfaed.tu-dresden.de/ccc-staff-castrillon/
-Jerónimo Castrillón Mazo,https://www.cfaed.tu-dresden.de/ccc-staff-castrillon/
 Jes Frellsen,https://pure.itu.dk/portal/en/persons/jes-frellsen(34a5f668-6dc6-4317-b63e-a4a075b0292e).html
 Jesper Bengtson,http://www.itu.dk/people/jebe/
 Jesper Buus Nielsen,http://www.cs.au.dk/~jbn/
@@ -4144,6 +4156,19 @@ Joanne Evans,http://monash.edu/research/explore/en/persons/joanne-evans(a6fe1ce6
 Joanne F. Selinski,http://www.cs.jhu.edu/~joanne/
 Joanne M. Atlee,https://cs.uwaterloo.ca/~jmatlee/
 Joannes J. Westerink,https://engineering.nd.edu/profiles/jwesterink/
+João Dias,https://pt-br.facebook.com/public/Joao-Dias/school/fac.ciencias.ul/
+João Dias Pereira,http://ihc.fcsh.unl.pt/pt/ihc/investigadores/item/1161-jdpereira
+João M. Lemos,https://sotis.tecnico.ulisboa.pt/researcher/ist45892
+João Madeiras Pereira,http://lisboa.academia.edu/Jo%C3%A3oMadeirasPereira
+João Miranda Lemos,https://fenix.tecnico.ulisboa.pt/homepage/ist11886
+João Nuno de Oliveira e Silva,https://fenix.tecnico.ulisboa.pt/homepage/ist14028
+João Paulo Cacho Teixeira,https://fenix.tecnico.ulisboa.pt/homepage/ist10847
+João Paulo Carvalho,https://www.l2f.inesc-id.pt/wiki/index.php/Jo%C3%A3o_Paulo_Carvalho
+João Paulo da Silva Neto,https://fenix.tecnico.ulisboa.pt/homepage/ist13220
+João Paulo Neto,https://www.it.pt/Members/Index/4973
+João Paulo Teixeira,http://www.garrigues.com/pt-PT/team/joao-paulo-teixeira-de-matos
+João Pedro Barreto 0002,http://www.ics.ul.pt/instituto/?ln=e&pid=232&mm=5&ctmid=2&mnid=1&doc=31809901190
+João Santana,http://lisboa.academia.edu/JoaoSantanaLopes
 Joaquim A. Jorge,http://web.tecnico.ulisboa.pt/jorgej/
 Joaquim Armando Pires Jorge,http://web.tecnico.ulisboa.pt/jorgej/
 Joaquin Vaschoren,http://www.win.tue.nl/~jvanscho/
@@ -4160,9 +4185,11 @@ Joel A. Tropp,http://users.cms.caltech.edu/~jtropp/
 Joel Carpenter,http://researchers.uq.edu.au/researcher/11891/
 Joel David Hamkins,http://jdh.hamkins.org/
 Joel Friedman,https://www.math.ubc.ca/~jf/
+Joël Goossens,http://beams.ulb.ac.be/users/jo%C3%ABl-goossens
 Joel H. Spencer,http://cs.nyu.edu/spencer/
 Joel I. Seiferas,https://www.cs.rochester.edu/~joel/
 Joel Moses,https://esd.mit.edu/Faculty_Pages/moses/moses.htm/
+Joël Ouaknine,https://www.cs.ox.ac.uk/joel.ouaknine/
 Joel Spencer,http://cs.nyu.edu/spencer/
 Joel Voldman,http://www.rle.mit.edu/biomicro/
 Joelle Pineau,http://cs.mcgill.ca/~jpineau/
@@ -4325,14 +4352,53 @@ Jordi Garcia Almiñana,http://personals.ac.upc.edu/jordig/
 Jordi Guitart,https://www.facebook.com/public/Jordi-Guitart/school/Polytechnic-University-of-Catalonia-109077209117931/
 Jordi Perello Muntan,http://people.ccaba.upc.edu/perello/
 Jordi Torres,https://www.facebook.com/public/Jordi-Torres-Sanchez/school/Polytechnic-University-of-Catalonia-109077209117931/
+Jörg Denzinger,http://cpsc.ucalgary.ca/~denzinge/
+Jörg Endrullis,http://joerg.endrullis.de/
+Jörg Kienzle,http://www.cs.mcgill.ca/~joerg/Home/Jorgs_Home.html/
+Jörg Müller,http://pure.au.dk/portal/en/persons/id(3e718f2c-7cc4-4cc5-8f05-87e65963d7c1).html/
+Jörg Ott,https://www.netlab.tkk.fi/~jo/
+Jörg Peters,http://www.cise.ufl.edu/~jorg/
+Jörg Sander,https://webdocs.cs.ualberta.ca/~joerg/
+Jörg-Rüdiger Sack,http://www.scs.carleton.ca/~sack/
 Jorge Arturo Cobb,http://www.utdallas.edu/~jcobb/
 Jorge Curiel-Esparza,https://www7.in.tum.de/~esparza/
 Jorge Fernandes,http://fcsh.unl.pt/faculdade/docentes/pfernandes
 Jorge Garcia Vidal,http://people.ac.upc.edu/jorge/
 Jorgen P. Bansler,http://diku.dk/Ansatte/beskrivelse/?id=160232/
+Jørgen P. Bansler,http://diku.dk/Ansatte/beskrivelse/?id=160232/
 Jorgen Peddersen,https://www.engineering.unsw.edu.au/computer-science-engineering/staff/jorgen-peddersen/
+Jörn Diedrichsen,http://www.diedrichsenlab.org/
+Jörn Janneck,http://www.lunduniversity.lu.se/lucat/user/6d94f235ba6e4b38f5fbc1a7b0ed0c00
+José A. B. Fortes,https://www.acis.ufl.edu/people/fortes/
+José A. B. Gerald,http://ieeexplore.ieee.org/document/7845358/
+José Alberto R. P. Sardinha,http://web.ist.utl.pt/ist25149/Publications.html
+José António Beltran Gerald,http://sips.inesc-id.pt/~jabg/index1.html
+José Bento,http://www.jbento.net/
+José Bento Ayres Pereira,http://www.jbento.net/
+José C. Monteiro,https://www.isa.utl.pt/home/node/349
+José F. Martínez,http://www.csl.cornell.edu/~martinez/
+José F. Morales,http://software.imdea.org/people/josef.morales/
+José Fernando Alves da Silva,https://fenix.tecnico.ulisboa.pt/homepage/ist11962
+José G. Delgado-Frias,http://www.eecs.wsu.edu/~jdelgado/
+José Luis Borbinha,http://joslusborbinha.cgpublisher.com/product/pub.222/prod.27
+José Luis Brinquete Borbinha,https://fenix.tecnico.ulisboa.pt/homepage/ist13085
+José M. Barceló,http://www.upc.edu/?set_language=en/
+José M. Barceló-Ordinas,http://compnet.ac.upc.edu/intranet/?q=node/169/
 Jose M. Carmena,https://www2.eecs.berkeley.edu/Faculty/Homepages/carmena.html/
+José M. Cela,http://personals.ac.upc.edu/cela/
+José M. Llabería,https://www.ac.upc.edu/en/content/llaberia/
+José M. Tribolet,https://fenix.tecnico.ulisboa.pt/homepage/ist10876
+José Maria Barceló-Ordinas,http://compnet.ac.upc.edu/intranet/?q=node/169/
+José María Cela,https://www.bsc.es/about-bsc/staff-directory/cela-espin-jose-maria/
+José María Llabería,https://www.ac.upc.edu/en/content/llaberia/
+José Martinez,http://www.csl.cornell.edu/~martinez/
+José Meseguer,http://formal.cs.uiuc.edu/meseguer/
+José Monteiro,http://lisboa.academia.edu/JoseMonteiro
+José N. Amaral,https://webdocs.cs.ualberta.ca/~amaral/
+José Nelson Amaral,https://webdocs.cs.ualberta.ca/~amaral/
+José R. Herrero,http://people.ac.upc.edu/josepr/
 Jose T. de Sousa,https://orcid.org/0000-0001-7525-7546
+José Tribolet,http://lisboa.academia.edu/Jos%C3%A9Tribolet
 Josef Sivic,http://www.di.ens.fr/~josef/
 Josep Solé-Pareta,http://www.archive.es.aau.dk/dk/es-news-single-view/artikel/guest-lecture-by-prof-josep-sole-pareta-universitat-politecnica-de-catalunya-upc-spain/
 Josep Torrellas,http://iacoma.cs.uiuc.edu/~torrella/
@@ -4372,55 +4438,12 @@ Joshua D. Guttman,http://www.cs.wpi.edu/~guttman/
 Joshua R. Smith,https://sensor.cs.washington.edu/jrs.html/
 Joshua Tanenbaum,http://josh.thegeekmovement.com/
 Josiah Poon,http://sydney.edu.au/engineering/people/josiah.poon.php/
-José A. B. Fortes,https://www.acis.ufl.edu/people/fortes/
-José A. B. Gerald,http://ieeexplore.ieee.org/document/7845358/
-José Alberto R. P. Sardinha,http://web.ist.utl.pt/ist25149/Publications.html
-José António Beltran Gerald,http://sips.inesc-id.pt/~jabg/index1.html
-José Bento,http://www.jbento.net/
-José Bento Ayres Pereira,http://www.jbento.net/
-José C. Monteiro,https://www.isa.utl.pt/home/node/349
-José F. Martínez,http://www.csl.cornell.edu/~martinez/
-José F. Morales,http://software.imdea.org/people/josef.morales/
-José Fernando Alves da Silva,https://fenix.tecnico.ulisboa.pt/homepage/ist11962
-José G. Delgado-Frias,http://www.eecs.wsu.edu/~jdelgado/
-José Luis Borbinha,http://joslusborbinha.cgpublisher.com/product/pub.222/prod.27
-José Luis Brinquete Borbinha,https://fenix.tecnico.ulisboa.pt/homepage/ist13085
-José M. Barceló,http://www.upc.edu/?set_language=en/
-José M. Barceló-Ordinas,http://compnet.ac.upc.edu/intranet/?q=node/169/
-José M. Cela,http://personals.ac.upc.edu/cela/
-José M. Llabería,https://www.ac.upc.edu/en/content/llaberia/
-José M. Tribolet,https://fenix.tecnico.ulisboa.pt/homepage/ist10876
-José Maria Barceló-Ordinas,http://compnet.ac.upc.edu/intranet/?q=node/169/
-José Martinez,http://www.csl.cornell.edu/~martinez/
-José María Cela,https://www.bsc.es/about-bsc/staff-directory/cela-espin-jose-maria/
-José María Llabería,https://www.ac.upc.edu/en/content/llaberia/
-José Meseguer,http://formal.cs.uiuc.edu/meseguer/
-José Monteiro,http://lisboa.academia.edu/JoseMonteiro
-José N. Amaral,https://webdocs.cs.ualberta.ca/~amaral/
-José Nelson Amaral,https://webdocs.cs.ualberta.ca/~amaral/
-José R. Herrero,http://people.ac.upc.edu/josepr/
-José Tribolet,http://lisboa.academia.edu/Jos%C3%A9Tribolet
 Joxan Jaffar,https://www.comp.nus.edu.sg/~joxan/
 Joyce C. Ho,http://joyceho.github.io/
 Joyce Y. Chai,http://www.cse.msu.edu/~jchai/
 Joyce Yue Chai,http://www.cse.msu.edu/~jchai/
 Joydeep Biswas,https://www.cics.umass.edu/person/biswas-joydeep/
 Jozsef Csicsvari,https://ist.ac.at/research/research-groups/csicsvari-group/
-João Dias,https://pt-br.facebook.com/public/Joao-Dias/school/fac.ciencias.ul/
-João Dias Pereira,http://ihc.fcsh.unl.pt/pt/ihc/investigadores/item/1161-jdpereira
-João M. Lemos,https://sotis.tecnico.ulisboa.pt/researcher/ist45892
-João Madeiras Pereira,http://lisboa.academia.edu/Jo%C3%A3oMadeirasPereira
-João Miranda Lemos,https://fenix.tecnico.ulisboa.pt/homepage/ist11886
-João Nuno de Oliveira e Silva,https://fenix.tecnico.ulisboa.pt/homepage/ist14028
-João Paulo Cacho Teixeira,https://fenix.tecnico.ulisboa.pt/homepage/ist10847
-João Paulo Carvalho,https://www.l2f.inesc-id.pt/wiki/index.php/Jo%C3%A3o_Paulo_Carvalho
-João Paulo Neto,https://www.it.pt/Members/Index/4973
-João Paulo Teixeira,http://www.garrigues.com/pt-PT/team/joao-paulo-teixeira-de-matos
-João Paulo da Silva Neto,https://fenix.tecnico.ulisboa.pt/homepage/ist13220
-João Pedro Barreto 0002,http://www.ics.ul.pt/instituto/?ln=e&pid=232&mm=5&ctmid=2&mnid=1&doc=31809901190
-João Santana,http://lisboa.academia.edu/JoaoSantanaLopes
-Joël Goossens,http://beams.ulb.ac.be/users/jo%C3%ABl-goossens
-Joël Ouaknine,https://www.cs.ox.ac.uk/joel.ouaknine/
 Juan Caballero,http://software.imdea.org/people/juan.caballero/
 Juan Carlos Cruellas,http://engineering.academickeys.com/browse_whoswho_by_institution/Polytechnic_University_of_Catalonia?sort=lname&start=74/
 Juan Cui,http://cse.unl.edu/~jcui/
@@ -4461,6 +4484,7 @@ Julian Garcia Gallego,http://monash.edu/research/explore/en/persons/julian-garci
 Julian Gough,http://bioinformatics.bris.ac.uk/people/julian_gough.html/
 Julian J. McAuley,http://cseweb.ucsd.edu/~jmcauley/
 Julian John McAuley,http://cseweb.ucsd.edu/~jmcauley/
+Julián Mestre,http://sydney.edu.au/engineering/it/~mestre/
 Julian Padget,http://www.bath.ac.uk/comp-sci/contacts/academics/julian_padget/
 Julian Togelius,http://engineering.nyu.edu/people/julian-togelius/
 Juliana Freire,http://engineering.nyu.edu/user/4254/
@@ -4476,7 +4500,6 @@ Julio C. Hernandez-Castro,https://www.cs.kent.ac.uk/~jch27/
 Julio César Hernández Castro,https://www.cs.kent.ac.uk/~jch27/
 Julita Corbalán,http://acemap.sjtu.edu.cn/author/page?AuthorID=812D57D8/
 Julius Bonart,https://www.imperial.ac.uk/people/j.bonart/
-Julián Mestre,http://sydney.edu.au/engineering/it/~mestre/
 Jun Huan,https://www.ittc.ku.edu/~jhuan/
 Jun Li,http://ix.cs.uoregon.edu/~lijun/
 Jun Luo,http://www.ntu.edu.sg/home/junluo/
@@ -4496,7 +4519,11 @@ Jur P. van den Berg,http://arl.cs.utah.edu/
 Jur van den Berg,http://arl.cs.utah.edu/
 Juraj Hromkovic,http://www.ite.ethz.ch/people/host/jhromkov/
 Jure Leskovec,https://cs.stanford.edu/people/jure/
+Jürgen Dingel,http://www.cs.queensu.ca/~dingel/
+Jürgen Giesl,http://verify.rwth-aachen.de/giesl/
 Jurgen J. Vinju,http://homepages.cwi.nl/~jurgenv/
+Jürgen Sachau,http://wwwen.uni.lu/snt/people/juergen_sachau/
+Jürgen Schmidhuber,http://search.usi.ch/people/855dfcba3eaf6e94156db5ff991ba300/schmidhuber-juergen
 Jurgen Vinju,http://homepages.cwi.nl/~jurgenv/
 Jurriaan Rot,http://www.summerschool.sei.ecnu.edu.cn/
 Justin Bradley,http://justinbradley.unl.edu/
@@ -4510,28 +4537,10 @@ Justin Zobel,http://people.eng.unimelb.edu.au/jzobel/
 Justine Cassell,https://www.hcii.cmu.edu/people/justine-cassell/
 Juyang Weng,http://www.cse.msu.edu/~weng/
 Jyh-Charn Liu,https://engineering.tamu.edu/cse/people/jliu/
-Jyh-Ming Lien,http://cs.gmu.edu/~jmlien/
 Jyh-haw Yeh,http://cs.boisestate.edu/~jhyeh/
+Jyh-Ming Lien,http://cs.gmu.edu/~jmlien/
 Jyotsna Bapat,http://www.iiitb.ac.in/faculty_page.php?name=JyotsnaBapat/
 Jyrki Katajainen,http://www.diku.dk/~jyrki/
-Jérémy Barbay,http://www.dcc.uchile.cl/~jbarbay/
-Jérôme Feret,http://www.di.ens.fr/~feret/
-Jérôme Waldispühl,http://www.cs.mcgill.ca/~jeromew/
-Jörg Denzinger,http://cpsc.ucalgary.ca/~denzinge/
-Jörg Endrullis,http://joerg.endrullis.de/
-Jörg Kienzle,http://www.cs.mcgill.ca/~joerg/Home/Jorgs_Home.html/
-Jörg Müller,http://pure.au.dk/portal/en/persons/id(3e718f2c-7cc4-4cc5-8f05-87e65963d7c1).html/
-Jörg Ott,https://www.netlab.tkk.fi/~jo/
-Jörg Peters,http://www.cise.ufl.edu/~jorg/
-Jörg Sander,https://webdocs.cs.ualberta.ca/~joerg/
-Jörg-Rüdiger Sack,http://www.scs.carleton.ca/~sack/
-Jörn Diedrichsen,http://www.diedrichsenlab.org/
-Jörn Janneck,http://www.lunduniversity.lu.se/lucat/user/6d94f235ba6e4b38f5fbc1a7b0ed0c00
-Jørgen P. Bansler,http://diku.dk/Ansatte/beskrivelse/?id=160232/
-Jürgen Dingel,http://www.cs.queensu.ca/~dingel/
-Jürgen Giesl,http://verify.rwth-aachen.de/giesl/
-Jürgen Sachau,http://wwwen.uni.lu/snt/people/juergen_sachau/
-Jürgen Schmidhuber,http://search.usi.ch/people/855dfcba3eaf6e94156db5ff991ba300/schmidhuber-juergen
 K. Anton Feenstra,http://www.few.vu.nl/~feenstra/
 K. Brent Venable,http://www2.tulane.edu/sse/cs/faculty/k-brent-venable.cfm
 K. C. Wang,https://school.eecs.wsu.edu/people/faculty/kc-wang/
@@ -4925,6 +4934,7 @@ Lars Arge,http://cs.au.dk/~large/
 Lars Birkedal,http://cs.au.dk/~birke/
 Lars Kulik,http://www.findanexpert.unimelb.edu.au/display/person97563/
 Lars Ruthotto,http://www.mathcs.emory.edu/faculty-member.php?name=Lars-Ruthotto
+László Babai,http://people.cs.uchicago.edu/~laci/
 Laszlo Erdös,https://ist.ac.at/research/research-groups/erdoes-group/
 Lata Narayanan,http://www.cs.concordia.ca/~lata
 Latifur Khan,https://www.utdallas.edu/~lkhan/
@@ -4972,6 +4982,7 @@ Lazaros F. Merakos,http://cnl.di.uoa.gr/merakos/
 Lazaros Merakos,http://cnl.di.uoa.gr/merakos/
 Le Song,http://www.cc.gatech.edu/~lsong/
 Leana Golubchik,http://bourbon.usc.edu/leana/
+Leandro Soares Indrusiak,http://www-users.cs.york.ac.uk/~lsi/
 Leandros Tassiulas,http://seas.yale.edu/faculty-research/faculty-directory/leandros-tassiulas/
 Lech Szymanski,http://www.cs.otago.ac.nz/staff/Lech_Szymanski/
 Lee A. D. Cooper,http://www.bmi.emory.edu/leecooper
@@ -5004,6 +5015,7 @@ Leo Joskowicz,http://www.cs.huji.ac.il/~josko/
 Leo Mark,https://pe.gatech.edu/executive-leadership-team/leo-mark-phd/
 Leon A. Watts,http://www.bath.ac.uk/comp-sci/contacts/academics/leon_watts/
 Leon Adam Watts,http://www.cs.bath.ac.uk/Leon/
+Léon J. M. Rothkrantz,http://ii.tudelft.nl/~leon/
 Leon J. Osterweil,http://laser.cs.umass.edu/people/ljo.html/
 Leon M. Tolbert,http://web.eecs.utk.edu/~tolbert/
 Leon Reznik,https://www.cs.rit.edu/~lr/
@@ -5128,8 +5140,8 @@ Lorna MacDonald,http://researchers.uq.edu.au/researcher/1071/
 Lorna Stewart,http://webdocs.cs.ualberta.ca/~stewart/
 Lorrie Faith Cranor,http://lorrie.cranor.org/
 Lotus Goldberg,http://www.brandeis.edu/facultyguide/person.html?emplid=19717dba85e7e7d919456954c1c56642a52e0740/
-Louis D'Alotto,https://www.york.cuny.edu/portal_college/ldaotto/
 Louis D. Nel,http://www.scs.carleton.ca/~ldnel/
+Louis D'Alotto,https://www.york.cuny.edu/portal_college/ldaotto/
 Louis I. Steinberg,https://www.cs.rutgers.edu/~lou/
 Louis Petingi,http://www.cs.csi.cuny.edu/~petingi/
 Louis Salvail,http://www.iro.umontreal.ca/~salvail/
@@ -5148,22 +5160,30 @@ Luca Allodi,https://www.tue.nl/en/university/departments/mathematics-and-compute
 Luca Barletta,http://home.deib.polimi.it/barletta/
 Luca Cardelli,http://lucacardelli.name/indexme.html/
 Luca Daniel,http://www.mit.edu/~dluca/
+Luca de Alfaro,https://users.soe.ucsc.edu/~luca/
 Luca Mottola,http://home.deib.polimi.it/mottola/
 Luca O. Breviglieri,http://home.deib.polimi.it/brevigli/
 Luca P. Carloni,http://www.cs.columbia.edu/~luca/
 Luca Trevisan,https://people.eecs.berkeley.edu/~luca/
-Luca de Alfaro,https://users.soe.ucsc.edu/~luca/
 Lucian Ilie,http://www.csd.uwo.ca/faculty/ilie/
 Luciano Baresi,http://home.deib.polimi.it/baresi/
 Luciano García-Bañuelos,http://www.ut.ee/en/luciano-garcia-banuelos/
 Lui Sha,https://cs.illinois.edu/directory/profile/lrs/
 Luis A. F. M. Ferreira,http://ciisa.fmv.ulisboa.pt/en/research-labs/research-lab-10/pessoas/item/64-luis-ferreira
+Luís Caldas de Oliveira,https://www.l2f.inesc-id.pt/wiki/index.php/Lu%C3%ADs_Caldas_de_Oliveira
 Luis Ceze,https://www.cs.washington.edu/people/faculty/luisceze/
+Luís E. T. Rodrigues,http://www.gsd.inesc-id.pt/~ler/
 Luis Eduardo Teixeira Rodrigues,http://www.gsd.inesc-id.pt/~ler/
 Luis Gravano,http://www.cs.columbia.edu/~gravano/
+Luís Guerra e Silva,http://algos.inesc-id.pt/~lgs/
+Luís M. Correia,http://www.di.fc.ul.pt/~lcorreia/
+Luís M. S. Russo,http://web.tecnico.ulisboa.pt/luis.russo/
+Luís Manuel Jesus Sousa Correia,https://fenix.tecnico.ulisboa.pt/homepage/ist12076
 Luis Miguel Silveira,http://algos.inesc-id.pt/~lms/
 Luis Rademacher,https://www.math.ucdavis.edu/~lrademac/
+Luís Veiga,http://www.gsd.inesc-id.pt/~lveiga/
 Luis Velasco,http://people.ac.upc.edu/lvelasco/
+Luísa Coheur,https://www.l2f.inesc-id.pt/wiki/index.php/Lu%C3%ADsa_Coheur
 Luisa Gargano,http://www.di.unisa.it/~lg/
 Lujo Bauer,http://www.ece.cmu.edu/~lbauer/
 Lukasz Jez,https://www.enterprisetimes.co.uk/2017/04/28/infor-donates-erp-to-wroclaw-university/
@@ -5179,14 +5199,6 @@ Luke S. Zettlemoyer,https://www.cs.washington.edu/people/faculty/lsz/
 Luke Zettlemoyer,https://www.cs.washington.edu/people/faculty/lsz/
 Luo Si,https://www.cs.purdue.edu/homes/lsi/
 Luqi,http://faculty.nps.edu/luqi/
-Luís Caldas de Oliveira,https://www.l2f.inesc-id.pt/wiki/index.php/Lu%C3%ADs_Caldas_de_Oliveira
-Luís E. T. Rodrigues,http://www.gsd.inesc-id.pt/~ler/
-Luís Guerra e Silva,http://algos.inesc-id.pt/~lgs/
-Luís M. Correia,http://www.di.fc.ul.pt/~lcorreia/
-Luís M. S. Russo,http://web.tecnico.ulisboa.pt/luis.russo/
-Luís Manuel Jesus Sousa Correia,https://fenix.tecnico.ulisboa.pt/homepage/ist12076
-Luís Veiga,http://www.gsd.inesc-id.pt/~lveiga/
-Luísa Coheur,https://www.l2f.inesc-id.pt/wiki/index.php/Lu%C3%ADsa_Coheur
 Lydia E. Kavraki,http://www.cs.rice.edu/~kavraki/
 Lydia Tapia,http://www.cs.unm.edu/~tapia/
 Lyle H. Ungar,http://www.cis.upenn.edu/~ungar/
@@ -5196,8 +5208,6 @@ Lynette Johns-Boast,https://researchers.anu.edu.au/researchers/johns-boast-l/
 Lynn Peterson,http://ranger.uta.edu/~peterson/peterson.html/
 Lynne E. Parker,http://web.eecs.utk.edu/~leparker/
 Lynne Parker,http://web.eecs.utk.edu/~leparker/
-László Babai,http://people.cs.uchicago.edu/~laci/
-Léon J. M. Rothkrantz,http://ii.tudelft.nl/~leon/
 M. Angela Sasse,http://sec.cs.ucl.ac.uk/people/m_angela_sasse/
 M. Balakrishnan,http://www.cse.iitd.ernet.in/~mbala/
 M. Birna van Riemsdijk,http://ii.tudelft.nl/~birna/
@@ -5213,11 +5223,11 @@ M. S. Ryoo,http://michaelryoo.com/
 M. Satyanarayanan,https://www.cs.cmu.edu/~satya/
 M. Sheelagh T. Carpendale,http://www.cpsc.ucalgary.ca/~sheelagh/
 M. Tamer Özsu,https://cs.uwaterloo.ca/~tozsu/
+M. Ümit Uyar,http://bioinspired.ccny.cuny.edu/uyar/
 M. V. N. Ashwin Kumar,https://users.cs.duke.edu/~ashwin/
 M. V. Panduranga Rao,https://cse.iith.ac.in/?q=People/Faculty/
-M. Ümit Uyar,http://bioinspired.ccny.cuny.edu/uyar/
-Maarten Jansen,http://homepages.ulb.ac.be/~majansen/
 Maarten de Rijke,https://staff.fnwi.uva.nl/m.derijke/
+Maarten Jansen,http://homepages.ulb.ac.be/~majansen/
 Maarten van Steen,http://www.distributed-systems.net/
 Maaz Bin Ahmad,http://homes.cs.washington.edu/~maazsaf/
 Maaz Bin Ahmed,https://uwaterloo.ca/electrical-computer-engineering/people-profiles/hamed-majedi/
@@ -5382,6 +5392,7 @@ Margo I. Seltzer,https://www.eecs.harvard.edu/margo/
 Margo Seltzer,https://www.eecs.harvard.edu/margo/
 Margrit Betke,http://www.cs.bu.edu/~betke/
 Maria Angelica Reyes Muñoz,http://directori.upc.edu/directori/dadesPersona.jsp?id=1003836/
+María Cecilia Rivara,https://www.dcc.uchile.cl/~mcrivara
 Maria Christakis,https://www.cs.kent.ac.uk/people/staff/mc817/
 Maria G. Fugini,http://home.deib.polimi.it/fugini/
 Maria Garcia de la Banda,http://www.csse.monash.edu.au/~mbanda/
@@ -5405,8 +5416,8 @@ Marian-Andrei Rizoiu,https://cs.anu.edu.au/people/marian-andrei-rizoiu-0/
 Mariana Raykova,http://cpsc.yale.edu/people/mariana-raykova/
 Marianne Graves Petersen,http://au.dk/en/mgraves@cs/
 Marianne Sheelagh Therese Carpendale,http://www.cpsc.ucalgary.ca/~sheelagh/
-Marie Durand,http://www2.cnrs.fr/en/2621.htm/
 Marie desJardins,http://www.csee.umbc.edu/~mariedj/
+Marie Durand,http://www2.cnrs.fr/en/2621.htm/
 Marilyn A. Walker,https://www.soe.ucsc.edu/people/maw/
 Marilyn Walker,https://www.soe.ucsc.edu/people/maw/
 Marina De Vos,http://www.bath.ac.uk/comp-sci/contacts/academics/marina_de_vos/
@@ -5419,6 +5430,10 @@ Mario Costa Sousa,http://www.cpsc.ucalgary.ca/~mario/
 Mario E. Magaña,http://eecs.oregonstate.edu/people/magana-mario/
 Mario Edgardo Magaña,http://eecs.oregonstate.edu/people/magana-mario/
 Mario Gerla,http://www.cs.ucla.edu/~gerla/
+Mário J. Silva,http://lisboa.academia.edu/M%C3%A1rioJSilva
+Mário Rui Gomes,https://pt-pt.facebook.com/public/M%C3%A1rio-Rui-Gomes
+Mário Serafim dos Santos Nunes,http://www.degois.pt/visualizador/curriculum.jsp?key=0616377318620172
+Mário Serafim Nunes,https://fenix.tecnico.ulisboa.pt/homepage/ist11453
 Mario Szegedy,http://www.cs.rutgers.edu/~szegedy/
 Mario Vento,http://mivia.unisa.it/people/vento/
 Marios C. Papaefthymiou,http://web.eecs.umich.edu/~marios/
@@ -5445,6 +5460,7 @@ Mark D. Hill,http://pages.cs.wisc.edu/~markhill/
 Mark D. Read,https://cs.anu.edu.au/people/mark-reid/
 Mark D. Reid,http://mark.reid.name/work/
 Mark Daley,http://daleylab.org/
+Mark de Berg,https://www.win.tue.nl/~mdberg/
 Mark Dredze,http://www.cs.jhu.edu/~mdredze/
 Mark E. Dean,http://www.eecs.utk.edu/people/faculty/markdean/
 Mark Fishel,http://lepo.it.da.ut.ee/~fishel/
@@ -5484,11 +5500,10 @@ Mark Silberstein,https://sites.google.com/site/silbersteinmark/
 Mark Smotherman,https://people.cs.clemson.edu/~mark/
 Mark Steedman,http://homepages.inf.ed.ac.uk/steedman/
 Mark Utting,http://www.cs.waikato.ac.nz/~marku/
+Mark van den Brand,http://www.win.tue.nl/~mvdbrand/
 Mark W. Schmidt,http://www.cs.ubc.ca/~schmidtm/
 Mark Wallace,http://monash.edu/research/explore/en/persons/mark-wallace(5ce2a207-2449-4c37-b816-6ccc3708c819).html/
 Mark Zhandry,https://www.cs.princeton.edu/~mzhandry/
-Mark de Berg,https://www.win.tue.nl/~mdberg/
-Mark van den Brand,http://www.win.tue.nl/~mvdbrand/
 Marko B. Popovic,http://www.wpi.edu/academics/facultydir/mbp.html
 Markus G. Kuhn,http://www.cl.cam.ac.uk/~mgk25/
 Markus H. Gross,https://graphics.ethz.ch/~grossm/
@@ -5542,8 +5557,8 @@ Martin Henz,https://www.comp.nus.edu.sg/~henz/
 Martin Höst,http://www.lunduniversity.lu.se/lucat/user/78d0f2fe1123024a5c3000141a36af85
 Martin J. Strauss,http://web.eecs.umich.edu/~martinjs/
 Martin J. Wainwright,https://www.eecs.berkeley.edu/~wainwrig/
-Martin Jaggi,http://people.inf.ethz.ch/jaggim/
 Martin Jägersand,https://webdocs.cs.ualberta.ca/~jag/
+Martin Jaggi,http://people.inf.ethz.ch/jaggim/
 Martin Karsten,https://cs.uwaterloo.ca/~mkarsten/
 Martin Kersten,http://homepages.cwi.nl/~mk/
 Martin Kreuzer,http://staff.fim.uni-passau.de/kreuzer/
@@ -5562,13 +5577,14 @@ Martin T. Vechev,http://www.srl.inf.ethz.ch/vechev.php/
 Martin Tompa,http://www.cs.washington.edu/people/faculty/tompa/
 Martin Vetterli,http://lcav.epfl.ch/martin.vetterli/
 Martin Vingron,http://www.molgen.mpg.de/109706/vingron
+Martin von Mohrenschildt,http://www.cas.mcmaster.ca/~mohrens/
 Martin Wollschlaeger,https://tu-dresden.de/ing/informatik/institut-fuer-angewandte-informatik/professur-fuer-prozesskommunikation/die-professur/inhaber?set_language=en/
 Martin Wollschläger,https://tu-dresden.de/ing/informatik/institut-fuer-angewandte-informatik/professur-fuer-prozesskommunikation/die-professur/beschaeftigte/
-Martin von Mohrenschildt,http://www.cas.mcmaster.ca/~mohrens/
 Martina A. Rau,https://edpsych.education.wisc.edu/people/faculty-staff/martina-rau/
 Martina Angela Sasse,http://sec.cs.ucl.ac.uk/people/m_angela_sasse/
 Martina Maggio,http://www.control.lth.se/Staff/MartinaMaggio.html
 Martine Labbé,http://homepages.ulb.ac.be/~mlabbe/
+Márton Karsai,http://perso.ens-lyon.fr/marton.karsai/Marton_Karsai/main.html/
 Marty A. Humphrey,https://www.cs.virginia.edu/people/faculty/humphrey.html/
 Marty Humphrey,https://www.cs.virginia.edu/people/faculty/humphrey.html/
 Marvin K. Nakayama,https://web.njit.edu/~marvin/
@@ -5581,13 +5597,12 @@ Mary Lou Soffa,http://www.cs.virginia.edu/~soffa/index.html%3Fp=6.html/
 Mary Shaw,http://www.cs.cmu.edu/~shaw/
 Mary W. Hall,http://www.cs.utah.edu/~mhall/
 Mary Wootters,https://engineering.stanford.edu/people/mary-wootters/
-María Cecilia Rivara,https://www.dcc.uchile.cl/~mcrivara
 Masaaki Mizuno,https://www.cs.ksu.edu/user/301/
 Masahiro Takatsuka,http://sydney.edu.au/engineering/people/masa.takatsuka.php/
 Masood Masoodian,http://www.cs.waikato.ac.nz/~masood/
+Massimiliano de Leoni,http://www.win.tue.nl/~mdeleoni/
 Massimiliano Pierobon,http://cse.unl.edu/~pierobon/
 Massimiliano Pontil,http://www0.cs.ucl.ac.uk/staff/M.Pontil/
-Massimiliano de Leoni,http://www.win.tue.nl/~mdeleoni/
 Massimo De Santo,http://www.unisa.it/docenti/massimodesanto/index/
 Massimo Tornatore,http://home.deib.polimi.it/tornatore/
 Matan Gavish,http://ratio.huji.ac.il/node/779/
@@ -5600,8 +5615,8 @@ Mathias Kölsch,http://www.movesinstitute.org/~kolsch/
 Mathias Payer,https://www.cs.purdue.edu/people/mpayer/
 Mathieu Blanchette,http://www.cs.mcgill.ca/~blanchem/
 Mathieu Desbrun,http://www.geometry.caltech.edu/~mathieu/
-Mathijs Michiel de Weerdt,http://www.alg.ewi.tudelft.nl/weerdt/
 Mathijs de Weerdt,http://www.alg.ewi.tudelft.nl/weerdt/
+Mathijs Michiel de Weerdt,http://www.alg.ewi.tudelft.nl/weerdt/
 Matias David Lee,https://angel.co/matias-david-lee/
 Mats Per Erik Heimdahl,http://www.umsec.umn.edu/directory/mats-heimdahl/
 Matt Bishop,http://nob.cs.ucdavis.edu/~bishop/
@@ -5684,8 +5699,8 @@ Max Mintz,http://www.cis.upenn.edu/~mintz/
 Max Mühlhäuser,https://www.informatik.tu-darmstadt.de/de/fachbereich/professoren-des-fachbereichs/single-view/artikel/prof-dr-max-muehlhaeuser/
 Maximilian Jösch,https://ist.ac.at/research/research-groups/joesch-group/
 Maya Cakmak,http://www.mayacakmak.com/
-Maya Ramanath,http://www.cse.iitd.ac.in/~ramanath/
 Maya Çakmak,https://www.cs.washington.edu/people/faculty/mcakmak/
+Maya Ramanath,http://www.cse.iitd.ac.in/~ramanath/
 Mayank Vatsa,https://www.iiitd.edu.in/~mayank/
 Mayur Naik,http://www.cis.upenn.edu/about-cis/events/
 Mea Wang,http://networks.cpsc.ucalgary.ca/mea/
@@ -5786,8 +5801,8 @@ Michael Granitzer,http://www.fim.uni-passau.de/medieninformatik
 Michael Grossberg,https://www.ccny.cuny.edu/profiles/michael-grossberg/
 Michael Guerzhoy,http://www.cs.toronto.edu/~guerzhoy/
 Michael H. Albert,http://www.cs.otago.ac.nz/staff/michael.html/
-Michael H. Bowling,https://webdocs.cs.ualberta.ca/~bowling/
 Michael H. Böhlen,https://www.ifi.uzh.ch/en/dbtg/Staff/Boehlen.html
+Michael H. Bowling,https://webdocs.cs.ualberta.ca/~bowling/
 Michael H. MacGregor,https://webdocs.cs.ualberta.ca/~macg/
 Michael Hatzopoulos,http://cgi.di.uoa.gr/~mike/
 Michael Henry Albert,http://www.cs.otago.ac.nz/staff/michael.html/
@@ -5864,6 +5879,7 @@ Michael R. Brent,http://mblab.wustl.edu/
 Michael R. Genesereth,http://logic.stanford.edu/people/genesereth/
 Michael R. Jantz,http://web.eecs.utk.edu/~mrjantz/
 Michael R. Lyu,http://www.cse.cuhk.edu.hk/lyu/
+Michaël Rao,http://perso.ens-lyon.fr/michael.rao/
 Michael Rappa,http://analytics.ncsu.edu/?page_id=7/
 Michael Rovatsos,http://homepages.inf.ed.ac.uk/mrovatso/
 Michael Rubenstein,http://www.mccormick.northwestern.edu/research-faculty/directory/profiles/rubenstein-michael.html/
@@ -5907,7 +5923,6 @@ Michalis Faloutsos,http://www.cs.ucr.edu/~michalis/
 Michalis K. Titsias,http://www.aueb.gr/users/mtitsias/
 Michalis Polychronakis,https://www3.cs.stonybrook.edu/~mikepo/
 Michalis Vazirgiannis,http://www.db-net.aueb.gr/michalis/
-Michaël Rao,http://perso.ens-lyon.fr/michael.rao/
 Michel A. Kinsy,http://web.mit.edu/mkinsy/www/
 Michel Abdalla,http://www.di.ens.fr/~mabdalla/
 Michel Barbeau,https://carleton.ca/scs/people/michel-barbeau/
@@ -6140,11 +6155,6 @@ Mythili Vutukuru,https://www.cse.iitb.ac.in/~mythili/
 Myung J. Lee,https://www.ccny.cuny.edu/profiles/myung-lee/
 Myung Jong Lee,https://www.ccny.cuny.edu/profiles/myung-lee/
 Myungjin Lee,http://homepages.inf.ed.ac.uk/mlee23/
-Mário J. Silva,http://lisboa.academia.edu/M%C3%A1rioJSilva
-Mário Rui Gomes,https://pt-pt.facebook.com/public/M%C3%A1rio-Rui-Gomes
-Mário Serafim Nunes,https://fenix.tecnico.ulisboa.pt/homepage/ist11453
-Mário Serafim dos Santos Nunes,http://www.degois.pt/visualizador/curriculum.jsp?key=0616377318620172
-Márton Karsai,http://perso.ens-lyon.fr/marton.karsai/Marton_Karsai/main.html/
 N. H. G. Baken,https://www.nas.ewi.tudelft.nl/people/Nico/Welcome.html/
 N. Hari Narayanan,http://www.eng.auburn.edu/~naraynh/
 N. M. Mosharaf Kabir Chowdhury,http://www.mosharaf.com/
@@ -6171,6 +6181,7 @@ Nagul Cooharojananone,http://pioneer.netserv.chula.ac.th/~cnagul/
 Naja L. Holten Møller,http://diku.dk/Ansatte/?pure=da/persons/340853/
 Nalini Venkatasubramanian,https://www.ics.uci.edu/~nalini/
 Nam Sung Kim,https://www.ece.illinois.edu/directory/profile/nskim/
+name,homepage
 Nan Yang,https://cecs.anu.edu.au/people/nan-yang/
 Nan Zhang,https://www.seas.gwu.edu/~nzhang10/
 Nan Zhang 0004,https://www.seas.gwu.edu/nan-zhang/
@@ -6235,6 +6246,7 @@ Neeraj Suri,https://www.deeds.informatik.tu-darmstadt.de/suri/
 Neil A. Dodgson,http://ecs.victoria.ac.nz/Main/NeilDodgson/
 Neil Anthony Dodgson,https://ecs.victoria.ac.nz/Main/NeilDodgson/
 Neil Bergmann,http://researchers.uq.edu.au/researcher/823/
+Neil C. Audsley,http://www-users.cs.york.ac.uk/~neil/
 Neil C. Rowe,http://faculty.nps.edu/ncrowe/
 Neil F. Stewart,http://www.iro.umontreal.ca/~stewart/
 Neil Frederick Stewart,http://www.google.com/search?q=Neil%20Frederick%20Stewart%20University%20of%20Montreal&btnI
@@ -6292,6 +6304,7 @@ Nicolai Marquardt,https://uclic.ucl.ac.uk/people/nicolai-marquardt/
 Nicolai Vorobjov,http://people.bath.ac.uk/masnnv/
 Nicolas Brisebarre,http://perso.ens-lyon.fr/nicolas.brisebarre/
 Nicolas Courtois,http://www0.cs.ucl.ac.uk/staff/n.courtois/
+Nicolás D'Ippolito,http://lafhis.dc.uba.ar/en/~dippolito
 Nicolas E. Gold,http://www.cs.ucl.ac.uk/staff/N.Gold/
 Nicolas Gold,http://www0.cs.ucl.ac.uk/people/N.Gold.html/
 Nicolas Guelfi,http://wwwen.uni.lu/recherche/fstc/computer_science_and_communications_research_unit/members/nicolas_guelfi/
@@ -6305,10 +6318,9 @@ Nicole Beckage,http://www.eecs.ku.edu/people/faculty/
 Nicole McFarlane,http://www.eecs.utk.edu/people/faculty/mcf/
 Nicoleta Roman,https://cse.osu.edu/people/roman.45/
 Nicoletta Di Blas,http://home.deib.polimi.it/diblas/
-Nicolás D'Ippolito,http://lafhis.dc.uba.ar/en/~dippolito
 Nicos Malevris,http://www.cs.aueb.gr/en/content/malevris-nikolaos
-Niels Olof Bouvin,http://pure.au.dk/portal/en/persons/niels-olof-bouvin(a100614b-adba-4dfe-9ada-8df77bfed841).html/
 Niels da Vitoria Lobo,http://crcv.ucf.edu/people/faculty/nielslobo.html/
+Niels Olof Bouvin,http://pure.au.dk/portal/en/persons/niels-olof-bouvin(a100614b-adba-4dfe-9ada-8df77bfed841).html/
 Nigel Grigg,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=769630/
 Nigel H. Goddard,http://homepages.inf.ed.ac.uk/ngoddard/
 Nigel P. Grigg,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=769630/
@@ -6426,6 +6438,7 @@ Olof B. Widlund,https://www.cs.nyu.edu/widlund/
 Olympia Hadjiliadis,http://userhome.brooklyn.cuny.edu/ohadjiliadis/
 Om P. Damani,https://www.cse.iitb.ac.in/~damani/
 Omar Fawzi,http://perso.ens-lyon.fr/omar.fawzi/
+Ömer Egecioglu,http://www.cs.ucsb.edu/~omer/
 Omer Reingold,https://omereingold.wordpress.com/
 Omkant Pandey,https://www.cs.stonybrook.edu/people/faculty/OmkantPandey/
 Omri Abend,http://www.cs.huji.ac.il/~oabend/
@@ -6474,9 +6487,9 @@ Pablo Barceló,https://users.dcc.uchile.cl/~pbarcelo/
 Pablo Barceló Baeza,http://www.uchile.cl/portafolio-academico/impresion.jsf?username=pbarcelo
 Pablo Bofill Soliguer,http://www.vogue.com/13402912/melissa-losada-pablo-bofill-dhuart-wedding-cadaques-spain/
 Pablo Cesar,http://mmc.tudelft.nl/mmc/people/
+Pablo de Cristóforis,https://www.dc.uba.ar/rrhh/profesores/decristoforis
 Pablo G. Turjanski,https://www.dc.uba.ar/inv/lsc/PTurjanski
 Pablo Royo,https://icarus.upc.edu/en/staff-and-collaborators/staff/
-Pablo de Cristóforis,https://www.dc.uba.ar/rrhh/profesores/decristoforis
 Padhraic Smyth,http://www.ics.uci.edu/~smyth/
 Padma Raghavan,http://www.cse.psu.edu/~pxr3/
 Padmini Srinivasan,http://homepage.cs.uiowa.edu/~psriniva/newsite/index.html/
@@ -6579,8 +6592,8 @@ Patrick Th. Eugster,https://www.dsp.cs.tu-darmstadt.de/de/dsp/group-members/
 Patrick Thiran,https://people.epfl.ch/patrick.thiran/
 Patrick Traynor,https://www.cise.ufl.edu/~traynor/
 Patrick Troy,https://www.cs.uic.edu/Troy/
-Patrick Yin Chiang,http://eecs.oregonstate.edu/~pchiang/
 Patrick van der Smagt,https://brml.org/people/smagt/
+Patrick Yin Chiang,http://eecs.oregonstate.edu/~pchiang/
 Patrik Haslum,https://cs.anu.edu.au/people/patrik-haslum/
 Pattarasinee Bhattarakosol,http://www.math.sc.chula.ac.th/en/profile/pattarasinee.b/
 Paul A. Bailes,http://www.itee.uq.edu.au/sse/our-people/
@@ -6645,6 +6658,7 @@ Paulo Jorge Esteves Veríssimo,http://wwwen.uni.lu/snt/people/paulo_esteves_veri
 Paulo Rogério Pereira,http://mariel.inesc-id.pt/people/prbp.html
 Paulo Veríssimo,http://wwwen.uni.lu/snt/people/paulo_esteves_verissimo/
 Pavel A. Pevzner,http://cseweb.ucsd.edu/~ppevzner/
+Pável Calado,https://fenix.tecnico.ulisboa.pt/homepage/ist14497
 Pavithra Prabhakar,http://people.cs.ksu.edu/~pprabhakar/home.html/
 Pavol Cerný,http://ecee.colorado.edu/pavol/
 Pavol Federl,http://contacts.ucalgary.ca/info/cpsc/profiles/102-12711/
@@ -6716,11 +6730,12 @@ Peter F. Linington,https://www.cs.kent.ac.uk/people/staff/pfl/
 Peter Fejer,http://www.cs.umb.edu/~fejer/
 Peter G. Harrison,http://www.imperial.ac.uk/people/p.harrison/
 Peter G. Jeavons,http://www.cs.ox.ac.uk/peter.jeavons/
+Péter Gács,http://www.cs.bu.edu/~gacs/
 Peter Grunwald,http://homepages.cwi.nl/~pdg/
 Peter Grünwald,http://homepages.cwi.nl/~pdg/
 Peter H. Welch,https://www.cs.kent.ac.uk/~phw/
-Peter Hubwieser,http://www.professoren.tum.de/en/hubwieser-peter/
 Peter Høyer,http://www.cpsc.ucalgary.ca/~hoyer/
+Peter Hubwieser,http://www.professoren.tum.de/en/hubwieser-peter/
 Peter J. Bentley,http://www0.cs.ucl.ac.uk/staff/p.bentley/
 Peter J. Denning,http://faculty.nps.edu/vitae/cgi-bin/vita.cgi?p=display_vita&id=1074712364/
 Peter J. Downey,https://www.cs.arizona.edu/~pete/
@@ -6775,13 +6790,13 @@ Peter Stuckey,http://people.eng.unimelb.edu.au/pstuckey/
 Peter Sutton,http://researchers.uq.edu.au/researcher/70/
 Peter Szolovits,http://groups.csail.mit.edu/medg/people/psz/
 Peter T. Kirstein,http://www0.cs.ucl.ac.uk/people/P.Kirstein.html/
+Peter van Beek,https://cs.uwaterloo.ca/~vanbeek/
 Peter W. O'Hearn,http://www0.cs.ucl.ac.uk/staff/p.ohearn/
 Peter Widmayer,https://www.inf.ethz.ch/personal/widmayer/
 Peter Winkler,https://math.dartmouth.edu/~pw/
 Peter Wonka,https://cidse.engineering.asu.edu/directory/wonka-peter/
 Peter Y. A. Ryan,http://wwwen.uni.lu/snt/research/apsia/prof_peter_ryan/
 Peter Z. Revesz,http://cse.unl.edu/~revesz/
-Peter van Beek,https://cs.uwaterloo.ca/~vanbeek/
 Petra Berenbrink,http://www.cs.sfu.ca/~petra
 Petros Drineas,http://www.drineas.org/
 Peyman Afshani,http://www.cs.au.dk/~peyman/
@@ -6920,8 +6935,6 @@ Purushottam Kar,http://www.cse.iitk.ac.in/users/purushot/
 Purushottam Kulkarni,https://www.cse.iitb.ac.in/~puru/
 Pushpak Bhattacharya,https://www.cse.iitb.ac.in/~pb/
 Pushpendra Singh,https://www.iiitd.edu.in/~pushpendra/
-Pável Calado,https://fenix.tecnico.ulisboa.pt/homepage/ist14497
-Péter Gács,http://www.cs.bu.edu/~gacs/
 Qi Rose Yu,http://www.ist.rit.edu/~qyu/
 Qi Wei,http://bioengineering.gmu.edu/faculty_page/wei/
 Qi Yu,http://www.ist.rit.edu/~qyu/
@@ -7191,10 +7204,10 @@ Ren Ng,http://www.eecs.berkeley.edu/Faculty/Homepages/yirenng.html/
 Renata Medeiros de Carvalho,https://studiegids.tue.nl/opleidingen/graduate-school/special-masters-tracks/eit-digital-embedded-systems/coaching-and-professional-skills/mentoring/
 Renate Scheidler,http://people.ucalgary.ca/~rscheidl/
 Renato Pajarola,http://www.ifi.uzh.ch/vmml/people/current-staff/pajarola.html
-Renee Elio,https://webdocs.cs.ualberta.ca/~ree/
 René Just,https://www.cics.umass.edu/person/just-ren%C3%A9/
 René Serral-Gracià,http://www.netit.upc.edu/rserral/
 René Witte,https://www.concordia.ca/encs/computer-science-software-engineering/faculty.html.html?fpid=rene-witte
+Renee Elio,https://webdocs.cs.ualberta.ca/~ree/
 Renée Elio,https://webdocs.cs.ualberta.ca/~ree/
 Renée J. Miller,http://www.cs.toronto.edu/~miller/
 Rephael Wenger,http://web.cse.ohio-state.edu/~wenger/
@@ -7303,13 +7316,13 @@ Rob Meredith,http://monash.edu/research/explore/en/persons/robert-meredith(d68a8
 Rob Miller,http://www.mit.edu/~rcm/
 Rob Smith,http://www0.cs.ucl.ac.uk/people/Rob.Smith.html/
 Rob V. van Nieuwpoort,http://www.cs.vu.nl/~rob/
-Rob van Nieuwpoort,http://www.cs.vu.nl/~rob/
 Rob van der Mei,http://www.few.vu.nl/~mei/
+Rob van Nieuwpoort,http://www.cs.vu.nl/~rob/
 Robbert Krebbers,http://robbertkrebbers.nl/
 Robby,http://robby.santoslab.org/
 Robby Bruce Findler,http://www.freetechbooks.com/robert-bruce-findler-a2099.html/
-Robert A. van Engelen,https://www.asee.org/public/conferences/32/papers/9523/view/
 Robert A. van de Geijn,http://cs.utexas.edu/~rvdg/
+Robert A. van Engelen,https://www.asee.org/public/conferences/32/papers/9523/view/
 Robert Amor,https://www.cs.auckland.ac.nz/~trebor/
 Robert B. Fisher,http://homepages.inf.ed.ac.uk/rbf/
 Robert B. Schnabel,http://newsinfo.iu.edu/news-archive/5281.html/
@@ -7351,6 +7364,7 @@ Robert H. Sloan,https://www.cs.uic.edu/Sloan/
 Robert Harle,https://www.cl.cam.ac.uk/research/dtg/www/people/rkh23/
 Robert Harper,http://www.cs.cmu.edu/~rwh/
 Robert Holte,https://webdocs.cs.ualberta.ca/~holte/
+Robert I. Davis,https://www-users.cs.york.ac.uk/~robdavis/
 Robert I. McKay,https://cecs.anu.edu.au/people/robert-ian-mckay/
 Robert I. Soare,http://people.cs.uchicago.edu/~soare/
 Robert Ian McKay,https://cs.anu.edu.au/people/robert-ian-mckay/
@@ -7402,13 +7416,13 @@ Robert Soulé,http://www.inf.usi.ch/faculty/soule/
 Robert St. Amant,http://www4.ncsu.edu/~stamant/
 Robert T. Collins,http://www.cse.psu.edu/~rtc12/
 Robert V. Kenyon,https://www.cs.uic.edu/bin/view/Kenyon/WebHome/
+Robert van Engelen,http://www.cs.fsu.edu/~engelen/
+Robert van Liere,http://homepages.cwi.nl/~robertl/
 Robert W. Doran,https://www.cs.auckland.ac.nz/~bob/
 Robert W. Lindeman,http://www.canterbury.ac.nz/spark/Researcher.aspx?researcherid=4447467/
 Robert Walls,http://rjwalls.github.io/
 Robert Weller,http://engineering.vanderbilt.edu/bio/robert-weller/
 Robert Williamson,http://axiom.anu.edu.au/~williams/
-Robert van Engelen,http://www.cs.fsu.edu/~engelen/
-Robert van Liere,http://homepages.cwi.nl/~robertl/
 Roberto De Prisco,http://www.di.unisa.it/~robdep/
 Roberto M. Negrini,http://www.deib.polimi.it/eng/people/details/474684/
 Roberto Negrini,http://home.deib.polimi.it/negrini/
@@ -7455,8 +7469,8 @@ Roger Espasa,http://engineering.academickeys.com/browse_whoswho_by_institution/P
 Roger T. Hartley,http://www.cs.nmsu.edu/~rth/publications/Publications.html/
 Roger Walker,http://ranger.uta.edu/~walker/
 Roger Zimmermann,https://www.comp.nus.edu.sg/~rogerz/roger.html/
-Rogers Mathew,http://cse.iitkgp.ac.in/~rogers/
 Rogério de Lemos,https://www.cs.kent.ac.uk/people/staff/rdl/
+Rogers Mathew,http://cse.iitkgp.ac.in/~rogers/
 Rohini K. Srihari,http://www.cse.buffalo.edu/people/?u=rohini/
 Rohit Parikh,http://www.sci.brooklyn.cuny.edu/cis/parikh/
 Roland H. C. Yap,https://www.comp.nus.edu.sg/~ryap/
@@ -7479,9 +7493,9 @@ Ron M. Roth,http://ronny.cswp.cs.technion.ac.il/
 Ron O. Dror,http://cs.stanford.edu/people/rondror/
 Ron Shamir,http://www.cs.tau.ac.il/~rshamir/
 Ron Steinfeld,http://users.monash.edu.au/~rste/
+Ron van der Meyden,http://www.cse.unsw.edu.au/~meyden/
 Ron Weiss,https://be.mit.edu/directory/ron-weiss/
 Ron Y. Pinter,http://www.cs.technion.ac.il/~pinter/
-Ron van der Meyden,http://www.cse.unsw.edu.au/~meyden/
 Ronald A. Metoyer,https://engineering.nd.edu/profiles/rmetoyer/
 Ronald A. Olsson,http://www.cs.ucdavis.edu/~olsson/
 Ronald A. Rensink,https://www.cs.ubc.ca/~rensink/
@@ -7489,6 +7503,7 @@ Ronald Baecker,http://ron.taglab.ca/
 Ronald C. Arkin,http://www.cc.gatech.edu/home/arkin/
 Ronald Cramer,http://homepages.cwi.nl/~cramer/
 Ronald D. Schrimpf,http://www.vuse.vanderbilt.edu/~schrimpf/
+Ronald de Wolf,http://homepages.cwi.nl/~rdewolf/
 Ronald Fedkiw,http://cs.stanford.edu/~fedkiw/
 Ronald G. Dreslinski,https://web.eecs.umich.edu/~rdreslin/
 Ronald Garcia,http://www.cs.ubc.ca/~rxg/
@@ -7502,7 +7517,6 @@ Ronald Parr,https://users.cs.duke.edu/~parr/
 Ronald Rosenfeld,http://www.cs.cmu.edu/~roni/
 Ronald S. Fearing,https://robotics.eecs.berkeley.edu/~ronf/
 Ronald Vullo,http://ist.rit.edu/~rpv/
-Ronald de Wolf,http://homepages.cwi.nl/~rdewolf/
 Rong Ge,https://users.cs.duke.edu/~rongge/
 Rong Ge 0001,https://users.cs.duke.edu/~rongge/
 Rong Ge 0002,https://people.cs.clemson.edu/~rge/
@@ -7532,6 +7546,7 @@ Roy P. Pargas,https://people.cs.clemson.edu/~pargas/
 Roy Schwartz,http://www.cs.technion.ac.il/people/schwartz/
 Roy Shilkrot,https://www.cs.stonybrook.edu/people/faculty/RoyShilkrot/
 Rubén Tous,http://personals.ac.upc.edu/rtous/
+Rüdiger L. Urbanke,https://people.epfl.ch/rudiger.urbanke/
 Rudolf H. Mak,https://www.tue.nl/en/university/departments/mathematics-and-computer-science/the-department/staff/detail/ep/e/d/ep-uid/19820121/
 Rudolf Mathon,http://www.cs.toronto.edu/dcs/people-faculty-combin.html/
 Rudolph P. Darken,http://faculty.nps.edu/vitae/cgi-bin/vita.cgi?p=display_vita&id=1023567683/
@@ -7595,7 +7610,6 @@ Rym Wenkstern,http://www.utdallas.edu/~rmili/
 Rym Zalila-Wenkstern,http://www.utdallas.edu/~rmili/
 Ryszard Janicki,http://www.cas.mcmaster.ca/~janicki/
 Ryuichi Shigemoto,https://ist.ac.at/research/research-groups/shigemoto-group/
-Rüdiger L. Urbanke,https://people.epfl.ch/rudiger.urbanke/
 S. A. Puzynina,http://www.ens-lyon.fr/
 S. Akshay,https://www.cse.iitb.ac.in/~akshayss/
 S. Arun-Kumar,http://www.cse.iitd.ernet.in/~sak/
@@ -7832,6 +7846,8 @@ Sebastian Riedel,http://www0.cs.ucl.ac.uk/people/S.Riedel.html/
 Sebastian Robert Riedel,http://www0.cs.ucl.ac.uk/people/S.Riedel.html/
 Sebastian Rudolph,https://iccl.inf.tu-dresden.de/web/Sebastian_Rudolph/en/
 Sebastian Thore Erdweg,http://www.informatik.uni-marburg.de/~seba/
+Sébastien Ourselin,http://cmic.cs.ucl.ac.uk/staff/sebastien_ourselin/
+Sébastien Roy,http://www.iro.umontreal.ca/~roys/en_index.shtml
 Seddik M. Djouadi,https://www.eecs.utk.edu/people/faculty/mdjouadi/
 See-Kiong Ng,http://datam.i2r.a-star.edu.sg/~skng/
 Seffi Naor,http://www.cs.technion.ac.il/~naor/
@@ -8088,6 +8104,7 @@ Songwu Lu,http://www.cs.ucla.edu/~slu/
 Sonia Chernova,http://www.cc.gatech.edu/~chernova/
 Sonia Chiasson,https://carleton.ca/scs/people/sonia-chiasson/
 Sonia Fahmy,https://www.cs.purdue.edu/homes/fahmy/
+Sónia Ferreira Pinto,https://sotis.tecnico.ulisboa.pt/keyword/0d0bf179-e55f-4b14-8c64-214087a98c3f
 Sonia Haiduc,https://www.cs.fsu.edu/~shaiduc/
 Sonny Chan,http://contacts.ucalgary.ca/info/cpsc/profiles/1-5063313/
 Soon Ae Chun,http://www.csi.cuny.edu/faculty/school_of_business/CHUN_SOON.html/
@@ -8095,6 +8112,9 @@ Sophia A. Malamud,http://www.brandeis.edu/facultyguide/person.html?emplid=3910d5
 Sophia Drossopoulou,https://wp.doc.ic.ac.uk/sd/
 Sophie Jörg,https://people.cs.clemson.edu/~sjoerg/
 Sorav Bansal,http://www.cse.iitd.ernet.in/~sbansal/
+Søren Debois,https://pure.itu.dk/portal/en/persons/soeren-debois(d3b41838-e2bf-4735-b1cd-03f60b49c7e5).html
+Søren Ingvor Olsen,http://diku.dk/english/staff/?pure=en/persons/5264/
+Søren Lauesen,https://pure.itu.dk/portal/en/persons/soeren-lauesen(ea6d10cf-6bb5-4414-8966-f1ed2591f794).html
 Sorin Istrail,http://www.brown.edu/Research/Istrail_Lab/sorin.php/
 Sorin Lerner,http://cseweb.ucsd.edu/~lerner/
 Soumen Chakrabarti,https://www.cse.iitb.ac.in/~soumen/
@@ -8154,8 +8174,8 @@ Stavros Kolliopoulos,http://cgi.di.uoa.gr/~sgk/papers/
 Stavros Toumpis,https://195.251.255.130/en/faculty/toumpis-stavros
 Stefan Decker,http://www.stefandecker.org/
 Stefan Dziembowski,http://www.crypto.edu.pl/Dziembowski/
-Stefan Gumhold,https://tu-dresden.de/ing/informatik/smt/cgv/
 Stefan Göller,http://www.lsv.ens-cachan.fr/~goeller/
+Stefan Gumhold,https://tu-dresden.de/ing/informatik/smt/cgv/
 Stefan Haar,http://www.lsv.ens-cachan.fr/~haar/
 Stefan Horst Sommer,http://research.ku.dk/search/?pure=en/persons/254908/
 Stefan Kahrs,https://www.cs.kent.ac.uk/~smk/
@@ -8191,6 +8211,12 @@ Steffen Hölldobler,http://www.computational-logic.org/~sh/
 Steffen Rothkugel,http://wwwen.uni.lu/research/fstc/communicative_systems_laboratory_com_sys/members/steffen_rothkugel/
 Steffen van Bakel,http://www.doc.ic.ac.uk/~svb/
 Stelian Coros,http://www.cs.cmu.edu/~scoros/
+Stéphan Thomassé,http://perso.ens-lyon.fr/stephan.thomasse/
+Stéphane Bressan,https://www.comp.nus.edu.sg/~steph/
+Stéphane Demri,http://www.lsv.ens-cachan.fr/~demri/
+Stéphane Lafortune,https://wiki.eecs.umich.edu/stephane/index.php/St%C3%A9phane_Lafortune/
+Stéphane Mallat,https://www.di.ens.fr/~mallat/
+Stéphanie Delaune,http://www.lsv.ens-cachan.fr/~delaune/
 Stephanie Forrest,https://www.cs.unm.edu/~forrest/
 Stephanie Weirich,https://www.cis.upenn.edu/~sweirich/
 Stephen A. Clark,https://sites.google.com/site/stephenclark609/
@@ -8302,12 +8328,6 @@ Stuart M. Shieber,http://www.eecs.harvard.edu/shieber/
 Stuart Marshall,http://ecs.victoria.ac.nz/Main/StuartMarshall/
 Stuart Russell,https://people.eecs.berkeley.edu/~russell/
 Stuart Smith,https://www.uml.edu/Sciences/computer-science/faculty/emeritus-faculty/smith-stuart.aspx
-Stéphan Thomassé,http://perso.ens-lyon.fr/stephan.thomasse/
-Stéphane Bressan,https://www.comp.nus.edu.sg/~steph/
-Stéphane Demri,http://www.lsv.ens-cachan.fr/~demri/
-Stéphane Lafortune,https://wiki.eecs.umich.edu/stephane/index.php/St%C3%A9phane_Lafortune/
-Stéphane Mallat,https://www.di.ens.fr/~mallat/
-Stéphanie Delaune,http://www.lsv.ens-cachan.fr/~delaune/
 Su-In Lee,http://suinlee.cs.washington.edu/
 Su-Lin Lee,http://www.imperial.ac.uk/people/su-lin.lee/
 Subash Shankar,http://www.cs.hunter.cuny.edu/~sshankar/
@@ -8360,6 +8380,7 @@ Sujoy Ghose,http://www.myopencourses.com/profile/prof-sujoy-ghosh/
 Sukhendu Das,http://www.cse.iitm.ac.in/~sdas/
 Sukumar Ghosh,https://www.cs.uiowa.edu/~ghosh/
 Sukumar Nandi,https://www.iitg.ernet.in/sukumar/
+Süleyman Cenk Sahinalp,https://www.soic.indiana.edu/all-people/profile.html?profile_id=291/
 Suman Banerjee,http://pages.cs.wisc.edu/~suman/
 Suman Jana,http://sumanj.info/
 Suman K. Mitra,http://intranet.daiict.ac.in/~suman_mitra/newSite/
@@ -8435,18 +8456,11 @@ Sylvia L. Osborn,http://www.csd.uwo.ca/faculty/sylvia/
 Sylvia Perez-Hardy,https://www.rit.edu/gccis/sylvia-perez-hardy/
 Sylvia Ratnasamy,http://www.eecs.berkeley.edu/~sylvia/
 Sylvie Hamel,http://www.iro.umontreal.ca/~hamelsyl/
-Sylvie Thièbaux,http://users.cecs.anu.edu.au/~thiebaux/
 Sylvie Thiébaux,http://users.cecs.anu.edu.au/~thiebaux/
+Sylvie Thièbaux,http://users.cecs.anu.edu.au/~thiebaux/
 Sze-Yeung Liu,http://research.ntu.edu.sg/expertise/academicprofile/Pages/StaffProfile.aspx?ST_EMAILID=elvisliu/
 Szymon Rusinkiewicz,https://www.cs.princeton.edu/~smr/
 Szymon Torunczyk,http://www.mimuw.edu.pl/~szymtor/
-Sébastien Ourselin,http://cmic.cs.ucl.ac.uk/staff/sebastien_ourselin/
-Sébastien Roy,http://www.iro.umontreal.ca/~roys/en_index.shtml
-Sónia Ferreira Pinto,https://sotis.tecnico.ulisboa.pt/keyword/0d0bf179-e55f-4b14-8c64-214087a98c3f
-Søren Debois,https://pure.itu.dk/portal/en/persons/soeren-debois(d3b41838-e2bf-4735-b1cd-03f60b49c7e5).html
-Søren Ingvor Olsen,http://diku.dk/english/staff/?pure=en/persons/5264/
-Søren Lauesen,https://pure.itu.dk/portal/en/persons/soeren-lauesen(ea6d10cf-6bb5-4414-8966-f1ed2591f794).html
-Süleyman Cenk Sahinalp,https://www.soic.indiana.edu/all-people/profile.html?profile_id=291/
 T. C. Chong,https://researchers.anu.edu.au/researchers/haberkorn-tc/
 T. C. Hu,http://cseweb.ucsd.edu/~hu/
 T. C. Nicholas Graham,http://www.cs.queensu.ca/~graham/
@@ -8491,10 +8505,10 @@ Tamara Denning,https://www.cs.utah.edu/~tdenning/
 Tamara L. Berg,http://tamaraberg.com/
 Tamara Munzner,https://www.cs.ubc.ca/~tmm/
 Tamara Sumner,http://spot.colorado.edu/~sumner/
+Tamás D. Gedeon,https://cs.anu.edu.au/people/tom-gedeon/
 Tamas Hausel,https://ist.ac.at/research/research-groups/hausel-group/
 Tamer Kahveci,http://www.cise.ufl.edu/~tamer/
 Tamma Bheemarjuna Reddy,http://www.iith.ac.in/~tbr/
-Tamás D. Gedeon,https://cs.anu.edu.au/people/tom-gedeon/
 Tandy J. Warnow,https://bioengineering.illinois.edu/directory/faculty/warnow/
 Tanir Ozcelebi,http://www.win.tue.nl/~tozceleb/
 Tanir Özçelebi,http://www.win.tue.nl/~tozceleb/
@@ -8729,6 +8743,8 @@ Tom Shrimpton,https://cise.ufl.edu/~teshrim/
 Tom Verhoeff,http://www.win.tue.nl/~wstomv/
 Tom Weidong Cai,http://sydney.edu.au/engineering/it/about/people/staff/tomc.shtml/
 Tom Yeh,http://tomyeh.info/
+Tomás García Ferrari,http://www.cms.waikato.ac.nz/people/tomasgf/
+Tomás Lozano-Pérez,http://people.csail.mit.edu/tlp/
 Tomas Sauer,http://www.fim.uni-passau.de/en/digital-image-processing/
 Tomaso Aste,http://www.cs.ucl.ac.uk/staff/tomaso_aste/
 Tomasz Arodz,http://www.people.vcu.edu/~tarodz/
@@ -8744,10 +8760,9 @@ Tommi S. Jaakkola,https://people.csail.mit.edu/tommi/
 Tommy Kaplan,http://www.cs.huji.ac.il/~tommy/
 Tommy Thorne,https://www.inf.ed.ac.uk/people/staff/Thomas_Thorne.html/
 Tomofumi Yuki,http://perso.ens-lyon.fr/tomofumi.yuki/
-Tomás García Ferrari,http://www.cms.waikato.ac.nz/people/tomasgf/
-Tomás Lozano-Pérez,http://people.csail.mit.edu/tlp/
 Tona Henderson,https://www.rit.edu/gccis/igm/tona-henderson/
 Toniann Pitassi,https://www.cs.toronto.edu/~toni/
+Tõnu Tamme,http://www.ut.ee/en/tonu-tamme/
 Tony F. Chan,http://president.ust.hk/eng/bio.html
 Tony Field,http://wp.doc.ic.ac.uk/ajf/
 Tony Givargis,https://www.ics.uci.edu/~givargis/
@@ -8762,10 +8777,10 @@ Tony Wirth,http://people.eng.unimelb.edu.au/awirth/
 Tor Aamodt,https://www.ece.ubc.ca/~aamodt/
 Tor Lattimore,http://tor-lattimore.com/
 Tor M. Aamodt,https://www.ece.ubc.ca/~aamodt/
-Torben Amtoft,http://cis.ksu.edu/~tamtoft/
-Torben Amtoft Hansen,http://cis.ksu.edu/~tamtoft/
 Torben Æ. Mogensen,http://www.diku.dk/~torbenm/
 Torben Ægidius Mogensen,http://www.diku.dk/~torbenm/
+Torben Amtoft,http://cis.ksu.edu/~tamtoft/
+Torben Amtoft Hansen,http://cis.ksu.edu/~tamtoft/
 Torsten Hoefler,https://htor.inf.ethz.ch/
 Torsten Höfler,https://htor.inf.ethz.ch/
 Torsten Kuhlen,http://www.campus.rwth-aachen.de/rwth/all/lecturer.asp?gguid=0x34077156CE85D51196710000F4B4937D/
@@ -8795,6 +8810,7 @@ Tuba Yavuz-Kahveci,http://www.tuba.ece.ufl.edu/
 Tucker Balch,http://www.cc.gatech.edu/home/tucker/
 Tucker Hermans,http://www.cs.utah.edu/~thermans/
 Tucker R. Balch,http://www.cc.gatech.edu/home/tucker/
+Tülay Adali,http://www.csee.umbc.edu/~adali/
 Tulika Mitra,http://www.comp.nus.edu.sg/~tulika/
 Tuomas Sandholm,http://www.cs.cmu.edu/~sandholm/
 Tuvi Etzion,http://www.cs.technion.ac.il/people/etzion/
@@ -8802,8 +8818,6 @@ Tyrone E. Duncan,https://www.math.ku.edu/people/faculty/duncan.html/
 Tyson Condie,http://clash.cs.ucla.edu/
 Tze Sing Eugene Ng,https://www.cs.rice.edu/~eugeneng/
 Tze-Yun Leong,https://www.comp.nus.edu.sg/~leongty/
-Tõnu Tamme,http://www.ut.ee/en/tonu-tamme/
-Tülay Adali,http://www.csee.umbc.edu/~adali/
 U. Ramakrishna,http://www.iith.ac.in/~ramakrishna/
 Ubbo Visser,http://www.cs.miami.edu/~visser/
 Udantha R. Abeyratne,http://researchers.uq.edu.au/researcher/1182/
@@ -8831,6 +8845,7 @@ Ulrike Stege,http://webhome.cs.uvic.ca/~stege/Ulrike_Steges_Homepage/Welcome.htm
 Umakishore Ramachandran,http://www.cc.gatech.edu/~rama/
 Umesh Bellur,https://www.cse.iitb.ac.in/~umesh/
 Umesh V. Vazirani,http://www.cs.berkeley.edu/~vazirani/
+Ümit V. Çatalyürek,http://bmi.osu.edu/umit/
 Umut A. Acar,http://www.umut-acar.org/
 Un-Ku Moon,http://web.engr.oregonstate.edu/~moon/
 Uri C. Weiser,http://webee.technion.ac.il/people/weiser/
@@ -8924,7 +8939,9 @@ Vibhav Gogate,http://www.hlt.utdallas.edu/~vgogate/
 Vicente Ordonez,http://www.cs.virginia.edu/~vicente/
 Vicente Ordóñez Román,http://www.cs.virginia.edu/~vicente/
 Vicki L. Hanson,http://staff.computing.dundee.ac.uk/vlh/
+Víctor A. Braberman,http://lafhis.dc.uba.ar/en/~vbraber
 Victor B. Zordan,http://www.cs.ucr.edu/~vbz/
+Victor de Boer,http://www.victordeboer.com/
 Victor Frost,http://www.ittc.ku.edu/~frost/
 Victor J. Milenkovic,http://www.cs.miami.edu/~vjm/
 Victor Jauregui,https://www.cse.unsw.edu.au/~vicj/
@@ -8937,7 +8954,6 @@ Victor W. Marek,https://www.cs.uky.edu/~marek/
 Victor W. Zue,https://www.csail.mit.edu/user/1522/
 Victor Y. Pan,http://comet.lehman.cuny.edu/vpan/
 Victor Zue,https://www.csail.mit.edu/user/1522/
-Victor de Boer,http://www.victordeboer.com/
 Victoria Interrante,http://www-users.cs.umn.edu/~interran/
 Victoria Stodden,https://ischool.illinois.edu/people/faculty/vcs/
 Viera K. Proulx,http://www.ccs.neu.edu/home/vkp/
@@ -8955,11 +8971,11 @@ Vikas Singh,https://www.biostat.wisc.edu/~vsingh/
 Vikram Goyal,https://www.iiitd.ac.in/vikram/
 Vikram Pudi,https://www.iiit.ac.in/people/faculty/vikram/
 Vikram S. Adve,http://web.engr.illinois.edu/~vadve/
+Viktor de Boer,http://www.victordeboer.com/
 Viktor Gruev,https://engineering-preview.wustl.edu/Profiles/Pages/Viktor-Gruev.aspx/
 Viktor K. Prasanna,http://ceng.usc.edu/~prasanna/
 Viktor Kuncak,http://lara.epfl.ch/~kuncak/
 Viktor Vafeiadis,http://www.mpi-sws.org/~viktor/
-Viktor de Boer,http://www.victordeboer.com/
 Vimal Kumar 0001,http://www.cms.waikato.ac.nz/people/vkumar/
 Vinay J. Ribeiro,http://www.cse.iitd.ernet.in/~vinay/
 Vinay P. Namboodiri,http://www.cse.iitk.ac.in/users/vinaypn/
@@ -9039,7 +9055,6 @@ Vojtech Rödl,http://www.mathcs.emory.edu/~rodl/
 Volkan Isler,http://www-users.cs.umn.edu/~isler/
 Volker Haarslev,http://www.cs.concordia.ca/~haarslev/
 Volker Müller 0001,http://wwwen.uni.lu/recherche/fstc/computer_science_and_communications_research_unit/members/volker_mueller/
-Víctor A. Braberman,http://lafhis.dc.uba.ar/en/~vbraber
 W. Bastiaan Kleijn,http://ecs.victoria.ac.nz/Main/BastiaanKleijn/
 W. Brent Seales,https://www.cs.uky.edu/people/faculty/bseales/
 W. Bruce Croft,http://ciir.cs.umass.edu/croft/
@@ -9258,13 +9273,13 @@ Xiangyun Zhou,http://users.cecs.anu.edu.au/~xyzhou/Default.html/
 Xiao Qin,http://www.eng.auburn.edu/~xqin/
 Xiao-Chuan Cai,https://www.cs.colorado.edu/~cai/
 Xiao-Wen Chang,http://cs.mcgill.ca/~chang/
-XiaoFeng Wang,http://www.informatics.indiana.edu/xw7/
 Xiaobai Sun,http://www.cs.duke.edu/people/women/individual/sun.php/
 Xiaobo Hu,http://www3.nd.edu/~shu/
 Xiaobo Sharon Hu,http://www3.nd.edu/~shu/
 Xiaodi Wu,https://ix.cs.uoregon.edu/~xiaodiwu/
 Xiaodong Zhang 0001,http://web.cse.ohio-state.edu/~zhang/
 Xiaofang Zhou,http://staff.itee.uq.edu.au/zxf/
+XiaoFeng Wang,http://www.informatics.indiana.edu/xw7/
 Xiaohu Guo,https://www.utdallas.edu/~xxg061000/
 Xiaohui Gu,https://www.csc.ncsu.edu/faculty/gu/
 Xiaohui Liang,http://www.cs.umb.edu/people/Xiaohui_Liang/
@@ -9580,12 +9595,3 @@ Zvi Galil,http://www.cc.gatech.edu/people/zvi-galil
 Zvi M. Kedem,http://cs.nyu.edu/kedem/
 Zvonimir Rakamaric,http://www.zvonimir.info/
 Zygmunt J. Haas,http://www.utdallas.edu/~zjh130030/
-Ágoston E. Eiben,http://www.cs.vu.nl/~gusz/
-Ákos Lédeczi,http://www.isis.vanderbilt.edu/akos/
-Éric Colin de Verdière,http://www.di.ens.fr/~colin/
-Éric Schost,https://cs.uwaterloo.ca/~eschost/
-Éric Tanter,https://www.dcc.uchile.cl/eric_tanter
-Étienne Lozes,http://www.lsv.ens-cachan.fr/~lozes/
-Éva Tardos,http://www.cs.cornell.edu/~eva/
-Ömer Egecioglu,http://www.cs.ucsb.edu/~omer/
-Ümit V. Çatalyürek,http://bmi.osu.edu/umit/


### PR DESCRIPTION
Hi,

This is a commit which adds the academics from the University of York real-time group. I'm not entirely certain why the diff for homepages is so large; probably a difference of opinion in sorting order between the original program and LibreOffice.

If there's anything I can do to help, just let me know.

- David Griffin