### PR TITLE
Added missing CMU faculty with appointments in CSD

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -861,6 +861,24 @@ Yiming Yang , Carnegie Mellon University
 Yong-Lae Park , Carnegie Mellon University
 Yuvraj Agarwal , Carnegie Mellon University
 Ziv Bar-Joseph , Carnegie Mellon University
+David Brumley , Carnegie Mellon University
+Virgil D. Gligor , Carnegie Mellon University
+Vyas Sekar , Carnegie Mellon University
+Bryan Parno , Carnegie Mellon University
+Alessandro Acquisti , Carnegie Mellon University
+Roy Maxion , Carnegie Mellon University
+Priya Narasimhan , Carnegie Mellon University
+Luis von Ahn , Carnegie Mellon University
+Greg Ganger , Carnegie Mellon University
+James C. Hoe , Carnegie Mellon University
+Bruce H. Krogh , Carnegie Mellon University
+Brandon Lucia , Carnegie Mellon University
+Radu Marculescu , Carnegie Mellon University
+Diana Marculescu , Carnegie Mellon University
+Ragunathan Rajkumar , Carnegie Mellon University
+Raj Rajkumar , Carnegie Mellon University
+Bruno Sinopoli , Carnegie Mellon University
+Richard M. Stern , Carnegie Mellon University
 Ada Wai-Chee Fu , Chinese University of Hong Kong
 Andrej Bogdanov , Chinese University of Hong Kong
 Bei Yu , Chinese University of Hong Kong


### PR DESCRIPTION
This commit adds CMU faculty who are tenure-track and have full advising
privileges in the CMU computer science department.