### PR TITLE
Fix minimum dependencies for building database

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ upwards of 19GiB of memory). To then rebuild the databases, just run
 ``make``.
 
 You will also need to install libxml2-utils (or whatever package
-includes xmllint on your distro), npm, typescript, and python-lxml at
+includes xmllint on your distro), npm, typescript, python-lxml, and basex at
 a minimum via a command line like:
 
-``apt-get install libxml2-utils, npm, python-lxml; npm install -g typescript``
+``apt-get install libxml2-utils npm python-lxml basex; npm install -g typescript``
 
 ### Acknowledgements and other rankings
 


### PR DESCRIPTION
"make update-dblp" on a fresh Ubuntu 16.04.2 install failed because basex was missing.  This commit adds basex to the list of dependencies in the README.  It also corrects the apt-get syntax in the README, making it possible to copy & paste from the README to the command line.


