### PR TITLE
Update on Princeton Faculty

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -4018,8 +4018,11 @@ Brian W. Kernighan , Princeton University
 David I. August , Princeton University
 David P. Dobkin , Princeton University
 David Walker , Princeton University
+David Wentzlaff , Princeton University
 Edward W. Felten , Princeton University
 Elad Hazan , Princeton University
+Gillat Kol , Princeton University
+H. Sebastian Seung , Princeton University
 Jaswinder Pal Singh , Princeton University
 Jennifer Rexford , Princeton University
 Kai Li , Princeton University
@@ -4031,13 +4034,23 @@ Michael J. Freedman , Princeton University
 Mona Singh , Princeton University
 Nick Feamster , Princeton University
 Olga G. Troyanskaya , Princeton University
-Rebecca Fiebrink , Princeton University
+Olga Russakovsky , Princeton University
+Prateek Mittal , Princeton University
+Ran Raz , Princeton University
 Robert E. Tarjan , Princeton University
 Robert Endre Tarjan , Princeton University
 Robert Sedgewick , Princeton University
+Ruby Lee , Princeton University
+Ryan P. Adams , Princeton University
+S. Matthew Weinberg , Princeton University
+Samory Kpotufe , Princeton University
 Sanjeev Arora , Princeton University
 Szymon Rusinkiewicz , Princeton University
 Thomas A. Funkhouser , Princeton University
+Wyatt Lloyd , Princeton University
+Yoram Singer , Princeton University
+Yuxin Chen , Princeton University
+Zachary Kincaid , Princeton University
 Zeev Dvir , Princeton University
 Aditya P. Mathur , Purdue University
 Ahmed K. Elmagarmid , Purdue University


### PR DESCRIPTION
Update on Princeton Faculty. 

Most of them can be found from http://www.cs.princeton.edu/people/faculty?type=main and http://www.cs.princeton.edu/people/faculty?type=associated but this update also includes new hires not reflected on the website yet. Note that CS associated faculties in other department can advice CS student. 