### PR TITLE
Update on Princeton University Faculty

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -4005,6 +4005,7 @@ Silvia Llorente , Polytechnic University of Catalonia
 Yolanda Becerra , Polytechnic University of Catalonia
 Aarti Gupta , Princeton University
 Adam Finkelstein , Princeton University
+Amir Ali Ahmadi , Princeton University
 Andrea S. LaPaugh , Princeton University
 Andrew W. Appel , Princeton University
 Arvind Narayanan , Princeton University
@@ -4035,17 +4036,19 @@ Mona Singh , Princeton University
 Nick Feamster , Princeton University
 Olga G. Troyanskaya , Princeton University
 Olga Russakovsky , Princeton University
+Paul D. Seymour , Princeton University
 Prateek Mittal , Princeton University
 Ran Raz , Princeton University
 Robert E. Tarjan , Princeton University
 Robert Endre Tarjan , Princeton University
 Robert Sedgewick , Princeton University
-Ruby Lee , Princeton University
+Ruby B. Lee , Princeton University
 S. Matthew Weinberg , Princeton University
 Samory Kpotufe , Princeton University
 Sanjeev Arora , Princeton University
 Szymon Rusinkiewicz , Princeton University
 Thomas A. Funkhouser , Princeton University
+Warren B. Powell , Princeton University
 Yuxin Chen , Princeton University
 Zachary Kincaid , Princeton University
 Zeev Dvir , Princeton University


### PR DESCRIPTION
Fix on DBLP name and updated few more Princeton CS associated faculties (http://www.cs.princeton.edu/people/faculty?type=associated). 