### PR TITLE
Princeton Interdisciplinary Faculties

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -4082,10 +4082,14 @@ David Walker , Princeton University
 David Wentzlaff , Princeton University
 Edward W. Felten , Princeton University
 Elad Hazan , Princeton University
+Emmanuel Abbe , Princeton University
 Gillat Kol , Princeton University
 H. Sebastian Seung , Princeton University
+H. Vincent Poor , Princeton University
 Jaswinder Pal Singh , Princeton University
 Jennifer Rexford , Princeton University
+Jonathan D. Cohen , Princeton University
+Jonathan W. Pillow , Princeton University
 Kai Li , Princeton University
 Kyle Jamieson , Princeton University
 Margaret Martonosi , Princeton University
@@ -4093,10 +4097,14 @@ Mark Braverman , Princeton University
 Mark Zhandry , Princeton University
 Michael J. Freedman , Princeton University
 Mona Singh , Princeton University
+Naomi Ehrich Leonard , Princeton University
+Nathaniel D. Daw , Princeton University
 Nick Feamster , Princeton University
+Niraj K. Jha , Princeton University
 Olga G. Troyanskaya , Princeton University
 Olga Russakovsky , Princeton University
 Paul D. Seymour , Princeton University
+Peter J. Ramadge , Princeton University
 Prateek Mittal , Princeton University
 Ran Raz , Princeton University
 Robert E. Tarjan , Princeton University
@@ -4106,6 +4114,7 @@ Ruby B. Lee , Princeton University
 S. Matthew Weinberg , Princeton University
 Samory Kpotufe , Princeton University
 Sanjeev Arora , Princeton University
+Sharad Malik , Princeton University
 Szymon Rusinkiewicz , Princeton University
 Thomas A. Funkhouser , Princeton University
 Warren B. Powell , Princeton University


### PR DESCRIPTION
Included some faculties from other departments (Princeton Neuroscience Institute, Electrical Engineering, Mechanical Engineering) in Princeton who can advise CS students working on interdisciplinary fields (e.g., computational neurosicence, machine learning, robotics, design automation). 
