### PR TITLE
Update faculty-affiliations.csv

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -8376,6 +8376,8 @@ Tomas Sauer , University of Passau
 Aaron Leon Roth , University of Pennsylvania
 Aaron Roth , University of Pennsylvania
 Alexander Rakhlin , University of Pennsylvania
+André DeHon , University of Pennsylvania
+Andre Scedrov , University of Pennsylvania
 Andreas Haeberlen , University of Pennsylvania
 Ani Nenkova , University of Pennsylvania
 Benjamin C. Pierce , University of Pennsylvania
@@ -8385,7 +8387,9 @@ Chris Callison-Burch , University of Pennsylvania
 Dan Roth , University of Pennsylvania
 Daniel D. Lee , University of Pennsylvania
 Daniel E. Koditschek , University of Pennsylvania
+George J. Pappas , Universtiy of Pennsylvania
 Insup Lee , University of Pennsylvania
+James C. Gee , University of Pennsylvania
 Jean Gallier , University of Pennsylvania
 Jean H. Gallier , University of Pennsylvania
 Jianbo Shi , University of Pennsylvania
@@ -8394,7 +8398,9 @@ Konstantinos Daniilidis , University of Pennsylvania
 Kostas Daniilidis , University of Pennsylvania
 Linh T. X. Phan , University of Pennsylvania
 Linh Thi Xuan Phan , University of Pennsylvania
+Li-San Wang , University of Pennsylvania
 Lyle H. Ungar , University of Pennsylvania
+Mark Liberman , University of Pennsylvania
 Matt Blaze , University of Pennsylvania
 Max Mintz , University of Pennsylvania
 Mayur Naik , University of Pennsylvania
@@ -8406,6 +8412,8 @@ Mitchell P. Marcus , University of Pennsylvania
 Nadia Heninger , University of Pennsylvania
 Norman I. Badler , University of Pennsylvania
 Rajeev Alur , University of Pennsylvania
+Rahul Mangharam , University of Pennsylvania
+Rakesh V. Vohra , University of Pennsylvania
 Sampath Kannan , University of Pennsylvania
 Sanjeev Khanna , University of Pennsylvania
 Sasha Rakhlin , University of Pennsylvania


### PR DESCRIPTION
Adding secondary faculty (all have PhD advising privileges):
http://www.cis.upenn.edu/about-people/faculty-affil.php