### PR TITLE
Add ICWSM to The web & information retrieval category

### DIFF
--- a/filter.xq
+++ b/filter.xq
@@ -20,6 +20,7 @@
 //inproceedings[booktitle="IJCAI"],
 //inproceedings[booktitle="WWW"],
 //inproceedings[booktitle="SIGIR"],
+//inproceedings[booktitle="ICWSM"],
 //inproceedings[booktitle="IEEE Visualization"],
 //inproceedings[booktitle="VR"],
 //article[journal="IEEE Trans. Vis. Comput. Graph."],

--- a/index.html
+++ b/index.html
@@ -421,6 +421,7 @@
 				<td>
 				  <a href="http://dblp.uni-trier.de/db/conf/sigir/index.html">SIGIR</a><br />
 				  <a href="http://dblp.uni-trier.de/db/conf/www/index.html">WWW</a><br />
+				  <a href="http://dblp.uni-trier.de/db/conf/icwsm/index.html">ICWSM</a><br />
 				</td>
 			      </tr>
 			    </tbody>

--- a/util/csrankings.py
+++ b/util/csrankings.py
@@ -90,7 +90,7 @@ areadict = {
     # - Two variants for each, as in DBLP.
     'metrics': ['SIGMETRICS', 'SIGMETRICS/Performance', 'IMC', 'Internet Measurement Conference'],
     # SIGIR
-    'ir': ['WWW', 'SIGIR'],
+    'ir': ['WWW', 'SIGIR', 'ICWSM'],
     # SIGCHI
     'chi': ['CHI', 'UbiComp', 'Ubicomp', 'UIST'],
     'nlp': ['EMNLP', 'ACL', 'ACL (1)', 'ACL (2)', 'NAACL', 'HLT-NAACL',

--- a/util/regenerate-data.py
+++ b/util/regenerate-data.py
@@ -42,7 +42,7 @@ areadict = {
     # - Two variants for each, as in DBLP.
     'metrics': ['SIGMETRICS', 'SIGMETRICS/Performance', 'IMC', 'Internet Measurement Conference'],
     # SIGIR
-    'ir': ['WWW', 'SIGIR'],
+    'ir': ['WWW', 'SIGIR', 'ICWSM'],
     # SIGCHI
     'chi': ['CHI', 'UbiComp', 'Ubicomp', 'UIST'],
     'nlp': ['EMNLP', 'ACL', 'ACL (1)', 'ACL (2)', 'NAACL', 'HLT-NAACL',


### PR DESCRIPTION
There are only two venues in the Web & Information retrieval category already: WWW and SIGIR.

ICWSM is arguably *at least* as strong a venue as SIGIR (it has a higher h5 ranking and a substantially higher h5 than SIGIR according to Google scholar).

Note: This pull request only contains the code to add ICWSM; a separate pull request will have a fully generated site which includes some new faculty from the University of Alabama at Birmingham. 