### PR TITLE
ICWSM and UAB integration

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -5839,6 +5839,10 @@ Sergey Polyakovskiy , University of Adelaide
 Sergey Polyakovsky , University of Adelaide
 Tat-Jun Chin , University of Adelaide
 Zbigniew Michalewicz , University of Adelaide
+Da Yan , University of Alabama at Birmingham
+Jeremy Blackburn , University of Alabama at Birmingham
+Nitesh Saxena , University of Alabama at Birmingham
+Ragib Hasan , University of Alabama at Birmingham
 Abram Hindle , University of Alberta
 Anup Basu , University of Alberta
 Csaba Szepesvári , University of Alberta

--- a/filter.xq
+++ b/filter.xq
@@ -20,6 +20,7 @@
 //inproceedings[booktitle="IJCAI"],
 //inproceedings[booktitle="WWW"],
 //inproceedings[booktitle="SIGIR"],
+//inproceedings[booktitle="ICWSM"],
 //inproceedings[booktitle="IEEE Visualization"],
 //inproceedings[booktitle="VR"],
 //article[journal="IEEE Trans. Vis. Comput. Graph."],

--- a/generated-author-info.csv
+++ b/generated-author-info.csv
@@ -62,6 +62,7 @@ A. Udaya Shankar,University of Maryland - College Park,mobile,,1.0,0.2,2006
 A. Udaya Shankar,University of Maryland - College Park,sec,,1.0,0.333333333333,1991
 A. W. Roscoe,University of Oxford,log,,1.0,0.142857142857,2012
 A. W. Roscoe,University of Oxford,sec,,1.0,1.0,1995
+Aaditeshwar Seth,IIT Delhi,ir,,1.0,0.5,2008
 Aaditeshwar Seth,IIT Delhi,mobile,,1.0,0.2,2006
 Aaron Bobick,Georgia Institute of Technology,robotics,,1.0,0.142857142857,2012
 Aaron Bobick,Georgia Institute of Technology,robotics,,1.0,0.25,2016
@@ -86,6 +87,7 @@ Aaron C. Courville,University of Montreal,vision,eccv,1.0,0.2,2012
 Aaron C. Courville,University of Montreal,vision,iccv,1.0,0.142857142857,2015
 Aaron Clauset,University of Colorado Boulder,act,,1.0,0.25,2005
 Aaron Clauset,University of Colorado Boulder,ai,aaai,1.0,0.5,2015
+Aaron Clauset,University of Colorado Boulder,ir,,1.0,0.25,2013
 Aaron Clauset,University of Colorado Boulder,ir,,1.0,0.333333333333,2016
 Aaron F. Bobick,Georgia Institute of Technology,ai,aaai,1.0,0.5,1999
 Aaron F. Bobick,Georgia Institute of Technology,chi,,1.0,0.333333333333,1997
@@ -120,6 +122,7 @@ Aaron J. Elmore,University of Chicago,mod,,1.0,0.166666666667,2013
 Aaron J. Elmore,University of Chicago,mod,,1.0,0.125,2014
 Aaron J. Elmore,University of Chicago,mod,,1.0,0.166666666667,2015
 Aaron J. Elmore,University of Chicago,mod,,2.0,0.333333333333,2016
+Aaron J. Elmore,University of Chicago,mod,,1.0,0.2,2017
 Aaron Leon Roth,University of Pennsylvania,act,,1.0,0.166666666667,2015
 Aaron Roth,University of Pennsylvania,act,,2.0,0.583333333333,2008
 Aaron Roth,University of Pennsylvania,act,,3.0,0.95,2010
@@ -459,6 +462,7 @@ Adam D. Smith,Pennsylvania State University,mlmining,,1.0,0.25,2010
 Adam D. Smith,Pennsylvania State University,mlmining,,1.0,0.5,2013
 Adam D. Smith,Pennsylvania State University,mlmining,,1.0,0.333333333333,2015
 Adam D. Smith,Pennsylvania State University,mod,,1.0,0.25,2011
+Adam D. Smith,Pennsylvania State University,sec,,1.0,0.333333333333,2017
 Adam Doupé,Arizona State University,sec,,1.0,0.25,2011
 Adam Doupé,Arizona State University,sec,,1.0,0.25,2012
 Adam Doupé,Arizona State University,sec,,1.0,0.166666666667,2013
@@ -605,6 +609,7 @@ Aditya Bhaskara,University of Utah,act,,1.0,0.2,2016
 Aditya Bhaskara,University of Utah,ir,,1.0,0.333333333333,2015
 Aditya Bhaskara,University of Utah,mlmining,,2.0,0.5,2014
 Aditya Bhaskara,University of Utah,mlmining,,2.0,0.416666666667,2016
+Aditya G. Parameswaran,University of Illinois at Urbana-Champaign,ir,,1.0,0.333333333333,2009
 Aditya G. Parameswaran,University of Illinois at Urbana-Champaign,mlmining,,2.0,0.583333333333,2012
 Aditya G. Parameswaran,University of Illinois at Urbana-Champaign,mlmining,,1.0,0.333333333333,2013
 Aditya G. Parameswaran,University of Illinois at Urbana-Champaign,mlmining,,1.0,0.25,2015
@@ -615,7 +620,7 @@ Aditya G. Parameswaran,University of Illinois at Urbana-Champaign,mod,,2.0,0.5,2
 Aditya G. Parameswaran,University of Illinois at Urbana-Champaign,mod,,2.0,0.666666666667,2014
 Aditya G. Parameswaran,University of Illinois at Urbana-Champaign,mod,,4.0,0.816666666667,2015
 Aditya G. Parameswaran,University of Illinois at Urbana-Champaign,mod,,3.0,0.7,2016
-Aditya G. Parameswaran,University of Illinois at Urbana-Champaign,mod,,2.0,0.45,2017
+Aditya G. Parameswaran,University of Illinois at Urbana-Champaign,mod,,3.0,0.65,2017
 Aditya Kanade,IISc Bangalore,ai,aaai,1.0,0.25,2017
 Aditya Kanade,IISc Bangalore,bed,,1.0,0.25,2008
 Aditya Kanade,IISc Bangalore,log,,1.0,0.333333333333,2008
@@ -743,6 +748,7 @@ Adriana Iamnitchi,University of South Florida,hpc,,2.0,0.5,2006
 Adriana Iamnitchi,University of South Florida,hpc,,1.0,0.5,2008
 Adriana Iamnitchi,University of South Florida,ir,,1.0,0.142857142857,2012
 Adriana Iamnitchi,University of South Florida,ir,,1.0,0.2,2015
+Adriana Iamnitchi,University of South Florida,ir,,1.0,0.25,2016
 Adriana Iamnitchi,University of South Florida,mobile,,1.0,0.2,2013
 Adwait Jog,College of William and Mary,arch,,2.0,0.267857142857,2013
 Adwait Jog,College of William and Mary,arch,,1.0,0.125,2014
@@ -1025,6 +1031,7 @@ Alan H. Barr,California Institute of Technology,vis,,1.0,0.25,2001
 Alan H. Barr,California Institute of Technology,vis,,1.0,0.5,2002
 Alan H. Barr,California Institute of Technology,vis,,1.0,0.5,2003
 Alan H. Barr,California Institute of Technology,vision,cvpr,1.0,1.0,1991
+Alan Hanjalic,TU Delft,ir,,1.0,0.25,2011
 Alan Hanjalic,TU Delft,ir,,2.0,0.366666666667,2012
 Alan Hanjalic,TU Delft,vision,cvpr,1.0,0.333333333333,2015
 Alan J. Hu,University of British Columbia,ai,aaai,1.0,0.25,2015
@@ -1093,7 +1100,10 @@ Alan Mislove,Northeastern University,comm,,1.0,0.25,2008
 Alan Mislove,Northeastern University,comm,,1.0,0.25,2010
 Alan Mislove,Northeastern University,comm,,1.0,0.333333333333,2011
 Alan Mislove,Northeastern University,ir,,1.0,0.333333333333,2009
+Alan Mislove,Northeastern University,ir,,1.0,0.2,2011
+Alan Mislove,Northeastern University,ir,,1.0,0.166666666667,2012
 Alan Mislove,Northeastern University,ir,,2.0,0.47619047619,2013
+Alan Mislove,Northeastern University,ir,,2.0,0.47619047619,2014
 Alan Mislove,Northeastern University,ir,,1.0,0.333333333333,2016
 Alan Mislove,Northeastern University,metrics,,1.0,0.25,2011
 Alan Mislove,Northeastern University,metrics,,2.0,0.342857142857,2014
@@ -1105,6 +1115,7 @@ Alan Mislove,Northeastern University,ops,,1.0,0.25,2013
 Alan Mislove,Northeastern University,ops,,1.0,0.166666666667,2016
 Alan Mislove,Northeastern University,sec,,1.0,0.142857142857,2014
 Alan Mislove,Northeastern University,sec,,1.0,0.142857142857,2016
+Alan Mislove,Northeastern University,sec,,1.0,0.166666666667,2017
 Alan Mycroft,University of Cambridge,plan,,1.0,0.5,1986
 Alan Mycroft,University of Cambridge,plan,,1.0,0.5,2017
 Alan Paul Fern,Oregon State University,ai,aaai,1.0,0.25,2014
@@ -1786,6 +1797,7 @@ Alexander Russell,University of Connecticut,crypt,,1.0,0.333333333333,2011
 Alexander Russell,University of Connecticut,crypt,,1.0,0.5,2017
 Alexander Russell,University of Connecticut,mlmining,,1.0,0.2,2002
 Alexander Schill,TU Dresden,comm,,1.0,0.333333333333,1997
+Alexander Schill,TU Dresden,ir,,2.0,0.45,2011
 Alexander Schliep,Rutgers University,bio,,1.0,0.333333333333,2003
 Alexander Schliep,Rutgers University,bio,,2.0,0.533333333333,2004
 Alexander Schliep,Rutgers University,bio,,2.0,1.0,2006
@@ -2033,6 +2045,7 @@ Alfonso Fuggetta,Politecnico di Milano,soft,,1.0,0.333333333333,1998
 Alfred Kobsa,University of California - Irvine,chi,,1.0,0.333333333333,2008
 Alfred Kobsa,University of California - Irvine,chi,,2.0,0.666666666667,2013
 Alfred Kobsa,University of California - Irvine,chi,,1.0,0.333333333333,2014
+Alfred Kobsa,University of California - Irvine,ir,,1.0,0.333333333333,2012
 Alfred Krzywicki,UNSW,ai,aaai,1.0,0.142857142857,2014
 Alfred L. Brown,University of Adelaide,plan,,1.0,0.2,1981
 Alfred L. Brown,University of Adelaide,soft,,1.0,0.2,1985
@@ -3020,6 +3033,7 @@ Amy Voida,University of Colorado Boulder,chi,,1.0,0.25,2014
 Amy Voida,University of Colorado Boulder,chi,,1.0,0.5,2016
 Amy Voida,University of Colorado Boulder,chi,,2.0,0.666666666667,2017
 Amy W. Apon,Clemson University,metrics,,1.0,0.2,1993
+Amélie Marian,Rutgers University,ir,,1.0,0.5,2014
 Amélie Marian,Rutgers University,mod,,1.0,0.25,2001
 Amélie Marian,Rutgers University,mod,,1.0,0.5,2003
 Amélie Marian,Rutgers University,mod,,1.0,0.2,2005
@@ -3168,6 +3182,7 @@ Anastasia Ailamaki,EPFL,mod,,4.0,1.25,2013
 Anastasia Ailamaki,EPFL,mod,,4.0,1.33333333333,2014
 Anastasia Ailamaki,EPFL,mod,,2.0,0.533333333333,2015
 Anastasia Ailamaki,EPFL,mod,,4.0,1.11666666667,2016
+Anastasia Ailamaki,EPFL,mod,,1.0,0.2,2017
 Anastasios Sidiropoulos,Ohio State University,act,,3.0,0.559523809524,2005
 Anastasios Sidiropoulos,Ohio State University,act,,1.0,0.333333333333,2007
 Anastasios Sidiropoulos,Ohio State University,act,,2.0,0.7,2008
@@ -3245,6 +3260,7 @@ Andrea C. Arpaci-Dusseau,University of Wisconsin - Madison,comm,,1.0,0.111111111
 Andrea C. Arpaci-Dusseau,University of Wisconsin - Madison,hpc,,1.0,0.2,2001
 Andrea C. Arpaci-Dusseau,University of Wisconsin - Madison,hpc,,1.0,0.125,2002
 Andrea C. Arpaci-Dusseau,University of Wisconsin - Madison,hpc,,1.0,0.2,2003
+Andrea C. Arpaci-Dusseau,University of Wisconsin - Madison,hpc,,1.0,0.25,2017
 Andrea C. Arpaci-Dusseau,University of Wisconsin - Madison,metrics,,1.0,0.333333333333,1998
 Andrea C. Arpaci-Dusseau,University of Wisconsin - Madison,mod,,1.0,0.2,1997
 Andrea C. Arpaci-Dusseau,University of Wisconsin - Madison,ops,,1.0,0.5,2001
@@ -3909,6 +3925,7 @@ Angelos D. Keromytis,Columbia University,sec,,3.0,0.833333333333,2013
 Angelos D. Keromytis,Columbia University,sec,,4.0,1.06944444444,2014
 Angelos D. Keromytis,Columbia University,sec,,2.0,0.45,2015
 Angelos D. Keromytis,Columbia University,sec,,4.0,1.28333333333,2016
+Angelos D. Keromytis,Columbia University,sec,,2.0,0.4,2017
 Angelos Stavrou,George Mason University,ir,,1.0,0.25,2015
 Angelos Stavrou,George Mason University,ops,,1.0,0.25,2007
 Angelos Stavrou,George Mason University,sec,,1.0,0.166666666667,2003
@@ -3939,6 +3956,7 @@ Aniket Kate,Purdue University,ops,,1.0,0.142857142857,2015
 Aniket Kate,Purdue University,sec,,1.0,0.25,2012
 Aniket Kate,Purdue University,sec,,1.0,0.25,2014
 Aniket Kate,Purdue University,sec,,1.0,0.333333333333,2015
+Aniket Kate,Purdue University,sec,,1.0,0.142857142857,2017
 Aniket Kittur,Carnegie Mellon University,ai,ijcai,1.0,0.2,2016
 Aniket Kittur,Carnegie Mellon University,chi,,1.0,0.25,2007
 Aniket Kittur,Carnegie Mellon University,chi,,1.0,0.333333333333,2009
@@ -3948,6 +3966,7 @@ Aniket Kittur,Carnegie Mellon University,chi,,2.0,0.833333333333,2012
 Aniket Kittur,Carnegie Mellon University,chi,,2.0,0.4,2013
 Aniket Kittur,Carnegie Mellon University,chi,,5.0,1.83333333333,2014
 Aniket Kittur,Carnegie Mellon University,chi,,4.0,1.08333333333,2016
+Aniket Kittur,Carnegie Mellon University,ir,,1.0,0.166666666667,2011
 Aniket Mahanti,University of Auckland,ir,,1.0,0.2,2008
 Anil K. Jain,Michigan State University,mlmining,,1.0,0.333333333333,2002
 Anil K. Jain,Michigan State University,mlmining,,1.0,0.333333333333,2007
@@ -4018,6 +4037,7 @@ Anil Vullikanti,Virginia Tech,comm,,1.0,0.333333333333,2016
 Anil Vullikanti,Virginia Tech,hpc,,1.0,0.25,2016
 Anil Vullikanti,Virginia Tech,mlmining,,1.0,0.0333333333333,2014
 Anil Vullikanti,Virginia Tech,mlmining,,1.0,0.0555555555556,2016
+Animesh Mukherjee,IIT Kharagpur,ir,,1.0,0.333333333333,2015
 Animesh Mukherjee,IIT Kharagpur,mlmining,,1.0,0.2,2014
 Animesh Mukherjee,IIT Kharagpur,mlmining,,1.0,0.25,2015
 Animesh Mukherjee,IIT Kharagpur,nlp,,1.0,0.25,2006
@@ -4625,6 +4645,9 @@ Anupam Gupta,Carnegie Mellon University,comm,,1.0,0.333333333333,2003
 Anupam Gupta,Carnegie Mellon University,mlmining,,1.0,0.25,2007
 Anupam Joshi,University of Maryland - Baltimore County,ai,aaai,1.0,0.2,2006
 Anupam Joshi,University of Maryland - Baltimore County,ir,,1.0,0.111111111111,2006
+Anupam Joshi,University of Maryland - Baltimore County,ir,,3.0,0.616666666667,2007
+Anupam Joshi,University of Maryland - Baltimore County,ir,,3.0,0.833333333333,2008
+Anupam Joshi,University of Maryland - Baltimore County,ir,,1.0,0.166666666667,2012
 Anurag Mittal,IIT Madras,mlmining,,1.0,0.333333333333,2016
 Anurag Mittal,IIT Madras,vision,cvpr,1.0,0.5,2000
 Anurag Mittal,IIT Madras,vision,cvpr,1.0,0.5,2004
@@ -4659,6 +4682,7 @@ Apostolos Gerasoulis,Rutgers University,hpc,,1.0,0.5,1992
 Apu Kapadia,Indiana University,chi,,2.0,0.416666666667,2014
 Apu Kapadia,Indiana University,chi,,2.0,0.45,2015
 Apu Kapadia,Indiana University,chi,,1.0,0.2,2016
+Apu Kapadia,Indiana University,ir,,1.0,0.142857142857,2016
 Apu Kapadia,Indiana University,mobile,,1.0,0.166666666667,2008
 Apu Kapadia,Indiana University,sec,,1.0,0.333333333333,2004
 Apu Kapadia,Indiana University,sec,,1.0,0.25,2007
@@ -4747,6 +4771,9 @@ Ari Juels,Cornell University,sec,,4.0,0.9,2015
 Ari Juels,Cornell University,sec,,4.0,0.933333333333,2016
 Ari Rappoport,Hebrew University of Jerusalem,graph,,1.0,0.5,1997
 Ari Rappoport,Hebrew University of Jerusalem,graph,,1.0,0.5,1998
+Ari Rappoport,Hebrew University of Jerusalem,ir,,1.0,0.5,2009
+Ari Rappoport,Hebrew University of Jerusalem,ir,,1.0,0.333333333333,2010
+Ari Rappoport,Hebrew University of Jerusalem,ir,,1.0,0.333333333333,2013
 Ari Rappoport,Hebrew University of Jerusalem,nlp,,1.0,0.5,2006
 Ari Rappoport,Hebrew University of Jerusalem,nlp,,3.0,1.33333333333,2007
 Ari Rappoport,Hebrew University of Jerusalem,nlp,,4.0,1.45,2008
@@ -5044,6 +5071,7 @@ Arunabha Sen,Arizona State University,comm,,1.0,0.5,1996
 Arunabha Sen,Arizona State University,comm,,1.0,0.333333333333,1998
 Arunabha Sen,Arizona State University,comm,,1.0,0.25,2004
 Arunabha Sen,Arizona State University,comm,,1.0,0.25,2006
+Arunabha Sen,Arizona State University,ir,,1.0,0.2,2009
 Arunava Banerjee,University of Florida,ai,ijcai,1.0,0.25,2001
 Arunava Banerjee,University of Florida,mlmining,,1.0,0.5,2002
 Arunava Banerjee,University of Florida,mlmining,,1.0,0.5,2010
@@ -5195,6 +5223,7 @@ Aslan Askarov,Aarhus University,sec,,1.0,0.5,2007
 Aslan Askarov,Aarhus University,sec,,1.0,0.333333333333,2010
 Aslan Askarov,Aarhus University,sec,,1.0,0.333333333333,2011
 Aslan Askarov,Aarhus University,sec,,2.0,0.5,2012
+Aslan Askarov,Aarhus University,sec,,1.0,0.5,2017
 Assaf Schuster,Technion - Israel Institute of Technology,arch,,1.0,0.333333333333,1989
 Assaf Schuster,Technion - Israel Institute of Technology,arch,,1.0,0.142857142857,2012
 Assaf Schuster,Technion - Israel Institute of Technology,arch,,1.0,0.333333333333,2014
@@ -5359,6 +5388,7 @@ Aviv Zohar,Hebrew University of Jerusalem,ir,,1.0,0.25,2012
 Aviv Zohar,Hebrew University of Jerusalem,metrics,,1.0,0.25,2010
 Aviv Zohar,Hebrew University of Jerusalem,mlmining,,1.0,0.2,2016
 Aviv Zohar,Hebrew University of Jerusalem,sec,,1.0,0.25,2015
+Aviv Zohar,Hebrew University of Jerusalem,sec,,1.0,0.333333333333,2017
 Avrim Blum,Carnegie Mellon University,act,,1.0,1.0,1989
 Avrim Blum,Carnegie Mellon University,act,,3.0,3.0,1990
 Avrim Blum,Carnegie Mellon University,act,,2.0,0.533333333333,1991
@@ -5450,6 +5480,7 @@ Azer Bestavros,Boston University,comm,,1.0,0.333333333333,2003
 Azer Bestavros,Boston University,comm,,2.0,0.583333333333,2005
 Azer Bestavros,Boston University,comm,,1.0,0.25,2006
 Azer Bestavros,Boston University,comm,,4.0,0.95,2007
+Azer Bestavros,Boston University,ir,,1.0,0.2,2007
 Azer Bestavros,Boston University,metrics,,1.0,0.5,1996
 Azer Bestavros,Boston University,metrics,,1.0,0.5,2002
 Azer Bestavros,Boston University,mlmining,,1.0,0.25,2013
@@ -5599,6 +5630,7 @@ Balaraman Ravindran,IIT Madras,ai,ijcai,1.0,0.5,2003
 Balaraman Ravindran,IIT Madras,ai,ijcai,3.0,1.16666666667,2007
 Balaraman Ravindran,IIT Madras,ai,ijcai,2.0,0.666666666667,2015
 Balaraman Ravindran,IIT Madras,bio,,1.0,0.25,2011
+Balaraman Ravindran,IIT Madras,ir,,1.0,0.166666666667,2012
 Balaraman Ravindran,IIT Madras,mlmining,,1.0,0.25,1998
 Balaraman Ravindran,IIT Madras,mlmining,,1.0,0.5,2003
 Balaraman Ravindran,IIT Madras,mlmining,,1.0,0.5,2008
@@ -5611,6 +5643,8 @@ Balaraman Ravindran,IIT Madras,robotics,,1.0,0.5,2014
 Baoxin Li,Arizona State University,ai,aaai,1.0,0.166666666667,2017
 Baoxin Li,Arizona State University,ai,ijcai,1.0,0.5,2009
 Baoxin Li,Arizona State University,ai,ijcai,1.0,0.5,2016
+Baoxin Li,Arizona State University,ir,,1.0,0.333333333333,2013
+Baoxin Li,Arizona State University,ir,,1.0,0.25,2015
 Baoxin Li,Arizona State University,ir,,1.0,0.125,2017
 Baoxin Li,Arizona State University,mlmining,,1.0,0.5,2012
 Baoxin Li,Arizona State University,robotics,,1.0,0.5,2006
@@ -5761,6 +5795,8 @@ Bart M. P. Jansen,TU Eindhoven,act,,1.0,0.5,2015
 Bart M. P. Jansen,TU Eindhoven,act,,1.0,0.5,2017
 Bart P. Knijnenburg,Clemson University,chi,,2.0,0.666666666667,2013
 Bart P. Knijnenburg,Clemson University,chi,,1.0,0.333333333333,2014
+Bart P. Knijnenburg,Clemson University,ir,,1.0,0.333333333333,2012
+Bart P. Knijnenburg,Clemson University,ir,,1.0,0.333333333333,2015
 Bart Selman,Cornell University,ai,aaai,1.0,0.5,1990
 Bart Selman,Cornell University,ai,aaai,1.0,0.5,1991
 Bart Selman,Cornell University,ai,aaai,3.0,1.16666666667,1992
@@ -5838,6 +5874,7 @@ Barton P. Miller,University of Wisconsin - Madison,plan,,1.0,0.333333333333,2000
 Barton P. Miller,University of Wisconsin - Madison,sec,,1.0,0.333333333333,2002
 Barton P. Miller,University of Wisconsin - Madison,sec,,1.0,0.333333333333,2005
 Barton P. Miller,University of Wisconsin - Madison,sec,,1.0,0.333333333333,2006
+Barzan Mozafari,University of Michigan,ir,,1.0,0.333333333333,2007
 Barzan Mozafari,University of Michigan,mod,,1.0,0.5,2009
 Barzan Mozafari,University of Michigan,mod,,1.0,0.333333333333,2010
 Barzan Mozafari,University of Michigan,mod,,1.0,0.333333333333,2012
@@ -6001,8 +6038,10 @@ Ben Y. Zhao,University of Chicago,comm,,1.0,0.125,2016
 Ben Y. Zhao,University of Chicago,ir,,1.0,0.166666666667,2010
 Ben Y. Zhao,University of Chicago,ir,,1.0,0.142857142857,2012
 Ben Y. Zhao,University of Chicago,ir,,1.0,0.2,2013
+Ben Y. Zhao,University of Chicago,ir,,1.0,0.166666666667,2014
 Ben Y. Zhao,University of Chicago,ir,,1.0,0.125,2015
-Ben Y. Zhao,University of Chicago,ir,,1.0,0.142857142857,2017
+Ben Y. Zhao,University of Chicago,ir,,1.0,0.25,2016
+Ben Y. Zhao,University of Chicago,ir,,3.0,0.452380952381,2017
 Ben Y. Zhao,University of Chicago,metrics,,3.0,0.509523809524,2010
 Ben Y. Zhao,University of Chicago,metrics,,2.0,0.366666666667,2011
 Ben Y. Zhao,University of Chicago,metrics,,1.0,0.142857142857,2012
@@ -6034,6 +6073,7 @@ Benedikt Schmidt,IMDEA Software Institute,sec,,1.0,0.142857142857,2013
 Benedikt Schmidt,IMDEA Software Institute,sec,,1.0,0.25,2014
 Benedikt Schmidt,IMDEA Software Institute,sec,,1.0,0.333333333333,2015
 Benedikt Schmidt,IMDEA Software Institute,sec,,1.0,0.25,2016
+Benedikt Schmidt,IMDEA Software Institute,sec,,1.0,0.166666666667,2017
 Beng Chin Ooi,National University of Singapore,mlmining,,1.0,0.25,2015
 Beng Chin Ooi,National University of Singapore,mod,,2.0,0.666666666667,1992
 Beng Chin Ooi,National University of Singapore,mod,,1.0,0.333333333333,1994
@@ -6353,6 +6393,7 @@ Benyuan Liu,University of Massachusetts Lowell,comm,,1.0,0.2,2011
 Benyuan Liu,University of Massachusetts Lowell,comm,,2.0,0.45,2012
 Benyuan Liu,University of Massachusetts Lowell,comm,,1.0,0.2,2013
 Benyuan Liu,University of Massachusetts Lowell,comm,,1.0,0.2,2016
+Benyuan Liu,University of Massachusetts Lowell,ir,,1.0,0.2,2014
 Benyuan Liu,University of Massachusetts Lowell,metrics,,1.0,0.25,2004
 Benyuan Liu,University of Massachusetts Lowell,mobile,,1.0,0.166666666667,2009
 Benyuan Liu,University of Massachusetts Lowell,sec,,1.0,0.166666666667,2014
@@ -6521,6 +6562,7 @@ Bernhard Schölkopf,Max Planck Institute,ai,ijcai,1.0,0.333333333333,2015
 Bernhard Schölkopf,Max Planck Institute,bio,,1.0,0.333333333333,2005
 Bernhard Schölkopf,Max Planck Institute,bio,,1.0,0.166666666667,2006
 Bernhard Schölkopf,Max Planck Institute,bio,,1.0,0.333333333333,2010
+Bernhard Schölkopf,Max Planck Institute,ir,,1.0,0.333333333333,2014
 Bernhard Schölkopf,Max Planck Institute,ir,,1.0,0.166666666667,2017
 Bernhard Schölkopf,Max Planck Institute,mlmining,,1.0,0.333333333333,1995
 Bernhard Schölkopf,Max Planck Institute,mlmining,,1.0,0.5,1996
@@ -6743,6 +6785,7 @@ Bill Tomlinson,University of California - Irvine,chi,,1.0,0.333333333333,2010
 Bill Tomlinson,University of California - Irvine,chi,,1.0,0.5,2011
 Bill Tomlinson,University of California - Irvine,chi,,1.0,0.2,2012
 Bill Tomlinson,University of California - Irvine,graph,,2.0,0.333333333333,2002
+Bill Tomlinson,University of California - Irvine,ir,,2.0,0.833333333333,2008
 Bin Ma,University of Waterloo,act,,2.0,0.533333333333,1999
 Bin Ma,University of Waterloo,act,,1.0,0.333333333333,2000
 Bin Ma,University of Waterloo,act,,1.0,0.2,2003
@@ -6786,6 +6829,7 @@ Bing Liu 0001,University of Illinois at Chicago,ir,,1.0,0.333333333333,2003
 Bing Liu 0001,University of Illinois at Chicago,ir,,2.0,0.833333333333,2005
 Bing Liu 0001,University of Illinois at Chicago,ir,,1.0,0.5,2006
 Bing Liu 0001,University of Illinois at Chicago,ir,,1.0,0.333333333333,2012
+Bing Liu 0001,University of Illinois at Chicago,ir,,2.0,0.416666666667,2013
 Bing Liu 0001,University of Illinois at Chicago,ir,,1.0,0.333333333333,2016
 Bing Liu 0001,University of Illinois at Chicago,ir,,1.0,0.142857142857,2017
 Bing Liu 0001,University of Illinois at Chicago,mlmining,,1.0,0.333333333333,1997
@@ -7066,6 +7110,7 @@ Bogdan Warinschi,University of Bristol,sec,,1.0,0.25,2012
 Bogdan Warinschi,University of Bristol,sec,,2.0,0.583333333333,2013
 Bogdan Warinschi,University of Bristol,sec,,1.0,0.2,2015
 Bogdan Warinschi,University of Bristol,sec,,1.0,0.25,2016
+Bogdan Warinschi,University of Bristol,sec,,1.0,0.166666666667,2017
 Boi Faltings,EPFL,ai,aaai,1.0,0.333333333333,2000
 Boi Faltings,EPFL,ai,aaai,2.0,0.833333333333,2005
 Boi Faltings,EPFL,ai,aaai,3.0,1.33333333333,2006
@@ -7327,6 +7372,7 @@ Brendan Juba,Washington University in St. Louis,ai,aaai,1.0,1.0,2016
 Brendan Juba,Washington University in St. Louis,ai,ijcai,1.0,1.0,2013
 Brendan Juba,Washington University in St. Louis,mlmining,,1.0,1.0,2006
 Brendan McCane,University of Otago,vision,cvpr,1.0,0.333333333333,1999
+Brendan O'Connor,University of Massachusetts Amherst,ir,,2.0,0.583333333333,2010
 Brendan O'Connor,University of Massachusetts Amherst,ir,,1.0,0.25,2017
 Brendan O'Connor,University of Massachusetts Amherst,nlp,,1.0,0.25,2008
 Brendan O'Connor,University of Massachusetts Amherst,nlp,,1.0,0.25,2010
@@ -7462,7 +7508,10 @@ Brian Demsky,University of California - Irvine,soft,,1.0,0.5,2005
 Brian Demsky,University of California - Irvine,soft,,1.0,0.5,2010
 Brian Demsky,University of California - Irvine,soft,,1.0,0.5,2017
 Brian Keegan,University of Colorado Boulder,chi,,1.0,0.166666666667,2015
-Brian Keegan,University of Colorado Boulder,ir,,1.0,0.25,2013
+Brian Keegan,University of Colorado Boulder,ir,,1.0,0.2,2011
+Brian Keegan,University of Colorado Boulder,ir,,2.0,0.45,2013
+Brian Keegan,University of Colorado Boulder,ir,,1.0,0.25,2014
+Brian Keegan,University of Colorado Boulder,ir,,1.0,0.5,2017
 Brian Mak,Hong Kong University of Science and Technology,mlmining,,1.0,0.333333333333,2003
 Brian Murphy,CUNY,crypt,,1.0,0.0588235294118,2000
 Brian Murphy,CUNY,nlp,,1.0,0.333333333333,2009
@@ -7637,6 +7686,7 @@ Bruce M. Maggs,Duke University,metrics,,1.0,0.166666666667,2016
 Bruce M. Maggs,Duke University,mod,,1.0,0.166666666667,2006
 Bruce M. Maggs,Duke University,mod,,1.0,0.142857142857,2008
 Bruce M. Maggs,Duke University,sec,,1.0,0.142857142857,2016
+Bruce M. Maggs,Duke University,sec,,1.0,0.166666666667,2017
 Bruce MacDowell Maggs,Duke University,metrics,,1.0,0.142857142857,2014
 Bruce MacDowell Maggs,Duke University,metrics,,1.0,0.142857142857,2016
 Bruce N. Walker,Georgia Institute of Technology,robotics,,1.0,0.25,2004
@@ -7701,9 +7751,6 @@ Bruno F. Ribeiro,Purdue University,metrics,,1.0,0.2,2012
 Bruno F. Ribeiro,Purdue University,metrics,,2.0,0.583333333333,2016
 Bruno Martins,Universidade de Lisboa,chi,,1.0,0.333333333333,2012
 Bruno Martins,Universidade de Lisboa,nlp,,1.0,0.333333333333,2015
-Bruno Ribeiro,Purdue University,ir,,1.0,1.0,2014
-Bruno Ribeiro,Purdue University,ir,,1.0,0.333333333333,2015
-Bruno Ribeiro,Purdue University,ir,,1.0,0.25,2016
 Bruno Salvy,Ecole Normale Superieure de Lyon,act,,1.0,0.166666666667,2007
 Bruno Sinopoli,Carnegie Mellon University,bed,,1.0,0.333333333333,2009
 Bruno Sinopoli,Carnegie Mellon University,bed,,1.0,0.25,2015
@@ -7731,12 +7778,14 @@ Bryan Ford,EPFL,sec,,1.0,0.2,2007
 Bryan Ford,EPFL,sec,,1.0,0.5,2010
 Bryan Ford,EPFL,sec,,3.0,0.916666666667,2013
 Bryan Ford,EPFL,sec,,2.0,0.277777777778,2016
+Bryan Ford,EPFL,sec,,1.0,0.125,2017
 Bryan Kian Hsiang Low,National University of Singapore,mlmining,,1.0,0.25,2014
 Bryan Kian Hsiang Low,National University of Singapore,mlmining,,1.0,0.333333333333,2015
 Bryan Kian Hsiang Low,National University of Singapore,mlmining,,1.0,0.333333333333,2016
 Bryan Minor,Washington State University,mlmining,,1.0,0.333333333333,2015
 Bryan Ng,Victoria University of Wellington,chi,,1.0,0.2,2016
 Bryan Pardo,Northwestern University,ai,aaai,1.0,0.5,2005
+Bryan Pardo,Northwestern University,ir,,1.0,0.333333333333,2009
 Bryan Parno,Carnegie Mellon University,arch,,1.0,0.2,2008
 Bryan Parno,Carnegie Mellon University,comm,,1.0,0.166666666667,2007
 Bryan Parno,Carnegie Mellon University,comm,,1.0,0.333333333333,2013
@@ -7765,6 +7814,7 @@ Bryan S. Morse,Brigham Young University,vision,cvpr,1.0,0.25,2009
 Bryan S. Morse,Brigham Young University,vision,cvpr,2.0,0.666666666667,2010
 Bryan S. Morse,Brigham Young University,vision,iccv,1.0,0.333333333333,2009
 Bu-Sung Lee,Nanyang Technological University,hpc,,1.0,0.25,2014
+Bu-Sung Lee,Nanyang Technological University,ir,,1.0,0.5,2011
 Bu-Sung Lee,Nanyang Technological University,ir,,1.0,0.142857142857,2012
 Bud Mishra,New York University,bed,,1.0,0.125,1991
 Bud Mishra,New York University,bio,,1.0,0.5,1998
@@ -8012,6 +8062,7 @@ Calton Pu,Georgia Institute of Technology,bed,,1.0,0.333333333333,2004
 Calton Pu,Georgia Institute of Technology,bio,,1.0,0.25,1994
 Calton Pu,Georgia Institute of Technology,hpc,,1.0,0.2,1992
 Calton Pu,Georgia Institute of Technology,hpc,,2.0,0.325,2015
+Calton Pu,Georgia Institute of Technology,ir,,1.0,0.333333333333,2010
 Calton Pu,Georgia Institute of Technology,mobile,,1.0,0.2,2000
 Calton Pu,Georgia Institute of Technology,mod,,1.0,1.0,1985
 Calton Pu,Georgia Institute of Technology,mod,,1.0,0.333333333333,1988
@@ -8286,6 +8337,9 @@ Carolyn Penstein Rosé,Carnegie Mellon University,ai,ijcai,1.0,0.2,2007
 Carolyn Penstein Rosé,Carnegie Mellon University,chi,,2.0,0.392857142857,2006
 Carolyn Penstein Rosé,Carnegie Mellon University,chi,,2.0,0.5,2007
 Carolyn Penstein Rosé,Carnegie Mellon University,chi,,1.0,0.333333333333,2017
+Carolyn Penstein Rosé,Carnegie Mellon University,ir,,1.0,0.25,2008
+Carolyn Penstein Rosé,Carnegie Mellon University,ir,,2.0,0.309523809524,2012
+Carolyn Penstein Rosé,Carnegie Mellon University,ir,,1.0,0.333333333333,2014
 Carolyn Penstein Rosé,Carnegie Mellon University,nlp,,1.0,0.25,1995
 Carolyn Penstein Rosé,Carnegie Mellon University,nlp,,1.0,0.5,1998
 Carolyn Penstein Rosé,Carnegie Mellon University,nlp,,1.0,0.25,2003
@@ -8360,6 +8414,7 @@ Cas J. F. Cremers,University of Oxford,sec,,1.0,0.25,2012
 Cas J. F. Cremers,University of Oxford,sec,,1.0,0.166666666667,2014
 Cas J. F. Cremers,University of Oxford,soft,,1.0,0.166666666667,2015
 Casey Fiesler,University of Colorado Boulder,chi,,1.0,0.333333333333,2016
+Casey Fiesler,University of Colorado Boulder,ir,,1.0,0.5,2017
 Casey Kennington,Boise State University,nlp,,2.0,0.75,2015
 Casey Kennington,Boise State University,nlp,,1.0,0.333333333333,2016
 Casimir A. Kulikowski,Rutgers University,ai,ijcai,3.0,0.97619047619,1977
@@ -8396,7 +8451,10 @@ Ce Zhang,ETH Zurich,nlp,,1.0,0.333333333333,2013
 Cecilia Mascolo,University of Cambridge,chi,,1.0,0.166666666667,2010
 Cecilia Mascolo,University of Cambridge,chi,,1.0,0.25,2013
 Cecilia Mascolo,University of Cambridge,chi,,1.0,0.142857142857,2014
-Cecilia Mascolo,University of Cambridge,ir,,1.0,0.25,2011
+Cecilia Mascolo,University of Cambridge,ir,,3.0,0.75,2011
+Cecilia Mascolo,University of Cambridge,ir,,2.0,0.4,2012
+Cecilia Mascolo,University of Cambridge,ir,,3.0,1.0,2014
+Cecilia Mascolo,University of Cambridge,ir,,1.0,0.333333333333,2015
 Cecilia Mascolo,University of Cambridge,ir,,1.0,0.2,2016
 Cecilia Mascolo,University of Cambridge,ir,,1.0,0.166666666667,2017
 Cecilia Mascolo,University of Cambridge,metrics,,1.0,0.333333333333,2012
@@ -9474,6 +9532,7 @@ Christo Wilson,Northeastern University,comm,,1.0,0.125,2016
 Christo Wilson,Northeastern University,ir,,1.0,0.166666666667,2010
 Christo Wilson,Northeastern University,ir,,1.0,0.142857142857,2012
 Christo Wilson,Northeastern University,ir,,1.0,0.142857142857,2013
+Christo Wilson,Northeastern University,ir,,1.0,0.142857142857,2014
 Christo Wilson,Northeastern University,ir,,2.0,0.583333333333,2016
 Christo Wilson,Northeastern University,metrics,,2.0,0.309523809524,2010
 Christo Wilson,Northeastern University,metrics,,2.0,0.366666666667,2011
@@ -9484,6 +9543,7 @@ Christo Wilson,Northeastern University,metrics,,3.0,0.72619047619,2016
 Christo Wilson,Northeastern University,ops,,1.0,0.2,2009
 Christo Wilson,Northeastern University,sec,,1.0,0.166666666667,2013
 Christo Wilson,Northeastern University,sec,,2.0,0.392857142857,2016
+Christo Wilson,Northeastern University,sec,,1.0,0.166666666667,2017
 Christof Fetzer,TU Dresden,comm,,1.0,0.2,2015
 Christof Fetzer,TU Dresden,ir,,1.0,0.2,2016
 Christof Fetzer,TU Dresden,ops,,1.0,0.5,2008
@@ -9887,12 +9947,12 @@ Christos Faloutsos,Carnegie Mellon University,chi,,1.0,0.25,2011
 Christos Faloutsos,Carnegie Mellon University,comm,,1.0,0.333333333333,1999
 Christos Faloutsos,Carnegie Mellon University,comm,,1.0,0.166666666667,2007
 Christos Faloutsos,Carnegie Mellon University,hpc,,1.0,0.333333333333,1999
-Christos Faloutsos,Carnegie Mellon University,ir,,1.0,0.25,2007
-Christos Faloutsos,Carnegie Mellon University,ir,,1.0,0.142857142857,2009
+Christos Faloutsos,Carnegie Mellon University,ir,,2.0,0.45,2007
+Christos Faloutsos,Carnegie Mellon University,ir,,2.0,0.392857142857,2009
 Christos Faloutsos,Carnegie Mellon University,ir,,1.0,0.25,2012
-Christos Faloutsos,Carnegie Mellon University,ir,,2.0,0.45,2013
+Christos Faloutsos,Carnegie Mellon University,ir,,3.0,0.783333333333,2013
 Christos Faloutsos,Carnegie Mellon University,ir,,2.0,0.583333333333,2014
-Christos Faloutsos,Carnegie Mellon University,ir,,1.0,0.333333333333,2015
+Christos Faloutsos,Carnegie Mellon University,ir,,2.0,0.583333333333,2015
 Christos Faloutsos,Carnegie Mellon University,ir,,2.0,0.583333333333,2016
 Christos Faloutsos,Carnegie Mellon University,ir,,1.0,0.333333333333,2017
 Christos Faloutsos,Carnegie Mellon University,mlmining,,2.0,0.583333333333,2001
@@ -10102,6 +10162,7 @@ Cindy Rubio-González,University of California - Davis,hpc,,1.0,0.111111111111,2
 Cindy Rubio-González,University of California - Davis,plan,,1.0,0.2,2009
 Cindy Rubio-González,University of California - Davis,soft,,1.0,0.333333333333,2015
 Cindy Rubio-González,University of California - Davis,soft,,1.0,0.1,2016
+Cindy X. Chen,University of Massachusetts Lowell,ir,,1.0,0.2,2014
 Cindy X. Chen,University of Massachusetts Lowell,mod,,1.0,0.333333333333,2013
 Cindy X. Chen,University of Massachusetts Lowell,mod,,1.0,0.25,2014
 Claire Cardie,Cornell University,ai,aaai,1.0,0.5,1991
@@ -10110,6 +10171,7 @@ Claire Cardie,Cornell University,ai,aaai,1.0,1.0,1993
 Claire Cardie,Cornell University,ai,aaai,1.0,0.5,1999
 Claire Cardie,Cornell University,ai,ijcai,1.0,0.333333333333,2007
 Claire Cardie,Cornell University,ir,,1.0,0.333333333333,2012
+Claire Cardie,Cornell University,ir,,2.0,0.583333333333,2013
 Claire Cardie,Cornell University,ir,,1.0,0.5,2014
 Claire Cardie,Cornell University,mlmining,,1.0,1.0,1993
 Claire Cardie,Cornell University,mlmining,,1.0,0.5,1997
@@ -10346,8 +10408,6 @@ Collin McMillan,University of Notre Dame,soft,,1.0,0.2,2011
 Collin McMillan,University of Notre Dame,soft,,2.0,0.533333333333,2012
 Collin McMillan,University of Notre Dame,soft,,1.0,0.2,2014
 Collin McMillan,University of Notre Dame,soft,,1.0,0.25,2017
-Cong Liu,University of Texas at Dallas,ai,aaai,1.0,0.2,2013
-Cong Liu,University of Texas at Dallas,ai,aaai,1.0,0.2,2014
 Cong Liu,University of Texas at Dallas,bed,,1.0,0.25,2005
 Cong Liu,University of Texas at Dallas,bed,,1.0,0.5,2009
 Cong Liu,University of Texas at Dallas,bed,,2.0,1.0,2010
@@ -10356,13 +10416,10 @@ Cong Liu,University of Texas at Dallas,bed,,1.0,0.166666666667,2013
 Cong Liu,University of Texas at Dallas,bed,,4.0,2.0,2014
 Cong Liu,University of Texas at Dallas,bed,,2.0,0.666666666667,2015
 Cong Liu,University of Texas at Dallas,bed,,3.0,1.0,2016
-Cong Liu,University of Texas at Dallas,comm,,1.0,0.25,2013
 Cong Liu,University of Texas at Dallas,comm,,1.0,0.166666666667,2014
-Cong Liu,University of Texas at Dallas,comm,,1.0,0.2,2015
 Cong Liu,University of Texas at Dallas,comm,,2.0,0.342857142857,2016
 Cong Liu,University of Texas at Dallas,da,,1.0,0.333333333333,2003
 Cong Liu,University of Texas at Dallas,da,,1.0,0.25,2015
-Cong Liu,University of Texas at Dallas,vision,cvpr,1.0,0.25,2013
 Connelly Barnes,University of Virginia,graph,,1.0,0.2,2007
 Connelly Barnes,University of Virginia,graph,,1.0,0.142857142857,2008
 Connelly Barnes,University of Virginia,graph,,1.0,0.25,2009
@@ -10497,9 +10554,10 @@ Cristian Danescu-Niculescu-Mizil,Cornell University,ir,,1.0,0.2,2010
 Cristian Danescu-Niculescu-Mizil,Cornell University,ir,,1.0,0.333333333333,2011
 Cristian Danescu-Niculescu-Mizil,Cornell University,ir,,1.0,0.25,2012
 Cristian Danescu-Niculescu-Mizil,Cornell University,ir,,1.0,0.2,2013
-Cristian Danescu-Niculescu-Mizil,Cornell University,ir,,1.0,0.2,2015
-Cristian Danescu-Niculescu-Mizil,Cornell University,ir,,1.0,0.25,2016
-Cristian Danescu-Niculescu-Mizil,Cornell University,ir,,2.0,0.666666666667,2017
+Cristian Danescu-Niculescu-Mizil,Cornell University,ir,,2.0,0.666666666667,2014
+Cristian Danescu-Niculescu-Mizil,Cornell University,ir,,2.0,0.533333333333,2015
+Cristian Danescu-Niculescu-Mizil,Cornell University,ir,,2.0,0.583333333333,2016
+Cristian Danescu-Niculescu-Mizil,Cornell University,ir,,4.0,1.2,2017
 Cristian Danescu-Niculescu-Mizil,Cornell University,mlmining,,1.0,0.333333333333,2014
 Cristian Danescu-Niculescu-Mizil,Cornell University,nlp,,1.0,0.333333333333,2009
 Cristian Danescu-Niculescu-Mizil,Cornell University,nlp,,1.0,0.25,2012
@@ -10538,6 +10596,7 @@ Cristina Nita-Rotaru,Northeastern University,mod,,1.0,0.142857142857,2015
 Cristina Nita-Rotaru,Northeastern University,sec,,1.0,0.5,2007
 Cristina Nita-Rotaru,Northeastern University,sec,,1.0,0.125,2012
 Cristina Nita-Rotaru,Northeastern University,sec,,1.0,0.25,2015
+Cristina Nita-Rotaru,Northeastern University,sec,,1.0,0.142857142857,2017
 Cristina Silvano,Politecnico di Milano,da,,1.0,0.25,2000
 Cristina Silvano,Politecnico di Milano,da,,1.0,0.166666666667,2002
 Cristina Silvano,Politecnico di Milano,da,,1.0,0.166666666667,2010
@@ -10641,6 +10700,11 @@ D. Michael Miller,University of Victoria,da,,2.0,0.666666666667,2003
 D. Michael Miller,University of Victoria,da,,1.0,0.333333333333,2012
 D. Scott McCrickard,Virginia Tech,chi,,1.0,0.142857142857,2003
 D. Scott McCrickard,Virginia Tech,chi,,1.0,0.2,2011
+Da Yan,University of Alabama at Birmingham,ir,,1.0,0.25,2015
+Da Yan,University of Alabama at Birmingham,mlmining,,1.0,0.166666666667,2016
+Da Yan,University of Alabama at Birmingham,mod,,1.0,0.333333333333,2011
+Da Yan,University of Alabama at Birmingham,mod,,3.0,0.666666666667,2014
+Da Yan,University of Alabama at Birmingham,mod,,1.0,0.125,2016
 Dabbala Rajagopal Reddy,Carnegie Mellon University,ai,ijcai,2.0,0.5,1973
 Dae Hyun Kim,Washington State University,da,,1.0,0.333333333333,2009
 Daehyun Kim,Washington State University,arch,,1.0,0.111111111111,2007
@@ -10756,6 +10820,7 @@ Damon McCoy,New York University,sec,,1.0,0.2,2013
 Damon McCoy,New York University,sec,,3.0,0.477777777778,2014
 Damon McCoy,New York University,sec,,1.0,0.0833333333333,2015
 Damon McCoy,New York University,sec,,2.0,0.180555555556,2016
+Damon McCoy,New York University,sec,,2.0,0.25,2017
 Dan Alistarh,IST Austria,act,,1.0,0.25,2011
 Dan Alistarh,IST Austria,act,,1.0,0.25,2012
 Dan Alistarh,IST Austria,act,,2.0,0.533333333333,2014
@@ -10825,8 +10890,9 @@ Dan Cosley,Cornell University,chi,,3.0,0.616666666667,2013
 Dan Cosley,Cornell University,chi,,1.0,0.25,2014
 Dan Cosley,Cornell University,chi,,1.0,0.25,2016
 Dan Cosley,Cornell University,ir,,1.0,0.2,2006
-Dan Cosley,Cornell University,ir,,1.0,0.5,2013
-Dan Cosley,Cornell University,ir,,1.0,0.25,2016
+Dan Cosley,Cornell University,ir,,1.0,0.2,2010
+Dan Cosley,Cornell University,ir,,2.0,0.833333333333,2013
+Dan Cosley,Cornell University,ir,,2.0,0.583333333333,2016
 Dan Cosley,Cornell University,mlmining,,1.0,0.2,2008
 Dan Cosley,Cornell University,mod,,1.0,0.333333333333,2002
 Dan Geiger,Technion - Israel Institute of Technology,act,,1.0,0.25,1994
@@ -10882,6 +10948,7 @@ Dan Halperin,Tel Aviv University,robotics,,1.0,0.5,2014
 Dan Halperin,Tel Aviv University,robotics,,5.0,2.08333333333,2015
 Dan Halperin,Tel Aviv University,robotics,,1.0,0.333333333333,2016
 Dan Hefetz,Case Western Reserve University,act,,1.0,0.25,2011
+Dan Huttenlocher,Cornell University,ir,,1.0,0.333333333333,2015
 Dan Huttenlocher,Cornell University,vision,cvpr,1.0,0.25,2011
 Dan Huttenlocher,Cornell University,vision,eccv,1.0,0.25,2012
 Dan I. Moldovan,University of Texas at Dallas,ai,aaai,1.0,0.5,1990
@@ -10905,6 +10972,8 @@ Dan I. Moldovan,University of Texas at Dallas,nlp,,1.0,0.5,2012
 Dan I. Moldovan,University of Texas at Dallas,nlp,,1.0,0.5,2013
 Dan Jurafsky,Stanford University,chi,,1.0,0.166666666667,2014
 Dan Jurafsky,Stanford University,ir,,1.0,0.2,2013
+Dan Jurafsky,Stanford University,ir,,1.0,0.333333333333,2014
+Dan Jurafsky,Stanford University,ir,,1.0,0.2,2017
 Dan Jurafsky,Stanford University,mlmining,,1.0,0.5,2012
 Dan Jurafsky,Stanford University,nlp,,1.0,0.5,2009
 Dan Jurafsky,Stanford University,nlp,,1.0,0.142857142857,2010
@@ -10942,6 +11011,7 @@ Dan Klein,University of California - Berkeley,nlp,,6.0,2.41666666667,2015
 Dan Klein,University of California - Berkeley,nlp,,4.0,1.41666666667,2016
 Dan Klein,University of California - Berkeley,robotics,,1.0,0.125,2013
 Dan Klein,University of California - Berkeley,vision,cvpr,1.0,0.25,2016
+Dan Knights,University of Minnesota,ir,,1.0,0.333333333333,2009
 Dan Olteanu,University of Oxford,ai,aaai,1.0,0.2,2014
 Dan Olteanu,University of Oxford,mod,,1.0,0.333333333333,2007
 Dan Olteanu,University of Oxford,mod,,1.0,0.5,2008
@@ -11068,6 +11138,7 @@ Dan Suciu,University of Washington,mod,,1.0,0.2,2013
 Dan Suciu,University of Washington,mod,,1.0,0.5,2014
 Dan Suciu,University of Washington,mod,,4.0,1.5,2015
 Dan Suciu,University of Washington,mod,,2.0,0.833333333333,2016
+Dan Suciu,University of Washington,mod,,1.0,0.333333333333,2017
 Dan Suciu,University of Washington,plan,,1.0,0.25,2017
 Dan Tsafrir,Technion - Israel Institute of Technology,arch,,1.0,0.142857142857,2012
 Dan Tsafrir,Technion - Israel Institute of Technology,arch,,1.0,0.333333333333,2014
@@ -11544,6 +11615,7 @@ Daniel J. Wigdor,University of Toronto,chi,,3.0,0.892857142857,2016
 Daniel J. Wigdor,University of Toronto,vis,,1.0,0.142857142857,2016
 Daniel Jiménez-González,Polytechnic University of Catalonia,hpc,,1.0,0.333333333333,2001
 Daniel Jurafsky,Stanford University,ai,aaai,1.0,1.0,1992
+Daniel Jurafsky,Stanford University,ir,,1.0,0.2,2011
 Daniel Jurafsky,Stanford University,mlmining,,1.0,0.5,2001
 Daniel Jurafsky,Stanford University,mlmining,,1.0,0.333333333333,2004
 Daniel Jurafsky,Stanford University,nlp,,2.0,0.833333333333,1995
@@ -11668,7 +11740,7 @@ Daniel P. Huttenlocher,Cornell University,act,,1.0,0.5,1994
 Daniel P. Huttenlocher,Cornell University,bio,,1.0,0.25,1999
 Daniel P. Huttenlocher,Cornell University,chi,,1.0,0.333333333333,2010
 Daniel P. Huttenlocher,Cornell University,ir,,1.0,0.25,2009
-Daniel P. Huttenlocher,Cornell University,ir,,1.0,0.333333333333,2010
+Daniel P. Huttenlocher,Cornell University,ir,,3.0,0.866666666667,2010
 Daniel P. Huttenlocher,Cornell University,ir,,1.0,0.25,2013
 Daniel P. Huttenlocher,Cornell University,ir,,1.0,0.25,2014
 Daniel P. Huttenlocher,Cornell University,ir,,1.0,0.2,2015
@@ -12006,6 +12078,7 @@ Danushka Bollegala,University of Liverpool,ai,ijcai,1.0,0.333333333333,2015
 Danushka Bollegala,University of Liverpool,ir,,1.0,0.333333333333,2007
 Danushka Bollegala,University of Liverpool,ir,,1.0,0.333333333333,2009
 Danushka Bollegala,University of Liverpool,ir,,1.0,0.333333333333,2010
+Danushka Bollegala,University of Liverpool,ir,,1.0,0.333333333333,2011
 Danushka Bollegala,University of Liverpool,nlp,,1.0,0.333333333333,2006
 Danushka Bollegala,University of Liverpool,nlp,,1.0,0.333333333333,2007
 Danushka Bollegala,University of Liverpool,nlp,,1.0,0.333333333333,2009
@@ -12127,6 +12200,7 @@ Dave Levin,University of Maryland - College Park,metrics,,1.0,0.142857142857,201
 Dave Levin,University of Maryland - College Park,ops,,1.0,0.166666666667,2016
 Dave Levin,University of Maryland - College Park,sec,,1.0,0.333333333333,2014
 Dave Levin,University of Maryland - College Park,sec,,2.0,0.309523809524,2016
+Dave Levin,University of Maryland - College Park,sec,,1.0,0.166666666667,2017
 Davi Geiger,New York University,mlmining,,1.0,0.5,1989
 Davi Geiger,New York University,mlmining,,1.0,0.5,1991
 Davi Geiger,New York University,mlmining,,1.0,0.5,1993
@@ -12431,6 +12505,7 @@ David Brumley,Carnegie Mellon University,sec,,4.0,1.28333333333,2012
 David Brumley,Carnegie Mellon University,sec,,4.0,1.08333333333,2013
 David Brumley,Carnegie Mellon University,sec,,3.0,0.592857142857,2014
 David Brumley,Carnegie Mellon University,sec,,1.0,0.333333333333,2015
+David Brumley,Carnegie Mellon University,sec,,1.0,0.25,2017
 David Brumley,Carnegie Mellon University,soft,,1.0,0.25,2014
 David Brumley,Carnegie Mellon University,soft,,1.0,0.333333333333,2015
 David C. Brown,Worcester Polytechnic Institute,ai,aaai,1.0,0.166666666667,2006
@@ -12468,6 +12543,7 @@ David Cash,Rutgers University,crypt,,1.0,0.5,2014
 David Cash,Rutgers University,sec,,1.0,0.333333333333,2011
 David Cash,Rutgers University,sec,,1.0,0.25,2015
 David Cash,Rutgers University,sec,,1.0,0.333333333333,2016
+David Cash,Rutgers University,sec,,1.0,0.166666666667,2017
 David Chiang,University of Notre Dame,nlp,,2.0,1.33333333333,2000
 David Chiang,University of Notre Dame,nlp,,1.0,1.0,2001
 David Chiang,University of Notre Dame,nlp,,2.0,1.16666666667,2005
@@ -12813,6 +12889,7 @@ David J. Crandall,Indiana University,chi,,1.0,0.2,2016
 David J. Crandall,Indiana University,chi,,1.0,0.333333333333,2017
 David J. Crandall,Indiana University,ir,,1.0,0.25,2009
 David J. Crandall,Indiana University,ir,,1.0,0.25,2012
+David J. Crandall,Indiana University,ir,,1.0,0.5,2013
 David J. Crandall,Indiana University,mlmining,,1.0,0.2,2008
 David J. Crandall,Indiana University,mlmining,,1.0,0.166666666667,2016
 David J. Crandall,Indiana University,vision,cvpr,1.0,0.5,2004
@@ -13048,7 +13125,8 @@ David L. Spooner,Rensselaer Polytechnic Institute,mod,,1.0,1.0,1984
 David L. Spooner,Rensselaer Polytechnic Institute,mod,,1.0,0.2,1986
 David L. Spooner,Rensselaer Polytechnic Institute,robotics,,1.0,0.333333333333,1985
 David Lazer,Northeastern University,chi,,1.0,0.25,2010
-David Lazer,Northeastern University,ir,,2.0,0.392857142857,2013
+David Lazer,Northeastern University,ir,,1.0,0.333333333333,2011
+David Lazer,Northeastern University,ir,,3.0,0.592857142857,2013
 David Lazer,Northeastern University,metrics,,1.0,0.2,2014
 David Lazer,Northeastern University,metrics,,1.0,0.2,2015
 David Lazer,Northeastern University,nlp,,1.0,0.333333333333,2015
@@ -13067,6 +13145,7 @@ David Lowe,University of Sydney,mlmining,,1.0,0.5,2002
 David Lowe,University of Sydney,vision,eccv,1.0,0.5,2006
 David M. Blei,Columbia University,ir,,1.0,0.5,2001
 David M. Blei,Columbia University,ir,,1.0,0.5,2003
+David M. Blei,Columbia University,ir,,1.0,0.5,2012
 David M. Blei,Columbia University,ir,,2.0,0.583333333333,2016
 David M. Blei,Columbia University,mlmining,,1.0,0.333333333333,2001
 David M. Blei,Columbia University,mlmining,,1.0,0.25,2003
@@ -13348,6 +13427,7 @@ David R. Choffnes,Northeastern University,metrics,,5.0,1.06904761905,2016
 David R. Choffnes,Northeastern University,mobile,,1.0,0.2,2015
 David R. Choffnes,Northeastern University,mobile,,1.0,0.2,2016
 David R. Choffnes,Northeastern University,sec,,1.0,0.142857142857,2016
+David R. Choffnes,Northeastern University,sec,,1.0,0.166666666667,2017
 David R. Karger,Massachusetts Institute of Technology,act,,1.0,0.333333333333,1991
 David R. Karger,Massachusetts Institute of Technology,act,,3.0,2.5,1993
 David R. Karger,Massachusetts Institute of Technology,act,,5.0,3.16666666667,1994
@@ -13562,6 +13642,7 @@ David W. Petr,University of Kansas,comm,,1.0,0.5,1991
 David W. Petr,University of Kansas,comm,,1.0,0.5,1993
 David W. Petr,University of Kansas,hpc,,1.0,0.25,1993
 David W. Petr,University of Kansas,hpc,,1.0,0.1,1995
+David Wagner,University of California - Berkeley,sec,,1.0,0.142857142857,2017
 David Walker,Princeton University,comm,,1.0,0.2,2012
 David Walker,Princeton University,comm,,1.0,0.2,2013
 David Walker,Princeton University,comm,,1.0,0.25,2015
@@ -13597,6 +13678,7 @@ David Wingate,Brigham Young University,mlmining,,1.0,0.25,2010
 David Wingate,Brigham Young University,mlmining,,2.0,0.5,2011
 David Wingate,Brigham Young University,mlmining,,1.0,0.25,2014
 David Yarowsky,Johns Hopkins University,ai,aaai,1.0,0.2,2016
+David Yarowsky,Johns Hopkins University,ir,,1.0,0.166666666667,2011
 David Yarowsky,Johns Hopkins University,nlp,,1.0,0.333333333333,1992
 David Yarowsky,Johns Hopkins University,nlp,,1.0,1.0,1994
 David Yarowsky,Johns Hopkins University,nlp,,1.0,1.0,1995
@@ -13726,6 +13808,7 @@ Dawson R. Engler,Stanford University,sec,,1.0,0.5,2002
 Dawson R. Engler,Stanford University,sec,,1.0,0.25,2003
 Dawson R. Engler,Stanford University,sec,,2.0,0.4,2006
 Dawson R. Engler,Stanford University,sec,,1.0,0.5,2015
+Dawson R. Engler,Stanford University,sec,,1.0,0.166666666667,2017
 Dawson R. Engler,Stanford University,soft,,1.0,0.5,2002
 Dawson R. Engler,Stanford University,soft,,1.0,0.25,2004
 DeLiang L. Wang,Ohio State University,mlmining,,1.0,0.5,1994
@@ -13963,6 +14046,7 @@ Deming Chen,University of Illinois at Urbana-Champaign,da,,2.0,0.833333333333,20
 Deming Chen,University of Illinois at Urbana-Champaign,da,,5.0,1.20833333333,2015
 Deming Chen,University of Illinois at Urbana-Champaign,da,,2.0,0.5,2016
 Denilson Barbosa,University of Alberta,ir,,1.0,0.333333333333,2003
+Denilson Barbosa,University of Alberta,ir,,1.0,0.5,2011
 Denilson Barbosa,University of Alberta,mod,,2.0,0.583333333333,2005
 Denilson Barbosa,University of Alberta,nlp,,3.0,0.866666666667,2013
 Denis Gracanin,Virginia Tech,robotics,,1.0,0.333333333333,1993
@@ -14030,6 +14114,7 @@ Dennis M. Volpano,Naval Postgraduate School,plan,,1.0,0.5,1998
 Dennis M. Volpano,Naval Postgraduate School,plan,,1.0,0.5,2000
 Dennis M. Volpano,Naval Postgraduate School,soft,,1.0,0.5,1985
 Dennis McLeod,University of Southern California,ai,ijcai,1.0,0.25,2007
+Dennis McLeod,University of Southern California,ir,,1.0,0.333333333333,2008
 Dennis McLeod,University of Southern California,mod,,1.0,0.5,1975
 Dennis McLeod,University of Southern California,mod,,1.0,0.5,1978
 Dennis McLeod,University of Southern California,mod,,1.0,0.5,1983
@@ -14097,6 +14182,11 @@ Derek Rayside,University of Waterloo,soft,,1.0,0.166666666667,2009
 Derek Rayside,University of Waterloo,soft,,1.0,0.25,2011
 Derek Rayside,University of Waterloo,soft,,1.0,0.142857142857,2015
 Derek Ruths,McGill University,chi,,1.0,0.5,2016
+Derek Ruths,McGill University,ir,,1.0,0.5,2011
+Derek Ruths,McGill University,ir,,1.0,0.333333333333,2012
+Derek Ruths,McGill University,ir,,1.0,0.5,2013
+Derek Ruths,McGill University,ir,,1.0,0.2,2015
+Derek Ruths,McGill University,ir,,1.0,0.142857142857,2016
 Derek Ruths,McGill University,nlp,,1.0,0.333333333333,2013
 Derek Ruths,McGill University,nlp,,1.0,0.25,2015
 Derek Ruths,McGill University,nlp,,1.0,0.333333333333,2016
@@ -14348,6 +14438,7 @@ Dick H. J. Epema,TU Delft,hpc,,2.0,0.416666666667,2008
 Dick H. J. Epema,TU Delft,hpc,,1.0,0.25,2009
 Dick H. J. Epema,TU Delft,hpc,,1.0,0.2,2010
 Dick H. J. Epema,TU Delft,hpc,,1.0,0.25,2011
+Dick H. J. Epema,TU Delft,hpc,,1.0,0.5,2017
 Dick H. J. Epema,TU Delft,metrics,,1.0,1.0,1995
 Dick H. J. Epema,TU Delft,metrics,,1.0,0.25,2014
 Diego Garbervetsky,University of Buenos Aires,soft,,1.0,0.25,2009
@@ -14970,6 +15061,7 @@ Don Towsley,University of Massachusetts Amherst,comm,,2.0,0.5,2013
 Don Towsley,University of Massachusetts Amherst,comm,,2.0,0.4,2014
 Don Towsley,University of Massachusetts Amherst,comm,,1.0,0.125,2015
 Don Towsley,University of Massachusetts Amherst,comm,,2.0,0.366666666667,2016
+Don Towsley,University of Massachusetts Amherst,hpc,,1.0,0.142857142857,2017
 Don Towsley,University of Massachusetts Amherst,metrics,,1.0,1.0,1983
 Don Towsley,University of Massachusetts Amherst,metrics,,1.0,0.2,2012
 Don Towsley,University of Massachusetts Amherst,metrics,,2.0,0.366666666667,2013
@@ -15072,7 +15164,7 @@ Donald Kossmann,ETH Zurich,mod,,1.0,0.333333333333,2013
 Donald Kossmann,ETH Zurich,mod,,2.0,0.5,2014
 Donald Kossmann,ETH Zurich,mod,,3.0,0.7,2015
 Donald Kossmann,ETH Zurich,mod,,1.0,0.25,2016
-Donald Kossmann,ETH Zurich,mod,,1.0,0.142857142857,2017
+Donald Kossmann,ETH Zurich,mod,,2.0,0.342857142857,2017
 Donald Kossmann,ETH Zurich,ops,,1.0,0.333333333333,2007
 Donald M. Chiarulli,University of Pittsburgh,da,,1.0,0.333333333333,1990
 Donald M. Chiarulli,University of Pittsburgh,da,,1.0,0.142857142857,1997
@@ -15135,15 +15227,13 @@ Donatella Sciuto,Politecnico di Milano,da,,1.0,0.142857142857,2012
 Donatella Sciuto,Politecnico di Milano,da,,1.0,0.166666666667,2013
 Dong Wang,University of Notre Dame,ai,aaai,1.0,0.5,2014
 Dong Wang,University of Notre Dame,ai,ijcai,1.0,0.25,2016
-Dong Wang,University of Notre Dame,bed,,1.0,0.166666666667,2010
-Dong Wang,University of Notre Dame,bed,,1.0,0.166666666667,2013
-Dong Wang,University of Notre Dame,bed,,1.0,0.2,2014
 Dong Wang,University of Notre Dame,chi,,1.0,0.333333333333,2016
 Dong Wang,University of Notre Dame,comm,,1.0,0.166666666667,2013
 Dong Wang,University of Notre Dame,comm,,1.0,0.2,2016
 Dong Wang,University of Notre Dame,da,,1.0,0.142857142857,2001
 Dong Wang,University of Notre Dame,ir,,1.0,0.142857142857,2010
 Dong Wang,University of Notre Dame,ir,,1.0,0.166666666667,2013
+Dong Wang,University of Notre Dame,ir,,1.0,0.333333333333,2016
 Dong Wang,University of Notre Dame,log,,1.0,0.25,2003
 Dong Wang,University of Notre Dame,mlmining,,1.0,0.25,2011
 Dong Wang,University of Notre Dame,mlmining,,1.0,0.2,2015
@@ -15363,6 +15453,7 @@ Dragomir R. Radev,Yale University,ir,,1.0,0.5,1995
 Dragomir R. Radev,Yale University,ir,,1.0,0.25,2000
 Dragomir R. Radev,Yale University,ir,,1.0,0.2,2002
 Dragomir R. Radev,Yale University,ir,,1.0,0.333333333333,2006
+Dragomir R. Radev,Yale University,ir,,2.0,0.75,2009
 Dragomir R. Radev,Yale University,mlmining,,1.0,0.333333333333,2010
 Dragomir R. Radev,Yale University,nlp,,1.0,1.0,1998
 Dragomir R. Radev,Yale University,nlp,,1.0,0.111111111111,2003
@@ -16006,6 +16097,7 @@ Elena Grigorescu,Purdue University,act,,1.0,0.25,2012
 Elena Grigorescu,Purdue University,act,,1.0,0.2,2013
 Elena Grigorescu,Purdue University,act,,1.0,0.333333333333,2016
 Elena Sherman,Boise State University,soft,,1.0,0.333333333333,2009
+Eleni Stroulia,University of Alberta,ir,,1.0,0.5,2009
 Eleni Stroulia,University of Alberta,mlmining,,1.0,0.333333333333,2002
 Eleni Stroulia,University of Alberta,robotics,,1.0,0.333333333333,1997
 Elham Kashefi,University of Edinburgh,act,,1.0,0.333333333333,2009
@@ -16185,6 +16277,7 @@ Elizabeth D. Mynatt,Georgia Institute of Technology,chi,,2.0,0.533333333333,2015
 Elizabeth M. Belding,University of California - Santa Barbara,comm,,1.0,0.333333333333,2008
 Elizabeth M. Belding,University of California - Santa Barbara,comm,,1.0,0.25,2016
 Elizabeth M. Belding,University of California - Santa Barbara,ir,,1.0,0.333333333333,2015
+Elizabeth M. Belding,University of California - Santa Barbara,ir,,1.0,0.333333333333,2017
 Elizabeth M. Belding,University of California - Santa Barbara,mobile,,1.0,0.25,2013
 Elizabeth M. Belding-Royer,University of California - Santa Barbara,comm,,1.0,0.333333333333,2000
 Elizabeth M. Belding-Royer,University of California - Santa Barbara,comm,,1.0,0.25,2006
@@ -16375,6 +16468,7 @@ Emil M. Petriu,University of Ottawa,robotics,,2.0,0.666666666667,1997
 Emil M. Petriu,University of Ottawa,vision,cvpr,1.0,0.333333333333,2013
 Emile A. Hendriks,TU Delft,vis,,1.0,0.125,2010
 Emile A. Hendriks,TU Delft,vision,cvpr,1.0,0.333333333333,2005
+Emiliano De Cristofaro,University College London,ir,,1.0,0.125,2017
 Emiliano De Cristofaro,University College London,metrics,,2.0,0.366666666667,2014
 Emiliano De Cristofaro,University College London,sec,,1.0,0.2,2011
 Emiliano De Cristofaro,University College London,sec,,1.0,0.25,2012
@@ -16742,7 +16836,11 @@ Eric Gilbert,Georgia Institute of Technology,chi,,2.0,0.583333333333,2013
 Eric Gilbert,Georgia Institute of Technology,chi,,3.0,0.783333333333,2014
 Eric Gilbert,Georgia Institute of Technology,chi,,4.0,2.08333333333,2015
 Eric Gilbert,Georgia Institute of Technology,chi,,1.0,0.25,2017
-Eric Gilbert,Georgia Institute of Technology,ir,,1.0,0.333333333333,2014
+Eric Gilbert,Georgia Institute of Technology,ir,,1.0,0.5,2010
+Eric Gilbert,Georgia Institute of Technology,ir,,1.0,0.5,2012
+Eric Gilbert,Georgia Institute of Technology,ir,,2.0,0.833333333333,2014
+Eric Gilbert,Georgia Institute of Technology,ir,,3.0,1.08333333333,2015
+Eric Gilbert,Georgia Institute of Technology,ir,,1.0,0.25,2017
 Eric Gilbert,Georgia Institute of Technology,nlp,,1.0,0.25,2014
 Eric J. Pauwels,CWI,vision,eccv,3.0,0.833333333333,1994
 Eric J. Pauwels,CWI,vision,eccv,1.0,0.5,2000
@@ -17072,8 +17170,8 @@ Eugene Agichtein,Emory University,ir,,1.0,0.2,2009
 Eugene Agichtein,Emory University,ir,,1.0,0.5,2010
 Eugene Agichtein,Emory University,ir,,4.0,1.14285714286,2011
 Eugene Agichtein,Emory University,ir,,3.0,0.95,2012
-Eugene Agichtein,Emory University,ir,,2.0,0.533333333333,2013
-Eugene Agichtein,Emory University,ir,,1.0,0.5,2015
+Eugene Agichtein,Emory University,ir,,3.0,0.866666666667,2013
+Eugene Agichtein,Emory University,ir,,2.0,0.833333333333,2015
 Eugene Agichtein,Emory University,ir,,1.0,0.5,2016
 Eugene Agichtein,Emory University,mlmining,,1.0,0.5,2004
 Eugene Agichtein,Emory University,mlmining,,1.0,0.5,2006
@@ -17228,6 +17326,7 @@ Evgenia Smirni,College of William and Mary,metrics,,1.0,0.333333333333,2008
 Evgenia Smirni,College of William and Mary,metrics,,1.0,0.2,2009
 Evgenia Smirni,College of William and Mary,metrics,,1.0,0.333333333333,2010
 Evimaria Terzi,Boston University,comm,,1.0,0.25,2012
+Evimaria Terzi,Boston University,ir,,1.0,0.333333333333,2012
 Evimaria Terzi,Boston University,ir,,1.0,0.25,2015
 Evimaria Terzi,Boston University,metrics,,1.0,0.25,2012
 Evimaria Terzi,Boston University,metrics,,1.0,0.333333333333,2016
@@ -17573,6 +17672,7 @@ Fei Wang,University of Connecticut,ai,aaai,1.0,0.25,2012
 Fei Wang,University of Connecticut,ai,aaai,3.0,0.491666666667,2017
 Fei Wang,University of Connecticut,ai,ijcai,1.0,0.333333333333,2013
 Fei Wang,University of Connecticut,comm,,1.0,0.142857142857,2014
+Fei Wang,University of Connecticut,ir,,1.0,0.25,2012
 Fei Wang,University of Connecticut,mlmining,,1.0,0.333333333333,2012
 Fei Wang,University of Connecticut,mlmining,,1.0,0.333333333333,2014
 Fei Wang,University of Connecticut,mlmining,,1.0,0.142857142857,2016
@@ -17676,6 +17776,7 @@ Feng Qian,Indiana University,mobile,,1.0,0.2,2016
 Feng Qian,Indiana University,mobile,,1.0,0.142857142857,2017
 Feng Qian,Indiana University,mod,,1.0,0.2,2014
 Feng Qian,Indiana University,plan,,1.0,0.2,2003
+Feng Qian,Indiana University,sec,,1.0,0.125,2017
 Feng Qin,Ohio State University,arch,,2.0,0.325,2004
 Feng Qin,Ohio State University,arch,,2.0,0.416666666667,2006
 Feng Qin,Ohio State University,arch,,1.0,0.2,2011
@@ -17998,6 +18099,7 @@ Frank S. de Boer,CWI,log,,1.0,1.0,1991
 Frank S. de Boer,CWI,log,,1.0,0.333333333333,1992
 Frank S. de Boer,CWI,log,,1.0,0.2,2015
 Frank S. de Boer,CWI,plan,,1.0,0.25,1994
+Frank Shipman,Texas A&M University,ir,,1.0,0.5,2014
 Frank Stajano,University of Cambridge,chi,,1.0,0.333333333333,2005
 Frank Stajano,University of Cambridge,sec,,1.0,0.25,2012
 Frank Tip,Northeastern University,plan,,1.0,0.333333333333,1995
@@ -18097,6 +18199,7 @@ Franziska Roesner,University of Washington,sec,,1.0,0.5,2013
 Franziska Roesner,University of Washington,sec,,2.0,0.283333333333,2014
 Franziska Roesner,University of Washington,sec,,1.0,0.25,2015
 Franziska Roesner,University of Washington,sec,,2.0,0.583333333333,2016
+Franziska Roesner,University of Washington,sec,,1.0,0.25,2017
 François Baccelli,Ecole Normale Superieure,comm,,1.0,0.333333333333,1999
 François Baccelli,Ecole Normale Superieure,comm,,1.0,0.5,2000
 François Baccelli,Ecole Normale Superieure,comm,,1.0,0.333333333333,2001
@@ -18535,7 +18638,7 @@ Gao Cong,Nanyang Technological University,mod,,2.0,0.583333333333,2013
 Gao Cong,Nanyang Technological University,mod,,2.0,0.5,2014
 Gao Cong,Nanyang Technological University,mod,,2.0,0.833333333333,2015
 Gao Cong,Nanyang Technological University,mod,,2.0,0.533333333333,2016
-Gao Cong,Nanyang Technological University,mod,,1.0,0.2,2017
+Gao Cong,Nanyang Technological University,mod,,2.0,0.45,2017
 Gao Cong,Nanyang Technological University,nlp,,1.0,0.142857142857,2007
 Gao Cong,Nanyang Technological University,nlp,,1.0,0.25,2008
 Garrett S. Rose,University of Tennessee,da,,1.0,0.25,2012
@@ -19441,7 +19544,7 @@ Gianluca De Marco,University of Salerno,act,,1.0,1.0,2008
 Gianluca Palermo,Politecnico di Milano,da,,1.0,0.166666666667,2010
 Gianluca Stringhini,University College London,ir,,1.0,0.142857142857,2013
 Gianluca Stringhini,University College London,ir,,1.0,0.111111111111,2014
-Gianluca Stringhini,University College London,ir,,1.0,0.142857142857,2017
+Gianluca Stringhini,University College London,ir,,2.0,0.267857142857,2017
 Gianluca Stringhini,University College London,metrics,,1.0,0.142857142857,2013
 Gianluca Stringhini,University College London,metrics,,1.0,0.166666666667,2014
 Gianluca Stringhini,University College London,metrics,,1.0,0.333333333333,2016
@@ -19549,6 +19652,8 @@ Gillian R. Hayes,University of California - Irvine,chi,,1.0,0.2,2013
 Gillian R. Hayes,University of California - Irvine,chi,,5.0,1.15,2014
 Gillian R. Hayes,University of California - Irvine,chi,,3.0,0.592857142857,2016
 Gillian R. Hayes,University of California - Irvine,chi,,3.0,0.67619047619,2017
+Gillian R. Hayes,University of California - Irvine,ir,,1.0,0.25,2012
+Gillian R. Hayes,University of California - Irvine,ir,,1.0,0.5,2017
 Gillian Smith,Northeastern University,chi,,1.0,1.0,2014
 Giora Slutzki,Iowa State University,act,,1.0,0.333333333333,1978
 Giora Slutzki,Iowa State University,ai,aaai,1.0,0.333333333333,2007
@@ -19619,6 +19724,8 @@ Giovanni Vigna,University of California - Santa Barbara,soft,,1.0,0.2,2015
 Girish Varma,IIIT Hyderabad,act,,1.0,0.333333333333,2012
 Girish Varma,IIIT Hyderabad,act,,1.0,0.2,2014
 Gita Reese Sukthankar,University of Central Florida,ai,aaai,1.0,0.333333333333,2015
+Gita Reese Sukthankar,University of Central Florida,ir,,1.0,0.333333333333,2010
+Gita Reese Sukthankar,University of Central Florida,ir,,1.0,0.5,2011
 Gita Sukthankar,University of Central Florida,ai,aaai,1.0,0.5,2006
 Gita Sukthankar,University of Central Florida,ai,aaai,1.0,0.5,2008
 Gita Sukthankar,University of Central Florida,ai,ijcai,1.0,0.5,2011
@@ -19653,6 +19760,8 @@ Giuseppe Carenini,University of British Columbia,ai,ijcai,1.0,0.333333333333,201
 Giuseppe Carenini,University of British Columbia,chi,,1.0,0.25,2013
 Giuseppe Carenini,University of British Columbia,chi,,1.0,0.166666666667,2014
 Giuseppe Carenini,University of British Columbia,ir,,1.0,0.333333333333,2007
+Giuseppe Carenini,University of British Columbia,ir,,1.0,0.25,2009
+Giuseppe Carenini,University of British Columbia,ir,,1.0,0.25,2011
 Giuseppe Carenini,University of British Columbia,mlmining,,1.0,0.333333333333,2005
 Giuseppe Carenini,University of British Columbia,nlp,,1.0,0.5,2000
 Giuseppe Carenini,University of British Columbia,nlp,,2.0,0.833333333333,2008
@@ -20566,6 +20675,7 @@ Gösta Grahne,Concordia University,mod,,1.0,1.0,1984
 Gösta Grahne,Concordia University,mod,,1.0,0.5,1985
 Gösta Grahne,Concordia University,mod,,1.0,0.333333333333,1987
 Günther Ruhe,University of Calgary,soft,,1.0,0.5,2007
+H. Andrew Schwartz,Stony Brook University,ir,,1.0,0.0909090909091,2013
 H. Andrew Schwartz,Stony Brook University,nlp,,1.0,0.125,2014
 H. Andrew Schwartz,Stony Brook University,nlp,,1.0,0.0909090909091,2015
 H. Andrew Schwartz,Stony Brook University,nlp,,2.0,0.375,2016
@@ -20849,8 +20959,10 @@ Haitao Zheng,University of Chicago,comm,,1.0,0.0909090909091,2015
 Haitao Zheng,University of Chicago,ir,,1.0,0.166666666667,2010
 Haitao Zheng,University of Chicago,ir,,1.0,0.142857142857,2012
 Haitao Zheng,University of Chicago,ir,,1.0,0.2,2013
+Haitao Zheng,University of Chicago,ir,,1.0,0.166666666667,2014
 Haitao Zheng,University of Chicago,ir,,1.0,0.125,2015
-Haitao Zheng,University of Chicago,ir,,1.0,0.142857142857,2017
+Haitao Zheng,University of Chicago,ir,,1.0,0.25,2016
+Haitao Zheng,University of Chicago,ir,,3.0,0.452380952381,2017
 Haitao Zheng,University of Chicago,metrics,,1.0,0.2,2010
 Haitao Zheng,University of Chicago,metrics,,1.0,0.2,2011
 Haitao Zheng,University of Chicago,metrics,,1.0,0.142857142857,2012
@@ -21074,6 +21186,7 @@ Hanna Kurniawati,University of Queensland,robotics,,2.0,0.533333333333,2011
 Hanna Kurniawati,University of Queensland,robotics,,1.0,0.333333333333,2013
 Hanna Kurniawati,University of Queensland,robotics,,1.0,0.2,2014
 Hanna Kurniawati,University of Queensland,robotics,,1.0,0.333333333333,2015
+Hannes Mühleisen,CWI,mod,,1.0,0.5,2017
 Hanoch Levy,Tel Aviv University,comm,,1.0,0.5,1989
 Hanoch Levy,Tel Aviv University,comm,,1.0,0.5,1992
 Hanoch Levy,Tel Aviv University,comm,,1.0,0.5,1993
@@ -21310,6 +21423,7 @@ Haoqi Zhang,Northwestern University,chi,,1.0,0.111111111111,2014
 Haoqi Zhang,Northwestern University,chi,,1.0,0.5,2015
 Haoqi Zhang,Northwestern University,chi,,2.0,0.7,2016
 Haoqi Zhang,Northwestern University,ir,,1.0,0.25,2012
+Haoqi Zhang,Northwestern University,ir,,1.0,0.111111111111,2014
 Harald C. Gall,University of Zurich,ir,,1.0,0.333333333333,2005
 Harald C. Gall,University of Zurich,soft,,2.0,0.4,2009
 Harald C. Gall,University of Zurich,soft,,1.0,0.25,2010
@@ -21389,6 +21503,7 @@ Hari Sundar,University of Utah,hpc,,1.0,0.333333333333,2010
 Hari Sundar,University of Utah,hpc,,1.0,0.166666666667,2012
 Hari Sundar,University of Utah,hpc,,2.0,0.666666666667,2013
 Hari Sundar,University of Utah,hpc,,1.0,0.5,2015
+Hari Sundar,University of Utah,hpc,,1.0,0.333333333333,2017
 Hari Sundar,University of Utah,vision,cvpr,1.0,0.2,2010
 Harish Karnick,IIT Kanpur,mlmining,,1.0,0.25,2013
 Harold Abelson,Massachusetts Institute of Technology,act,,1.0,1.0,1978
@@ -21540,6 +21655,7 @@ Hector Garcia-Molina,Stanford University,ir,,3.0,0.833333333333,2001
 Hector Garcia-Molina,Stanford University,ir,,1.0,0.5,2002
 Hector Garcia-Molina,Stanford University,ir,,1.0,0.333333333333,2003
 Hector Garcia-Molina,Stanford University,ir,,1.0,0.333333333333,2008
+Hector Garcia-Molina,Stanford University,ir,,1.0,0.2,2009
 Hector Garcia-Molina,Stanford University,ir,,1.0,0.5,2011
 Hector Garcia-Molina,Stanford University,ir,,1.0,0.25,2012
 Hector Garcia-Molina,Stanford University,metrics,,1.0,0.333333333333,1987
@@ -21813,6 +21929,8 @@ Henry A. Kautz,University of Rochester,ai,ijcai,1.0,0.333333333333,2013
 Henry A. Kautz,University of Rochester,ai,ijcai,1.0,0.125,2016
 Henry A. Kautz,University of Rochester,chi,,1.0,0.25,2003
 Henry A. Kautz,University of Rochester,chi,,1.0,0.111111111111,2004
+Henry A. Kautz,University of Rochester,ir,,1.0,0.333333333333,2012
+Henry A. Kautz,University of Rochester,ir,,1.0,0.2,2015
 Henry A. Kautz,University of Rochester,mlmining,,1.0,0.333333333333,2000
 Henry A. Kautz,University of Rochester,mlmining,,1.0,0.333333333333,2005
 Henry A. Kautz,University of Rochester,mlmining,,1.0,0.333333333333,2012
@@ -22329,8 +22447,9 @@ Hrishikesh B. Acharya,Rochester Institute of Technology,comm,,1.0,0.5,2011
 Hrishikesh B. Acharya,Rochester Institute of Technology,comm,,1.0,0.0769230769231,2014
 Hsin-Hsi Chen,National Taiwan University,ai,aaai,1.0,0.333333333333,2006
 Hsin-Hsi Chen,National Taiwan University,ai,aaai,1.0,0.5,2010
-Hsin-Hsi Chen,National Taiwan University,ir,,1.0,0.2,2007
+Hsin-Hsi Chen,National Taiwan University,ir,,2.0,0.7,2007
 Hsin-Hsi Chen,National Taiwan University,ir,,1.0,0.333333333333,2008
+Hsin-Hsi Chen,National Taiwan University,ir,,1.0,0.333333333333,2010
 Hsin-Hsi Chen,National Taiwan University,ir,,1.0,0.5,2015
 Hsin-Hsi Chen,National Taiwan University,nlp,,1.0,0.5,1994
 Hsin-Hsi Chen,National Taiwan University,nlp,,1.0,0.333333333333,1999
@@ -22413,10 +22532,13 @@ Huan Liu,Arizona State University,ai,ijcai,1.0,0.25,2016
 Huan Liu,Arizona State University,comm,,1.0,0.5,2005
 Huan Liu,Arizona State University,comm,,1.0,0.333333333333,2006
 Huan Liu,Arizona State University,ir,,1.0,0.2,2005
-Huan Liu,Arizona State University,ir,,1.0,0.25,2013
-Huan Liu,Arizona State University,ir,,1.0,0.333333333333,2014
-Huan Liu,Arizona State University,ir,,1.0,0.333333333333,2016
-Huan Liu,Arizona State University,ir,,1.0,0.166666666667,2017
+Huan Liu,Arizona State University,ir,,3.0,0.95,2009
+Huan Liu,Arizona State University,ir,,1.0,0.25,2011
+Huan Liu,Arizona State University,ir,,1.0,0.333333333333,2012
+Huan Liu,Arizona State University,ir,,2.0,0.5,2013
+Huan Liu,Arizona State University,ir,,2.0,0.833333333333,2014
+Huan Liu,Arizona State University,ir,,2.0,0.583333333333,2016
+Huan Liu,Arizona State University,ir,,2.0,0.416666666667,2017
 Huan Liu,Arizona State University,mlmining,,1.0,0.5,1996
 Huan Liu,Arizona State University,mlmining,,1.0,0.333333333333,2002
 Huan Liu,Arizona State University,mlmining,,2.0,1.0,2003
@@ -22540,6 +22662,7 @@ Huy L. Nguyen,Northeastern University,mlmining,,2.0,0.75,2015
 Huy L. Nguyên,Northeastern University,act,,2.0,0.583333333333,2015
 Huzefa Rangwala,George Mason University,ai,ijcai,1.0,0.5,2011
 Huzefa Rangwala,George Mason University,ai,ijcai,1.0,0.2,2013
+Huzefa Rangwala,George Mason University,ir,,1.0,0.5,2010
 Huzefa Rangwala,George Mason University,mlmining,,1.0,0.2,2012
 Huzefa Rangwala,George Mason University,mlmining,,1.0,0.25,2016
 Huzur Saran,IIT Delhi,act,,1.0,0.333333333333,1988
@@ -22800,6 +22923,7 @@ Ian T. Foster,University of Chicago,hpc,,2.0,0.3,2012
 Ian T. Foster,University of Chicago,hpc,,2.0,0.4,2013
 Ian T. Foster,University of Chicago,hpc,,2.0,0.375,2014
 Ian T. Foster,University of Chicago,hpc,,1.0,0.2,2015
+Ian T. Foster,University of Chicago,hpc,,2.0,0.392857142857,2017
 Ian T. Foster,University of Chicago,sec,,1.0,0.25,1998
 Ian Warren,University of Auckland,soft,,1.0,0.5,2004
 Iasonas Polakis,University of Illinois at Chicago,ir,,1.0,0.142857142857,2011
@@ -23221,6 +23345,7 @@ Irfan A. Essa,Georgia Institute of Technology,graph,,1.0,0.25,2000
 Irfan A. Essa,Georgia Institute of Technology,graph,,1.0,0.5,2001
 Irfan A. Essa,Georgia Institute of Technology,graph,,1.0,0.2,2003
 Irfan A. Essa,Georgia Institute of Technology,graph,,1.0,0.25,2005
+Irfan A. Essa,Georgia Institute of Technology,ir,,1.0,0.25,2017
 Irfan A. Essa,Georgia Institute of Technology,mlmining,,1.0,0.333333333333,1994
 Irfan A. Essa,Georgia Institute of Technology,mlmining,,1.0,0.5,2000
 Irfan A. Essa,Georgia Institute of Technology,mlmining,,1.0,0.0294117647059,2013
@@ -23362,6 +23487,7 @@ Ivan Beschastnikh,University of British Columbia,chi,,1.0,0.166666666667,2017
 Ivan Beschastnikh,University of British Columbia,comm,,1.0,0.2,2008
 Ivan Beschastnikh,University of British Columbia,comm,,1.0,0.142857142857,2014
 Ivan Beschastnikh,University of British Columbia,hpc,,1.0,0.5,2006
+Ivan Beschastnikh,University of British Columbia,ir,,1.0,0.333333333333,2008
 Ivan Beschastnikh,University of British Columbia,ops,,1.0,0.25,2011
 Ivan Beschastnikh,University of British Columbia,sec,,1.0,0.125,2010
 Ivan Beschastnikh,University of British Columbia,soft,,1.0,0.2,2011
@@ -23878,6 +24004,7 @@ Jagath C. Rajapakse,Nanyang Technological University,mlmining,,1.0,0.5,2000
 Jaideep Srivastava,University of Minnesota,ai,aaai,1.0,0.166666666667,2010
 Jaideep Srivastava,University of Minnesota,bed,,1.0,0.5,1991
 Jaideep Srivastava,University of Minnesota,hpc,,1.0,0.5,1997
+Jaideep Srivastava,University of Minnesota,ir,,1.0,0.2,2011
 Jaideep Srivastava,University of Minnesota,mlmining,,1.0,0.333333333333,1998
 Jaideep Srivastava,University of Minnesota,mlmining,,1.0,0.5,1999
 Jaideep Srivastava,University of Minnesota,mlmining,,1.0,0.333333333333,2002
@@ -23924,7 +24051,7 @@ Jaime G. Carbonell,Carnegie Mellon University,bio,,1.0,0.333333333333,2013
 Jaime G. Carbonell,Carnegie Mellon University,bio,,1.0,0.25,2016
 Jaime G. Carbonell,Carnegie Mellon University,ir,,1.0,0.333333333333,1998
 Jaime G. Carbonell,Carnegie Mellon University,ir,,1.0,0.25,1999
-Jaime G. Carbonell,Carnegie Mellon University,ir,,1.0,0.25,2008
+Jaime G. Carbonell,Carnegie Mellon University,ir,,2.0,0.5,2008
 Jaime G. Carbonell,Carnegie Mellon University,mlmining,,1.0,0.25,2002
 Jaime G. Carbonell,Carnegie Mellon University,mlmining,,1.0,0.333333333333,2005
 Jaime G. Carbonell,Carnegie Mellon University,mlmining,,1.0,0.5,2007
@@ -24133,10 +24260,13 @@ James C. Lester,North Carolina State University,nlp,,1.0,0.5,2002
 James C. Lester,North Carolina State University,nlp,,1.0,0.2,2011
 James Caverlee,Texas A&M University,ai,aaai,1.0,0.5,2016
 James Caverlee,Texas A&M University,ir,,1.0,0.333333333333,2006
-James Caverlee,Texas A&M University,ir,,1.0,0.333333333333,2010
-James Caverlee,Texas A&M University,ir,,1.0,0.25,2013
+James Caverlee,Texas A&M University,ir,,1.0,0.5,2008
+James Caverlee,Texas A&M University,ir,,2.0,0.666666666667,2009
+James Caverlee,Texas A&M University,ir,,2.0,0.666666666667,2010
+James Caverlee,Texas A&M University,ir,,3.0,0.916666666667,2011
+James Caverlee,Texas A&M University,ir,,3.0,0.916666666667,2013
 James Caverlee,Texas A&M University,ir,,1.0,0.25,2014
-James Caverlee,Texas A&M University,ir,,1.0,0.25,2015
+James Caverlee,Texas A&M University,ir,,2.0,0.583333333333,2015
 James Cheney,University of Edinburgh,log,,1.0,0.5,2004
 James Cheney,University of Edinburgh,log,,1.0,0.333333333333,2008
 James Cheney,University of Edinburgh,mod,,1.0,0.333333333333,2006
@@ -24319,6 +24449,7 @@ James Fogarty,University of Washington,chi,,2.0,0.666666666667,2014
 James Fogarty,University of Washington,chi,,3.0,0.7,2015
 James Fogarty,University of Washington,chi,,3.0,0.733333333333,2016
 James Fogarty,University of Washington,chi,,6.0,1.16111111111,2017
+James Fogarty,University of Washington,ir,,1.0,0.25,2008
 James Geller,NJIT,ai,ijcai,1.0,0.5,1987
 James H. Anderson,University of North Carolina,act,,1.0,0.5,1994
 James H. Anderson,University of North Carolina,act,,1.0,0.5,2002
@@ -24344,6 +24475,7 @@ James H. Anderson,University of North Carolina,bed,,2.0,0.833333333333,2014
 James H. Anderson,University of North Carolina,bed,,2.0,0.583333333333,2015
 James H. Anderson,University of North Carolina,bed,,3.0,0.833333333333,2016
 James H. Anderson,University of North Carolina,bed,,2.0,0.325,2017
+James H. Martin,University of Colorado Boulder,ir,,1.0,0.125,2011
 James H. Martin,University of Colorado Boulder,nlp,,1.0,0.2,2004
 James H. Martin,University of Colorado Boulder,nlp,,1.0,0.2,2005
 James H. Martin,University of Colorado Boulder,nlp,,1.0,0.5,2006
@@ -24627,7 +24759,7 @@ James Worrell,University of Oxford,log,,1.0,0.333333333333,2015
 James Worrell,University of Oxford,log,,3.0,0.75,2016
 Jamie Callan,Carnegie Mellon University,ir,,1.0,0.5,2005
 Jamie Callan,Carnegie Mellon University,ir,,2.0,0.75,2007
-Jamie Callan,Carnegie Mellon University,ir,,1.0,0.25,2008
+Jamie Callan,Carnegie Mellon University,ir,,2.0,0.5,2008
 Jamie Callan,Carnegie Mellon University,ir,,1.0,0.25,2009
 Jamie Callan,Carnegie Mellon University,ir,,1.0,0.5,2012
 Jamie Callan,Carnegie Mellon University,ir,,1.0,0.5,2015
@@ -24877,6 +25009,7 @@ Janyce Wiebe,University of Pittsburgh,ai,aaai,1.0,1.0,2000
 Janyce Wiebe,University of Pittsburgh,ai,aaai,1.0,0.333333333333,2004
 Janyce Wiebe,University of Pittsburgh,ai,aaai,1.0,0.333333333333,2005
 Janyce Wiebe,University of Pittsburgh,ai,ijcai,1.0,0.5,2016
+Janyce Wiebe,University of Pittsburgh,ir,,1.0,0.25,2007
 Janyce Wiebe,University of Pittsburgh,nlp,,1.0,0.5,1988
 Janyce Wiebe,University of Pittsburgh,nlp,,1.0,0.5,1991
 Janyce Wiebe,University of Pittsburgh,nlp,,1.0,0.5,1994
@@ -25050,6 +25183,8 @@ Jason I. Hong,Carnegie Mellon University,chi,,1.0,0.25,2017
 Jason I. Hong,Carnegie Mellon University,ir,,1.0,0.5,2001
 Jason I. Hong,Carnegie Mellon University,ir,,1.0,0.333333333333,2007
 Jason I. Hong,Carnegie Mellon University,ir,,1.0,0.5,2009
+Jason I. Hong,Carnegie Mellon University,ir,,2.0,0.416666666667,2012
+Jason I. Hong,Carnegie Mellon University,ir,,1.0,0.25,2017
 Jason I. Hong,Carnegie Mellon University,mlmining,,1.0,0.166666666667,2013
 Jason I. Hong,Carnegie Mellon University,mobile,,1.0,0.5,2004
 Jason I. Hong,Carnegie Mellon University,mobile,,2.0,0.342857142857,2009
@@ -25317,6 +25452,7 @@ Jean-Pierre Hubaux,EPFL,sec,,1.0,0.2,2012
 Jean-Pierre Hubaux,EPFL,sec,,1.0,0.25,2013
 Jean-Pierre Hubaux,EPFL,sec,,1.0,0.142857142857,2014
 Jean-Pierre Hubaux,EPFL,sec,,2.0,0.45,2015
+Jean-Pierre Hubaux,EPFL,sec,,1.0,0.166666666667,2017
 Jean-Sébastien Coron,University of Luxembourg,crypt,,1.0,0.333333333333,1999
 Jean-Sébastien Coron,University of Luxembourg,crypt,,3.0,1.75,2000
 Jean-Sébastien Coron,University of Luxembourg,crypt,,1.0,0.25,2001
@@ -25368,6 +25504,8 @@ Jed R. Brubaker,University of Colorado Boulder,chi,,1.0,0.2,2013
 Jed R. Brubaker,University of Colorado Boulder,chi,,2.0,0.533333333333,2014
 Jed R. Brubaker,University of Colorado Boulder,chi,,2.0,0.75,2016
 Jed R. Brubaker,University of Colorado Boulder,chi,,1.0,0.5,2017
+Jed R. Brubaker,University of Colorado Boulder,ir,,1.0,0.25,2012
+Jed R. Brubaker,University of Colorado Boulder,ir,,1.0,0.2,2014
 Jedidiah R. Crandall,University of New Mexico,arch,,2.0,0.611111111111,2004
 Jedidiah R. Crandall,University of New Mexico,arch,,1.0,0.166666666667,2006
 Jedidiah R. Crandall,University of New Mexico,comm,,2.0,0.833333333333,2015
@@ -25536,6 +25674,7 @@ Jeffrey P. Bigham,Carnegie Mellon University,chi,,2.0,1.16666666667,2014
 Jeffrey P. Bigham,Carnegie Mellon University,chi,,5.0,1.08333333333,2015
 Jeffrey P. Bigham,Carnegie Mellon University,chi,,3.0,0.452380952381,2016
 Jeffrey P. Bigham,Carnegie Mellon University,chi,,4.0,0.785714285714,2017
+Jeffrey P. Bigham,Carnegie Mellon University,ir,,1.0,0.2,2008
 Jeffrey P. Bigham,Carnegie Mellon University,nlp,,1.0,0.25,2013
 Jeffrey Philip Bigham,Carnegie Mellon University,ai,aaai,1.0,0.25,2013
 Jeffrey S. Chase,Duke University,arch,,1.0,0.333333333333,1992
@@ -25549,6 +25688,7 @@ Jeffrey S. Chase,Duke University,hpc,,2.0,0.533333333333,2004
 Jeffrey S. Chase,Duke University,hpc,,1.0,0.333333333333,2005
 Jeffrey S. Chase,Duke University,hpc,,1.0,0.166666666667,2006
 Jeffrey S. Chase,Duke University,hpc,,1.0,0.142857142857,2012
+Jeffrey S. Chase,Duke University,hpc,,1.0,0.142857142857,2017
 Jeffrey S. Chase,Duke University,metrics,,1.0,0.142857142857,1998
 Jeffrey S. Chase,Duke University,metrics,,1.0,0.333333333333,2004
 Jeffrey S. Chase,Duke University,mod,,1.0,0.333333333333,2006
@@ -25661,11 +25801,15 @@ Jennifer Mankoff,University of Washington,chi,,4.0,1.16666666667,2015
 Jennifer Mankoff,University of Washington,chi,,5.0,1.15,2016
 Jennifer Mankoff,University of Washington,chi,,5.0,0.935714285714,2017
 Jennifer Mankoff,University of Washington,graph,,1.0,0.142857142857,2016
+Jennifer Mankoff,University of Washington,ir,,1.0,0.0833333333333,2010
 Jennifer Neville,Purdue University,ai,aaai,1.0,0.5,2011
 Jennifer Neville,Purdue University,ai,aaai,1.0,0.25,2015
 Jennifer Neville,Purdue University,ai,aaai,1.0,0.5,2017
 Jennifer Neville,Purdue University,comm,,1.0,0.333333333333,2012
+Jennifer Neville,Purdue University,ir,,1.0,0.5,2009
 Jennifer Neville,Purdue University,ir,,2.0,0.833333333333,2010
+Jennifer Neville,Purdue University,ir,,1.0,0.5,2011
+Jennifer Neville,Purdue University,ir,,1.0,0.333333333333,2012
 Jennifer Neville,Purdue University,ir,,1.0,0.2,2014
 Jennifer Neville,Purdue University,ir,,1.0,0.333333333333,2015
 Jennifer Neville,Purdue University,mlmining,,1.0,0.5,2002
@@ -25785,6 +25929,12 @@ Jeremiah Blocki,Purdue University,ai,aaai,1.0,0.2,2015
 Jeremiah Blocki,Purdue University,ai,ijcai,1.0,0.2,2013
 Jeremiah Blocki,Purdue University,crypt,,1.0,0.5,2016
 Jeremiah Blocki,Purdue University,crypt,,1.0,0.333333333333,2017
+Jeremy Blackburn,University of Alabama at Birmingham,chi,,1.0,0.333333333333,2015
+Jeremy Blackburn,University of Alabama at Birmingham,comm,,1.0,0.111111111111,2015
+Jeremy Blackburn,University of Alabama at Birmingham,ir,,1.0,0.142857142857,2012
+Jeremy Blackburn,University of Alabama at Birmingham,ir,,1.0,0.5,2014
+Jeremy Blackburn,University of Alabama at Birmingham,ir,,1.0,0.125,2017
+Jeremy Blackburn,University of Alabama at Birmingham,mobile,,1.0,0.2,2013
 Jeremy Buhler,Washington University in St. Louis,bio,,1.0,0.5,2001
 Jeremy Buhler,Washington University in St. Louis,bio,,1.0,1.0,2002
 Jeremy Buhler,Washington University in St. Louis,bio,,2.0,0.533333333333,2003
@@ -25925,6 +26075,7 @@ Jessica Lin 0001,George Mason University,mlmining,,1.0,0.2,2004
 Jessica Staddon,North Carolina State University,crypt,,1.0,0.5,1998
 Jessica Staddon,North Carolina State University,crypt,,1.0,0.333333333333,1999
 Jessica Staddon,North Carolina State University,crypt,,1.0,0.333333333333,2000
+Jessica Staddon,North Carolina State University,ir,,1.0,0.25,2012
 Jessica Staddon,North Carolina State University,mlmining,,1.0,0.333333333333,2008
 Jessica Staddon,North Carolina State University,sec,,1.0,0.5,2001
 Jessica Staddon,North Carolina State University,sec,,1.0,0.166666666667,2002
@@ -26153,6 +26304,7 @@ Jianfei Cai,Nanyang Technological University,vision,eccv,1.0,0.2,2014
 Jianfei Cai,Nanyang Technological University,vision,eccv,3.0,1.0,2016
 Jianfei Cai,Nanyang Technological University,vision,iccv,1.0,0.25,2015
 Jiang Ming,University of Texas at Arlington,sec,,2.0,0.45,2015
+Jiang Ming,University of Texas at Arlington,sec,,1.0,0.333333333333,2017
 Jiang Ming,University of Texas at Arlington,soft,,1.0,0.2,2014
 Jiang Yu Zheng,Indiana University-Purdue University Indianapolis,robotics,,1.0,0.333333333333,1986
 Jiang Yu Zheng,Indiana University-Purdue University Indianapolis,robotics,,1.0,0.333333333333,1996
@@ -26323,6 +26475,7 @@ Jie Zhang 0002,Nanyang Technological University,ai,aaai,1.0,0.5,2007
 Jie Zhang 0002,Nanyang Technological University,ai,aaai,2.0,0.666666666667,2014
 Jie Zhang 0002,Nanyang Technological University,ai,aaai,1.0,0.2,2016
 Jie Zhang 0002,Nanyang Technological University,ai,ijcai,3.0,1.0,2013
+Jie Zhang 0002,Nanyang Technological University,ir,,1.0,0.5,2008
 Jie Zheng,Nanyang Technological University,bio,,1.0,0.2,2015
 Jiebo Luo,University of Rochester,ai,aaai,1.0,0.166666666667,2014
 Jiebo Luo,University of Rochester,ai,aaai,2.0,0.392857142857,2015
@@ -26331,6 +26484,9 @@ Jiebo Luo,University of Rochester,ai,aaai,2.0,0.5,2017
 Jiebo Luo,University of Rochester,ai,ijcai,1.0,0.125,2016
 Jiebo Luo,University of Rochester,ir,,1.0,0.142857142857,2011
 Jiebo Luo,University of Rochester,ir,,1.0,0.166666666667,2014
+Jiebo Luo,University of Rochester,ir,,1.0,0.2,2015
+Jiebo Luo,University of Rochester,ir,,1.0,0.25,2016
+Jiebo Luo,University of Rochester,ir,,2.0,0.4,2017
 Jiebo Luo,University of Rochester,nlp,,1.0,0.142857142857,2015
 Jiebo Luo,University of Rochester,vision,cvpr,1.0,0.5,2000
 Jiebo Luo,University of Rochester,vision,cvpr,1.0,0.333333333333,2003
@@ -26425,6 +26581,7 @@ Jimeng Sun,Georgia Institute of Technology,ai,aaai,1.0,0.125,2017
 Jimeng Sun,Georgia Institute of Technology,ai,ijcai,1.0,0.333333333333,2007
 Jimeng Sun,Georgia Institute of Technology,hpc,,1.0,0.2,2015
 Jimeng Sun,Georgia Institute of Technology,ir,,1.0,0.333333333333,2015
+Jimeng Sun,Georgia Institute of Technology,ir,,1.0,0.2,2016
 Jimeng Sun,Georgia Institute of Technology,mlmining,,1.0,0.333333333333,2006
 Jimeng Sun,Georgia Institute of Technology,mlmining,,1.0,0.25,2007
 Jimeng Sun,Georgia Institute of Technology,mlmining,,1.0,0.2,2008
@@ -26452,10 +26609,11 @@ Jimmy J. Lin,University of Waterloo,ir,,1.0,1.0,2005
 Jimmy J. Lin,University of Waterloo,ir,,2.0,0.75,2006
 Jimmy J. Lin,University of Waterloo,ir,,1.0,0.5,2007
 Jimmy J. Lin,University of Waterloo,ir,,1.0,0.5,2008
-Jimmy J. Lin,University of Waterloo,ir,,1.0,1.0,2009
+Jimmy J. Lin,University of Waterloo,ir,,2.0,1.5,2009
 Jimmy J. Lin,University of Waterloo,ir,,1.0,0.333333333333,2010
 Jimmy J. Lin,University of Waterloo,ir,,3.0,0.916666666667,2011
-Jimmy J. Lin,University of Waterloo,ir,,1.0,0.166666666667,2013
+Jimmy J. Lin,University of Waterloo,ir,,2.0,0.7,2012
+Jimmy J. Lin,University of Waterloo,ir,,2.0,0.666666666667,2013
 Jimmy J. Lin,University of Waterloo,ir,,1.0,0.25,2014
 Jimmy J. Lin,University of Waterloo,ir,,1.0,0.25,2015
 Jimmy J. Lin,University of Waterloo,ir,,1.0,0.333333333333,2016
@@ -26971,6 +27129,7 @@ Johanna D. Moore,University of Edinburgh,ai,ijcai,1.0,0.5,2001
 Johanna D. Moore,University of Edinburgh,chi,,1.0,1.0,1989
 Johanna D. Moore,University of Edinburgh,chi,,1.0,0.5,1994
 Johanna D. Moore,University of Edinburgh,chi,,1.0,0.5,1995
+Johanna D. Moore,University of Edinburgh,ir,,1.0,0.333333333333,2011
 Johanna D. Moore,University of Edinburgh,nlp,,1.0,0.5,1989
 Johanna D. Moore,University of Edinburgh,nlp,,1.0,0.5,1995
 Johanna D. Moore,University of Edinburgh,nlp,,1.0,0.333333333333,1997
@@ -27566,6 +27725,7 @@ John R. Gilbert,University of California - Santa Barbara,plan,,1.0,0.25,1993
 John R. Kender,Columbia University,ai,aaai,2.0,0.833333333333,1986
 John R. Kender,Columbia University,ai,ijcai,1.0,1.0,1979
 John R. Kender,Columbia University,ai,ijcai,1.0,0.5,1991
+John R. Kender,Columbia University,ir,,1.0,0.2,2011
 John R. Kender,Columbia University,vision,cvpr,2.0,1.0,1988
 John R. Kender,Columbia University,vision,cvpr,1.0,0.5,1997
 John R. Kender,Columbia University,vision,cvpr,1.0,0.5,1998
@@ -27748,7 +27908,8 @@ Jon Crowcroft,University of Cambridge,comm,,1.0,0.25,2003
 Jon Crowcroft,University of Cambridge,comm,,2.0,0.333333333333,2006
 Jon Crowcroft,University of Cambridge,comm,,1.0,0.333333333333,2014
 Jon Crowcroft,University of Cambridge,comm,,2.0,0.22619047619,2015
-Jon Crowcroft,University of Cambridge,ir,,1.0,0.25,2011
+Jon Crowcroft,University of Cambridge,ir,,2.0,0.5,2011
+Jon Crowcroft,University of Cambridge,ir,,3.0,0.809523809524,2012
 Jon Crowcroft,University of Cambridge,ir,,2.0,0.5,2013
 Jon Crowcroft,University of Cambridge,ir,,1.0,0.333333333333,2014
 Jon Crowcroft,University of Cambridge,metrics,,1.0,0.5,2006
@@ -27800,14 +27961,14 @@ Jon M. Kleinberg,Cornell University,chi,,1.0,0.333333333333,2010
 Jon M. Kleinberg,Cornell University,ir,,1.0,0.333333333333,2007
 Jon M. Kleinberg,Cornell University,ir,,1.0,0.25,2008
 Jon M. Kleinberg,Cornell University,ir,,2.0,0.5,2009
-Jon M. Kleinberg,Cornell University,ir,,1.0,0.333333333333,2010
-Jon M. Kleinberg,Cornell University,ir,,2.0,0.833333333333,2011
+Jon M. Kleinberg,Cornell University,ir,,4.0,1.36666666667,2010
+Jon M. Kleinberg,Cornell University,ir,,5.0,1.53333333333,2011
 Jon M. Kleinberg,Cornell University,ir,,1.0,0.25,2012
 Jon M. Kleinberg,Cornell University,ir,,2.0,0.583333333333,2013
-Jon M. Kleinberg,Cornell University,ir,,2.0,0.45,2014
-Jon M. Kleinberg,Cornell University,ir,,2.0,0.45,2015
-Jon M. Kleinberg,Cornell University,ir,,3.0,0.833333333333,2016
-Jon M. Kleinberg,Cornell University,ir,,2.0,0.583333333333,2017
+Jon M. Kleinberg,Cornell University,ir,,3.0,0.65,2014
+Jon M. Kleinberg,Cornell University,ir,,3.0,0.783333333333,2015
+Jon M. Kleinberg,Cornell University,ir,,4.0,1.33333333333,2016
+Jon M. Kleinberg,Cornell University,ir,,3.0,0.916666666667,2017
 Jon M. Kleinberg,Cornell University,mlmining,,1.0,1.0,2001
 Jon M. Kleinberg,Cornell University,mlmining,,2.0,2.0,2002
 Jon M. Kleinberg,Cornell University,mlmining,,2.0,0.666666666667,2003
@@ -27824,6 +27985,9 @@ Jon M. Kleinberg,Cornell University,mod,,1.0,0.333333333333,1998
 Jon M. Kleinberg,Cornell University,nlp,,1.0,0.25,2012
 Jon McCormack,Monash University,ai,ijcai,1.0,0.5,2015
 Jon Oberlander,University of Edinburgh,ai,ijcai,1.0,0.166666666667,2009
+Jon Oberlander,University of Edinburgh,ir,,1.0,0.5,2007
+Jon Oberlander,University of Edinburgh,ir,,1.0,0.333333333333,2009
+Jon Oberlander,University of Edinburgh,ir,,1.0,0.333333333333,2014
 Jon Oberlander,University of Edinburgh,nlp,,1.0,0.333333333333,1992
 Jon Oberlander,University of Edinburgh,nlp,,1.0,0.25,2004
 Jon Oberlander,University of Edinburgh,nlp,,1.0,0.5,2006
@@ -27846,12 +28010,6 @@ Jonathan Appavoo,Boston University,ops,,1.0,0.142857142857,2005
 Jonathan Appavoo,Boston University,ops,,1.0,0.0833333333333,2006
 Jonathan Appavoo,Boston University,ops,,1.0,0.166666666667,2007
 Jonathan Appavoo,Boston University,ops,,1.0,0.2,2016
-Jonathan Bell,George Mason University,ops,,1.0,0.166666666667,2014
-Jonathan Bell,George Mason University,ops,,1.0,0.2,2015
-Jonathan Bell,George Mason University,soft,,1.0,0.333333333333,2013
-Jonathan Bell,George Mason University,soft,,1.0,0.5,2014
-Jonathan Bell,George Mason University,soft,,1.0,0.25,2015
-Jonathan Bell,George Mason University,soft,,1.0,0.166666666667,2016
 Jonathan Berant,Tel Aviv University,nlp,,1.0,0.333333333333,2009
 Jonathan Berant,Tel Aviv University,nlp,,1.0,0.333333333333,2010
 Jonathan Berant,Tel Aviv University,nlp,,1.0,0.333333333333,2011
@@ -27916,6 +28074,7 @@ Jonathan Katz,University of Maryland - College Park,sec,,1.0,0.2,2013
 Jonathan Katz,University of Maryland - College Park,sec,,3.0,0.733333333333,2014
 Jonathan Katz,University of Maryland - College Park,sec,,3.0,0.916666666667,2015
 Jonathan Katz,University of Maryland - College Park,sec,,4.0,0.82619047619,2016
+Jonathan Katz,University of Maryland - College Park,sec,,1.0,0.2,2017
 Jonathan Lee,National Taiwan University,hpc,,2.0,0.366666666667,2014
 Jonathan P. Whiteley,University of Oxford,mlmining,,1.0,0.2,2000
 Jonathan Richard Shewchuk,University of California - Berkeley,graph,,1.0,0.333333333333,2003
@@ -28002,6 +28161,7 @@ Joost-Pieter Katoen,RWTH Aachen,log,,3.0,1.75,2016
 Jop Briët,CWI,act,,1.0,0.333333333333,2015
 Jordan L. Boyd-Graber,University of Colorado Boulder,chi,,1.0,0.125,2006
 Jordan L. Boyd-Graber,University of Colorado Boulder,ir,,1.0,0.25,2012
+Jordan L. Boyd-Graber,University of Colorado Boulder,ir,,1.0,0.333333333333,2014
 Jordan L. Boyd-Graber,University of Colorado Boulder,mlmining,,1.0,0.5,2008
 Jordan L. Boyd-Graber,University of Colorado Boulder,mlmining,,2.0,0.533333333333,2009
 Jordan L. Boyd-Graber,University of Colorado Boulder,mlmining,,1.0,0.25,2012
@@ -28102,6 +28262,7 @@ Joseph A. Konstan,University of Minnesota,chi,,1.0,0.333333333333,2011
 Joseph A. Konstan,University of Minnesota,ir,,1.0,0.25,1999
 Joseph A. Konstan,University of Minnesota,ir,,1.0,0.25,2001
 Joseph A. Konstan,University of Minnesota,ir,,1.0,0.25,2005
+Joseph A. Konstan,University of Minnesota,ir,,1.0,0.333333333333,2012
 Joseph A. Konstan,University of Minnesota,ir,,1.0,0.2,2014
 Joseph B. Evans,University of Kansas,comm,,1.0,0.333333333333,1993
 Joseph B. Evans,University of Kansas,comm,,1.0,0.5,1994
@@ -28487,6 +28648,7 @@ Juan Caballero,IMDEA Software Institute,sec,,1.0,0.0555555555556,2012
 Juan Caballero,IMDEA Software Institute,sec,,1.0,0.166666666667,2014
 Juan Caballero,IMDEA Software Institute,sec,,3.0,0.783333333333,2015
 Juan Caballero,IMDEA Software Institute,sec,,1.0,0.333333333333,2016
+Juan Caballero,IMDEA Software Institute,sec,,1.0,0.2,2017
 Juan J. Navarro,Polytechnic University of Catalonia,arch,,1.0,0.333333333333,1986
 Juan J. Navarro,Polytechnic University of Catalonia,arch,,1.0,0.25,1989
 Juan J. Navarro,Polytechnic University of Catalonia,arch,,1.0,0.166666666667,1992
@@ -28616,6 +28778,7 @@ Julian A. Padget,University of Bath,plan,,1.0,0.5,1985
 Julian C. Bradfield,University of Edinburgh,log,,1.0,1.0,1992
 Julian Gough,University of Bristol,bio,,1.0,0.333333333333,2001
 Julian J. McAuley,University of California - San Diego,ai,aaai,1.0,0.142857142857,2017
+Julian J. McAuley,University of California - San Diego,ir,,1.0,0.333333333333,2013
 Julian J. McAuley,University of California - San Diego,ir,,1.0,0.2,2014
 Julian J. McAuley,University of California - San Diego,ir,,1.0,0.25,2015
 Julian J. McAuley,University of California - San Diego,mlmining,,1.0,0.5,2012
@@ -28830,8 +28993,9 @@ Junghoo Cho,University of California - Los Angeles,ir,,1.0,0.5,2002
 Junghoo Cho,University of California - Los Angeles,ir,,2.0,0.833333333333,2004
 Junghoo Cho,University of California - Los Angeles,ir,,1.0,0.333333333333,2005
 Junghoo Cho,University of California - Los Angeles,ir,,1.0,0.5,2006
-Junghoo Cho,University of California - Los Angeles,ir,,1.0,0.5,2007
+Junghoo Cho,University of California - Los Angeles,ir,,3.0,1.0,2007
 Junghoo Cho,University of California - Los Angeles,ir,,1.0,0.5,2008
+Junghoo Cho,University of California - Los Angeles,ir,,1.0,0.25,2009
 Junghoo Cho,University of California - Los Angeles,ir,,1.0,0.333333333333,2011
 Junghoo Cho,University of California - Los Angeles,ir,,1.0,0.5,2012
 Junghoo Cho,University of California - Los Angeles,ir,,1.0,0.25,2013
@@ -28886,16 +29050,17 @@ Juraj Hromkovic,ETH Zurich,act,,1.0,0.5,1996
 Jure Leskovec,Stanford University,ai,aaai,1.0,0.333333333333,2005
 Jure Leskovec,Stanford University,chi,,1.0,0.333333333333,2010
 Jure Leskovec,Stanford University,comm,,1.0,0.166666666667,2007
-Jure Leskovec,Stanford University,ir,,1.0,0.333333333333,2007
+Jure Leskovec,Stanford University,ir,,2.0,0.533333333333,2007
 Jure Leskovec,Stanford University,ir,,2.0,0.75,2008
-Jure Leskovec,Stanford University,ir,,2.0,0.666666666667,2010
-Jure Leskovec,Stanford University,ir,,1.0,0.333333333333,2011
-Jure Leskovec,Stanford University,ir,,1.0,0.5,2012
-Jure Leskovec,Stanford University,ir,,4.0,1.15,2013
-Jure Leskovec,Stanford University,ir,,4.0,1.15,2014
-Jure Leskovec,Stanford University,ir,,4.0,1.23333333333,2015
+Jure Leskovec,Stanford University,ir,,1.0,0.25,2009
+Jure Leskovec,Stanford University,ir,,3.0,1.0,2010
+Jure Leskovec,Stanford University,ir,,3.0,0.733333333333,2011
+Jure Leskovec,Stanford University,ir,,2.0,1.0,2012
+Jure Leskovec,Stanford University,ir,,5.0,1.48333333333,2013
+Jure Leskovec,Stanford University,ir,,5.0,1.48333333333,2014
+Jure Leskovec,Stanford University,ir,,5.0,1.56666666667,2015
 Jure Leskovec,Stanford University,ir,,3.0,0.833333333333,2016
-Jure Leskovec,Stanford University,ir,,2.0,0.392857142857,2017
+Jure Leskovec,Stanford University,ir,,3.0,0.592857142857,2017
 Jure Leskovec,Stanford University,mlmining,,1.0,0.5,2003
 Jure Leskovec,Stanford University,mlmining,,1.0,0.333333333333,2005
 Jure Leskovec,Stanford University,mlmining,,2.0,0.833333333333,2006
@@ -29117,6 +29282,7 @@ K. Selçuk Candan,Arizona State University,ir,,1.0,0.2,2003
 K. Selçuk Candan,Arizona State University,ir,,1.0,0.166666666667,2004
 K. Selçuk Candan,Arizona State University,ir,,1.0,0.333333333333,2005
 K. Selçuk Candan,Arizona State University,ir,,1.0,0.333333333333,2009
+K. Selçuk Candan,Arizona State University,ir,,1.0,0.166666666667,2010
 K. Selçuk Candan,Arizona State University,ir,,1.0,0.333333333333,2017
 K. Selçuk Candan,Arizona State University,mlmining,,1.0,0.5,2014
 K. Selçuk Candan,Arizona State University,mod,,1.0,0.25,1996
@@ -29223,6 +29389,7 @@ Kai Zheng,University of California - Irvine,comm,,1.0,0.25,2004
 Kai Zheng,University of California - Irvine,comm,,1.0,0.25,2005
 Kai Zheng,University of California - Irvine,comm,,1.0,0.2,2010
 Kai Zheng,University of California - Irvine,comm,,1.0,0.2,2014
+Kai Zheng,University of California - Irvine,ir,,1.0,0.2,2014
 Kai Zheng,University of California - Irvine,ir,,1.0,0.166666666667,2015
 Kai Zheng,University of California - Irvine,ir,,1.0,0.166666666667,2016
 Kai Zheng,University of California - Irvine,mlmining,,1.0,0.2,2015
@@ -29553,7 +29720,8 @@ Karl Aberer,EPFL,hpc,,1.0,0.333333333333,2012
 Karl Aberer,EPFL,ir,,1.0,0.333333333333,2003
 Karl Aberer,EPFL,ir,,1.0,0.2,2007
 Karl Aberer,EPFL,ir,,1.0,0.2,2009
-Karl Aberer,EPFL,ir,,1.0,0.5,2013
+Karl Aberer,EPFL,ir,,2.0,0.75,2013
+Karl Aberer,EPFL,ir,,1.0,0.25,2015
 Karl Aberer,EPFL,ir,,1.0,0.166666666667,2017
 Karl Aberer,EPFL,mod,,1.0,0.25,2005
 Karl Aberer,EPFL,mod,,1.0,0.25,2006
@@ -29609,7 +29777,9 @@ Karrie Karahalios,University of Illinois at Urbana-Champaign,chi,,2.0,0.33333333
 Karrie Karahalios,University of Illinois at Urbana-Champaign,chi,,1.0,0.125,2015
 Karrie Karahalios,University of Illinois at Urbana-Champaign,chi,,3.0,0.542857142857,2016
 Karrie Karahalios,University of Illinois at Urbana-Champaign,chi,,2.0,0.533333333333,2017
+Karrie Karahalios,University of Illinois at Urbana-Champaign,ir,,1.0,0.5,2010
 Karrie Karahalios,University of Illinois at Urbana-Champaign,ir,,1.0,0.25,2016
+Karrie Karahalios,University of Illinois at Urbana-Champaign,ir,,1.0,0.25,2017
 Karrie Karahalios,University of Illinois at Urbana-Champaign,mod,,1.0,0.2,2016
 Karsten Weihe,TU Darmstadt,act,,1.0,0.333333333333,1993
 Karsten Weihe,TU Darmstadt,act,,1.0,1.0,1994
@@ -29629,6 +29799,7 @@ Karthik Dantu,University at Buffalo,robotics,,1.0,0.25,2012
 Karthik Dantu,University at Buffalo,robotics,,1.0,0.25,2014
 Karthik Pattabiraman,University of British Columbia,arch,,1.0,0.25,2011
 Karthik Pattabiraman,University of British Columbia,hpc,,1.0,0.25,2016
+Karthik Pattabiraman,University of British Columbia,hpc,,1.0,0.2,2017
 Karthik Pattabiraman,University of British Columbia,ops,,1.0,0.333333333333,2008
 Karthik Pattabiraman,University of British Columbia,soft,,2.0,0.583333333333,2014
 Karthik Pattabiraman,University of British Columbia,soft,,1.0,0.333333333333,2015
@@ -29827,6 +29998,8 @@ Kathleen Fisher,Tufts University,plan,,1.0,0.25,2008
 Kathleen Fisher,Tufts University,plan,,2.0,0.7,2011
 Kathleen Fisher,Tufts University,plan,,1.0,0.2,2012
 Kathleen M. Carley,Carnegie Mellon University,chi,,1.0,0.333333333333,2012
+Kathleen M. Carley,Carnegie Mellon University,ir,,1.0,0.25,2013
+Kathleen M. Carley,Carnegie Mellon University,ir,,1.0,0.25,2015
 Kathleen M. Carley,Carnegie Mellon University,ir,,1.0,0.333333333333,2016
 Kathleen McKeown,Columbia University,ai,aaai,1.0,0.5,1990
 Kathleen McKeown,Columbia University,ai,aaai,1.0,0.2,1992
@@ -30049,6 +30222,7 @@ Kemal Oflazer,Carnegie Mellon University,nlp,,1.0,0.25,2012
 Kemal Oflazer,Carnegie Mellon University,nlp,,4.0,1.11666666667,2013
 Kemal Oflazer,Carnegie Mellon University,nlp,,1.0,0.25,2014
 Kemao Qian,Nanyang Technological University,vision,cvpr,1.0,0.333333333333,2016
+Ken Baclawski,Northeastern University,ir,,1.0,0.5,2007
 Ken Barker,University of Calgary,ai,aaai,1.0,0.125,2002
 Ken Barker,University of Calgary,ai,aaai,1.0,0.333333333333,2006
 Ken Barker,University of Calgary,ai,aaai,1.0,0.0666666666667,2007
@@ -30164,6 +30338,7 @@ Kenneth M. Anderson,University of Colorado Boulder,soft,,1.0,1.0,1999
 Kenneth M. Anderson,University of Colorado Boulder,soft,,1.0,0.333333333333,2002
 Kenneth Mark Anderson,University of Colorado Boulder,chi,,1.0,0.25,2014
 Kenneth Mark Anderson,University of Colorado Boulder,chi,,1.0,0.2,2016
+Kenneth Mark Anderson,University of Colorado Boulder,ir,,1.0,0.125,2011
 Kenneth O. Stanley,University of Central Florida,ai,aaai,1.0,0.5,2008
 Kenneth O. Stanley,University of Central Florida,ai,aaai,1.0,0.25,2015
 Kenneth O. Stanley,University of Central Florida,robotics,,1.0,0.25,2011
@@ -30664,6 +30839,7 @@ Kirk Pruhs,University of Pittsburgh,mod,,1.0,0.25,2006
 Kirk W. Cameron,Virginia Tech,hpc,,1.0,0.5,2004
 Kirk W. Cameron,Virginia Tech,hpc,,1.0,0.333333333333,2005
 Kirk W. Cameron,Virginia Tech,hpc,,1.0,0.333333333333,2006
+Kirk W. Cameron,Virginia Tech,hpc,,1.0,0.333333333333,2017
 Kirsten Cater,University of Bristol,chi,,1.0,0.25,2012
 Kirsten F. Cater,University of Bristol,chi,,1.0,0.2,2013
 Kishore Kothapalli,IIIT Hyderabad,hpc,,1.0,0.333333333333,2009
@@ -30936,8 +31112,10 @@ Krishna M. Sivalingam,IIT Madras,comm,,1.0,0.25,1999
 Krishna M. Sivalingam,IIT Madras,comm,,1.0,0.5,2002
 Krishna M. Sivalingam,IIT Madras,comm,,1.0,0.5,2003
 Krishna M. Sivalingam,IIT Madras,hpc,,1.0,1.0,1995
-Krishna P. Gummadi,Max Planck Institute,ir,,2.0,0.333333333333,2016
-Krishna P. Gummadi,Max Planck Institute,ir,,2.0,0.5,2017
+Krishna P. Gummadi,Max Planck Institute,ir,,1.0,0.333333333333,2014
+Krishna P. Gummadi,Max Planck Institute,ir,,2.0,0.4,2015
+Krishna P. Gummadi,Max Planck Institute,ir,,4.0,1.0,2016
+Krishna P. Gummadi,Max Planck Institute,ir,,3.0,0.666666666667,2017
 Krishna P. Gummadi,Max Planck Institute,metrics,,1.0,0.333333333333,2015
 Krishna P. Gummadi,Max Planck Institute,metrics,,1.0,0.142857142857,2016
 Krishna P. Gummadi,Max Planck Institute,mlmining,,1.0,0.2,2015
@@ -31021,6 +31199,9 @@ Kristian J. Hammond,Northwestern University,ai,ijcai,1.0,1.0,1987
 Kristian J. Hammond,Northwestern University,ai,ijcai,1.0,1.0,1989
 Kristian J. Hammond,Northwestern University,ai,ijcai,1.0,0.333333333333,1995
 Kristian J. Hammond,Northwestern University,ir,,1.0,0.25,2002
+Kristian J. Hammond,Northwestern University,ir,,1.0,0.25,2007
+Kristian J. Hammond,Northwestern University,ir,,2.0,0.666666666667,2009
+Kristian J. Hammond,Northwestern University,ir,,1.0,0.5,2011
 Kristofer S. J. Pister,University of California - Berkeley,arch,,1.0,0.166666666667,2000
 Kristofer S. J. Pister,University of California - Berkeley,comm,,1.0,0.333333333333,2001
 Kristofer S. J. Pister,University of California - Berkeley,mobile,,1.0,0.333333333333,1999
@@ -31519,7 +31700,8 @@ Lap-Fai Yu,University of Massachusetts Boston,vision,cvpr,1.0,0.25,2013
 Lap-Fai Yu,University of Massachusetts Boston,vision,iccv,1.0,0.333333333333,2015
 Larissa Meinicke,University of Queensland,log,,1.0,0.333333333333,2012
 Larry Birnbaum,Northwestern University,ai,aaai,1.0,0.25,2017
-Larry Birnbaum,Northwestern University,ir,,1.0,0.333333333333,2007
+Larry Birnbaum,Northwestern University,ir,,2.0,0.583333333333,2007
+Larry Birnbaum,Northwestern University,ir,,2.0,0.666666666667,2009
 Larry Carter,University of California - San Diego,act,,1.0,0.5,1977
 Larry Carter,University of California - San Diego,act,,1.0,0.2,1978
 Larry Carter,University of California - San Diego,act,,1.0,0.5,1979
@@ -32096,6 +32278,7 @@ Leo Joskowicz,Hebrew University of Jerusalem,robotics,,2.0,0.583333333333,1998
 Leo Joskowicz,Hebrew University of Jerusalem,robotics,,1.0,0.333333333333,1999
 Leo Joskowicz,Hebrew University of Jerusalem,robotics,,1.0,0.5,2005
 Leon Adam Watts,University of Bath,chi,,1.0,0.5,2010
+Leon J. Osterweil,University of Massachusetts Amherst,ir,,1.0,0.142857142857,2012
 Leon J. Osterweil,University of Massachusetts Amherst,soft,,1.0,0.5,1981
 Leon J. Osterweil,University of Massachusetts Amherst,soft,,1.0,1.0,1982
 Leon J. Osterweil,University of Massachusetts Amherst,soft,,1.0,1.0,1987
@@ -32396,8 +32579,11 @@ Letizia Tanca,Politecnico di Milano,mod,,1.0,0.2,1990
 Lewis D. Griffin,University College London,vision,cvpr,1.0,0.5,2008
 Lexing Xie,Australian National University,ai,aaai,1.0,0.333333333333,2016
 Lexing Xie,Australian National University,ai,aaai,1.0,0.2,2017
-Lexing Xie,Australian National University,ir,,1.0,0.125,2012
-Lexing Xie,Australian National University,ir,,1.0,0.166666666667,2017
+Lexing Xie,Australian National University,ir,,1.0,0.166666666667,2010
+Lexing Xie,Australian National University,ir,,1.0,0.2,2011
+Lexing Xie,Australian National University,ir,,2.0,0.458333333333,2012
+Lexing Xie,Australian National University,ir,,1.0,0.333333333333,2015
+Lexing Xie,Australian National University,ir,,2.0,0.666666666667,2017
 Lexing Xie,Australian National University,vision,cvpr,1.0,0.333333333333,2008
 Leysia Palen,University of Colorado Boulder,chi,,1.0,0.5,1996
 Leysia Palen,University of Colorado Boulder,chi,,1.0,0.125,1997
@@ -32411,6 +32597,7 @@ Leysia Palen,University of Colorado Boulder,chi,,1.0,0.25,2014
 Leysia Palen,University of Colorado Boulder,chi,,1.0,0.25,2015
 Leysia Palen,University of Colorado Boulder,chi,,2.0,0.7,2016
 Leysia Palen,University of Colorado Boulder,chi,,1.0,0.333333333333,2017
+Leysia Palen,University of Colorado Boulder,ir,,1.0,0.125,2011
 Li Fei-Fei,Stanford University,ai,aaai,1.0,0.166666666667,2017
 Li Fei-Fei,Stanford University,vision,cvpr,5.0,1.33333333333,2016
 Li Fei-Fei,Stanford University,vision,eccv,1.0,0.333333333333,2014
@@ -32524,6 +32711,8 @@ Licia Capra,University College London,chi,,1.0,0.333333333333,2014
 Licia Capra,University College London,chi,,1.0,0.142857142857,2015
 Licia Capra,University College London,chi,,1.0,0.125,2016
 Licia Capra,University College London,ir,,1.0,0.25,2010
+Licia Capra,University College London,ir,,1.0,0.333333333333,2012
+Licia Capra,University College London,ir,,1.0,0.25,2013
 Licia Capra,University College London,ir,,2.0,0.7,2016
 Licia Capra,University College London,mlmining,,1.0,0.5,2011
 Licia Capra,University College London,mobile,,1.0,0.333333333333,2008
@@ -32609,7 +32798,7 @@ Lillian Lee,Cornell University,ir,,1.0,0.5,2006
 Lillian Lee,Cornell University,ir,,1.0,0.25,2009
 Lillian Lee,Cornell University,ir,,1.0,0.25,2012
 Lillian Lee,Cornell University,ir,,1.0,0.5,2015
-Lillian Lee,Cornell University,ir,,2.0,0.5,2016
+Lillian Lee,Cornell University,ir,,3.0,0.833333333333,2016
 Lillian Lee,Cornell University,ir,,2.0,0.666666666667,2017
 Lillian Lee,Cornell University,mlmining,,1.0,0.166666666667,2011
 Lillian Lee,Cornell University,nlp,,1.0,0.333333333333,1993
@@ -32855,7 +33044,8 @@ Lise Getoor,University of California - Santa Cruz,ai,aaai,1.0,0.142857142857,201
 Lise Getoor,University of California - Santa Cruz,ai,ijcai,1.0,0.5,1995
 Lise Getoor,University of California - Santa Cruz,ai,ijcai,1.0,0.25,1999
 Lise Getoor,University of California - Santa Cruz,ai,ijcai,1.0,0.333333333333,2011
-Lise Getoor,University of California - Santa Cruz,ir,,1.0,0.5,2009
+Lise Getoor,University of California - Santa Cruz,ir,,2.0,0.75,2009
+Lise Getoor,University of California - Santa Cruz,ir,,1.0,0.333333333333,2011
 Lise Getoor,University of California - Santa Cruz,ir,,1.0,0.2,2017
 Lise Getoor,University of California - Santa Cruz,mlmining,,1.0,0.25,2001
 Lise Getoor,University of California - Santa Cruz,mlmining,,1.0,0.5,2003
@@ -32917,6 +33107,7 @@ Long Lu,Stony Brook University,sec,,1.0,0.2,2013
 Long Lu,Stony Brook University,sec,,1.0,0.2,2014
 Long Lu,Stony Brook University,sec,,1.0,0.166666666667,2015
 Long Lu,Stony Brook University,sec,,1.0,0.25,2016
+Long Lu,Stony Brook University,sec,,1.0,0.125,2017
 Long Quan,Hong Kong University of Science and Technology,graph,,1.0,0.166666666667,2006
 Long Quan,Hong Kong University of Science and Technology,graph,,2.0,0.45,2007
 Long Quan,Hong Kong University of Science and Technology,graph,,3.0,0.616666666667,2008
@@ -33008,7 +33199,13 @@ Loren G. Terveen,University of Minnesota,chi,,1.0,0.333333333333,2014
 Loren G. Terveen,University of Minnesota,chi,,1.0,0.142857142857,2017
 Loren G. Terveen,University of Minnesota,ir,,1.0,0.333333333333,2000
 Loren G. Terveen,University of Minnesota,ir,,1.0,0.2,2006
+Loren G. Terveen,University of Minnesota,ir,,1.0,0.333333333333,2011
+Loren G. Terveen,University of Minnesota,ir,,1.0,0.2,2012
+Loren G. Terveen,University of Minnesota,ir,,1.0,0.25,2013
 Loren G. Terveen,University of Minnesota,ir,,1.0,0.2,2014
+Loren G. Terveen,University of Minnesota,ir,,1.0,0.25,2015
+Loren G. Terveen,University of Minnesota,ir,,2.0,0.416666666667,2016
+Loren G. Terveen,University of Minnesota,ir,,1.0,0.2,2017
 Lorenzo Alvisi,Cornell University,comm,,1.0,0.2,2001
 Lorenzo Alvisi,Cornell University,comm,,1.0,0.2,2009
 Lorenzo Alvisi,Cornell University,comm,,1.0,0.142857142857,2013
@@ -33064,6 +33261,7 @@ Lorenzo Torresani,Dartmouth College,vision,eccv,1.0,0.333333333333,2016
 Lorenzo Torresani,Dartmouth College,vision,iccv,1.0,0.25,2009
 Lorenzo Torresani,Dartmouth College,vision,iccv,1.0,0.333333333333,2011
 Lorenzo Torresani,Dartmouth College,vision,iccv,2.0,0.533333333333,2015
+Lori A. Clarke,University of Massachusetts Amherst,ir,,1.0,0.142857142857,2012
 Lori A. Clarke,University of Massachusetts Amherst,soft,,1.0,0.5,1981
 Lori A. Clarke,University of Massachusetts Amherst,soft,,2.0,0.583333333333,1985
 Lori A. Clarke,University of Massachusetts Amherst,soft,,1.0,0.5,1989
@@ -33375,6 +33573,7 @@ Luis Gravano,Columbia University,hpc,,1.0,0.25,1991
 Luis Gravano,Columbia University,ir,,1.0,0.333333333333,2000
 Luis Gravano,Columbia University,ir,,1.0,0.333333333333,2001
 Luis Gravano,Columbia University,ir,,1.0,0.25,2003
+Luis Gravano,Columbia University,ir,,3.0,0.866666666667,2011
 Luis Gravano,Columbia University,mod,,1.0,0.333333333333,1994
 Luis Gravano,Columbia University,mod,,1.0,0.5,1995
 Luis Gravano,Columbia University,mod,,1.0,0.5,1996
@@ -33439,6 +33638,7 @@ Lukasz Ziarek,University at Buffalo,mobile,,1.0,0.125,2017
 Lukasz Ziarek,University at Buffalo,ops,,1.0,0.2,2010
 Lukasz Ziarek,University at Buffalo,plan,,1.0,0.166666666667,2010
 Lukasz Ziarek,University at Buffalo,plan,,1.0,0.333333333333,2011
+Luke N. Olson,University of Illinois at Urbana-Champaign,hpc,,1.0,0.25,2017
 Luke Ong,University of Oxford,log,,1.0,1.0,2015
 Luke S. Zettlemoyer,University of Washington,ai,aaai,1.0,0.333333333333,2005
 Luke S. Zettlemoyer,University of Washington,ai,aaai,1.0,0.2,2008
@@ -33545,6 +33745,8 @@ Lyle H. Ungar,University of Pennsylvania,ai,aaai,1.0,0.25,2017
 Lyle H. Ungar,University of Pennsylvania,ai,ijcai,1.0,0.5,2001
 Lyle H. Ungar,University of Pennsylvania,comm,,1.0,0.166666666667,2003
 Lyle H. Ungar,University of Pennsylvania,ir,,1.0,0.25,2002
+Lyle H. Ungar,University of Pennsylvania,ir,,1.0,0.0909090909091,2013
+Lyle H. Ungar,University of Pennsylvania,ir,,1.0,0.2,2016
 Lyle H. Ungar,University of Pennsylvania,mlmining,,1.0,0.5,1995
 Lyle H. Ungar,University of Pennsylvania,mlmining,,1.0,0.333333333333,1997
 Lyle H. Ungar,University of Pennsylvania,mlmining,,2.0,0.833333333333,2000
@@ -33617,6 +33819,7 @@ László Babai,University of Chicago,act,,1.0,1.0,2016
 Léon J. M. Rothkrantz,TU Delft,ai,aaai,1.0,0.5,2000
 Léon J. M. Rothkrantz,TU Delft,vision,cvpr,1.0,0.333333333333,2007
 M. Angela Sasse,University College London,chi,,1.0,0.166666666667,2016
+M. Angela Sasse,University College London,sec,,1.0,0.166666666667,2017
 M. Balakrishnan,IIT Delhi,arch,,1.0,0.333333333333,1986
 M. Balakrishnan,IIT Delhi,bed,,1.0,0.333333333333,2006
 M. Balakrishnan,IIT Delhi,da,,1.0,0.5,1989
@@ -33708,7 +33911,7 @@ M. Ümit Uyar,CUNY,comm,,1.0,0.2,1993
 Maarten de Rijke,VU Amsterdam,ai,ijcai,1.0,0.5,2007
 Maarten de Rijke,VU Amsterdam,ir,,1.0,0.333333333333,2004
 Maarten de Rijke,VU Amsterdam,ir,,1.0,0.333333333333,2006
-Maarten de Rijke,VU Amsterdam,ir,,2.0,0.533333333333,2007
+Maarten de Rijke,VU Amsterdam,ir,,6.0,2.28333333333,2007
 Maarten de Rijke,VU Amsterdam,ir,,1.0,0.333333333333,2008
 Maarten de Rijke,VU Amsterdam,ir,,2.0,0.5,2011
 Maarten de Rijke,VU Amsterdam,ir,,1.0,0.166666666667,2012
@@ -33816,6 +34019,7 @@ Magdalena Balazinska,University of Washington,mod,,3.0,0.916666666667,2012
 Magdalena Balazinska,University of Washington,mod,,2.0,0.45,2013
 Magdalena Balazinska,University of Washington,mod,,3.0,1.0,2015
 Magdalena Balazinska,University of Washington,mod,,1.0,0.333333333333,2016
+Magdalena Balazinska,University of Washington,mod,,1.0,0.333333333333,2017
 Magdalena Balazinska,University of Washington,sec,,1.0,0.2,2002
 Magy Seif El-Nasr,Northeastern University,chi,,1.0,0.142857142857,2010
 Magy Seif El-Nasr,Northeastern University,ir,,1.0,0.142857142857,2017
@@ -34002,6 +34206,7 @@ Malcolm P. Atkinson,University of Edinburgh,soft,,1.0,0.2,1985
 Malik Magdon-Ismail,Rensselaer Polytechnic Institute,act,,1.0,0.333333333333,2011
 Malik Magdon-Ismail,Rensselaer Polytechnic Institute,act,,1.0,0.166666666667,2013
 Malik Magdon-Ismail,Rensselaer Polytechnic Institute,ai,aaai,1.0,0.2,2013
+Malik Magdon-Ismail,Rensselaer Polytechnic Institute,ir,,1.0,0.25,2011
 Malik Magdon-Ismail,Rensselaer Polytechnic Institute,ir,,1.0,0.333333333333,2012
 Malik Magdon-Ismail,Rensselaer Polytechnic Institute,mlmining,,1.0,0.5,1997
 Malik Magdon-Ismail,Rensselaer Polytechnic Institute,mlmining,,1.0,0.5,1998
@@ -34167,6 +34372,7 @@ Manuel Egele,Boston University,sec,,1.0,0.166666666667,2012
 Manuel Egele,Boston University,sec,,1.0,0.25,2013
 Manuel Egele,Boston University,sec,,1.0,0.25,2014
 Manuel Egele,Boston University,sec,,2.0,0.291666666667,2015
+Manuel Gomez-Rodriguez,Max Planck Institute,ir,,1.0,0.333333333333,2014
 Manuel Gomez-Rodriguez,Max Planck Institute,ir,,3.0,0.75,2017
 Manuel Gomez-Rodriguez,Max Planck Institute,mlmining,,1.0,0.333333333333,2010
 Manuel Gomez-Rodriguez,Max Planck Institute,mlmining,,1.0,0.333333333333,2011
@@ -34372,6 +34578,7 @@ Marc Snir,University of Illinois at Urbana-Champaign,hpc,,1.0,0.0769230769231,20
 Marc Snir,University of Illinois at Urbana-Champaign,hpc,,2.0,0.833333333333,2011
 Marc Snir,University of Illinois at Urbana-Champaign,hpc,,1.0,0.25,2012
 Marc Snir,University of Illinois at Urbana-Champaign,hpc,,2.0,0.458333333333,2013
+Marc Snir,University of Illinois at Urbana-Champaign,hpc,,1.0,0.25,2017
 Marc Snir,University of Illinois at Urbana-Champaign,soft,,1.0,0.25,2011
 Marc Stevens,CWI,crypt,,1.0,0.333333333333,2007
 Marc Stevens,CWI,crypt,,1.0,0.142857142857,2009
@@ -34698,7 +34905,7 @@ Maria-Florina Balcan,Carnegie Mellon University,mlmining,,2.0,0.833333333333,201
 Maria-Florina Balcan,Carnegie Mellon University,mlmining,,6.0,1.39285714286,2014
 Maria-Florina Balcan,Carnegie Mellon University,mlmining,,3.0,1.03333333333,2016
 Marian-Andrei Rizoiu,Australian National University,ai,ijcai,1.0,0.25,2011
-Marian-Andrei Rizoiu,Australian National University,ir,,1.0,0.166666666667,2017
+Marian-Andrei Rizoiu,Australian National University,ir,,2.0,0.666666666667,2017
 Marianne Graves Petersen,Aarhus University,chi,,1.0,0.25,2012
 Marianne Graves Petersen,Aarhus University,chi,,1.0,0.25,2014
 Marianne Graves Petersen,Aarhus University,chi,,1.0,0.2,2016
@@ -34947,6 +35154,8 @@ Mark D. Reid,Australian National University,mlmining,,1.0,0.333333333333,2016
 Mark Dredze,Johns Hopkins University,ai,aaai,1.0,0.25,2016
 Mark Dredze,Johns Hopkins University,ai,ijcai,1.0,0.333333333333,2009
 Mark Dredze,Johns Hopkins University,chi,,1.0,0.2,2016
+Mark Dredze,Johns Hopkins University,ir,,1.0,0.5,2011
+Mark Dredze,Johns Hopkins University,ir,,2.0,0.833333333333,2014
 Mark Dredze,Johns Hopkins University,mlmining,,2.0,0.666666666667,2008
 Mark Dredze,Johns Hopkins University,mlmining,,1.0,0.333333333333,2009
 Mark Dredze,Johns Hopkins University,mlmining,,1.0,0.5,2012
@@ -35134,7 +35343,9 @@ Mark S. Ackerman,University of Michigan,chi,,1.0,0.25,2012
 Mark S. Ackerman,University of Michigan,chi,,3.0,0.833333333333,2015
 Mark S. Ackerman,University of Michigan,chi,,1.0,0.111111111111,2017
 Mark S. Ackerman,University of Michigan,ir,,1.0,0.333333333333,2007
-Mark S. Ackerman,University of Michigan,ir,,1.0,0.25,2008
+Mark S. Ackerman,University of Michigan,ir,,2.0,0.583333333333,2008
+Mark S. Ackerman,University of Michigan,ir,,1.0,0.25,2010
+Mark S. Ackerman,University of Michigan,ir,,2.0,0.45,2011
 Mark S. Ackerman,University of Michigan,mobile,,1.0,0.25,2004
 Mark S. Drew,Simon Fraser University,vis,,1.0,0.25,2002
 Mark S. Drew,Simon Fraser University,vision,cvpr,1.0,0.5,1988
@@ -35289,6 +35500,7 @@ Marleen de Bruijne,DIKU,mlmining,,1.0,0.2,2013
 Marlon Dumas,University of Tartu,ir,,1.0,0.2,2002
 Marlon Dumas,University of Tartu,ir,,1.0,0.2,2003
 Marlon Dumas,University of Tartu,ir,,1.0,0.5,2010
+Marlon Dumas,University of Tartu,ir,,1.0,0.333333333333,2014
 Marsette Vona,Northeastern University,robotics,,1.0,0.25,1998
 Marsette Vona,Northeastern University,robotics,,1.0,0.5,1999
 Marsette Vona,Northeastern University,robotics,,2.0,1.0,2000
@@ -35346,6 +35558,7 @@ Martha E. Pollack,University of Michigan,nlp,,1.0,1.0,1986
 Martha E. Pollack,University of Michigan,nlp,,1.0,0.5,1988
 Martha E. Pollack,University of Michigan,soft,,1.0,0.333333333333,1999
 Martha E. Pollack,University of Michigan,soft,,1.0,0.333333333333,2000
+Martha Larson,TU Delft,ir,,1.0,0.25,2011
 Martha Larson,TU Delft,ir,,2.0,0.366666666667,2012
 Martha Larson,TU Delft,vision,cvpr,1.0,0.333333333333,2015
 Martha Mercaldi,Columbia University,arch,,2.0,0.267857142857,2006
@@ -35354,6 +35567,7 @@ Martha Mercaldi Kim,Columbia University,arch,,1.0,0.25,2007
 Martha Mercaldi Kim,Columbia University,arch,,1.0,0.25,2008
 Martha Palmer,University of Colorado Boulder,ai,aaai,1.0,0.333333333333,2015
 Martha Palmer,University of Colorado Boulder,ai,ijcai,1.0,0.5,1981
+Martha Palmer,University of Colorado Boulder,ir,,1.0,0.125,2011
 Martha Palmer,University of Colorado Boulder,nlp,,1.0,1.0,1981
 Martha Palmer,University of Colorado Boulder,nlp,,1.0,0.166666666667,1986
 Martha Palmer,University of Colorado Boulder,nlp,,1.0,0.5,2004
@@ -35395,6 +35609,7 @@ Marti A. Hearst,University of California - Berkeley,chi,,1.0,0.333333333333,2016
 Marti A. Hearst,University of California - Berkeley,ir,,1.0,0.5,1993
 Marti A. Hearst,University of California - Berkeley,ir,,1.0,0.5,1996
 Marti A. Hearst,University of California - Berkeley,ir,,1.0,0.5,1997
+Marti A. Hearst,University of California - Berkeley,ir,,2.0,1.0,2009
 Marti A. Hearst,University of California - Berkeley,mlmining,,1.0,0.333333333333,1996
 Marti A. Hearst,University of California - Berkeley,nlp,,1.0,1.0,1994
 Marti A. Hearst,University of California - Berkeley,nlp,,1.0,1.0,1999
@@ -35923,6 +36138,7 @@ Masahiro Takatsuka,University of Sydney,vision,cvpr,1.0,0.25,1999
 Mashael AlSabah,Qatar University,sec,,1.0,0.333333333333,2012
 Mashael AlSabah,Qatar University,sec,,1.0,0.5,2013
 Mashael AlSabah,Qatar University,sec,,1.0,0.2,2015
+Massimiliano Pontil,University College London,ir,,1.0,0.25,2011
 Massimiliano Pontil,University College London,mlmining,,2.0,0.416666666667,2000
 Massimiliano Pontil,University College London,mlmining,,1.0,0.2,2001
 Massimiliano Pontil,University College London,mlmining,,2.0,1.0,2004
@@ -35957,6 +36173,7 @@ Matei Ripeanu,University of British Columbia,hpc,,2.0,0.75,2010
 Matei Ripeanu,University of British Columbia,hpc,,1.0,0.25,2011
 Matei Ripeanu,University of British Columbia,hpc,,1.0,0.25,2014
 Matei Ripeanu,University of British Columbia,hpc,,1.0,0.166666666667,2016
+Matei Ripeanu,University of British Columbia,hpc,,1.0,0.2,2017
 Matei Ripeanu,University of British Columbia,ir,,1.0,0.142857142857,2012
 Matei Zaharia,Stanford University,comm,,3.0,0.491666666667,2011
 Matei Zaharia,Stanford University,comm,,2.0,0.361111111111,2012
@@ -36018,6 +36235,7 @@ Mathias Payer,Purdue University,sec,,1.0,0.25,2013
 Mathias Payer,Purdue University,sec,,1.0,0.25,2014
 Mathias Payer,Purdue University,sec,,1.0,0.2,2015
 Mathias Payer,Purdue University,sec,,2.0,0.392857142857,2016
+Mathias Payer,Purdue University,sec,,1.0,0.142857142857,2017
 Mathieu Blanchette,McGill University,bio,,1.0,0.5,1999
 Mathieu Blanchette,McGill University,bio,,1.0,0.333333333333,2000
 Mathieu Blanchette,McGill University,bio,,2.0,1.5,2001
@@ -36171,6 +36389,7 @@ Matthew Fredrikson,Carnegie Mellon University,log,,1.0,0.142857142857,2012
 Matthew Fredrikson,Carnegie Mellon University,log,,1.0,0.5,2014
 Matthew Fredrikson,Carnegie Mellon University,sec,,2.0,0.75,2011
 Matthew Fredrikson,Carnegie Mellon University,sec,,3.0,0.766666666667,2014
+Matthew Fredrikson,Carnegie Mellon University,sec,,1.0,0.25,2017
 Matthew Green 0001,Johns Hopkins University,crypt,,1.0,0.166666666667,2017
 Matthew Green 0001,Johns Hopkins University,sec,,1.0,0.166666666667,2005
 Matthew Green 0001,Johns Hopkins University,sec,,1.0,0.333333333333,2010
@@ -36487,6 +36706,7 @@ Max Mintz,University of Pennsylvania,vision,iccv,1.0,0.333333333333,1998
 Max Mühlhäuser,TU Darmstadt,chi,,1.0,0.2,2014
 Max Mühlhäuser,TU Darmstadt,chi,,1.0,0.166666666667,2015
 Max Mühlhäuser,TU Darmstadt,chi,,1.0,0.2,2017
+Max Mühlhäuser,TU Darmstadt,ir,,1.0,0.2,2013
 Max Mühlhäuser,TU Darmstadt,metrics,,1.0,0.5,1983
 Max Mühlhäuser,TU Darmstadt,nlp,,1.0,0.333333333333,2007
 Max Mühlhäuser,TU Darmstadt,soft,,1.0,1.0,1988
@@ -36859,6 +37079,7 @@ Michael Buro,University of Alberta,ai,ijcai,2.0,1.0,2011
 Michael Buro,University of Alberta,ai,ijcai,1.0,0.5,2015
 Michael C. Ferris,University of Wisconsin - Madison,comm,,1.0,0.25,2002
 Michael C. Mozer,University of Colorado Boulder,chi,,1.0,0.2,2016
+Michael C. Mozer,University of Colorado Boulder,ir,,1.0,0.333333333333,2009
 Michael C. Mozer,University of Colorado Boulder,mlmining,,2.0,0.533333333333,2001
 Michael C. Mozer,University of Colorado Boulder,mlmining,,2.0,1.0,2004
 Michael C. Mozer,University of Colorado Boulder,mlmining,,1.0,0.333333333333,2006
@@ -37230,6 +37451,7 @@ Michael J. Cafarella,University of Michigan,ai,ijcai,1.0,0.2,2007
 Michael J. Cafarella,University of Michigan,arch,,1.0,0.2,2016
 Michael J. Cafarella,University of Michigan,ir,,1.0,0.111111111111,2004
 Michael J. Cafarella,University of Michigan,ir,,1.0,0.5,2005
+Michael J. Cafarella,University of Michigan,ir,,1.0,0.25,2013
 Michael J. Cafarella,University of Michigan,mlmining,,1.0,0.5,2014
 Michael J. Cafarella,University of Michigan,mod,,1.0,0.2,2008
 Michael J. Cafarella,University of Michigan,mod,,1.0,0.333333333333,2009
@@ -37291,10 +37513,12 @@ Michael J. Fischer,Yale University,act,,1.0,0.5,1993
 Michael J. Fischer,Yale University,act,,1.0,0.2,2001
 Michael J. Fischer,Yale University,crypt,,1.0,0.5,1991
 Michael J. Fischer,Yale University,ops,,1.0,0.166666666667,1981
+Michael J. Fischer,Yale University,sec,,1.0,0.125,2017
 Michael J. Franklin,University of Chicago,comm,,1.0,0.5,1998
 Michael J. Franklin,University of Chicago,comm,,1.0,0.111111111111,2012
 Michael J. Franklin,University of Chicago,comm,,1.0,0.2,2016
 Michael J. Franklin,University of Chicago,comm,,1.0,0.166666666667,2017
+Michael J. Franklin,University of Chicago,hpc,,1.0,0.333333333333,2017
 Michael J. Franklin,University of Chicago,mod,,1.0,0.25,1991
 Michael J. Franklin,University of Chicago,mod,,2.0,0.533333333333,1992
 Michael J. Franklin,University of Chicago,mod,,1.0,0.333333333333,1993
@@ -37355,6 +37579,7 @@ Michael J. O'Donnell,University of Chicago,plan,,1.0,0.5,1979
 Michael J. O'Donnell,University of Chicago,plan,,1.0,0.5,1984
 Michael J. Paul,University of Colorado Boulder,ai,aaai,1.0,0.5,2010
 Michael J. Paul,University of Colorado Boulder,ai,aaai,1.0,0.25,2016
+Michael J. Paul,University of Colorado Boulder,ir,,2.0,0.666666666667,2011
 Michael J. Paul,University of Colorado Boulder,ir,,1.0,0.333333333333,2015
 Michael J. Paul,University of Colorado Boulder,mlmining,,1.0,0.5,2012
 Michael J. Paul,University of Colorado Boulder,nlp,,1.0,0.5,2009
@@ -37749,7 +37974,10 @@ Michael S. Bernstein,Stanford University,chi,,3.0,0.511111111111,2014
 Michael S. Bernstein,Stanford University,chi,,4.0,0.842857142857,2015
 Michael S. Bernstein,Stanford University,chi,,7.0,1.95321750322,2016
 Michael S. Bernstein,Stanford University,chi,,3.0,0.7,2017
+Michael S. Bernstein,Stanford University,ir,,1.0,0.166666666667,2011
 Michael S. Bernstein,Stanford University,ir,,1.0,0.333333333333,2014
+Michael S. Bernstein,Stanford University,ir,,1.0,0.333333333333,2016
+Michael S. Bernstein,Stanford University,ir,,1.0,0.2,2017
 Michael S. Bernstein,Stanford University,vis,,1.0,0.333333333333,2014
 Michael S. Bernstein,Stanford University,vision,cvpr,1.0,0.142857142857,2015
 Michael S. Bernstein,Stanford University,vision,cvpr,1.0,0.25,2016
@@ -38034,9 +38262,11 @@ Michalis Polychronakis,Stony Brook University,sec,,2.0,0.583333333333,2012
 Michalis Polychronakis,Stony Brook University,sec,,1.0,0.333333333333,2013
 Michalis Polychronakis,Stony Brook University,sec,,3.0,0.783333333333,2014
 Michalis Polychronakis,Stony Brook University,sec,,1.0,0.166666666667,2016
+Michalis Polychronakis,Stony Brook University,sec,,1.0,0.25,2017
 Michalis Vazirgiannis,Athens University of Economics and Business,ai,aaai,1.0,0.25,2014
 Michalis Vazirgiannis,Athens University of Economics and Business,ai,aaai,1.0,0.333333333333,2017
 Michalis Vazirgiannis,Athens University of Economics and Business,ai,ijcai,1.0,0.333333333333,2007
+Michalis Vazirgiannis,Athens University of Economics and Business,ir,,1.0,0.2,2015
 Michalis Vazirgiannis,Athens University of Economics and Business,mlmining,,1.0,0.333333333333,2003
 Michalis Vazirgiannis,Athens University of Economics and Business,mod,,1.0,0.25,2007
 Michalis Vazirgiannis,Athens University of Economics and Business,mod,,1.0,0.25,2008
@@ -38096,6 +38326,7 @@ Michelle L. Mazurek,University of Maryland - College Park,sec,,2.0,0.19444444444
 Michelle L. Mazurek,University of Maryland - College Park,sec,,1.0,0.111111111111,2013
 Michelle L. Mazurek,University of Maryland - College Park,sec,,1.0,0.1,2015
 Michelle L. Mazurek,University of Maryland - College Park,sec,,4.0,1.0,2016
+Michelle L. Mazurek,University of Maryland - College Park,sec,,1.0,0.142857142857,2017
 Michelle L. Mazurek,University of Maryland - College Park,vis,,1.0,0.25,2013
 Michelle Mills Strout,University of Arizona,arch,,1.0,0.25,1998
 Michelle Mills Strout,University of Arizona,hpc,,1.0,0.2,2007
@@ -38668,6 +38899,7 @@ Miodrag Potkonjak,University of California - Los Angeles,mobile,,2.0,0.583333333
 Miodrag Potkonjak,University of California - Los Angeles,mobile,,2.0,0.583333333333,2003
 Mira Gonen,Ariel University,act,,1.0,0.333333333333,2010
 Mira Mezini,TU Darmstadt,plan,,1.0,0.166666666667,2013
+Mira Mezini,TU Darmstadt,sec,,1.0,0.2,2017
 Mira Mezini,TU Darmstadt,soft,,1.0,0.5,2004
 Mira Mezini,TU Darmstadt,soft,,1.0,0.5,2005
 Mira Mezini,TU Darmstadt,soft,,2.0,0.583333333333,2008
@@ -38682,6 +38914,7 @@ Mircea Nicolescu,University of Nevada,vision,cvpr,1.0,0.5,2003
 Mircea Nicolescu,University of Nevada,vision,cvpr,1.0,0.25,2007
 Mircea Nicolescu,University of Nevada,vision,eccv,1.0,0.5,2002
 Mircea Teodorescu,University of California - Santa Cruz,robotics,,3.0,0.625,2016
+Mirek Riedewald,Northeastern University,ir,,1.0,0.166666666667,2012
 Mirek Riedewald,Northeastern University,ir,,1.0,0.25,2017
 Mirek Riedewald,Northeastern University,mlmining,,1.0,0.125,2006
 Mirek Riedewald,Northeastern University,mlmining,,1.0,0.25,2008
@@ -39160,7 +39393,12 @@ Mor Naaman,Cornell University,chi,,2.0,0.583333333333,2016
 Mor Naaman,Cornell University,chi,,3.0,0.75,2017
 Mor Naaman,Cornell University,ir,,1.0,0.333333333333,2007
 Mor Naaman,Cornell University,ir,,1.0,0.5,2008
-Mor Naaman,Cornell University,ir,,1.0,0.5,2009
+Mor Naaman,Cornell University,ir,,2.0,0.833333333333,2009
+Mor Naaman,Cornell University,ir,,3.0,0.866666666667,2011
+Mor Naaman,Cornell University,ir,,1.0,0.25,2012
+Mor Naaman,Cornell University,ir,,2.0,0.75,2013
+Mor Naaman,Cornell University,ir,,1.0,0.2,2014
+Mor Naaman,Cornell University,ir,,2.0,0.583333333333,2015
 Mor Naaman,Cornell University,ir,,1.0,0.2,2016
 Mordecai J. Golin,Hong Kong University of Science and Technology,act,,2.0,1.25,1993
 Mordecai J. Golin,Hong Kong University of Science and Technology,act,,1.0,1.0,1996
@@ -39377,6 +39615,7 @@ Muhammad Ali Babar,University of Adelaide,soft,,1.0,0.166666666667,2016
 Muhammad Naveed 0001,University of Southern California,sec,,1.0,0.125,2013
 Muhammad Naveed 0001,University of Southern California,sec,,4.0,0.819047619048,2014
 Muhammad Naveed 0001,University of Southern California,sec,,2.0,0.4,2015
+Muhammad Naveed 0001,University of Southern California,sec,,1.0,0.2,2017
 Muhammad Shahzad,North Carolina State University,chi,,1.0,0.333333333333,2016
 Muhammad Shahzad,North Carolina State University,comm,,1.0,0.5,2015
 Muhammad Shahzad,North Carolina State University,metrics,,1.0,0.5,2013
@@ -39432,7 +39671,13 @@ Munmun De Choudhury,Georgia Institute of Technology,chi,,2.0,0.666666666667,2014
 Munmun De Choudhury,Georgia Institute of Technology,chi,,4.0,1.11666666667,2016
 Munmun De Choudhury,Georgia Institute of Technology,chi,,3.0,1.03333333333,2017
 Munmun De Choudhury,Georgia Institute of Technology,ir,,1.0,0.25,2009
-Munmun De Choudhury,Georgia Institute of Technology,ir,,1.0,0.25,2010
+Munmun De Choudhury,Georgia Institute of Technology,ir,,2.0,0.416666666667,2010
+Munmun De Choudhury,Georgia Institute of Technology,ir,,1.0,0.333333333333,2011
+Munmun De Choudhury,Georgia Institute of Technology,ir,,2.0,0.666666666667,2012
+Munmun De Choudhury,Georgia Institute of Technology,ir,,1.0,0.25,2013
+Munmun De Choudhury,Georgia Institute of Technology,ir,,2.0,0.7,2014
+Munmun De Choudhury,Georgia Institute of Technology,ir,,1.0,0.25,2016
+Munmun De Choudhury,Georgia Institute of Technology,ir,,1.0,0.5,2017
 Murali Annavaram,University of Southern California,arch,,1.0,0.333333333333,2001
 Murali Annavaram,University of Southern California,arch,,1.0,0.142857142857,2003
 Murali Annavaram,University of Southern California,arch,,1.0,0.166666666667,2004
@@ -40208,6 +40453,7 @@ Nick Feamster,Princeton University,comm,,1.0,0.111111111111,2012
 Nick Feamster,Princeton University,comm,,1.0,0.1,2014
 Nick Feamster,Princeton University,comm,,3.0,1.0,2015
 Nick Feamster,Princeton University,comm,,2.0,0.285714285714,2016
+Nick Feamster,Princeton University,ir,,1.0,0.333333333333,2012
 Nick Feamster,Princeton University,metrics,,1.0,0.25,2003
 Nick Feamster,Princeton University,metrics,,2.0,0.666666666667,2004
 Nick Feamster,Princeton University,metrics,,1.0,0.25,2007
@@ -40228,7 +40474,9 @@ Nick Feamster,Princeton University,sec,,2.0,0.533333333333,2010
 Nick Feamster,Princeton University,sec,,1.0,0.166666666667,2013
 Nick Feamster,Princeton University,sec,,1.0,0.333333333333,2014
 Nick Feamster,Princeton University,sec,,2.0,0.45,2016
+Nick Feamster,Princeton University,sec,,2.0,0.4,2017
 Nick Koudas,University of Toronto,ir,,1.0,0.25,2003
+Nick Koudas,University of Toronto,ir,,1.0,0.333333333333,2009
 Nick Koudas,University of Toronto,mlmining,,1.0,0.2,2002
 Nick Koudas,University of Toronto,mlmining,,1.0,0.333333333333,2003
 Nick Koudas,University of Toronto,mlmining,,1.0,0.333333333333,2013
@@ -40282,6 +40530,7 @@ Nick Nikiforakis,Stony Brook University,sec,,2.0,0.375,2012
 Nick Nikiforakis,Stony Brook University,sec,,2.0,0.309523809524,2013
 Nick Nikiforakis,Stony Brook University,sec,,1.0,0.25,2014
 Nick Nikiforakis,Stony Brook University,sec,,3.0,0.708333333333,2015
+Nick Nikiforakis,Stony Brook University,sec,,2.0,0.75,2017
 Nick R. Jennings,Imperial College London,ai,ijcai,1.0,0.25,2015
 Nick Roussopoulos,University of Maryland - College Park,ai,ijcai,1.0,0.25,1973
 Nick Roussopoulos,University of Maryland - College Park,mod,,1.0,0.5,1975
@@ -40404,6 +40653,7 @@ Nigel Shadbolt,University of Oxford,chi,,2.0,0.45,2016
 Nigel Shadbolt,University of Oxford,chi,,1.0,0.166666666667,2017
 Nigel Shadbolt,University of Oxford,ir,,1.0,0.333333333333,2003
 Nigel Shadbolt,University of Oxford,ir,,1.0,0.2,2009
+Nigel Shadbolt,University of Oxford,ir,,1.0,0.166666666667,2014
 Nigel Shadbolt,University of Oxford,ir,,1.0,0.25,2015
 Nigel Topham,University of Edinburgh,robotics,,1.0,0.0833333333333,2015
 Niki Trigoni,University of Oxford,ai,aaai,1.0,0.2,2017
@@ -40522,6 +40772,7 @@ Nilanjan Banerjee,University of Maryland - Baltimore County,comm,,1.0,0.33333333
 Nilanjan Banerjee,University of Maryland - Baltimore County,comm,,1.0,0.142857142857,2016
 Nilanjan Banerjee,University of Maryland - Baltimore County,da,,1.0,0.2,2005
 Nilanjan Banerjee,University of Maryland - Baltimore County,da,,1.0,0.25,2007
+Nilanjan Banerjee,University of Maryland - Baltimore County,ir,,1.0,0.166666666667,2012
 Nilanjan Banerjee,University of Maryland - Baltimore County,mobile,,1.0,0.25,2005
 Nilanjan Banerjee,University of Maryland - Baltimore County,mobile,,1.0,0.2,2007
 Nilanjan Banerjee,University of Maryland - Baltimore County,mobile,,1.0,0.25,2008
@@ -40529,7 +40780,8 @@ Niloy Ganguly,IIT Kharagpur,chi,,1.0,0.2,2015
 Niloy Ganguly,IIT Kharagpur,comm,,1.0,0.25,2010
 Niloy Ganguly,IIT Kharagpur,comm,,1.0,0.142857142857,2016
 Niloy Ganguly,IIT Kharagpur,ir,,3.0,0.575,2012
-Niloy Ganguly,IIT Kharagpur,ir,,1.0,0.25,2017
+Niloy Ganguly,IIT Kharagpur,ir,,1.0,0.333333333333,2016
+Niloy Ganguly,IIT Kharagpur,ir,,2.0,0.416666666667,2017
 Niloy Ganguly,IIT Kharagpur,mlmining,,1.0,0.2,2014
 Niloy Ganguly,IIT Kharagpur,mlmining,,1.0,0.2,2016
 Niloy Ganguly,IIT Kharagpur,nlp,,1.0,0.25,2006
@@ -40601,6 +40853,7 @@ Ninghui Li,Purdue University,sec,,2.0,0.291666666667,2012
 Ninghui Li,Purdue University,sec,,1.0,0.2,2013
 Ninghui Li,Purdue University,sec,,1.0,0.25,2014
 Ninghui Li,Purdue University,sec,,2.0,0.4,2016
+Ninghui Li,Purdue University,sec,,1.0,0.142857142857,2017
 Nir Ailon,Technion - Israel Institute of Technology,act,,1.0,0.5,2004
 Nir Ailon,Technion - Israel Institute of Technology,act,,2.0,0.833333333333,2005
 Nir Ailon,Technion - Israel Institute of Technology,act,,2.0,0.75,2006
@@ -40696,6 +40949,15 @@ Nisheeth K. Vishnoi,EPFL,vision,cvpr,1.0,0.333333333333,2011
 Nisheeth Srivastava,IIT Kanpur,mlmining,,1.0,0.5,2012
 Nisheeth Srivastava,IIT Kanpur,mlmining,,1.0,0.25,2013
 Nisheeth Srivastava,IIT Kanpur,mlmining,,1.0,0.333333333333,2014
+Nitesh Saxena,University of Alabama at Birmingham,chi,,1.0,0.25,2010
+Nitesh Saxena,University of Alabama at Birmingham,chi,,2.0,0.833333333333,2011
+Nitesh Saxena,University of Alabama at Birmingham,ir,,1.0,0.333333333333,2017
+Nitesh Saxena,University of Alabama at Birmingham,sec,,1.0,0.25,2006
+Nitesh Saxena,University of Alabama at Birmingham,sec,,1.0,0.5,2010
+Nitesh Saxena,University of Alabama at Birmingham,sec,,1.0,0.25,2011
+Nitesh Saxena,University of Alabama at Birmingham,sec,,1.0,0.5,2014
+Nitesh Saxena,University of Alabama at Birmingham,sec,,1.0,0.25,2015
+Nitesh Saxena,University of Alabama at Birmingham,sec,,1.0,0.25,2016
 Nitesh V. Chawla,University of Notre Dame,ai,aaai,1.0,0.5,2007
 Nitesh V. Chawla,University of Notre Dame,hpc,,1.0,0.25,2006
 Nitesh V. Chawla,University of Notre Dame,ir,,1.0,0.5,2012
@@ -40743,6 +41005,9 @@ Noa Agmon,Bar-Ilan University,robotics,,1.0,0.333333333333,2013
 Noa Agmon,Bar-Ilan University,robotics,,1.0,0.333333333333,2014
 Noa Agmon,Bar-Ilan University,robotics,,2.0,1.0,2015
 Noah A. Smith,University of Washington,ai,aaai,2.0,0.583333333333,2015
+Noah A. Smith,University of Washington,ir,,1.0,0.2,2009
+Noah A. Smith,University of Washington,ir,,2.0,0.75,2010
+Noah A. Smith,University of Washington,ir,,1.0,0.333333333333,2013
 Noah A. Smith,University of Washington,ir,,1.0,0.142857142857,2016
 Noah A. Smith,University of Washington,mlmining,,2.0,0.533333333333,2008
 Noah A. Smith,University of Washington,mlmining,,1.0,0.333333333333,2009
@@ -40929,6 +41194,7 @@ Norman M. Sadeh,Carnegie Mellon University,chi,,3.0,0.60119047619,2013
 Norman M. Sadeh,Carnegie Mellon University,chi,,2.0,0.416666666667,2014
 Norman M. Sadeh,Carnegie Mellon University,chi,,1.0,0.125,2015
 Norman M. Sadeh,Carnegie Mellon University,ir,,1.0,0.333333333333,2007
+Norman M. Sadeh,Carnegie Mellon University,ir,,1.0,0.25,2012
 Norman M. Sadeh,Carnegie Mellon University,ir,,1.0,0.333333333333,2014
 Norman M. Sadeh,Carnegie Mellon University,ir,,1.0,0.142857142857,2016
 Norman M. Sadeh,Carnegie Mellon University,mlmining,,1.0,0.166666666667,2013
@@ -41259,6 +41525,7 @@ Oskar von Stryk,TU Darmstadt,robotics,,2.0,0.75,2014
 Oskar von Stryk,TU Darmstadt,robotics,,1.0,0.5,2015
 Oskar von Stryk,TU Darmstadt,robotics,,1.0,0.333333333333,2016
 Osmar R. Zaïane,University of Alberta,ai,aaai,1.0,0.5,2017
+Osmar R. Zaïane,University of Alberta,ir,,1.0,0.25,2011
 Osmar R. Zaïane,University of Alberta,mlmining,,1.0,0.5,1995
 Osmar R. Zaïane,University of Alberta,mlmining,,1.0,0.0833333333333,1996
 Osmar R. Zaïane,University of Alberta,mlmining,,1.0,0.5,2003
@@ -41326,7 +41593,9 @@ P. Krishna Gummadi,Max Planck Institute,comm,,1.0,0.166666666667,2003
 P. Krishna Gummadi,Max Planck Institute,comm,,2.0,0.45,2008
 P. Krishna Gummadi,Max Planck Institute,comm,,2.0,0.416666666667,2010
 P. Krishna Gummadi,Max Planck Institute,ir,,1.0,0.333333333333,2009
-P. Krishna Gummadi,Max Planck Institute,ir,,2.0,0.325,2012
+P. Krishna Gummadi,Max Planck Institute,ir,,1.0,0.25,2010
+P. Krishna Gummadi,Max Planck Institute,ir,,1.0,0.25,2011
+P. Krishna Gummadi,Max Planck Institute,ir,,4.0,0.775,2012
 P. Krishna Gummadi,Max Planck Institute,metrics,,1.0,0.25,2006
 P. Krishna Gummadi,Max Planck Institute,metrics,,2.0,0.45,2011
 P. Krishna Gummadi,Max Planck Institute,ops,,1.0,0.2,2002
@@ -41415,6 +41684,8 @@ Pablo Barceló,Universidad de Chile,plan,,1.0,0.5,2016
 Pablo de Cristóforis,University of Buenos Aires,robotics,,1.0,0.2,2015
 Pablo de Cristóforis,University of Buenos Aires,robotics,,1.0,0.2,2016
 Padhraic Smyth,University of California - Irvine,act,,1.0,0.25,2013
+Padhraic Smyth,University of California - Irvine,ir,,1.0,0.333333333333,2011
+Padhraic Smyth,University of California - Irvine,ir,,1.0,0.5,2015
 Padhraic Smyth,University of California - Irvine,mlmining,,1.0,0.333333333333,1988
 Padhraic Smyth,University of California - Irvine,mlmining,,1.0,1.0,1990
 Padhraic Smyth,University of California - Irvine,mlmining,,1.0,0.5,1991
@@ -41452,7 +41723,8 @@ Padmini Srinivasan,University of Iowa,bio,,1.0,0.333333333333,2011
 Padmini Srinivasan,University of Iowa,chi,,1.0,0.2,2017
 Padmini Srinivasan,University of Iowa,ir,,1.0,0.333333333333,1998
 Padmini Srinivasan,University of Iowa,ir,,1.0,0.25,2001
-Padmini Srinivasan,University of Iowa,ir,,1.0,0.25,2012
+Padmini Srinivasan,University of Iowa,ir,,1.0,0.5,2011
+Padmini Srinivasan,University of Iowa,ir,,2.0,0.75,2012
 Padmini Srinivasan,University of Iowa,mlmining,,1.0,0.333333333333,2016
 Padmini Srinivasan,University of Iowa,nlp,,1.0,0.2,2015
 Padmini Srinivasan,University of Iowa,robotics,,1.0,0.333333333333,1993
@@ -41549,7 +41821,6 @@ Panos Kalnis,KAUST,mod,,1.0,0.25,2011
 Panos Kalnis,KAUST,mod,,1.0,0.2,2013
 Panos Kalnis,KAUST,mod,,1.0,0.25,2014
 Panos Kalnis,KAUST,mod,,1.0,0.125,2015
-Panos Kalnis,KAUST,mod,,1.0,0.125,2017
 Panos Kalnis,KAUST,ops,,1.0,0.166666666667,2013
 Paolo A. G. Sivilotti,Ohio State University,hpc,,1.0,0.142857142857,1996
 Paolo A. G. Sivilotti,Ohio State University,soft,,1.0,0.5,2001
@@ -41571,7 +41842,7 @@ Paolo Ferragina,University of Pisa,bio,,1.0,0.166666666667,1999
 Paolo Ferragina,University of Pisa,ir,,1.0,0.25,2006
 Paolo Ferragina,University of Pisa,ir,,1.0,0.5,2007
 Paolo Ferragina,University of Pisa,ir,,1.0,0.333333333333,2013
-Paolo Ferragina,University of Pisa,ir,,2.0,0.380952380952,2015
+Paolo Ferragina,University of Pisa,ir,,3.0,0.714285714286,2015
 Paolo Ferragina,University of Pisa,ir,,1.0,0.2,2016
 Paolo Giacomazzi,Politecnico di Milano,comm,,1.0,0.333333333333,1991
 Paolo Ienne,EPFL,arch,,1.0,0.111111111111,2015
@@ -41593,7 +41864,6 @@ Paolo Papotti,Arizona State University,mod,,3.0,0.833333333333,2013
 Paolo Papotti,Arizona State University,mod,,1.0,0.25,2014
 Paolo Papotti,Arizona State University,mod,,5.0,0.745634920635,2015
 Paolo Papotti,Arizona State University,mod,,2.0,0.253968253968,2016
-Paolo Papotti,Arizona State University,mod,,1.0,0.125,2017
 Paolo Romano 0002,Universidade de Lisboa,arch,,1.0,0.166666666667,2016
 Paolo Romano 0002,Universidade de Lisboa,ops,,1.0,0.25,2016
 Parag Singla,IIT Delhi,ai,aaai,1.0,0.5,2005
@@ -41638,6 +41908,7 @@ Parth H. Pathak,George Mason University,mobile,,1.0,0.2,2015
 Partha Dasgupta,Arizona State University,hpc,,1.0,0.333333333333,1995
 Partha Mukhopadhyay,CMI,act,,2.0,0.583333333333,2010
 Partha Mukhopadhyay,CMI,act,,1.0,0.25,2017
+Partha P. Talukdar,IISc Bangalore,ir,,1.0,0.333333333333,2016
 Partha P. Talukdar,IISc Bangalore,nlp,,2.0,0.833333333333,2015
 Partha P. Talukdar,IISc Bangalore,nlp,,1.0,0.333333333333,2016
 Partha Pratim Chakrabarti,IIT Kharagpur,da,,1.0,0.2,2014
@@ -42052,6 +42323,7 @@ Paul C. van Oorschot,Carleton University,sec,,2.0,0.75,2010
 Paul C. van Oorschot,Carleton University,sec,,2.0,0.416666666667,2012
 Paul C. van Oorschot,Carleton University,sec,,1.0,0.5,2013
 Paul C. van Oorschot,Carleton University,sec,,1.0,0.333333333333,2014
+Paul C. van Oorschot,Carleton University,sec,,1.0,0.5,2017
 Paul D. Seymour,Princeton University,act,,1.0,0.333333333333,1985
 Paul D. Seymour,Princeton University,act,,1.0,0.333333333333,1990
 Paul D. Seymour,Princeton University,act,,1.0,0.2,1992
@@ -42554,7 +42826,7 @@ Peter C. Rigby,Concordia University,soft,,1.0,0.333333333333,2008
 Peter C. Rigby,Concordia University,soft,,1.0,0.5,2011
 Peter C. Rigby,Concordia University,soft,,2.0,1.0,2013
 Peter C. Rigby,Concordia University,soft,,1.0,0.25,2016
-Peter Christen,Australian National University,ir,,1.0,0.125,2012
+Peter Christen,Australian National University,ir,,2.0,0.458333333333,2012
 Peter Christen,Australian National University,mlmining,,1.0,1.0,2008
 Peter Christen,Australian National University,mlmining,,1.0,0.25,2015
 Peter Desnoyers,Northeastern University,mobile,,1.0,0.333333333333,2005
@@ -43266,6 +43538,7 @@ Philip S. Yu,University of Illinois at Chicago,mod,,2.0,0.366666666667,2011
 Philip S. Yu,University of Illinois at Chicago,mod,,1.0,0.25,2012
 Philip S. Yu,University of Illinois at Chicago,mod,,2.0,0.5,2013
 Philip S. Yu,University of Illinois at Chicago,mod,,1.0,0.25,2015
+Philip S. Yu,University of Illinois at Chicago,mod,,1.0,0.25,2017
 Philip S. Yu,University of Illinois at Chicago,vision,cvpr,1.0,0.166666666667,2013
 Philip S. Yu,University of Illinois at Chicago,vision,cvpr,1.0,0.2,2014
 Philip S. Yu,University of Illinois at Chicago,vision,iccv,1.0,0.2,2013
@@ -43490,6 +43763,7 @@ Phyllis G. Frankl,New York University,soft,,1.0,0.25,1997
 Phyllis G. Frankl,New York University,soft,,1.0,0.5,1998
 Phyllis G. Frankl,New York University,soft,,1.0,0.333333333333,2005
 Piero Fraternali,Politecnico di Milano,ir,,1.0,0.25,2010
+Piero Fraternali,Politecnico di Milano,ir,,1.0,0.25,2015
 Piero Fraternali,Politecnico di Milano,mod,,1.0,0.333333333333,1999
 Piero Fraternali,Politecnico di Milano,mod,,1.0,0.333333333333,2012
 Pierpaolo Degano,University of Pisa,act,,1.0,0.5,1984
@@ -43818,6 +44092,8 @@ Ponnurangam Kumaraguru,IIIT Delhi,chi,,1.0,0.2,2010
 Ponnurangam Kumaraguru,IIIT Delhi,chi,,1.0,0.333333333333,2011
 Ponnurangam Kumaraguru,IIIT Delhi,chi,,1.0,0.2,2012
 Ponnurangam Kumaraguru,IIIT Delhi,chi,,1.0,0.333333333333,2017
+Ponnurangam Kumaraguru,IIIT Delhi,ir,,1.0,0.142857142857,2013
+Ponnurangam Kumaraguru,IIIT Delhi,ir,,1.0,0.2,2016
 Ponnuswamy Sadayappan,Ohio State University,hpc,,1.0,0.5,1989
 Ponnuswamy Sadayappan,Ohio State University,robotics,,1.0,0.333333333333,1992
 Poorvi L. Vora,George Washington University,sec,,1.0,0.0833333333333,2010
@@ -44074,6 +44350,7 @@ Prateek Mittal,Princeton University,sec,,2.0,0.533333333333,2010
 Prateek Mittal,Princeton University,sec,,2.0,0.4,2011
 Prateek Mittal,Princeton University,sec,,3.0,0.592857142857,2015
 Prateek Mittal,Princeton University,sec,,1.0,0.333333333333,2016
+Prateek Mittal,Princeton University,sec,,1.0,0.2,2017
 Prateek Saxena,National University of Singapore,plan,,1.0,0.25,2014
 Prateek Saxena,National University of Singapore,sec,,1.0,0.166666666667,2010
 Prateek Saxena,National University of Singapore,sec,,3.0,0.866666666667,2011
@@ -44230,6 +44507,7 @@ Qiang Liu,Dartmouth College,ai,aaai,1.0,0.333333333333,2015
 Qiang Liu,Dartmouth College,ai,aaai,1.0,0.25,2016
 Qiang Liu,Dartmouth College,ai,aaai,1.0,0.166666666667,2017
 Qiang Liu,Dartmouth College,comm,,1.0,0.333333333333,2013
+Qiang Liu,Dartmouth College,hpc,,1.0,0.142857142857,2017
 Qiang Liu,Dartmouth College,mlmining,,1.0,0.25,2010
 Qiang Liu,Dartmouth College,mlmining,,1.0,0.5,2011
 Qiang Liu,Dartmouth College,mlmining,,2.0,0.833333333333,2012
@@ -44323,12 +44601,13 @@ Qiaozhu Mei,University of Michigan,ir,,1.0,0.25,2006
 Qiaozhu Mei,University of Michigan,ir,,2.0,0.533333333333,2007
 Qiaozhu Mei,University of Michigan,ir,,2.0,0.583333333333,2008
 Qiaozhu Mei,University of Michigan,ir,,1.0,0.2,2009
+Qiaozhu Mei,University of Michigan,ir,,1.0,0.333333333333,2011
 Qiaozhu Mei,University of Michigan,ir,,1.0,0.25,2012
-Qiaozhu Mei,University of Michigan,ir,,1.0,0.5,2013
-Qiaozhu Mei,University of Michigan,ir,,2.0,0.5,2014
-Qiaozhu Mei,University of Michigan,ir,,2.0,0.5,2015
+Qiaozhu Mei,University of Michigan,ir,,2.0,0.833333333333,2013
+Qiaozhu Mei,University of Michigan,ir,,3.0,0.7,2014
+Qiaozhu Mei,University of Michigan,ir,,3.0,0.666666666667,2015
 Qiaozhu Mei,University of Michigan,ir,,2.0,0.392857142857,2016
-Qiaozhu Mei,University of Michigan,ir,,1.0,0.25,2017
+Qiaozhu Mei,University of Michigan,ir,,2.0,0.416666666667,2017
 Qiaozhu Mei,University of Michigan,metrics,,1.0,0.125,2015
 Qiaozhu Mei,University of Michigan,mlmining,,1.0,0.5,2005
 Qiaozhu Mei,University of Michigan,mlmining,,3.0,0.95,2006
@@ -44555,6 +44834,7 @@ Rachid Guerraoui,EPFL,comm,,1.0,0.5,2011
 Rachid Guerraoui,EPFL,comm,,1.0,0.25,2016
 Rachid Guerraoui,EPFL,log,,2.0,0.833333333333,2009
 Rachid Guerraoui,EPFL,mod,,1.0,0.25,2015
+Rachid Guerraoui,EPFL,mod,,1.0,0.25,2017
 Rachid Guerraoui,EPFL,ops,,1.0,0.333333333333,2007
 Rachid Guerraoui,EPFL,ops,,1.0,0.25,2010
 Rachid Guerraoui,EPFL,ops,,1.0,0.333333333333,2012
@@ -44585,6 +44865,8 @@ Rada Chirkova,North Carolina State University,mod,,1.0,0.5,2008
 Rada Mihalcea,University of Michigan,ai,aaai,1.0,0.5,1999
 Rada Mihalcea,University of Michigan,ai,aaai,1.0,0.333333333333,2006
 Rada Mihalcea,University of Michigan,ai,aaai,1.0,0.5,2011
+Rada Mihalcea,University of Michigan,ir,,1.0,0.5,2007
+Rada Mihalcea,University of Michigan,ir,,1.0,0.166666666667,2015
 Rada Mihalcea,University of Michigan,nlp,,1.0,0.5,1999
 Rada Mihalcea,University of Michigan,nlp,,1.0,0.142857142857,2000
 Rada Mihalcea,University of Michigan,nlp,,1.0,0.111111111111,2001
@@ -45255,6 +45537,7 @@ Ramana Rao Kompella,Purdue University,comm,,2.0,0.5,2012
 Ramana Rao Kompella,Purdue University,comm,,1.0,0.25,2013
 Ramana Rao Kompella,Purdue University,hpc,,1.0,0.25,2010
 Ramana Rao Kompella,Purdue University,hpc,,1.0,0.166666666667,2012
+Ramana Rao Kompella,Purdue University,ir,,1.0,0.333333333333,2012
 Ramana Rao Kompella,Purdue University,metrics,,1.0,0.333333333333,2004
 Ramana Rao Kompella,Purdue University,metrics,,2.0,0.5,2011
 Ramana Rao Kompella,Purdue University,metrics,,1.0,0.333333333333,2012
@@ -45553,6 +45836,7 @@ Randal C. Burns,Johns Hopkins University,hpc,,1.0,0.2,2011
 Randal C. Burns,Johns Hopkins University,hpc,,1.0,0.2,2012
 Randal C. Burns,Johns Hopkins University,hpc,,1.0,0.333333333333,2013
 Randal C. Burns,Johns Hopkins University,hpc,,1.0,0.5,2015
+Randal C. Burns,Johns Hopkins University,hpc,,1.0,0.2,2017
 Randal C. Burns,Johns Hopkins University,sec,,1.0,0.142857142857,2007
 Randal C. Nelson,University of Rochester,ai,aaai,1.0,0.333333333333,2002
 Randal C. Nelson,University of Rochester,graph,,1.0,0.5,1986
@@ -45724,6 +46008,7 @@ Ranjit Jhala,University of California - San Diego,plan,,3.0,0.75,2012
 Ranjit Jhala,University of California - San Diego,plan,,2.0,0.666666666667,2016
 Ranjit Jhala,University of California - San Diego,sec,,1.0,0.25,2010
 Ranjit Jhala,University of California - San Diego,sec,,1.0,0.166666666667,2015
+Ranjit Jhala,University of California - San Diego,sec,,1.0,0.166666666667,2017
 Ranjit Jhala,University of California - San Diego,soft,,1.0,0.2,2004
 Ranjit Jhala,University of California - San Diego,soft,,2.0,0.666666666667,2005
 Ranjit Jhala,University of California - San Diego,soft,,1.0,0.5,2006
@@ -46003,6 +46288,8 @@ Raymond T. Ng,University of British Columbia,bio,,1.0,0.142857142857,2006
 Raymond T. Ng,University of British Columbia,bio,,1.0,0.25,2007
 Raymond T. Ng,University of British Columbia,bio,,1.0,0.125,2009
 Raymond T. Ng,University of British Columbia,ir,,1.0,0.333333333333,2007
+Raymond T. Ng,University of British Columbia,ir,,1.0,0.25,2009
+Raymond T. Ng,University of British Columbia,ir,,1.0,0.25,2011
 Raymond T. Ng,University of British Columbia,mlmining,,1.0,0.333333333333,1999
 Raymond T. Ng,University of British Columbia,mlmining,,1.0,0.333333333333,2001
 Raymond T. Ng,University of British Columbia,mlmining,,1.0,0.25,2004
@@ -46164,6 +46451,7 @@ Remzi H. Arpaci-Dusseau,University of Wisconsin - Madison,hpc,,1.0,0.25,1999
 Remzi H. Arpaci-Dusseau,University of Wisconsin - Madison,hpc,,1.0,0.2,2001
 Remzi H. Arpaci-Dusseau,University of Wisconsin - Madison,hpc,,1.0,0.125,2002
 Remzi H. Arpaci-Dusseau,University of Wisconsin - Madison,hpc,,1.0,0.2,2003
+Remzi H. Arpaci-Dusseau,University of Wisconsin - Madison,hpc,,1.0,0.25,2017
 Remzi H. Arpaci-Dusseau,University of Wisconsin - Madison,mod,,1.0,0.2,1997
 Remzi H. Arpaci-Dusseau,University of Wisconsin - Madison,ops,,1.0,0.5,2001
 Remzi H. Arpaci-Dusseau,University of Wisconsin - Madison,ops,,2.0,0.583333333333,2002
@@ -46411,6 +46699,7 @@ Richard E. Ladner,University of Washington,chi,,1.0,0.2,2009
 Richard E. Ladner,University of Washington,chi,,3.0,0.666666666667,2011
 Richard E. Ladner,University of Washington,chi,,1.0,0.333333333333,2013
 Richard E. Ladner,University of Washington,chi,,1.0,0.333333333333,2015
+Richard E. Ladner,University of Washington,ir,,1.0,0.2,2008
 Richard E. Ladner,University of Washington,mlmining,,1.0,0.333333333333,1989
 Richard E. Ladner,University of Washington,nlp,,1.0,0.333333333333,2006
 Richard E. Newman-Wolfe,University of Florida,sec,,1.0,0.5,1995
@@ -47052,6 +47341,7 @@ Robert E. Kraut,Carnegie Mellon University,chi,,7.0,2.25,2014
 Robert E. Kraut,Carnegie Mellon University,chi,,1.0,0.166666666667,2016
 Robert E. Kraut,Carnegie Mellon University,chi,,1.0,0.333333333333,2017
 Robert E. Kraut,Carnegie Mellon University,ir,,1.0,0.2,2006
+Robert E. Kraut,Carnegie Mellon University,ir,,1.0,0.25,2016
 Robert E. Mahony,Australian National University,robotics,,1.0,0.5,2000
 Robert E. Mahony,Australian National University,robotics,,2.0,0.833333333333,2001
 Robert E. Mahony,Australian National University,robotics,,4.0,1.33333333333,2002
@@ -47178,6 +47468,7 @@ Robert Kleinberg,Cornell University,act,,1.0,0.333333333333,2014
 Robert Kleinberg,Cornell University,act,,2.0,0.5,2017
 Robert Kleinberg,Cornell University,ai,aaai,1.0,0.5,2010
 Robert Kleinberg,Cornell University,comm,,1.0,1.0,2007
+Robert Kleinberg,Cornell University,ir,,1.0,0.25,2013
 Robert Kleinberg,Cornell University,mlmining,,1.0,0.333333333333,2008
 Robert Kleinberg,Cornell University,mlmining,,1.0,0.25,2012
 Robert Kleinberg,Cornell University,mlmining,,1.0,0.25,2013
@@ -47763,6 +48054,7 @@ Romit Roy Choudhury,University of Illinois at Urbana-Champaign,comm,,3.0,0.66666
 Romit Roy Choudhury,University of Illinois at Urbana-Champaign,comm,,1.0,0.333333333333,2015
 Romit Roy Choudhury,University of Illinois at Urbana-Champaign,comm,,1.0,0.5,2016
 Romit Roy Choudhury,University of Illinois at Urbana-Champaign,comm,,1.0,0.142857142857,2017
+Romit Roy Choudhury,University of Illinois at Urbana-Champaign,ir,,1.0,0.25,2014
 Romit Roy Choudhury,University of Illinois at Urbana-Champaign,ir,,1.0,0.333333333333,2016
 Romit Roy Choudhury,University of Illinois at Urbana-Champaign,mobile,,1.0,0.25,2002
 Romit Roy Choudhury,University of Illinois at Urbana-Champaign,mobile,,1.0,0.2,2008
@@ -48267,9 +48559,11 @@ Roxana Geambasu,Columbia University,ops,,1.0,0.2,2016
 Roxana Geambasu,Columbia University,sec,,1.0,0.25,2009
 Roxana Geambasu,Columbia University,sec,,1.0,0.125,2014
 Roxana Geambasu,Columbia University,sec,,1.0,0.166666666667,2015
+Roxana Geambasu,Columbia University,sec,,1.0,0.2,2017
 Roxana Girju,University of Illinois at Urbana-Champaign,ai,aaai,1.0,0.2,2005
 Roxana Girju,University of Illinois at Urbana-Champaign,ai,aaai,1.0,0.333333333333,2008
 Roxana Girju,University of Illinois at Urbana-Champaign,ai,aaai,1.0,0.5,2010
+Roxana Girju,University of Illinois at Urbana-Champaign,ir,,1.0,1.0,2010
 Roxana Girju,University of Illinois at Urbana-Champaign,nlp,,1.0,0.142857142857,2000
 Roxana Girju,University of Illinois at Urbana-Champaign,nlp,,1.0,0.111111111111,2001
 Roxana Girju,University of Illinois at Urbana-Champaign,nlp,,1.0,0.333333333333,2003
@@ -48705,6 +48999,7 @@ S. Muthukrishnan,Rutgers University,bio,,1.0,0.5,1997
 S. Muthukrishnan,Rutgers University,comm,,3.0,1.03333333333,2000
 S. Muthukrishnan,Rutgers University,comm,,1.0,0.5,2004
 S. Muthukrishnan,Rutgers University,ir,,1.0,0.25,2006
+S. Muthukrishnan,Rutgers University,ir,,1.0,0.2,2007
 S. Muthukrishnan,Rutgers University,ir,,2.0,0.45,2009
 S. Muthukrishnan,Rutgers University,ir,,2.0,0.833333333333,2010
 S. Muthukrishnan,Rutgers University,ir,,1.0,0.2,2011
@@ -48803,6 +49098,7 @@ Sabarish V. Babu,Clemson University,vis,,1.0,0.1,2014
 Sabarish V. Babu,Clemson University,vis,,1.0,0.111111111111,2015
 Sabarish V. Babu,Clemson University,vis,,2.0,0.25,2016
 Sabine Bergler,Concordia University,ai,aaai,1.0,0.5,2006
+Sabine Bergler,Concordia University,ir,,1.0,0.333333333333,2007
 Sabine Bergler,Concordia University,nlp,,1.0,0.5,2008
 Sabine Süsstrunk,EPFL,vision,cvpr,2.0,0.5,2009
 Sabine Süsstrunk,EPFL,vision,cvpr,1.0,0.5,2011
@@ -48881,6 +49177,7 @@ Salvatore J. Stolfo,Columbia University,sec,,1.0,0.25,2001
 Salvatore J. Stolfo,Columbia University,sec,,1.0,0.2,2007
 Salvatore J. Stolfo,Columbia University,sec,,1.0,0.2,2008
 Salvatore J. Stolfo,Columbia University,sec,,1.0,0.333333333333,2015
+Salvatore J. Stolfo,Columbia University,sec,,1.0,0.2,2017
 Salvatore La Torre,University of Salerno,log,,1.0,0.5,2001
 Salvatore La Torre,University of Salerno,log,,1.0,0.333333333333,2002
 Salvatore La Torre,University of Salerno,log,,1.0,0.333333333333,2003
@@ -48956,6 +49253,7 @@ Samer Al-Kiswany,University of Waterloo,hpc,,1.0,0.2,2008
 Samer Al-Kiswany,University of Waterloo,hpc,,1.0,0.25,2010
 Samer Al-Kiswany,University of Waterloo,hpc,,1.0,0.25,2011
 Samer Al-Kiswany,University of Waterloo,hpc,,1.0,0.25,2014
+Samer Al-Kiswany,University of Waterloo,hpc,,1.0,0.25,2017
 Samer Al-Kiswany,University of Waterloo,ops,,2.0,0.333333333333,2014
 Samer Al-Kiswany,University of Waterloo,ops,,1.0,0.111111111111,2015
 Sami S. Brandt,DIKU,vision,cvpr,1.0,0.5,2004
@@ -49085,7 +49383,7 @@ Samuel Madden,Massachusetts Institute of Technology,mod,,4.0,1.14285714286,2013
 Samuel Madden,Massachusetts Institute of Technology,mod,,3.0,0.658333333333,2014
 Samuel Madden,Massachusetts Institute of Technology,mod,,4.0,0.554700854701,2015
 Samuel Madden,Massachusetts Institute of Technology,mod,,2.0,0.416666666667,2016
-Samuel Madden,Massachusetts Institute of Technology,mod,,2.0,0.416666666667,2017
+Samuel Madden,Massachusetts Institute of Technology,mod,,3.0,0.666666666667,2017
 Samuel Madden,Massachusetts Institute of Technology,ops,,1.0,0.25,2002
 Samuel Madden,Massachusetts Institute of Technology,ops,,1.0,0.25,2007
 Samuel Madden,Massachusetts Institute of Technology,ops,,1.0,0.2,2010
@@ -49115,6 +49413,7 @@ Sanda M. Harabagiu,University of Texas at Dallas,ai,ijcai,2.0,0.666666666667,200
 Sanda M. Harabagiu,University of Texas at Dallas,ir,,1.0,0.5,2001
 Sanda M. Harabagiu,University of Texas at Dallas,ir,,1.0,0.5,2005
 Sanda M. Harabagiu,University of Texas at Dallas,ir,,1.0,0.333333333333,2006
+Sanda M. Harabagiu,University of Texas at Dallas,ir,,1.0,0.5,2011
 Sanda M. Harabagiu,University of Texas at Dallas,mlmining,,1.0,0.25,2009
 Sanda M. Harabagiu,University of Texas at Dallas,nlp,,1.0,0.142857142857,2000
 Sanda M. Harabagiu,University of Texas at Dallas,nlp,,2.0,0.444444444444,2001
@@ -51407,6 +51706,7 @@ Siau-Cheng Khoo,National University of Singapore,soft,,1.0,0.25,2012
 Siau-Cheng Khoo,National University of Singapore,soft,,1.0,0.5,2013
 Siau-Cheng Khoo,National University of Singapore,soft,,2.0,0.47619047619,2014
 Sibel Adali,Rensselaer Polytechnic Institute,ai,aaai,1.0,0.333333333333,2017
+Sibel Adali,Rensselaer Polytechnic Institute,ir,,1.0,0.25,2011
 Sibel Adali,Rensselaer Polytechnic Institute,ir,,1.0,0.333333333333,2012
 Sibel Adali,Rensselaer Polytechnic Institute,mod,,1.0,0.25,1996
 Sibel Adali,Rensselaer Polytechnic Institute,mod,,1.0,0.25,1998
@@ -52197,6 +52497,7 @@ Srinivas Devadas,Massachusetts Institute of Technology,sec,,1.0,0.166666666667,2
 Srinivas Devadas,Massachusetts Institute of Technology,sec,,1.0,0.142857142857,2013
 Srinivas Devadas,Massachusetts Institute of Technology,sec,,2.0,0.342857142857,2015
 Srinivas Devadas,Massachusetts Institute of Technology,sec,,1.0,0.333333333333,2016
+Srinivas Devadas,Massachusetts Institute of Technology,sec,,1.0,0.5,2017
 Srinivasa G. Narasimhan,Carnegie Mellon University,graph,,1.0,0.25,2005
 Srinivasa G. Narasimhan,Carnegie Mellon University,graph,,1.0,0.166666666667,2006
 Srinivasa G. Narasimhan,Carnegie Mellon University,graph,,1.0,0.333333333333,2009
@@ -52256,7 +52557,7 @@ Srinivasan Parthasarathy,Ohio State University,hpc,,2.0,0.5,2008
 Srinivasan Parthasarathy,Ohio State University,hpc,,1.0,0.2,2014
 Srinivasan Parthasarathy,Ohio State University,hpc,,1.0,0.2,2015
 Srinivasan Parthasarathy,Ohio State University,ir,,1.0,0.333333333333,2013
-Srinivasan Parthasarathy,Ohio State University,ir,,1.0,0.166666666667,2014
+Srinivasan Parthasarathy,Ohio State University,ir,,2.0,0.366666666667,2014
 Srinivasan Parthasarathy,Ohio State University,ir,,1.0,0.5,2015
 Srinivasan Parthasarathy,Ohio State University,ir,,1.0,0.2,2016
 Srinivasan Parthasarathy,Ohio State University,mlmining,,1.0,0.5,2001
@@ -52473,6 +52774,7 @@ Stefan Decker,RWTH Aachen,ir,,1.0,0.166666666667,2001
 Stefan Decker,RWTH Aachen,ir,,1.0,0.111111111111,2002
 Stefan Decker,RWTH Aachen,ir,,1.0,0.25,2003
 Stefan Decker,RWTH Aachen,ir,,1.0,0.2,2007
+Stefan Decker,RWTH Aachen,ir,,1.0,0.25,2010
 Stefan Decker,RWTH Aachen,ir,,1.0,0.5,2012
 Stefan Dziembowski,University of Warsaw,act,,1.0,0.333333333333,2000
 Stefan Dziembowski,University of Warsaw,act,,1.0,0.5,2002
@@ -52619,6 +52921,7 @@ Stefan Savage,University of California - San Diego,sec,,1.0,0.25,2013
 Stefan Savage,University of California - San Diego,sec,,2.0,0.236111111111,2014
 Stefan Savage,University of California - San Diego,sec,,1.0,0.166666666667,2015
 Stefan Savage,University of California - San Diego,sec,,1.0,0.125,2016
+Stefan Savage,University of California - San Diego,sec,,1.0,0.142857142857,2017
 Stefan Schaal,University of Southern California,ai,ijcai,1.0,0.333333333333,2007
 Stefan Schaal,University of Southern California,mlmining,,1.0,0.5,1993
 Stefan Schaal,University of Southern California,mlmining,,1.0,0.5,1995
@@ -52774,6 +53077,7 @@ Stefano Zanero,Politecnico di Milano,ir,,1.0,0.142857142857,2013
 Stefano Zanero,Politecnico di Milano,ir,,1.0,0.111111111111,2014
 Stefano Zanero,Politecnico di Milano,sec,,1.0,0.166666666667,2010
 Stefano Zanero,Politecnico di Milano,sec,,1.0,0.125,2014
+Stefano Zanero,Politecnico di Milano,sec,,1.0,0.166666666667,2017
 Stefanos Zafeiriou,Imperial College London,mlmining,,1.0,0.25,2014
 Stefanos Zafeiriou,Imperial College London,vision,cvpr,1.0,0.5,2009
 Stefanos Zafeiriou,Imperial College London,vision,cvpr,1.0,0.142857142857,2010
@@ -53354,6 +53658,9 @@ Steven Skiena,Stony Brook University,bio,,2.0,0.833333333333,1999
 Steven Skiena,Stony Brook University,bio,,2.0,1.33333333333,2001
 Steven Skiena,Stony Brook University,bio,,3.0,1.33333333333,2002
 Steven Skiena,Stony Brook University,bio,,1.0,0.333333333333,2012
+Steven Skiena,Stony Brook University,ir,,2.0,0.666666666667,2007
+Steven Skiena,Stony Brook University,ir,,1.0,0.333333333333,2008
+Steven Skiena,Stony Brook University,ir,,2.0,1.0,2010
 Steven Skiena,Stony Brook University,ir,,1.0,0.25,2015
 Steven Skiena,Stony Brook University,mlmining,,1.0,0.2,2009
 Steven Skiena,Stony Brook University,mlmining,,1.0,0.333333333333,2014
@@ -53539,6 +53846,9 @@ Subbarao Kambhampati,Arizona State University,ai,ijcai,3.0,0.666666666667,2007
 Subbarao Kambhampati,Arizona State University,ai,ijcai,2.0,0.583333333333,2009
 Subbarao Kambhampati,Arizona State University,ai,ijcai,3.0,1.16666666667,2013
 Subbarao Kambhampati,Arizona State University,ir,,1.0,0.5,2011
+Subbarao Kambhampati,Arizona State University,ir,,1.0,0.333333333333,2013
+Subbarao Kambhampati,Arizona State University,ir,,1.0,0.333333333333,2014
+Subbarao Kambhampati,Arizona State University,ir,,1.0,0.25,2015
 Subbarao Kambhampati,Arizona State University,mlmining,,1.0,0.333333333333,2012
 Subbarao Kambhampati,Arizona State University,mlmining,,1.0,0.333333333333,2013
 Subbarao Kambhampati,Arizona State University,mod,,1.0,0.166666666667,2007
@@ -53670,6 +53980,7 @@ Sudeepa Roy,Duke University,mod,,1.0,0.2,2013
 Sudeepa Roy,Duke University,mod,,1.0,0.5,2014
 Sudeepa Roy,Duke University,mod,,1.0,0.333333333333,2015
 Sudeepa Roy,Duke University,mod,,1.0,0.333333333333,2017
+Sudeshna Sarkar,IIT Kharagpur,ir,,1.0,0.333333333333,2009
 Sudeshna Sarkar,IIT Kharagpur,nlp,,1.0,0.333333333333,2007
 Sudeshna Sarkar,IIT Kharagpur,nlp,,1.0,0.333333333333,2008
 Sudhakar Ganti,University of Victoria,comm,,1.0,0.333333333333,2010
@@ -53758,6 +54069,7 @@ Suman Jana,Columbia University,sec,,3.0,1.16666666667,2012
 Suman Jana,Columbia University,sec,,2.0,0.47619047619,2013
 Suman Jana,Columbia University,sec,,2.0,0.4,2014
 Suman Jana,Columbia University,sec,,2.0,0.45,2016
+Suman Jana,Columbia University,sec,,2.0,0.4,2017
 Sumanta N. Pattanaik,University of Central Florida,graph,,1.0,0.25,1996
 Sumanta N. Pattanaik,University of Central Florida,graph,,2.0,0.35,1997
 Sumanta N. Pattanaik,University of Central Florida,graph,,1.0,0.25,1998
@@ -54298,6 +54610,7 @@ Tadayoshi Kohno,University of Washington,sec,,2.0,0.366666666667,2012
 Tadayoshi Kohno,University of Washington,sec,,2.0,0.75,2013
 Tadayoshi Kohno,University of Washington,sec,,1.0,0.2,2014
 Tadayoshi Kohno,University of Washington,sec,,1.0,0.25,2016
+Tadayoshi Kohno,University of Washington,sec,,1.0,0.25,2017
 Tadayoshi Kohno,University of Washington,vision,eccv,1.0,0.333333333333,2010
 Taesoo Kim,Georgia Institute of Technology,comm,,1.0,0.2,2017
 Taesoo Kim,Georgia Institute of Technology,ops,,1.0,0.25,2010
@@ -54529,6 +54842,7 @@ Tamara Sumner,University of Colorado Boulder,nlp,,1.0,0.333333333333,2015
 Tamara Sumner,University of Colorado Boulder,nlp,,2.0,0.666666666667,2016
 Tamer Elsayed,Qatar University,ai,aaai,1.0,0.25,2011
 Tamer Elsayed,Qatar University,ir,,2.0,0.583333333333,2011
+Tamer Elsayed,Qatar University,ir,,1.0,0.5,2014
 Tamer Elsayed,Qatar University,nlp,,1.0,0.333333333333,2008
 Tamer Kahveci,University of Florida,bio,,1.0,0.333333333333,2008
 Tamer Kahveci,University of Florida,bio,,1.0,0.5,2010
@@ -54553,6 +54867,7 @@ Tandy J. Warnow,University of Illinois at Urbana-Champaign,bio,,1.0,0.3333333333
 Tandy J. Warnow,University of Illinois at Urbana-Champaign,bio,,1.0,0.2,2012
 Tandy J. Warnow,University of Illinois at Urbana-Champaign,bio,,1.0,0.333333333333,2014
 Tandy J. Warnow,University of Illinois at Urbana-Champaign,bio,,1.0,0.5,2015
+Tanmoy Chakraborty 0002,IIIT Delhi,ir,,1.0,0.2,2016
 Tanmoy Chakraborty 0002,IIIT Delhi,mlmining,,1.0,0.2,2014
 Tanmoy Chakraborty 0002,IIIT Delhi,mlmining,,1.0,0.25,2015
 Tanmoy Chakraborty 0002,IIIT Delhi,nlp,,1.0,0.5,2016
@@ -55409,6 +55724,7 @@ Thomas Ristenpart,Cornell University,sec,,3.0,0.833333333333,2013
 Thomas Ristenpart,Cornell University,sec,,7.0,1.5,2014
 Thomas Ristenpart,Cornell University,sec,,6.0,1.48333333333,2015
 Thomas Ristenpart,Cornell University,sec,,3.0,0.6,2016
+Thomas Ristenpart,Cornell University,sec,,2.0,0.366666666667,2017
 Thomas Rothvoss,University of Washington,act,,1.0,0.5,2016
 Thomas Rothvoss,University of Washington,act,,1.0,0.5,2017
 Thomas Rothvoß,University of Washington,act,,1.0,0.25,2008
@@ -55698,6 +56014,9 @@ Tim Finin,University of Maryland - Baltimore County,ai,aaai,1.0,0.2,2006
 Tim Finin,University of Maryland - Baltimore County,ai,aaai,1.0,0.5,2008
 Tim Finin,University of Maryland - Baltimore County,ai,ijcai,1.0,0.333333333333,1979
 Tim Finin,University of Maryland - Baltimore County,ir,,1.0,0.111111111111,2006
+Tim Finin,University of Maryland - Baltimore County,ir,,4.0,0.759523809524,2007
+Tim Finin,University of Maryland - Baltimore County,ir,,3.0,0.833333333333,2008
+Tim Finin,University of Maryland - Baltimore County,ir,,1.0,0.5,2009
 Tim Kraska,Brown University,ir,,1.0,0.166666666667,2009
 Tim Kraska,Brown University,mod,,1.0,0.166666666667,2007
 Tim Kraska,Brown University,mod,,1.0,0.2,2008
@@ -55709,7 +56028,7 @@ Tim Kraska,Brown University,mod,,3.0,0.509523809524,2013
 Tim Kraska,Brown University,mod,,2.0,0.416666666667,2014
 Tim Kraska,Brown University,mod,,4.0,0.66978021978,2015
 Tim Kraska,Brown University,mod,,3.0,0.65,2016
-Tim Kraska,Brown University,mod,,3.0,0.666666666667,2017
+Tim Kraska,Brown University,mod,,5.0,1.2,2017
 Tim Kraska,Brown University,ops,,1.0,0.2,2013
 Tim Menzies,North Carolina State University,soft,,1.0,0.333333333333,2001
 Tim Menzies,North Carolina State University,soft,,1.0,0.25,2009
@@ -55733,6 +56052,7 @@ Tim Oates,University of Maryland - Baltimore County,ai,ijcai,1.0,0.333333333333,
 Tim Oates,University of Maryland - Baltimore County,ai,ijcai,1.0,0.5,2007
 Tim Oates,University of Maryland - Baltimore County,ai,ijcai,1.0,0.333333333333,2009
 Tim Oates,University of Maryland - Baltimore County,ai,ijcai,1.0,0.5,2015
+Tim Oates,University of Maryland - Baltimore County,ir,,1.0,0.2,2007
 Tim Oates,University of Maryland - Baltimore County,mlmining,,1.0,0.5,1996
 Tim Oates,University of Maryland - Baltimore County,mlmining,,1.0,0.5,1997
 Tim Oates,University of Maryland - Baltimore County,mlmining,,1.0,0.333333333333,1999
@@ -55758,6 +56078,7 @@ Tim Roughgarden,Stanford University,comm,,1.0,0.25,2009
 Tim Roughgarden,Stanford University,mlmining,,1.0,0.5,2013
 Tim Roughgarden,Stanford University,mlmining,,2.0,0.75,2015
 Tim Weninger,University of Notre Dame,ai,aaai,1.0,0.5,2017
+Tim Weninger,University of Notre Dame,ir,,1.0,0.25,2007
 Tim Weninger,University of Notre Dame,ir,,1.0,0.333333333333,2010
 Tim Weninger,University of Notre Dame,ir,,1.0,0.2,2011
 Tim Weninger,University of Notre Dame,mod,,1.0,0.25,2011
@@ -56412,6 +56733,7 @@ Torsten Hoefler,ETH Zurich,hpc,,6.0,1.91666666667,2013
 Torsten Hoefler,ETH Zurich,hpc,,5.0,1.7,2014
 Torsten Hoefler,ETH Zurich,hpc,,7.0,2.73333333333,2015
 Torsten Hoefler,ETH Zurich,hpc,,7.0,2.29090909091,2016
+Torsten Hoefler,ETH Zurich,hpc,,2.0,0.533333333333,2017
 Torsten Hoefler,ETH Zurich,mod,,1.0,0.2,2017
 Torsten Kuhlen,RWTH Aachen,hpc,,1.0,0.2,2004
 Torsten Kuhlen,RWTH Aachen,hpc,,1.0,0.166666666667,2006
@@ -56996,6 +57318,7 @@ V. S. Subrahmanian,University of Maryland - College Park,ai,ijcai,1.0,0.33333333
 V. S. Subrahmanian,University of Maryland - College Park,ai,ijcai,3.0,1.0,2005
 V. S. Subrahmanian,University of Maryland - College Park,ai,ijcai,2.0,0.45,2007
 V. S. Subrahmanian,University of Maryland - College Park,ai,ijcai,1.0,0.2,2011
+V. S. Subrahmanian,University of Maryland - College Park,ir,,2.0,0.45,2007
 V. S. Subrahmanian,University of Maryland - College Park,ir,,1.0,0.333333333333,2008
 V. S. Subrahmanian,University of Maryland - College Park,ir,,1.0,0.25,2017
 V. S. Subrahmanian,University of Maryland - College Park,mlmining,,1.0,0.2,2014
@@ -57022,6 +57345,8 @@ Vadim Bulitko,University of Alberta,ai,aaai,1.0,0.5,2012
 Vadim Bulitko,University of Alberta,ai,ijcai,2.0,0.45,2007
 Vadim Bulitko,University of Alberta,ai,ijcai,1.0,0.333333333333,2009
 Vadim Bulitko,University of Alberta,ai,ijcai,1.0,0.5,2011
+Vagelis Hristidis,University of California - Riverside,ir,,1.0,0.25,2013
+Vagelis Hristidis,University of California - Riverside,ir,,1.0,0.333333333333,2014
 Vagelis Hristidis,University of California - Riverside,mlmining,,1.0,0.142857142857,2010
 Vagelis Hristidis,University of California - Riverside,mlmining,,1.0,0.333333333333,2011
 Vagelis Hristidis,University of California - Riverside,mlmining,,1.0,0.25,2014
@@ -57199,9 +57524,13 @@ Vassilis Kostakos,University of Melbourne,chi,,4.0,0.733333333333,2014
 Vassilis Kostakos,University of Melbourne,chi,,1.0,0.2,2015
 Vassilis Kostakos,University of Melbourne,chi,,4.0,0.642857142857,2016
 Vassilis Kostakos,University of Melbourne,chi,,1.0,0.142857142857,2017
+Vassilis Kostakos,University of Melbourne,ir,,1.0,0.166666666667,2011
 Vassos Hadzilacos,University of Toronto,act,,1.0,0.5,1997
 Vasudeva Varma,IIIT Hyderabad,ir,,1.0,0.333333333333,2006
+Vasudeva Varma,IIIT Hyderabad,ir,,1.0,0.333333333333,2011
+Vasudeva Varma,IIIT Hyderabad,ir,,1.0,0.5,2012
 Vasudeva Varma,IIIT Hyderabad,ir,,1.0,0.25,2013
+Vasudeva Varma,IIIT Hyderabad,ir,,1.0,0.2,2016
 Venkat Anantharam,University of California - Berkeley,comm,,1.0,0.333333333333,1996
 Venkat Anantharam,University of California - Berkeley,comm,,1.0,0.25,1999
 Venkat Anantharam,University of California - Berkeley,comm,,1.0,0.5,2000
@@ -57286,6 +57615,7 @@ Vern Paxson,University of California - Berkeley,sec,,3.0,0.8,2013
 Vern Paxson,University of California - Berkeley,sec,,4.0,0.777777777778,2014
 Vern Paxson,University of California - Berkeley,sec,,2.0,0.333333333333,2015
 Vern Paxson,University of California - Berkeley,sec,,4.0,0.741666666667,2016
+Vern Paxson,University of California - Berkeley,sec,,1.0,0.2,2017
 Vernon Rego,Purdue University,comm,,1.0,1.0,1986
 Vernon Rego,Purdue University,hpc,,1.0,0.333333333333,1992
 Verónica Becher,University of Buenos Aires,ai,aaai,1.0,0.5,1993
@@ -57913,6 +58243,7 @@ Vitaly Shmatikov,Cornell University,sec,,3.0,1.0,2013
 Vitaly Shmatikov,Cornell University,sec,,1.0,0.2,2014
 Vitaly Shmatikov,Cornell University,sec,,1.0,0.5,2015
 Vitaly Shmatikov,Cornell University,sec,,1.0,0.2,2016
+Vitaly Shmatikov,Cornell University,sec,,1.0,0.25,2017
 Vittorio Ferrari,University of Edinburgh,mlmining,,1.0,0.5,2007
 Vittorio Ferrari,University of Edinburgh,mlmining,,1.0,0.333333333333,2009
 Vittorio Ferrari,University of Edinburgh,mlmining,,1.0,0.5,2010
@@ -58250,6 +58581,8 @@ Walid G. Aref,Purdue University,mod,,1.0,0.142857142857,2015
 Walid G. Aref,Purdue University,mod,,1.0,0.333333333333,2016
 Walid G. Aref,Purdue University,mod,,1.0,0.5,2017
 Walid Magdy,University of Edinburgh,ir,,1.0,0.5,2010
+Walid Magdy,University of Edinburgh,ir,,1.0,0.2,2013
+Walid Magdy,University of Edinburgh,ir,,1.0,0.5,2014
 Walid Magdy,University of Edinburgh,nlp,,1.0,0.5,2006
 Wally Smith,University of Melbourne,chi,,1.0,0.2,2014
 Wally Smith,University of Melbourne,chi,,1.0,0.333333333333,2015
@@ -58441,6 +58774,7 @@ Wei Gao,University of Tennessee,comm,,2.0,0.833333333333,2016
 Wei Gao,University of Tennessee,ir,,1.0,0.142857142857,2007
 Wei Gao,University of Tennessee,ir,,1.0,0.25,2010
 Wei Gao,University of Tennessee,ir,,1.0,0.25,2011
+Wei Gao,University of Tennessee,ir,,1.0,0.25,2012
 Wei Gao,University of Tennessee,mlmining,,1.0,0.25,2013
 Wei Gao,University of Tennessee,nlp,,1.0,0.25,2009
 Wei Gao,University of Tennessee,nlp,,3.0,0.7,2011
@@ -58755,7 +59089,7 @@ Wenjie Zhang,UNSW,mod,,2.0,0.4,2013
 Wenjie Zhang,UNSW,mod,,1.0,0.2,2014
 Wenjie Zhang,UNSW,mod,,3.0,0.566666666667,2015
 Wenjie Zhang,UNSW,mod,,3.0,0.6,2016
-Wenjie Zhang,UNSW,mod,,2.0,0.533333333333,2017
+Wenjie Zhang,UNSW,mod,,3.0,0.733333333333,2017
 Wenjing Lou,Virginia Tech,comm,,1.0,0.333333333333,2004
 Wenjing Lou,Virginia Tech,comm,,1.0,0.333333333333,2005
 Wenjing Lou,Virginia Tech,comm,,1.0,0.333333333333,2006
@@ -58800,6 +59134,7 @@ Wenke Lee,Georgia Institute of Technology,sec,,4.0,0.816666666667,2013
 Wenke Lee,Georgia Institute of Technology,sec,,5.0,0.933333333333,2014
 Wenke Lee,Georgia Institute of Technology,sec,,3.0,0.616666666667,2015
 Wenke Lee,Georgia Institute of Technology,sec,,2.0,0.375,2016
+Wenke Lee,Georgia Institute of Technology,sec,,1.0,0.25,2017
 Wensheng Zhang 0001,Iowa State University,bed,,1.0,0.25,2010
 Wensheng Zhang 0001,Iowa State University,comm,,1.0,0.5,2004
 Wensheng Zhang 0001,Iowa State University,comm,,2.0,0.75,2005
@@ -58918,6 +59253,7 @@ William D. Clinger,Northeastern University,plan,,1.0,0.5,1997
 William D. Clinger,Northeastern University,plan,,1.0,1.0,1998
 William D. Gropp,University of Illinois at Urbana-Champaign,hpc,,1.0,0.2,1999
 William D. Gropp,University of Illinois at Urbana-Champaign,hpc,,1.0,0.25,2011
+William D. Gropp,University of Illinois at Urbana-Champaign,hpc,,1.0,0.25,2017
 William E. Howden,University of California - San Diego,soft,,1.0,1.0,1978
 William E. Howden,University of California - San Diego,soft,,1.0,1.0,1981
 William E. Skeith III,CUNY,crypt,,1.0,0.5,2005
@@ -58984,6 +59320,7 @@ William Gropp,University of Illinois at Urbana-Champaign,hpc,,1.0,0.5,2016
 William H. Hsu,Kansas State University,ai,aaai,1.0,0.25,1993
 William H. Hsu,Kansas State University,ai,aaai,1.0,0.25,1998
 William H. Hsu,Kansas State University,bio,,1.0,0.25,1993
+William H. Hsu,Kansas State University,ir,,1.0,0.25,2007
 William H. Hsu,Kansas State University,ir,,1.0,0.333333333333,2010
 William H. Sanders,University of Illinois at Urbana-Champaign,comm,,1.0,0.2,2009
 William H. Wilson,UNSW,nlp,,1.0,0.5,1998
@@ -59147,6 +59484,9 @@ William W. Cohen,Carnegie Mellon University,ir,,1.0,0.333333333333,2002
 William W. Cohen,Carnegie Mellon University,ir,,1.0,0.333333333333,2003
 William W. Cohen,Carnegie Mellon University,ir,,1.0,0.5,2005
 William W. Cohen,Carnegie Mellon University,ir,,1.0,0.333333333333,2006
+William W. Cohen,Carnegie Mellon University,ir,,3.0,1.25,2008
+William W. Cohen,Carnegie Mellon University,ir,,2.0,0.7,2009
+William W. Cohen,Carnegie Mellon University,ir,,1.0,0.25,2012
 William W. Cohen,Carnegie Mellon University,mlmining,,2.0,2.0,1995
 William W. Cohen,Carnegie Mellon University,mlmining,,2.0,0.833333333333,1997
 William W. Cohen,Carnegie Mellon University,mlmining,,1.0,1.0,2000
@@ -59519,10 +59859,10 @@ Xi Chen,Columbia University,act,,1.0,0.5,2005
 Xi Chen,Columbia University,act,,2.0,0.833333333333,2007
 Xi Chen,Columbia University,act,,1.0,0.25,2010
 Xi Chen,Columbia University,act,,3.0,0.866666666667,2013
-Xi Chen,Columbia University,act,,2.0,0.533333333333,2014
-Xi Chen,Columbia University,act,,3.0,0.75,2015
-Xi Chen,Columbia University,act,,2.0,0.75,2016
-Xi Chen,Columbia University,act,,3.0,0.916666666667,2017
+Xi Chen,Columbia University,act,,1.0,0.2,2014
+Xi Chen,Columbia University,act,,2.0,0.5,2015
+Xi Chen,Columbia University,act,,1.0,0.5,2016
+Xi Chen,Columbia University,act,,1.0,0.25,2017
 Xi Chen,Columbia University,ai,aaai,1.0,0.25,2010
 Xi Chen,Columbia University,arch,,1.0,0.2,2015
 Xi Chen,Columbia University,comm,,1.0,0.5,2010
@@ -59586,7 +59926,8 @@ Xia Hu,Texas A&M University,ai,ijcai,1.0,0.333333333333,2015
 Xia Hu,Texas A&M University,ir,,1.0,0.25,2010
 Xia Hu,Texas A&M University,ir,,1.0,0.25,2013
 Xia Hu,Texas A&M University,ir,,1.0,0.333333333333,2014
-Xia Hu,Texas A&M University,ir,,1.0,0.166666666667,2017
+Xia Hu,Texas A&M University,ir,,1.0,0.25,2016
+Xia Hu,Texas A&M University,ir,,2.0,0.416666666667,2017
 Xia Hu,Texas A&M University,mlmining,,1.0,0.25,2014
 Xia Ning,Indiana University-Purdue University Indianapolis,ai,ijcai,1.0,0.142857142857,2015
 Xia Ning,Indiana University-Purdue University Indianapolis,mlmining,,1.0,0.333333333333,2013
@@ -59829,6 +60170,7 @@ Xiaojin Zhu 0001,University of Wisconsin - Madison,ai,ijcai,1.0,1.0,2013
 Xiaojin Zhu 0001,University of Wisconsin - Madison,ai,ijcai,1.0,0.2,2016
 Xiaojin Zhu 0001,University of Wisconsin - Madison,arch,,1.0,0.25,2015
 Xiaojin Zhu 0001,University of Wisconsin - Madison,comm,,1.0,0.2,2011
+Xiaojin Zhu 0001,University of Wisconsin - Madison,ir,,1.0,0.25,2014
 Xiaojin Zhu 0001,University of Wisconsin - Madison,metrics,,1.0,0.25,2007
 Xiaojin Zhu 0001,University of Wisconsin - Madison,mlmining,,1.0,0.333333333333,2003
 Xiaojin Zhu 0001,University of Wisconsin - Madison,mlmining,,2.0,0.583333333333,2004
@@ -59851,6 +60193,7 @@ Xiaojin Zhu 0001,University of Wisconsin - Madison,nlp,,1.0,0.25,2013
 Xiaojing Liao,College of William and Mary,ir,,1.0,0.166666666667,2016
 Xiaojing Liao,College of William and Mary,sec,,1.0,0.125,2015
 Xiaojing Liao,College of William and Mary,sec,,4.0,0.535714285714,2016
+Xiaojing Liao,College of William and Mary,sec,,1.0,0.125,2017
 Xiaojuan Ma,Hong Kong University of Science and Technology,chi,,1.0,0.333333333333,2010
 Xiaojuan Ma,Hong Kong University of Science and Technology,chi,,2.0,0.666666666667,2014
 Xiaojuan Ma,Hong Kong University of Science and Technology,chi,,1.0,0.1,2016
@@ -60231,7 +60574,7 @@ Xuemin Lin,UNSW,mod,,5.0,1.01666666667,2013
 Xuemin Lin,UNSW,mod,,3.0,0.566666666667,2014
 Xuemin Lin,UNSW,mod,,5.0,1.06666666667,2015
 Xuemin Lin,UNSW,mod,,5.0,1.05,2016
-Xuemin Lin,UNSW,mod,,3.0,0.6,2017
+Xuemin Lin,UNSW,mod,,4.0,0.8,2017
 Xueyan Tang,Nanyang Technological University,comm,,1.0,0.5,2004
 Xueyan Tang,Nanyang Technological University,comm,,1.0,0.5,2006
 Xueyan Tang,Nanyang Technological University,comm,,1.0,0.5,2011
@@ -60273,6 +60616,8 @@ Y. Narahari,IISc Bangalore,robotics,,1.0,0.333333333333,2000
 Y. Narahari,IISc Bangalore,robotics,,1.0,0.5,2002
 Yaacov Yesha,University of Maryland - Baltimore County,act,,1.0,0.2,1978
 Yaacov Yesha,University of Maryland - Baltimore County,act,,1.0,0.5,1986
+Yaacov Yesha,University of Maryland - Baltimore County,ir,,1.0,0.142857142857,2007
+Yaacov Yesha,University of Maryland - Baltimore County,ir,,1.0,0.166666666667,2008
 Yadati Narahari,IISc Bangalore,ai,aaai,1.0,0.25,2015
 Yadati Narahari,IISc Bangalore,robotics,,1.0,0.333333333333,2002
 Yadati Narahari,IISc Bangalore,robotics,,2.0,0.666666666667,2003
@@ -60458,6 +60803,7 @@ Yang Liu 0004,University of Texas at Dallas,ai,aaai,1.0,0.333333333333,2010
 Yang Liu 0004,University of Texas at Dallas,ai,aaai,1.0,0.333333333333,2011
 Yang Liu 0004,University of Texas at Dallas,ai,aaai,1.0,0.5,2012
 Yang Liu 0004,University of Texas at Dallas,ai,ijcai,1.0,0.5,2015
+Yang Liu 0004,University of Texas at Dallas,ir,,1.0,0.333333333333,2009
 Yang Liu 0004,University of Texas at Dallas,nlp,,1.0,1.0,2003
 Yang Liu 0004,University of Texas at Dallas,nlp,,1.0,0.25,2004
 Yang Liu 0004,University of Texas at Dallas,nlp,,1.0,0.25,2005
@@ -60798,10 +61144,12 @@ Yehuda Lindell,Bar-Ilan University,sec,,1.0,0.5,2008
 Yehuda Lindell,Bar-Ilan University,sec,,1.0,0.25,2013
 Yehuda Lindell,Bar-Ilan University,sec,,3.0,1.25,2015
 Yehuda Lindell,Bar-Ilan University,sec,,3.0,0.733333333333,2016
+Yehuda Lindell,Bar-Ilan University,sec,,1.0,0.111111111111,2017
 Yejin Choi,University of Washington,ai,aaai,1.0,0.125,2015
 Yejin Choi,University of Washington,ai,aaai,1.0,0.25,2016
 Yejin Choi,University of Washington,ai,ijcai,1.0,0.333333333333,2007
 Yejin Choi,University of Washington,ir,,1.0,0.166666666667,2010
+Yejin Choi,University of Washington,ir,,1.0,0.25,2012
 Yejin Choi,University of Washington,nlp,,1.0,0.25,2005
 Yejin Choi,University of Washington,nlp,,1.0,0.333333333333,2006
 Yejin Choi,University of Washington,nlp,,1.0,0.5,2007
@@ -60816,6 +61164,8 @@ Yejin Choi,University of Washington,nlp,,5.0,1.36666666667,2016
 Yejin Choi,University of Washington,vision,cvpr,1.0,0.142857142857,2011
 Yejin Choi,University of Washington,vision,iccv,1.0,0.2,2013
 Yejin Choi,University of Washington,vision,iccv,1.0,0.166666666667,2015
+Yelena Yesha,University of Maryland - Baltimore County,ir,,1.0,0.142857142857,2007
+Yelena Yesha,University of Maryland - Baltimore County,ir,,1.0,0.166666666667,2008
 Yelena Yesha,University of Maryland - Baltimore County,metrics,,1.0,0.333333333333,1996
 Yevgeniy Dodis,New York University,act,,1.0,0.5,1999
 Yevgeniy Dodis,New York University,act,,1.0,0.333333333333,2003
@@ -61231,7 +61581,7 @@ Yiyu Shi,University of Notre Dame,da,,3.0,0.642857142857,2015
 Yiyu Shi,University of Notre Dame,da,,1.0,0.25,2016
 Yizhou Sun,University of California - Los Angeles,ai,aaai,1.0,0.142857142857,2015
 Yizhou Sun,University of California - Los Angeles,ai,ijcai,1.0,0.2,2016
-Yizhou Sun,University of California - Los Angeles,ir,,1.0,0.25,2016
+Yizhou Sun,University of California - Los Angeles,ir,,2.0,0.45,2016
 Yizhou Sun,University of California - Los Angeles,ir,,1.0,0.142857142857,2017
 Yizhou Sun,University of California - Los Angeles,mlmining,,3.0,0.783333333333,2009
 Yizhou Sun,University of California - Los Angeles,mlmining,,1.0,0.166666666667,2010
@@ -62093,8 +62443,6 @@ Zhen Zhang,Ecole Normale Superieure,ai,aaai,1.0,0.142857142857,2017
 Zhen Zhang,Ecole Normale Superieure,bio,,1.0,0.125,2016
 Zhen Zhang,Ecole Normale Superieure,comm,,1.0,0.333333333333,2012
 Zhen Zhang,Ecole Normale Superieure,da,,1.0,0.333333333333,2008
-Zhen Zhang,Ecole Normale Superieure,mod,,1.0,0.333333333333,2004
-Zhen Zhang,Ecole Normale Superieure,mod,,1.0,0.333333333333,2005
 Zhen Zhang,Ecole Normale Superieure,mod,,1.0,0.166666666667,2006
 Zhen Zhang,Ecole Normale Superieure,robotics,,1.0,0.333333333333,2004
 Zhen Zhang,Ecole Normale Superieure,vision,cvpr,1.0,0.142857142857,2015
@@ -62177,11 +62525,11 @@ Zhenming Liu,College of William and Mary,act,,1.0,0.2,2012
 Zhenming Liu,College of William and Mary,act,,1.0,0.5,2013
 Zhenming Liu,College of William and Mary,ai,ijcai,1.0,0.25,2011
 Zhenming Liu,College of William and Mary,comm,,1.0,0.333333333333,2015
+Zhenming Liu,College of William and Mary,ir,,1.0,0.142857142857,2011
 Zhenming Liu,College of William and Mary,mlmining,,1.0,0.333333333333,2012
 Zhentao Li,Ecole Normale Superieure,act,,1.0,0.333333333333,2010
 Zhentao Li,Ecole Normale Superieure,mlmining,,1.0,0.333333333333,2014
-Zhi Wang,Florida State University,comm,,2.0,0.4,2014
-Zhi Wang,Florida State University,comm,,1.0,0.25,2015
+Zhi Wang,Florida State University,comm,,1.0,0.2,2014
 Zhi Wang,Florida State University,mlmining,,1.0,0.166666666667,2016
 Zhi Wang,Florida State University,ops,,1.0,0.2,2010
 Zhi Wang,Florida State University,ops,,1.0,0.25,2012
@@ -62224,6 +62572,7 @@ Zhi-Li Zhang,University of Minnesota,mobile,,1.0,0.2,2009
 Zhi-Li Zhang,University of Minnesota,mobile,,2.0,0.5,2010
 Zhi-Li Zhang,University of Minnesota,mobile,,1.0,0.142857142857,2012
 Zhi-Li Zhang,University of Minnesota,sec,,1.0,0.25,2013
+Zhi-Li Zhang,University of Minnesota,sec,,1.0,0.333333333333,2017
 Zhibin Li,University of Edinburgh,robotics,,1.0,0.2,2009
 Zhibin Li,University of Edinburgh,robotics,,1.0,0.25,2011
 Zhibin Li,University of Edinburgh,robotics,,3.0,0.783333333333,2012

--- a/homepages.csv
+++ b/homepages.csv
@@ -1940,6 +1940,7 @@ D. Mitch Wilkes,http://engineering.vanderbilt.edu/bio/mitchell-wilkes/
 D. Mitchell Wilkes,http://engineering.vanderbilt.edu/bio/mitchell-wilkes/
 D. Scott McCrickard,http://www.cs.vt.edu/~mccricks/
 D. T. Huynh,http://www.utdallas.edu/~huynh/
+Da Yan,https://www.uab.edu/cas/cis/people/faculty-directory/da-yan
 Dabbala Rajagopal Reddy,http://www.ri.cmu.edu/people/reddy_raj.html/
 Dae Hyun Kim,https://school.eecs.wsu.edu/people/faculty/dae-hyun-kim/
 Daehyun Kim,https://school.eecs.wsu.edu/people/faculty/dae-hyun-kim/
@@ -4319,6 +4320,7 @@ Jens Krinke,http://www0.cs.ucl.ac.uk/staff/J.Krinke/
 Jens Palsberg,http://www.cs.ucla.edu/~palsberg/
 Jeremiah Blocki,https://www.cs.purdue.edu/homes/jblocki/
 Jeremy Aarons,http://monash.academia.edu/JeremyAarons/
+Jeremy Blackburn,https://idrama.science
 Jeremy Buhler,http://www.cse.wustl.edu/~jbuhler/
 Jeremy D. Buhler,http://www.cse.wustl.edu/~jbuhler/
 Jeremy Dawson,http://users.cecs.anu.edu.au/~jeremy/
@@ -6845,6 +6847,7 @@ Nirmala Shenoy,https://www.rit.edu/gccis/nirmala-shenoy/
 Nisheeth K. Vishnoi,http://theory.epfl.ch/vishnoi/Home.html/
 Nisheeth Srivastava,http://www.iitk.ac.in/new/nisheeth-srivastava/
 Nita Parekh,https://www.iiit.ac.in/people/faculty/nita/
+Nitesh Saxena,http://saxena.cis.uab.edu/
 Nitesh V. Chawla,http://www3.nd.edu/~nchawla/
 Nitin Auluck,http://www.iitrpr.ac.in/cse/nitin
 Nitin H. Vaidya,http://disc.ece.illinois.edu/
@@ -7545,6 +7548,7 @@ Raghu Machiraju,http://web.cse.ohio-state.edu/~raghu/
 Raghu Meka,http://www.raghumeka.org/
 Raghu Reddy,http://faculty.iiit.ac.in/~raghu.reddy/
 Raghunath Tewari,http://www.cse.iitk.ac.in/users/rtewari/
+Ragib Hasan,http://ragibhasan.com/
 Ragunathan Rajkumar,https://users.ece.cmu.edu/~raj/
 Rahul Banerjee,http://www.bits-pilani.ac.in/pilani/rahulbanerjee/profile/
 Rahul C. Basole,http://www.cc.gatech.edu/people/rahul-basole/

--- a/index.html
+++ b/index.html
@@ -421,6 +421,7 @@
 				<td>
 				  <a href="http://dblp.uni-trier.de/db/conf/sigir/index.html">SIGIR</a><br />
 				  <a href="http://dblp.uni-trier.de/db/conf/www/index.html">WWW</a><br />
+				  <a href="http://dblp.uni-trier.de/db/conf/icwsm/index.html">ICWSM</a><br />
 				</td>
 			      </tr>
 			    </tbody>

--- a/util/csrankings.py
+++ b/util/csrankings.py
@@ -90,7 +90,7 @@ areadict = {
     # - Two variants for each, as in DBLP.
     'metrics': ['SIGMETRICS', 'SIGMETRICS/Performance', 'IMC', 'Internet Measurement Conference'],
     # SIGIR
-    'ir': ['WWW', 'SIGIR'],
+    'ir': ['WWW', 'SIGIR', 'ICWSM'],
     # SIGCHI
     'chi': ['CHI', 'UbiComp', 'Ubicomp', 'UIST'],
     'nlp': ['EMNLP', 'ACL', 'ACL (1)', 'ACL (2)', 'NAACL', 'HLT-NAACL',

--- a/util/regenerate-data.py
+++ b/util/regenerate-data.py
@@ -42,7 +42,7 @@ areadict = {
     # - Two variants for each, as in DBLP.
     'metrics': ['SIGMETRICS', 'SIGMETRICS/Performance', 'IMC', 'Internet Measurement Conference'],
     # SIGIR
-    'ir': ['WWW', 'SIGIR'],
+    'ir': ['WWW', 'SIGIR', 'ICWSM'],
     # SIGCHI
     'chi': ['CHI', 'UbiComp', 'Ubicomp', 'UIST'],
     'nlp': ['EMNLP', 'ACL', 'ACL (1)', 'ACL (2)', 'NAACL', 'HLT-NAACL',


### PR DESCRIPTION
This pull request has a fully generated site which adds ICWSM to the Web & Information retrieval category. There are only two venues currently in the Web & Information retrieval category already: WWW and SIGIR.

ICWSM is arguably at least as strong a venue as SIGIR (it has a higher h5 ranking and a substantially higher h5 than SIGIR according to Google scholar).

This pull request also includes some faculty from the University of Alabama at Birmingham and is fully generated, ready to go live (at least it looked ready to go live on my machine :)).

Please disregard #364 if this pull request is deemed suitable.