### PR TITLE
Updated UbiComp conference

### DIFF
--- a/index.html
+++ b/index.html
@@ -964,7 +964,7 @@
 			      <tr style="width:100%">
 				<td>
 				  <a href="http://dblp.uni-trier.de/db/conf/chi/">CHI</a><br />
-				  <a href="http://dblp.uni-trier.de/db/conf/huc/">UbiComp</a><br />
+				  <a href="http://dblp.uni-trier.de/db/conf/huc/">UbiComp</a> / <a href="http://dblp.uni-trier.de/db/conf/pervasive/">Pervasive</a> / <a href="http://dblp.uni-trier.de/db/journals/imwut/">IMWUT</a><br /> 
 				  <a href="http://dblp.uni-trier.de/db/conf/uist/">UIST</a><br />
 				</td>
 			      </tr>


### PR DESCRIPTION
From 2017 onwards, the main technical track of the UbiComp conference will be published in a journal format entitled Proceedings of the ACM on Interactive, Mobile, Wearable and Ubiquitous Technologies (IMWUT) http://dblp.uni-trier.de/db/journals/imwut/ 
As such, papers appearing in IWMUT should be considered under UbiComp.
Additionally, the UbiComp conference was formed in 2013 as a merger of two conferences: Ubicomp, and Pervasive. While Pervasive has ceased to exist, it should be considered for historical purposes/stats: http://dblp.uni-trier.de/db/conf/pervasive/index.html