### PR TITLE
Updated UbiComp conference

### DIFF
--- a/venues.csv
+++ b/venues.csv
@@ -21,6 +21,8 @@ area,canonical,alternate,default
 "chi","CHI","CHI",True
 "chi","UbiComp","UbiComp",True
 "chi","UbiComp","Ubicomp",True
+"chi","Pervasive","Pervasive Computing",True
+"chi","IMWUT","Proceedings of the ACM on Interactive, Mobile, Wearable and Ubiquitous Technologies",True
 "chi","UIST","UIST",True
 "comm","SIGCOMM","SIGCOMM",True
 "comm","INFOCOM","INFOCOM",True


### PR DESCRIPTION
From 2017 onwards, the main technical track of the UbiComp conference will be published in a journal format entitled Proceedings of the ACM on Interactive, Mobile, Wearable and Ubiquitous Technologies (IMWUT) http://dblp.uni-trier.de/db/journals/imwut/ 
As such, papers appearing in IWMUT should be considered under UbiComp.
Additionally, the UbiComp conference was formed in 2013 as a merger of two conferences: Ubicomp, and Pervasive. While Pervasive has ceased to exist, it should be considered for historical purposes/stats: http://dblp.uni-trier.de/db/conf/pervasive/index.html