### PR TITLE
Update faculty-affiliations.csv

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -3388,6 +3388,48 @@ Wray L. Buntine , Monash University
 Wray Lindsay Buntine , Monash University
 Yen Cheung , Monash University
 Yuan-Fang Li , Monash University
+Xuandong Li, Nanjing University
+Jia-Fu Xu, Nanjing University
+Jian Lv, Nanjing University
+Daoxu Chen, Nanjing University
+Zhi-hua Zhou, Nanjing University
+Guihai Chen, Nanjing University
+Fangmin Song, Nanjing University
+Hao Huang, Nanjing University
+Jiajun Chen, Nanjing University
+Junyuan Xie, Nanjing University
+Zhengxing Sun, Nanjing University
+Bing Mao, Nanjing University
+Sanglu Lu, Nanjing University
+Jinxi Zhao, Nanjing University
+Bin Luo, Nanjing University
+Gangshan Wu, Nanjing University
+Qingkai Zeng, Nanjing University
+Wanchun Dou, Nanjing University
+Jianhua Zhao, Nanjing University
+Baowen Xu, Nanjing University
+Lijun Chen, Nanjing University
+Xianping Tao, Nanjing University
+Yang Gao, Nanjing University
+Qing Gu, Nanjing University
+Xiaoxing Ma, Nanjing University
+Feng Xu, Nanjing University
+Yuan Jiang, Nanjing University
+Yanwen Guo, Nanjing University
+Baoliu Ye, Nanjing University
+Yihua Huang, Nanjing University
+Yuming Zhou, Nanjing University
+Yuzhong Qu, Nanjing University
+Changhai Nie, Nanjing University
+Sheng Zhong, Nanjing University
+Chongjun Wang, Nanjing University
+Furao Shen, Nanjing University
+Jian-Xin Wu, Nanjing University
+Linzhang Wang, Nanjing University
+Yubing Wang, Nanjing University
+Chang Xu, Nanjing University
+Yitong Yin, Nanjing University
+Wu-Jun Li, Nanjing University
 Alexandros V. Gerbessiotis , NJIT
 Ali Mili , NJIT
 Andrew Sohn , NJIT


### PR DESCRIPTION
Hi Emery,

I have deleted those who cannot supervise PhD directly. 

I used to work for NJU CS and I know the names of those PhD supervisors. Note that some associate professor is PhD supervisor (e.g., Wu-jun Li) and some professors are not PhD supervisors. 

Regards,
Barry