### PR TITLE
removing Murali Krishna Ramanathan's affiliation from IISc

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -1739,7 +1739,6 @@ Vijay Natarajan , IISc Bangalore
 Dilip P. Patil , IISc Bangalore
 Arpita Patra , IISc Bangalore
 Raghavan Komondoor , IISc Bangalore
-Murali Krishna Ramanathan , IISc Bangalore
 Uday Bondhugula , IISc Bangalore
 Chandan Saha , IISc Bangalore
 Shirish K. Shevade , IISc Bangalore


### PR DESCRIPTION
Please update the faculty affiliation page as I have moved out of IISc. 