### PR TITLE
[Fixed] Add USTC, China

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -115,6 +115,7 @@ University of Pisa, europe
 University of Queensland,australasia
 University of Salerno,europe
 University of Saskatchewan,canada
+University of Science and Technology of China,asia
 University of Sydney,australasia
 University of Tartu,europe
 University of Tokyo,asia

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -9271,6 +9271,37 @@ Ralph Deters , University of Saskatchewan
 Raymond Spiteri , University of Saskatchewan
 Regan Mandryk , University of Saskatchewan
 Tony Kusalik , University of Saskatchewan
+Chen Gong , University of Science and Technology of China
+Enhong Chen , University of Science and Technology of China
+Falin Liu , University of Science and Technology of China
+Feng Wu , University of Science and Technology of China
+Hong An , University of Science and Technology of China
+Honggang Hu , University of Science and Technology of China
+Houqiang Li , University of Science and Technology of China
+Huanhuan Chen , University of Science and Technology of China
+Jie Wang , University of Science and Technology of China
+Kai Xing , University of Science and Technology of China
+Ke Tang , University of Science and Technology of China
+Lan Zhang , University of Science and Technology of China
+Li-Rong Dai , University of Science and Technology of China
+Lihua Yue , University of Science and Technology of China
+Liusheng Huang , University of Science and Technology of China
+Naijie Gu , University of Science and Technology of China
+Nenghai Yu , University of Science and Technology of China
+Panlong Yang , University of Science and Technology of China
+Sian-Jheng Lin , University of Science and Technology of China
+Weiping Li , University of Science and Technology of China
+Wenyi Zhang , University of Science and Technology of China
+Xiang-Yang Li , University of Science and Technology of China
+Xiaoping Chen , University of Science and Technology of China
+Xike Xie , University of Science and Technology of China
+Xinyu Feng , University of Science and Technology of China
+Xuehai Zhou , University of Science and Technology of China
+Yan Xiong , University of Science and Technology of China
+Yinlong Xu , University of Science and Technology of China
+Yongdong Zhang , University of Science and Technology of China
+Zhiwei Xiong , University of Science and Technology of China
+Zuqing Zhu , University of Science and Technology of China
 Adriana Iamnitchi , University of South Florida
 Alessio Gaspar , University of South Florida
 Alfredo Weitzenfeld , University of South Florida


### PR DESCRIPTION
This is a modified pull request according to @emeryberger .

We make the following updates:

1. Only full professors. Because most associate professors cannot advise Ph.D. students, except with specific approval, in China.

2.  Only keep the computer science and relevant departments. We remain the "Department of Electronic Engineering and Information Science" because most Computer Graphic people are there.  We remain the "Department of Information Security" because most Security people sit there.

The name list in English (may not be fully updated) can be found in http://en.sist.ustc.edu.cn/ and http://en.cs.ustc.edu.cn/ 

Some new faculty members are not updated into these lists, but we have some proof of concept -- for example, [Jie Wang](http://staff.ustc.edu.cn/~jwangx/) and [Sian-Jheng Lin](https://arxiv.org/pdf/1702.02671.pdf).

The list is sharply reduced. 

I double-check and these professors are
1.  full time, we exclude some faculty like Guoliang Chen and Jian Li because they are actually not full-time here, although the department website has their names.
2.  secured the position, the equivalent of "tenure" in China. 
3.  with papers in top conferences listed in CSRankings list. 