### PR TITLE
[Final] USTC, China

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -115,6 +115,7 @@ University of Pisa, europe
 University of Queensland,australasia
 University of Salerno,europe
 University of Saskatchewan,canada
+University of Science and Technology of China,asia
 University of Sydney,australasia
 University of Tartu,europe
 University of Tokyo,asia

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -9271,6 +9271,24 @@ Ralph Deters , University of Saskatchewan
 Raymond Spiteri , University of Saskatchewan
 Regan Mandryk , University of Saskatchewan
 Tony Kusalik , University of Saskatchewan
+Enhong Chen , University of Science and Technology of China
+Hong An , University of Science and Technology of China
+Huanhuan Chen , University of Science and Technology of China
+Kai Xing , University of Science and Technology of China
+Ke Tang , University of Science and Technology of China
+Lan Zhang , University of Science and Technology of China
+Lihua Yue , University of Science and Technology of China
+Liusheng Huang , University of Science and Technology of China
+Naijie Gu , University of Science and Technology of China
+Panlong Yang , University of Science and Technology of China
+Xiang-Yang Li , University of Science and Technology of China
+Xiaoping Chen , University of Science and Technology of China
+Xike Xie , University of Science and Technology of China
+Xinming Zhang , University of Science and Technology of China
+Xinyu Feng , University of Science and Technology of China
+Xuehai Zhou , University of Science and Technology of China
+Yan Xiong , University of Science and Technology of China
+Yinlong Xu , University of Science and Technology of China
 Adriana Iamnitchi , University of South Florida
 Alessio Gaspar , University of South Florida
 Alfredo Weitzenfeld , University of South Florida


### PR DESCRIPTION
Thanks for detailed instruction by @emeryberger.

It is much easy to follow the definition "can advise a Ph.D. student **in the computer science department**". So the list is reduced again.

I would like to add that, this requirement should be put to all China universities in the future -- because in China, associate and assistant professors cannot advise Ph.D., unlike U.S. system, except with special approval. 

And it is still a problem that, in China, many research areas are not accumulated into computer science -- it needs nation-level correction. 


All these professors in this PR are:

1. Full and tenured professors that must be able to advise and enroll Ph.D. students in the department of computer science and technology. These students will earn a degree in computer science rather than anything else.

2. All professors are in Department of Computer Science and Technology.

3. All these professors have at least one top conference.


Our source is the latest faculty list of Computer Science, included one or two new faculty members.

It is noticeable, from this lesson, that "being divided makes weakness" -- the layout of faculty fails to meet the actual research area. In some computer science areas, faculty members sit in a ``wrong'' department. And their students earn a degree in EE instead of CS, which is weird -- I guess this issue would be resolved after some years of adjustment and revolution. 