### PR TITLE
Add POMACS (=SIGMETRICS) to Measurements & performance analysis

### DIFF
--- a/filter.xq
+++ b/filter.xq
@@ -79,6 +79,7 @@
 //inproceedings[booktitle="DAC"],
 //inproceedings[booktitle="SIGMETRICS"],
 //inproceedings[booktitle="SIGMETRICS/Performance"],
+//article[journal="POMACS"],
 //inproceedings[booktitle="IMC"],
 //inproceedings[booktitle="Internet Measurement Conference"],
 //inproceedings[booktitle="SIGCOMM"],

--- a/util/csrankings.py
+++ b/util/csrankings.py
@@ -88,7 +88,7 @@ areadict = {
     'graph': ['ACM Trans. Graph.', 'SIGGRAPH'],
     # SIGMETRICS
     # - Two variants for each, as in DBLP.
-    'metrics': ['SIGMETRICS', 'SIGMETRICS/Performance', 'IMC', 'Internet Measurement Conference'],
+    'metrics': ['SIGMETRICS', 'SIGMETRICS/Performance', 'IMC', 'Internet Measurement Conference','POMACS'],
     # SIGIR
     'ir': ['WWW', 'SIGIR'],
     # SIGCHI

--- a/util/regenerate-data.py
+++ b/util/regenerate-data.py
@@ -40,7 +40,7 @@ areadict = {
     'graph': ['ACM Trans. Graph.', 'SIGGRAPH'],
     # SIGMETRICS
     # - Two variants for each, as in DBLP.
-    'metrics': ['SIGMETRICS', 'SIGMETRICS/Performance', 'IMC', 'Internet Measurement Conference'],
+    'metrics': ['SIGMETRICS', 'SIGMETRICS/Performance', 'POMACS','IMC', 'Internet Measurement Conference'],
     # SIGIR
     'ir': ['WWW', 'SIGIR'],
     # SIGCHI


### PR DESCRIPTION
Starting 2017, Sigmetrics papers will be published in Proceedings of the ACM Series on Computing Systems Modeling, Measurement and Evaluation (POMACS). 

Call for paper from Sigmetrics'17 (the end of the 2nd paragraph)
[https://www.sigmetrics.org/sigmetrics2017/Call%20for%20Papers.html
](https://www.sigmetrics.org/sigmetrics2017/Call%20for%20Papers.html)

Links to POMACS:
[http://pomacs.acm.org/](http://pomacs.acm.org/)