### PR TITLE
added Stony Brook faculty

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -5197,13 +5197,19 @@ Rong Zhao , Stony Brook University
 Roy Shilkrot , Stony Brook University
 Samir R. Das , Stony Brook University
 Samir Ranjan Das , Stony Brook University
+Sangjin Hong , Stony Brook University
 Scott A. Smolka , Stony Brook University
 Scott D. Stoller , Stony Brook University
 Steven Skiena , Stony Brook University
+Wei Zhu , Stony Brook University
 Xianfeng David Gu , Stony Brook University
 Xianfeng Gu , Stony Brook University
+Xiangmin Jiao , Stony Brook University
 Xiaojun Bi , Stony Brook University
+Xin Wang 0001 , Stony Brook University
 Yanhong A. Liu , Stony Brook University
+Yuanyuan Yang , Stony Brook University
+Zhenhua Liu , Stony Brook University
 Ahmad-Reza Sadeghi , TU Darmstadt
 Alejandro P. Buchmann , TU Darmstadt
 Andreas Koch , TU Darmstadt


### PR DESCRIPTION
Hi Emery,

I am adding 6 faculty members from Stony Brook whose base is not the CS department, but are affiliated with it and can thus advise students. You can see all of our affiliated faculty (including the 6 I added) here: https://www.cs.stonybrook.edu/people/faculty (you have to click on the "Affiliated faculty" tab).

Nick