### PR TITLE
Updated faculty list, IT University of Copenhagen

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -2656,7 +2656,7 @@ Vladimir Kolmogorov , IST Austria
 Alessandro Bruni , IT University of Copenhagen
 Andres Faina , IT University of Copenhagen
 Andrzej Wasowski , IT University of Copenhagen
-Björn Thór Jónsson , IT University of Copenhagen
+Björn Þór Jónsson 0001 , IT University of Copenhagen
 Carsten Schürmann , IT University of Copenhagen
 Claus Brabrand , IT University of Copenhagen
 Dan Witzner Hansen , IT University of Copenhagen
@@ -2673,9 +2673,10 @@ Rasmus Ejlers Møgelberg , IT University of Copenhagen
 Rasmus Pagh , IT University of Copenhagen
 Riko Jacob , IT University of Copenhagen
 Rune Møller Jensen , IT University of Copenhagen
+Sami Sebastian Brandt , IT University of Copenhagen
 Søren Debois , IT University of Copenhagen
 Søren Lauesen , IT University of Copenhagen
-Thomas Hildebrandt , IT University of Copenhagen
+Thomas Troels Hildebrandt , IT University of Copenhagen
 Thore Husfeldt , IT University of Copenhagen
 Troels Bjerre Lund , IT University of Copenhagen
 Troels Bjerre Sørensen , IT University of Copenhagen


### PR DESCRIPTION
Including correcting DBLP names for some faculty; keeping Troels Bjerre Sørensen (but he should not be counted as two faculty members)