### PR TITLE
change the name of a professor at SJTU

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -4935,7 +4935,7 @@ Minglu Li , Shanghai Jiao Tong University
 Minyi Guo , Shanghai Jiao Tong University
 Minyou Wu , Shanghai Jiao Tong University
 Qianni Deng , Shanghai Jiao Tong University
-Qili Zhu , Shanghai Jiao Tong University
+Kenny Q. Zhu , Shanghai Jiao Tong University
 Quan Chen , Shanghai Jiao Tong University
 Rong Chen , Shanghai Jiao Tong University
 Ruimin Shen , Shanghai Jiao Tong University


### PR DESCRIPTION
Prof. Kenny Q. Zhu used the name "Kenny Q. Zhu" for all his papers and the current name "Qili Zhu" refers to the wrong person in dblp.