### PR TITLE
Added Yulia Tsvetkov to CMU

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -897,6 +897,7 @@ William W. Cohen , Carnegie Mellon University
 William Whittaker , Carnegie Mellon University
 Yiming Yang , Carnegie Mellon University
 Yong-Lae Park , Carnegie Mellon University
+Yulia Tsvetkov , Carnegie Mellon University
 Yuvraj Agarwal , Carnegie Mellon University
 Ziv Bar-Joseph , Carnegie Mellon University
 Andy Podgurski , Case Western Reserve University

--- a/homepages.csv
+++ b/homepages.csv
@@ -11353,6 +11353,7 @@ Yuho Jin,http://www.cs.nmsu.edu/~yjin/
 Yuhong Guo,https://carleton.ca/scs/people/yuhong-guo/
 Yuhong Yan,http://users.encs.concordia.ca/~yuhong/
 Yulei Sui,http://www.cse.unsw.edu.au/~ysui/
+Yulia Tsvetkov,http://www.cs.cmu.edu/~ytsvetko/
 Yumei Huo,http://www.cs.csi.cuny.edu/~yumei/
 Yuming Zhou,https://cs.nju.edu.cn/zhouyuming/
 Yun Fu,http://www1.ece.neu.edu/~yunfu/


### PR DESCRIPTION
As of Fall, she is an assistant professor at CMU: http://lti.cs.cmu.edu/people/222218131/yulia-tsvetkov