### PR TITLE
Adam Smith and Sofya Raskhodnikova ---> Boston University

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -4280,7 +4280,7 @@ Sung Yang Bang , POSTECH
 Sungwoo Park , POSTECH
 Wook-Shin Han , POSTECH
 Young-Joo Suh , POSTECH
-Adam D. Smith , Pennsylvania State University
+Adam D. Smith , Boston University
 Anand Sivasubramaniam , Pennsylvania State University
 Bhuvan Urgaonkar , Pennsylvania State University
 C. Lee Giles , Pennsylvania State University
@@ -4318,7 +4318,7 @@ Raj Acharya , Pennsylvania State University
 Robert T. Collins , Pennsylvania State University
 Sean Hallgren , Pennsylvania State University
 Sencun Zhu , Pennsylvania State University
-Sofya Raskhodnikova , Pennsylvania State University
+Sofya Raskhodnikova , Boston University
 Thomas F. La Porta , Pennsylvania State University
 Tom La Porta , Pennsylvania State University
 Trent Jaeger , Pennsylvania State University


### PR DESCRIPTION
Adam Smith and Sofya Raskhodnikova have moved to Boston University (http://www.bu.edu/cs/people/faculty/).