### PR TITLE
New faculty members at UToronto, UMD, UWaterloo, UBC, MIT, CMU, UCLA

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -942,6 +942,12 @@ Yong-Lae Park , Carnegie Mellon University
 Yulia Tsvetkov , Carnegie Mellon University
 Yuvraj Agarwal , Carnegie Mellon University
 Ziv Bar-Joseph , Carnegie Mellon University
+Nathan Beckmann , Carnegie Mellon University
+Igor Mordatch , Carnegie Mellon University
+Justine Sherry , Carnegie Mellon University
+Ioannis Gkioulekas , Carnegie Mellon University
+Mayank Goel , Carnegie Mellon University
+Fei Fang , Carnegie Mellon University
 Andy Podgurski , Case Western Reserve University
 Behnam Malakooti , Case Western Reserve University
 Chris Fietkiewicz , Case Western Reserve University
@@ -3299,6 +3305,9 @@ William T. Freeman , Massachusetts Institute of Technology
 William T. Peake , Massachusetts Institute of Technology
 Wojciech Matusik , Massachusetts Institute of Technology
 Yury Polyanskiy , Massachusetts Institute of Technology
+Adam Belay , Massachusetts Institute of Technology
+Stefanie Müller , Massachusetts Institute of Technology
+Max M. Shulaker , Massachusetts Institute of Technology
 Alan C. Wright , Massey University
 Amjed Tahir , Massey University
 Aruna Shekar , Massey University
@@ -6718,6 +6727,10 @@ V. S. Lakshmanan , University of British Columbia
 William Aiello , University of British Columbia
 William S. Evans , University of British Columbia
 Wolfgang Heidrich , University of British Columbia
+Leonid Sigal , University of British Columbia
+Thomas Fritz , University of British Columbia
+Dongwook Yoon , University of British Columbia
+Siamak Ravanbakhsh , University of British Columbia
 Agustín Gravano , University of Buenos Aires
 Alejandro Martínez-Ríos , University of Buenos Aires
 Carlos Gustavo López Pombo , University of Buenos Aires
@@ -7093,6 +7106,8 @@ Tyson Condie , University of California - Los Angeles
 Wei Wang 0010 , University of California - Los Angeles
 Yizhou Sun , University of California - Los Angeles
 Yuval Tamir , University of California - Los Angeles
+Tony Nowatzki , University of California - Los Angeles
+Eran Halperin , University of California - Los Angeles
 Ahmed Eldawy , University of California - Riverside
 Amit K. Roy-Chowdhury , University of California - Riverside
 Amr Magdy 0001 , University of California - Riverside
@@ -8505,6 +8520,9 @@ V. S. Subrahmanian , University of Maryland - College Park
 William I. Gasarch , University of Maryland - College Park
 Yiannis Aloimonos , University of Maryland - College Park
 Zia Khan , University of Maryland - College Park
+Mark D. M. Leiserson , University of Maryland - College Park
+Furong Huang , University of Maryland - College Park
+Xiaodi Wu , University of Maryland - College Park
 Akshay Krishnamurthy , University of Massachusetts Amherst
 Alexandra Meliou , University of Massachusetts Amherst
 Amir Houman Sadr , University of Massachusetts Amherst
@@ -10167,6 +10185,8 @@ Vassos Hadzilacos , University of Toronto
 Wayne Enright , University of Toronto
 Wayne H. Enright , University of Toronto
 Yashar Ganjali , University of Toronto
+Syed Ishtiaque Ahmed , University of Toronto
+Nisarg Shah 0001 , University of Toronto
 Aditya Bhaskara , University of Utah
 Al Davis , University of Utah
 Alan L. Davis , University of Utah
@@ -10558,6 +10578,7 @@ William Cowan , University of Waterloo
 Yaoliang Yu , University of Waterloo
 Yuying Li , University of Waterloo
 Éric Schost , University of Waterloo
+Ali José Mashtizadeh , University of Waterloo
 Amitava Datta , University of Western Australia
 Bruce S. Gardiner , University of Western Australia
 Cara K. MacNish , University of Western Australia


### PR DESCRIPTION
3 new faculty members at UMD (http://www.cs.umd.edu/article/2017/05/four-new-professors-join-computer-science-faculty; https://www.cs.umd.edu/article/2016/08/department-hires-four-new-professors)

2 new faculty members at UToronto (http://web.cs.toronto.edu/news/current/The_Department_of_Computer_Science_welcomes_its_newest_Faculty_appointments.htm; http://web.cs.toronto.edu/news/current/U_of_T_computer_science_welcomes_eight_new_faculty_members.htm)

1 new faculty member at UWaterloo (https://uwaterloo.ca/computer-science/about/people/mashti)

4 new faculty members at UBC (https://www.cs.ubc.ca/news/2017/10/ubc-computer-science-welcomes-nine-new-faculty-members)

6 new faculty members at CMU (http://www.cs.cmu.edu/~awm/2016_scs_cmu_new_faculty_profiles.pdf)

3 new faculty members at MIT (https://www.eecs.mit.edu/news-events/media/new-eecs-faculty-2016-2017)

2 new faculty members at UCLA (http://engineering.ucla.edu/new-faculty-2016/)