### PR TITLE
Christos H. Papadimitriou has moved to Columbia

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -1128,6 +1128,8 @@ Augustin Chaintreau , Columbia University
 Changxi Zheng , Columbia University
 Cliff Stein , Columbia University
 Clifford Stein , Columbia University
+Christos H. Papadimitriou , Columbia University
+Christos Harilaos Papadimitriou , Columbia University
 Dan Rubenstein , Columbia University
 Daniel J. Hsu , Columbia University
 David M. Blei , Columbia University
@@ -6856,8 +6858,6 @@ Björn Hartmann , University of California - Berkeley
 Borivoje Nikolic , University of California - Berkeley
 Brian A. Barsky , University of California - Berkeley
 Chang Ming Wu , University of California - Berkeley
-Christos H. Papadimitriou , University of California - Berkeley
-Christos Harilaos Papadimitriou , University of California - Berkeley
 Chunlei Liu , University of California - Berkeley
 Claire J. Tomlin , University of California - Berkeley
 Claire Tomlin , University of California - Berkeley


### PR DESCRIPTION
See [https://www.cs.columbia.edu/2017/christos-papadimitriou-four-decades-of-exploring-the-boundaries-of-computation/](https://www.cs.columbia.edu/2017/christos-papadimitriou-four-decades-of-exploring-the-boundaries-of-computation/)