### PR TITLE
Few updates

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -1998,7 +1998,7 @@ Thomas M. Conte , Georgia Institute of Technology
 Tucker Balch , Georgia Institute of Technology
 Tucker R. Balch , Georgia Institute of Technology
 Umakishore Ramachandran , Georgia Institute of Technology
-Vijay V. Vazirani , Georgia Institute of Technology
+Vijay V. Vazirani ,  University of California - Irvine
 Vivek Sarkar , Georgia Institute of Technology
 Wenke Lee , Georgia Institute of Technology
 William R. Harris , Georgia Institute of Technology
@@ -6690,7 +6690,6 @@ Arvind Gupta , University of British Columbia
 Bill Aiello , University of British Columbia
 Chen Greif , University of British Columbia
 Cristina Conati , University of British Columbia
-David G. Kirkpatrick , University of British Columbia
 David Poole , University of British Columbia
 Dinesh K. Pai , University of British Columbia
 Dongwook Yoon , University of British Columbia
@@ -6711,7 +6710,6 @@ Julia Mosin , University of British Columbia
 Julia Rubin , University of British Columbia
 Karon E. MacLean , University of British Columbia
 Karthik Pattabiraman , University of British Columbia
-Kellogg S. Booth , University of British Columbia
 Kevin Leyton-Brown , University of British Columbia
 Laks V. S. Lakshmanan , University of British Columbia
 Leonid Sigal , University of British Columbia
@@ -6738,7 +6736,7 @@ Uri M. Ascher , University of British Columbia
 V. S. Lakshmanan , University of British Columbia
 William Aiello , University of British Columbia
 William S. Evans , University of British Columbia
-Wolfgang Heidrich , University of British Columbia
+Wolfgang Heidrich , KAUST
 Agustín Gravano , University of Buenos Aires
 Alejandro Martínez-Ríos , University of Buenos Aires
 Carlos Gustavo López Pombo , University of Buenos Aires
@@ -10118,7 +10116,6 @@ Bianca Schroeder , University of Toronto
 Bianca Schröder , University of Toronto
 Bogdan Simion , University of Toronto
 Brendan J. Frey , University of Toronto
-Charles Rackoff , University of Toronto
 Christina C. Christara , University of Toronto
 Cristiana Amza , University of Toronto
 Daniel J. Wigdor , University of Toronto
@@ -10127,7 +10124,6 @@ David I. W. Levin , University of Toronto
 David J. Fleet , University of Toronto
 David K. Duvenaud , University of Toronto
 David Lie , University of Toronto
-David Liu , University of Toronto
 Derek G. Corneil , University of Toronto
 Derek Gordon Corneil , University of Toronto
 Diane Horton , University of Toronto
@@ -10179,7 +10175,6 @@ Rudolf Mathon , University of Toronto
 Sam Toueg , University of Toronto
 Sanja Fidler , University of Toronto
 Sheila A. McIlraith , University of Toronto
-Stephen A. Cook , University of Toronto
 Steve Easterbrook , University of Toronto
 Steve Engels , University of Toronto
 Steve M. Easterbrook , University of Toronto
@@ -10560,7 +10555,6 @@ Ondrej Lhoták , University of Waterloo
 Pascal Poupart , University of Waterloo
 Patrick Lam , University of Waterloo
 Peter A. Buhr , University of Waterloo
-Peter A. Forsyth , University of Waterloo
 Peter van Beek , University of Waterloo
 Prabhakar Ragde , University of Waterloo
 Raouf Boutaba , University of Waterloo
@@ -11288,3 +11282,5 @@ Zhipeng Wang , Zhejiang University
 Zhong Ren 0001 , Zhejiang University
 Zonghua Gu , Zhejiang University
 Zonghui Wang , Zhejiang University
+K. V. Rashmi , Carnegie Mellon University
+Nihar B. Shah , Carnegie Mellon University

--- a/homepages.csv
+++ b/homepages.csv
@@ -5518,6 +5518,7 @@ K. Sreenivasa Rao,http://sit.iitkgp.ernet.in/~ksrao/
 K. Srinathan,https://www.iiit.ac.in/people/faculty/srinathan/
 K. T. Tim Cheng,http://www.ece.ust.hk/ece.php/profile/facultydetail/timcheng
 K. V. Dinesha,http://www.iiitb.ac.in/faculty_page.php?name=KVDinesha/
+K. V. Rashmi,http://www.cs.cmu.edu/~rvinayak/
 K. V. Subrahmanyam,http://www.cmi.ac.in/~kv/
 Kadangode K. Ramakrishnan,http://www.cs.ucr.edu/~kk/
 Kadri Muischnek,http://www.ut.ee/en/kadri-muischnek/
@@ -7666,6 +7667,7 @@ Nigel R. Shadbolt,http://users.ecs.soton.ac.uk/nrs/
 Nigel Shadbolt,http://www.jesus.ox.ac.uk/people/professor-sir-nigel-shadbolt/
 Nigel Topham,http://homepages.inf.ed.ac.uk/npt/
 Nihal P. Jayamaha,https://www.massey.ac.nz/massey/learning/colleges/college-of-sciences/staff-list.cfm?stref=416150/
+Nihar B. Shah,http://www.cs.cmu.edu/~nihars/
 Niki Kittur,http://kittur.org/
 Niki Trigoni,https://www.cs.ox.ac.uk/niki.trigoni/
 Nikil D. Dutt,http://www.ics.uci.edu/~dutt/
@@ -11154,7 +11156,7 @@ Wojciech Szpankowski,https://www.cs.purdue.edu/people/spa/
 Wolfgang Banzhaf,http://research.msu.edu/tag/wolfgang-banzhaf/
 Wolfgang E. Nagel,https://tu-dresden.de/die_tu_dresden/zentrale_einrichtungen/zih/wir_ueber_uns/mitarbeiter/nagel/
 Wolfgang Emmerich,http://www0.cs.ucl.ac.uk/staff/w.emmerich/
-Wolfgang Heidrich,https://www.cs.ubc.ca/~heidrich/
+Wolfgang Heidrich,http://vccimaging.org/People/heidriw/
 Wolfgang Lehner,https://wwwdb.inf.tu-dresden.de/team/head/wolfgang-lehner/
 Wolfgang Prinz,http://dbis.rwth-aachen.de/cms/staff/prinz/
 Wolfgang Thomas,https://www.lii.rwth-aachen.de/en/mitarbeiter/13-mitarbeiter/professoren/7-wolfgang-thomas.html/


### PR DESCRIPTION
Wolfgang Heidrich seems to have moved to KAUST http://vccimaging.org/People/heidriw/
Removed David Liu , University of Toronto as he is listed as Asst. Prof. teaching stream  http://www.cs.toronto.edu/~david/
Removed Charles Rackoff , University of Toronto as he is listed as Professor Emeritus  http://www.cs.toronto.edu/~rackoff/
Removed Stephen A. Cook , University of Toronto as he is listed as Professor Emeritus http://www.cs.toronto.edu/~sacook/
Removed Peter A. Forsyth , University of Waterloo as he is listed as Professor Emeritus https://cs.uwaterloo.ca/people-profiles/peter-forsyth
Removed David G. Kirkpatrick , University of British Columbia as he is listed as Professor Emeritus https://www.cs.ubc.ca/people/david-kirkpatrick
Removed Kellogg S. Booth , University of British Columbia as he is listed as Professor Emeritus http://www.cs.ubc.ca/~ksbooth/
Moved Vijay V. Vazirani to University of California - Irvine  https://www.cs.uci.edu/faculty/
Added K. V. Rashmi to CMU   http://www.cs.cmu.edu/~rvinayak/
Added Nihar B. Shah to CMU http://www.cs.cmu.edu/~nihars/