### PR TITLE
Fixing homepage (Keval Vora)

### DIFF
--- a/homepages.csv
+++ b/homepages.csv
@@ -5770,7 +5770,7 @@ Ketan Mayer-Patel,http://www.cs.unc.edu/~kmp/
 Ketan Mulmuley,https://www.cs.uchicago.edu/directory/ketan-mulmuley/
 Ketan Patel,http://www.cs.unc.edu/~kmp/
 Keting Jia,http://www.castu.tsinghua.edu.cn/publish/casen/1257/index.html
-Keval Vora,https://www.sfu.ca/computing/people/faculty/kevalvora111.html
+Keval Vora,http://www.cs.sfu.ca/~keval
 Kevin B. Korb,http://monash.edu/research/explore/en/persons/kevin-korb(3170934f-4d80-435b-ad14-0af80566ad5a).html/
 Kevin Bierre,https://www.rit.edu/gccis/igm/kevin-bierre/
 Kevin Bryson,http://www0.cs.ucl.ac.uk/people/K.Bryson.html/


### PR DESCRIPTION
Fixed homepage for Keval Vora: http://www.cs.sfu.ca/~keval