### PR TITLE
Adding joint appointments at UCF

### DIFF
--- a/dblp-aliases.csv
+++ b/dblp-aliases.csv
@@ -12716,6 +12716,7 @@ Ivan Gesteira Costa,Ivan G. Costa
 Ivan Giannoccaro,N. I. Giannoccaro
 Ivan Giannoccaro,Nicola Ivan Giannoccaro
 Ivan Herreros,Ivan Herreros-Alonso
+Ivan I. Garibary,Ivan Garibay
 Ivan J. Jureta,Ivan Jureta
 Ivan J. Tashev,Ivan Tashev
 Ivan M. Buzurovic,Ivan Buzurovic

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -7668,16 +7668,24 @@ Cliff Changchun Zou , University of Central Florida
 Damian Dechev , University of Central Florida
 Damla Turgut , University of Central Florida
 Dan C. Marinescu , University of Central Florida
+Deliang Fan , University of Central Florida
 Fei Liu 0004 , University of Central Florida
 Gary T. Leavens , University of Central Florida
 Gita Reese Sukthankar , University of Central Florida
 Gita Sukthankar , University of Central Florida
+Greg Welch , University of Central Florida
+Gregory F. Welch , University of Central Florida
 Guo-Jun Qi , University of Central Florida
 Guojun Qi , University of Central Florida
 Haiyan Hu , University of Central Florida
 Hassan Foroosh , University of Central Florida
+Ivan Garibay , University of Central Florida
+Ivan I. Garibay , University of Central Florida
+Issa Batarseh , University of Central Florida
+Jiann-Shiun Yuan , University of Central Florida
 Joseph J. LaViola , University of Central Florida
 Joseph J. LaViola Jr. , University of Central Florida
+Jun Wang 0001 , University of Central Florida
 Kenneth O. Stanley , University of Central Florida
 Kien A. Hua , University of Central Florida
 Ladislau Bölöni , University of Central Florida
@@ -7686,15 +7694,21 @@ Mainak Chatterjee , University of Central Florida
 Mark Heinrich , University of Central Florida
 Mostafa Bassiouni , University of Central Florida
 Mubarak Shah , University of Central Florida
+Murat Yuksel , University of Central Florida
 Narsingh Deo , University of Central Florida
+Nazanin Rahnavard , University of Central Florida
 Niels da Vitoria Lobo , University of Central Florida
 Pamela J. Wisniewski , University of Central Florida
 Pamela Karr , University of Central Florida
 Pamela Karr Wisniewski , University of Central Florida
 Pawel Wocjan , University of Central Florida
+Randall Shumaker , University of Central Florida
+R. Paul Wiegand , University of Central Florida
 Ratan Guha , University of Central Florida
 Ratan K. Guha , University of Central Florida
+Rickard Ewetz , University of Central Florida
 Ronald D. Dutton , University of Central Florida
+Ronald F. DeMara , University of Central Florida
 Shaojie Zhang , University of Central Florida
 Sharma Thankachan , University of Central Florida
 Sharma V. Thankachan , University of Central Florida
@@ -7703,6 +7717,9 @@ Sumanta N. Pattanaik , University of Central Florida
 Sumit Kumar Jha , University of Central Florida
 Ulas Bagci , University of Central Florida
 Xinwen Fu , University of Central Florida
+Yaser P. Fallah , University of Central Florida
+Yaser Pourmohammadi , University of Central Florida
+Yaser Pourmohammadi Fallah , University of Central Florida
 Aaron J. Elmore , University of Chicago
 Alexander A. Razborov , University of Chicago
 Andrew A. Chien , University of Chicago

--- a/homepages.csv
+++ b/homepages.csv
@@ -2580,6 +2580,7 @@ Dekai Wu,http://www.cs.ust.hk/~dekai/
 Delaram Kahrobaei,https://wfs.gc.cuny.edu/DKahrobaei/www/
 Delbert Willie,https://nau.edu/siccs/faculty/
 Delfina Malandrino,http://www.di.unisa.it/~delmal/
+Deliang Fan,http://www.eecs.ucf.edu/~dfan/
 Demetri Terzopoulos,http://www.cs.ucla.edu/~dt/
 Demetrios Achlioptas,https://users.soe.ucsc.edu/~optas/
 Deming Chen,https://www.ece.illinois.edu/directory/profile/dchen/
@@ -3731,7 +3732,7 @@ Greg N. Frederickson,https://www.cs.purdue.edu/people/gnf/
 Greg Shakhnarovich,http://ttic.uchicago.edu/~gregory/
 Greg Turk,http://www.cc.gatech.edu/~turk/
 Greg Wadley,http://people.eng.unimelb.edu.au/gwadley/
-Greg Welch,https://www.cs.unc.edu/~welch/
+Greg Welch,http://www.ist.ucf.edu/people/gwelch/
 Gregg Rothermel,http://cse.unl.edu/~grother/
 Gregor Kiczales,https://www.cs.ubc.ca/~gregor/
 Gregor Richards,http://the.gregor.institute/
@@ -3741,7 +3742,7 @@ Gregory Butler,http://www.cs.concordia.ca/~gregb/
 Gregory D. Abowd,http://ubicomp.cc.gatech.edu/gregory-d-abowd/
 Gregory D. Hager,http://www.cs.jhu.edu/~hager/
 Gregory Dudek,http://www.cim.mcgill.ca/~dudek/
-Gregory F. Welch,http://cs.unc.edu/people/gregory-f-welch/
+Gregory F. Welch,http://www.ist.ucf.edu/people/gwelch/
 Gregory H. Wakefield,http://mcubed.umich.edu/users/ghw/
 Gregory Hooper,https://www.uq.edu.au/study/course.html?course_code=MMDS7963/
 Gregory J. E. Rawlins,http://www.cs.indiana.edu/~rawlins/
@@ -4398,6 +4399,7 @@ Islene Calciolari Garcia,https://github.com/islene
 Ismailcem Budak Arpinar,http://cobweb.cs.uga.edu/~budak/
 Israat Haque,https://www.dal.ca/faculty/computerscience/news-events/events/2017/05/01/cs_seminar__israat_haque___software_defined_architectures_and_protocols_for_emerging_wireless_networks.html
 Israel Cidon,http://cidon.eew.technion.ac.il/
+Issa Batarseh,http://www.cecs.ucf.edu/faculty/issa-batarseh/
 Issei Sato,http://www.ms.k.u-tokyo.ac.jp/sato/
 Itamar Arel,http://www.eecs.utk.edu/people/faculty/ielhanan/
 Itsik Pe'er,http://www.cs.columbia.edu/~itsik/
@@ -4406,8 +4408,10 @@ Ivan Beschastnikh,http://www.cs.ubc.ca/~bestchai/
 Ivan Bjerre Damgård,http://pure.au.dk/portal/en/persons/id(70603eb5-52fd-41e3-8752-15d803c3af5c).html/
 Ivan Damgård,http://pure.au.dk/portal/en/persons/id(70603eb5-52fd-41e3-8752-15d803c3af5c).html/
 Ivan Flechais,https://www.cs.ox.ac.uk/people/ivan.flechais/
+Ivan Garibay,http://ivan.research.ucf.edu/
 Ivan Hal Sudborough,https://explorer.utdallas.edu/editprofile.php?pid=13187/
 Ivan Herman,http://homepages.cwi.nl/~ivan/
+Ivan I. Garibay,http://ivan.research.ucf.edu/
 Ivan Laptev,https://www.di.ens.fr/~laptev/
 Ivan Martinovic,https://www.cs.ox.ac.uk/people/ivan.martinovic/
 Ivan Titov,http://ivan-titov.org/
@@ -4908,6 +4912,7 @@ Jianhua Zhao,https://cs.nju.edu.cn/58/18/c2639a153624/page.htm
 Jianke Zhu,http://mypage.zju.edu.cn/jkzhu
 Jianmin Li,http://www.tsinghua.edu.cn/publish/csen/4623/2010/20101225164517300815523/20101225164517300815523_.html
 Jianmin Zheng,http://www.ntu.edu.sg/home/asjmzheng/
+Jiann-Shiun Yuan,https://sites.google.com/site/yuanjs168/
 Jiannan Wang,http://www.cs.sfu.ca
 Jianping Pan,https://webhome.cs.uvic.ca/~pan/
 Jianping Wu,http://www.tsinghua.edu.cn/publish/ceen/3155/2011/20110316074606924284214/20110316074606924284214_.html
@@ -5455,6 +5460,7 @@ Jun Luo,http://www.ntu.edu.sg/home/junluo/
 Jun Sun,http://www.icst.pku.edu.cn/vip/people-sunjE.html
 Jun Suzuki,http://www.cs.umb.edu/~jxs/
 Jun Wang,http://web4.cs.ucl.ac.uk/staff/jun.wang/blog/
+Jun Wang 0001,http://www.cass.eecs.ucf.edu/?page_id=1249
 Jun Wang 0012,http://www.cs.ucl.ac.uk/people/J.Wang.html
 Jun Xu,http://www.cc.gatech.edu/~jx/
 Jun Yang,https://users.cs.duke.edu/~junyang/
@@ -7473,6 +7479,7 @@ Murat Arcak,https://www2.eecs.berkeley.edu/Faculty/Homepages/arcak.html/
 Murat Demirbas,http://www.cse.buffalo.edu/~demirbas/
 Murat Dundar,http://cadkd.cs.iupui.edu/
 Murat Kantarcioglu,http://www.utdallas.edu/~muratk/
+Murat Yuksel,http://www.ece.ucf.edu/~yuksem/
 Muriel Médard,http://www.rle.mit.edu/ncrc/
 Murray Cole,http://homepages.inf.ed.ac.uk/mic/
 Murray Shanahan,https://www.doc.ic.ac.uk/~mpsha/
@@ -7598,6 +7605,7 @@ Naveen Garg,http://www.cse.iitd.ernet.in/~naveen/
 Naveen Sharma,https://www.rit.edu/gccis/naveen-sharma-0/
 Navneet Goyal,http://universe.bits-pilani.ac.in/pilani/goel/profile/
 Nawaf Alkharboush,http://www.kau.edu.sa/Contacts.aspx?Site_ID=861&Lng=EN&Cont=16331
+Nazanin Rahnavard,http://cwnlab.eecs.ucf.edu/
 Nazim Agoulmine,http://phome.postech.ac.kr/user/indexSub.action?codyMenuSeq=18447&siteId=itce&menuUIType=sub
 Nazim H. Madhavji,http://www.csd.uwo.ca/courses/CS3307a/
 Nazli Goharian,http://people.cs.georgetown.edu/~nazli/
@@ -8480,6 +8488,7 @@ R. K. Bagga,https://www.iiit.ac.in/people/faculty/rbagga/
 R. Lyndon While,http://uwa.edu.au/people/lyndon.while/
 R. Michael Young,https://www.csc.ncsu.edu/people/rmyoung/
 R. Mukundan,http://www.cosc.canterbury.ac.nz/mukundan/
+R. Paul Wiegand,http://www.tesseract.org/paul/
 R. Rodrey Howell,http://people.cs.ksu.edu/~rhowell/
 R. Ryan Williams,http://web.stanford.edu/~rrwill/
 R. Sekar,http://seclab.cs.sunysb.edu/sekar/
@@ -8650,6 +8659,7 @@ Randall Berry,http://www.ece.northwestern.edu/~rberry/
 Randall Bramley,https://www.soic.indiana.edu/all-people/profile.html?profile_id=169/
 Randall D. Beer,http://mypage.iu.edu/~rdbeer/
 Randall Davis,https://www.csail.mit.edu/user/805/
+Randall Shumaker,http://www.iems.ucf.edu/people/randall-shumaker
 Randy Avent,https://www.csc.ncsu.edu/people/rkavent/
 Randy E. Ellis,http://www.cs.queensu.ca/~ellis/
 Randy Goebel,https://webdocs.cs.ualberta.ca/~goebel/
@@ -8844,6 +8854,7 @@ Richard Zanibbi,https://www.cs.rit.edu/~rlaz/
 Rick Alterman,http://www.brandeis.edu/facultyguide/person.html?emplid=4a09ce0d1a4b429db8f07e9e0210e5e2e7ab094b/
 Rick L. Stevens,https://cs.uchicago.edu/directory/rick-stevens/
 Rick Stevens,https://cs.uchicago.edu/directory/rick-stevens/
+Rickard Ewetz,http://www.ece.ucf.edu/~ewetz/
 Rico Sennrich,http://homepages.inf.ed.ac.uk/rsennric/
 Rida A. Bazzi,http://bazzi.faculty.asu.edu/
 Ridha Khedri,http://www.cas.mcmaster.ca/~khedri/
@@ -9077,6 +9088,7 @@ Ronald C. Arkin,http://www.cc.gatech.edu/home/arkin/
 Ronald Cramer,http://homepages.cwi.nl/~cramer/
 Ronald D. Dutton,http://www.cs.ucf.edu/~dutton/
 Ronald D. Schrimpf,http://www.vuse.vanderbilt.edu/~schrimpf/
+Ronald F. DeMara,http://cal.ucf.edu/
 Ronald Fedkiw,http://cs.stanford.edu/~fedkiw/
 Ronald G. Dreslinski,https://web.eecs.umich.edu/~rdreslin/
 Ronald Garcia,http://www.cs.ubc.ca/~rxg/
@@ -11479,6 +11491,9 @@ Yaoxue Zhang,http://media.cs.tsinghua.edu.cn/~zyxe/
 Yaoyun Shi,https://web.eecs.umich.edu/~shiyy/
 Yaqiong Xu,http://eecs.vanderbilt.edu/people/yaqiongxu/group.html/
 Yaron Singer,http://seas.harvard.edu/~yaron/
+Yaser P. Fallah,http://www.eecs.ucf.edu/~yfallah/
+Yaser Pourmohammadi,http://www.eecs.ucf.edu/~yfallah/
+Yaser Pourmohammadi Fallah,http://www.eecs.ucf.edu/~yfallah/
 Yaser S. Abu-Mostafa,https://work.caltech.edu/
 Yaser Sheikh,http://www.cs.cmu.edu/~yaser/
 Yash Vasavada,http://www.daiict.ac.in/daiict/people/faculty.html


### PR DESCRIPTION
Adding faculty members who have what at UCF is called a "secondary joint appointment" that allows them to supervise CS PhD students. These are all full time faculty at UCF. Greg Welch had moved to UCF a few years ago.