### PR TITLE
Prof. Matt moved to Borealis AI

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -11307,8 +11307,6 @@ José G. Delgado-Frias , Washington State University
 K. C. Wang , Washington State University
 Krishnamoorthy Sivakumar , Washington State University
 Larry Holder , Washington State University
-Matthew E. Taylor , Washington State University
-Matthew Edmund Taylor , Washington State University
 Murari Kejariwal , Washington State University
 Noel Schulz , Washington State University
 Partha Pratim Pande , Washington State University


### PR DESCRIPTION
http://borealisai.com/2017/10/26/borealis-ai-welcomes-prof-matt-taylor-to-our-edmonton-family/