### PR TITLE
Remove some bogus PKU entries

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -4344,14 +4344,10 @@ Sungwoo Park , POSTECH
 Wook-Shin Han , POSTECH
 Young-Joo Suh , POSTECH
 Aixia Jia , Peking University
-Baobao Chang , Peking University
 Bin Cui , Peking University
 Bin Sun , Peking University
 Bing Xie , Peking University
 Bingfeng Zhou , Peking University
-Chao Xu , Peking University
-Chao Xu 0006 , Peking University
-Chao Zhang , Peking University
 Chao Zhang 0001 , Peking University
 Chenren Xu , Peking University
 Dan Hao , Peking University
@@ -4360,10 +4356,7 @@ Deshun Yang , Peking University
 Dingsheng Luo , Peking University
 Donggang Cao , Peking University
 Dongyan Zhao , Peking University
-Feng Chen , Peking University
 Fuqing Yang , Peking University
-Gang Huang , Peking University
-Gang Huang 0001 , Peking University
 Gang Zeng , Peking University
 Ge Li , Peking University
 Guangyu Sun , Peking University
@@ -4372,27 +4365,22 @@ Guojie Song , Peking University
 Guoping Wang , Peking University
 Haiyan Zhao , Peking University
 Hanpin Wang , Peking University
-Heng Wang , Peking University
 Hong Mei , Peking University
 Hongbin Zha , Peking University
 Hongfei Yan , Peking University
 Hongjie Chen , Peking University
 Hongyan Li , Peking University
-Houfeng Wang , Peking University
 Huarui Zhang , Peking University
 Huashan Yu , Peking University
 Huijing Zhao , Peking University
 Huiming Duan , Peking University
 Huisheng Chi , Peking University
 Huizhu Jia , Peking University
-Jian Wang , Peking University
 Jian-bin Hu , Peking University
 Jianguo Xiao , Peking University
 Jiasu Sun , Peking University
 Jiaying Liu , Peking University
 Jin Xu , Peking University
-Jing Chen , Peking University
-Jing Chen 0002 , Peking University
 Jinshi Cui , Peking University
 Juju Feng , Peking University
 Jun Gao , Peking University
@@ -4407,14 +4395,8 @@ Liangcai Gao , Peking University
 Lifu Wang , Peking University
 Ling-Yu Duan , Peking University
 Lingyu Duan , Peking University
-Liwei Wang , Peking University
 Liyong Tang , Peking University
-Lu Zhang , Peking University
-Lu Zhang 0023 , Peking University
-Ming Zhang 0004 , Peking University
 Minghui Zhou , Peking University
-Ning Zhang , Peking University
-Ning Zhang 0003 , Peking University
 Ping Wang , Peking University
 Qianxiang Wang , Peking University
 Rui Yan , Peking University
@@ -4424,9 +4406,7 @@ Sheng Li 0002 , Peking University
 Shikun Zhang , Peking University
 Shiliang Zhang , Peking University
 Siwei Ma , Peking University
-Sujian Li , Peking University
 Tao Wang 0004 , Peking University
-Tengjiao Wang , Peking University
 Tian Liu , Peking University
 Tianshu Qu , Peking University
 Tiejun Huang , Peking University
@@ -4434,16 +4414,11 @@ Tingting Jiang , Peking University
 Tong Lin , Peking University
 Tong Yang , Peking University
 Tong Zhao , Peking University
-Wei Chen , Peking University
-Wei Chen 0021 , Peking University
 Wei Yan , Peking University
 Wei Zeng , Peking University
-Wei Zhang , Peking University
-Wei Zhang 0004 , Peking University
 Weiping Huang , Peking University
 Weiwei Sun , Peking University
 Weizhong Shao , Peking University
-Wen Gao , Peking University
 Wen Gao 0001 , Peking University
 Wen Zhao , Peking University
 Wenhui Hu , Peking University
@@ -4453,7 +4428,6 @@ Xianghua Ying , Peking University
 Xiangqun Chen , Peking University
 Xiaodong Xie , Peking University
 Xiaojun Wan , Peking University
-Xiaolin Wang , Peking University
 Xiaoming Li , Peking University
 Xiaoou Chen , Peking University
 Xiaoqing Lv , Peking University
@@ -4501,7 +4475,6 @@ Zhengmao Xie , Peking University
 Zhi Guan , Peking University
 Zhi Jin , Peking University
 Zhi Yang , Peking University
-Zhifang Sui , Peking University
 Zhihong Deng , Peking University
 Zhihong Liu , Peking University
 Zhiyi Ma , Peking University

--- a/homepages.csv
+++ b/homepages.csv
@@ -1104,7 +1104,6 @@ Balasubramaniam Srinivasan,http://monash.edu/research/explore/en/persons/balasub
 Balasubramanian Raman,http://www.iitr.ac.in/departments/CSE/pages/Home+Departments_and_Centres+Mathematics+People+Faculty+Balasubramanian_R_.html/
 Balwinder Sodhi,http://www.iitrpr.ac.in/sodhi/
 Bangti Jin,http://www0.cs.ucl.ac.uk/staff/B.Jin/
-Baobao Chang,http://icl.pku.edu.cn/members/chbb/
 Baochun Li,http://iqua.ece.toronto.edu/bli/
 Baogang Wei,http://mypage.zju.edu.cn/wbg
 Baoliang Lu,http://bcmi.sjtu.edu.cn/~blu/
@@ -1707,8 +1706,6 @@ Chanik Park,http://cpmi.postech.ac.kr/prof-chanik-park/
 Chao Li,http://www.cs.sjtu.edu.cn/~lichao/
 Chao Tian,http://www.eecs.utk.edu/people/faculty/ctian1/
 Chao Wang 0001,http://www-bcf.usc.edu/~wang626/
-Chao Xu,http://loop.frontiersin.org/people/266002/overview
-Chao Xu 0006,http://www.cis.pku.edu.cn/faculty/vision/xuchao/xuchao01.htm
 Chao Zhang,http://chao.100871.net/
 Chao Zhang 0001,http://www.cis.pku.edu.cn/faculty/vision/zhangchao/zhangchao.htm
 Chaoli Wang,http://www3.nd.edu/~cwang11/about.html/
@@ -3295,7 +3292,6 @@ Felix Freitag,http://people.ac.upc.edu/felix/
 Felix Wolf,https://www.parallel.informatik.tu-darmstadt.de/
 Felix Wolf 0001,https://www.parallel.informatik.tu-darmstadt.de/team/felix-wolf/
 Femke van Raamsdonk,http://www.cs.vu.nl/~femke/
-Feng Chen,http://en.coe.pku.edu.cn/Outstanding-Talents/63.htm
 Feng Gu,http://www.cs.csi.cuny.edu/~gu/
 Feng Liu,http://researchers.uq.edu.au/researcher/951/
 Feng Luo,https://people.cs.clemson.edu/~luofeng/
@@ -3488,8 +3484,6 @@ Ganesh Gopalakrishnan,https://www.cs.utah.edu/~ganesh/
 Ganesh Ramakrishnan,https://www.cse.iitb.ac.in/~ganesh/
 Gang Chen 0001,http://mypage.zju.edu.cn/0098112
 Gang Chen 0002,https://ecs.victoria.ac.nz/Main/AaronChen/
-Gang Huang,https://www.cincinnatichildrens.org/bio/h/gang-huang
-Gang Huang 0001,http://sei.pku.edu.cn/~huanggang/index_en.htm
 Gang Pan,http://www.cs.zju.edu.cn/~gpan
 Gang Tan,http://www.cse.psu.edu/~gxt29/
 Gang Wang,http://people.cs.vt.edu/gangwang/
@@ -4077,7 +4071,6 @@ Hemanta Kumar Maji,https://www.cs.purdue.edu/homes/hmaji/
 Heng Huang,http://ranger.uta.edu/~heng/
 Heng Ji,http://nlp.cs.rpi.edu/hengji.html/
 Heng Tao Shen,http://staff.itee.uq.edu.au/shenht/
-Heng Wang,https://www.facebook.com/public/Heng-Wang/school/Peking-University-103771729661827/
 Heng Yin,http://www.cs.ucr.edu/~heng/
 Heni Ben Amor,https://cidse.engineering.asu.edu/directory/ben-amor-heni/
 Henk J. Sips,http://www.ds.ewi.tudelft.nl/henk/
@@ -4186,7 +4179,6 @@ Hossein Saiedian,http://people.eecs.ku.edu/~saiedian/
 Hossein Sameti,http://sina.sharif.ir/~sameti
 Houari A. Sahraoui,http://www.iro.umontreal.ca/~sahraouh/
 Houari Sahraoui,http://www.iro.umontreal.ca/~sahraouh/
-Houfeng Wang,http://icl.pku.edu.cn/members/wanghf/index.htm
 Houman Homayoun,https://ece.gmu.edu/~hhomayou/
 Hovav Shacham,http://cseweb.ucsd.edu/~hovav/
 Hovhannes Harutyunyan,http://www.concordia.ca/faculty/hovhannes-harutyunyan.html
@@ -5039,7 +5031,6 @@ Jin-yi Cai,http://pages.cs.wisc.edu/~jyc/
 Jinah Park,http://cgv.kaist.ac.kr/professor
 Jinbo Bi,http://www.engr.uconn.edu/~jinbo/
 Jinbo Xu,http://ttic.uchicago.edu/~jinbo/
-Jing Chen,http://www3.cs.stonybrook.edu/~jingchen/
 Jing Chen 0001,http://www3.cs.stonybrook.edu/~jingchen/
 Jing Chen 0002,http://www.cis.pku.edu.cn/auditory/Staff/chenj.htm
 Jing Gao,https://www.cse.buffalo.edu/~jing/
@@ -6371,7 +6362,6 @@ Lu Hongtao,http://english.seiee.sjtu.edu.cn/english/detail/841_674.htm
 Lu Ruan,http://www.cs.iastate.edu/~ruan/
 Lu Su,http://www.cse.buffalo.edu/people/?u=lusu/
 Lu Wang,http://www.ccs.neu.edu/home/luwang/
-Lu Zhang,https://m.facebook.com/public/Lu-Zhang/school/Peking-University-103771729661827/
 Lu Zhang 0023,http://sei.pku.edu.cn/~zhanglu/
 Luay Nakhleh,https://www.cs.rice.edu/~nakhleh/
 Lubomir Bic,http://www.ics.uci.edu/~bic/
@@ -7376,8 +7366,6 @@ Ming Liu 0001,http://www.ece.ust.hk/ece.php/profile/facultydetail/eelium
 Ming Ouhyoung,https://www.csie.ntu.edu.tw/~ming/
 Ming Ouyang,http://www.cs.umb.edu/people/Ming_Ouyang/
 Ming Yin,https://www.cs.purdue.edu/people/faculty/mingyin/
-Ming Zhang,http://net.pku.edu.cn/dlib/mzhang/
-Ming Zhang 0004,https://arxiv.org/abs/0904.1091
 Ming Zhao,https://cidse.engineering.asu.edu/directory/zhao-ming/
 Ming-Deh A. Huang,http://www-bcf.usc.edu/~mdhuang/
 Ming-Deh Huang,http://www-bcf.usc.edu/~mdhuang/
@@ -7820,7 +7808,6 @@ Nima Honarmand,http://compas.cs.stonybrook.edu/~nhonarmand/
 Nina Amenta,http://www.cs.ucdavis.edu/~amenta/
 Nina S. T. Hirata,https://www.ime.usp.br/~nina/
 Nina Sumiko Tomita Hirata,http://www.ime.usp.br/~nina
-Ning Zhang,https://people.eecs.berkeley.edu/~nzhang/
 Ning Zhang 0003,https://www.morganlewis.com/bios/ningzhang
 Ninghui Li,https://www.cs.purdue.edu/homes/ninghui/
 Nir Ailon,http://nailon.net.technion.ac.il/
@@ -10257,7 +10244,6 @@ Suely Oliveira,https://www.cs.uiowa.edu/~oliveira/
 Sugata Gangopadhyay,http://www.iitr.ac.in/departments/CSE/pages/Home+Departments_and_Centres+Mathematics+People+Faculty+Gangopadhyay_Sugata.html/
 Sugih Jamin,http://web.eecs.umich.edu/~sugih/
 Sujata Pal,http://www.iitrpr.ac.in/cse/sujata
-Sujian Li,http://icl.pku.edu.cn/members/lisujian/default.htm
 Sujit Gujar,https://www.iiit.ac.in/people/faculty/sujit.g/
 Sujit Kumar Chakrabarti,http://www.iiitb.ac.in/faculty_page.php?name=SujitKumarChakrabarti/
 Sujoy Ghose,http://www.myopencourses.com/profile/prof-sujoy-ghosh/
@@ -10482,7 +10468,6 @@ Tek-Jin Nam,http://cidr.kaist.ac.kr/members/
 Telikepalli Kavitha,http://www.tcs.tifr.res.in/~kavitha/
 Temuulen Sankey,https://nau.edu/cefns/natsci/seses/faculty/teki-sankey/
 Ten-Hwang Lai,http://web.cse.ohio-state.edu/~lai/
-Tengjiao Wang,http://www1.se.cuhk.edu.hk/~wise/index.php/people
 Teofilo F. Gonzalez,http://www.cs.ucsb.edu/~teo/
 Terence Sim,https://www.comp.nus.edu.sg/~tsim/
 Teresa K. Attwood,https://www.research.manchester.ac.uk/portal/teresa.k.attwood.html
@@ -11149,9 +11134,7 @@ Wee Keong Ng,http://www.ntu.edu.sg/home/awkng/
 Wee Kheng Leow,https://www.comp.nus.edu.sg/~leowwk/
 Wee Sun Lee,https://www.comp.nus.edu.sg/~leews/
 Wei Bao,http://rp-www.cs.usyd.edu.au/~weibao/
-Wei Chen,https://www.facebook.com/public/Wei-Chen/school/Peking-University-103771729661827/
 Wei Chen 0001,http://www.cad.zju.edu.cn/home/chenwei
-Wei Chen 0021,http://dblp.org/pers/c/Chen_0006:Wei
 Wei Cheng,http://www.people.vcu.edu/~wcheng3/
 Wei Ding,http://www.cs.umb.edu/~ding/
 Wei Ding 0003,http://www.cs.umb.edu/~ding/
@@ -11175,7 +11158,6 @@ Wei Xu 0004,https://cse.osu.edu/node/1671
 Wei Xue,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101224235122610366982/20101224235122610366982_.html
 Wei Yan,http://net.pku.edu.cn/~yw/
 Wei Zeng,http://biopic.pku.edu.cn/english/detail.aspx?id=44
-Wei Zhang,https://www.facebook.com/public/Wei-Zhang/school/Peking-University-103771729661827/
 Wei Zhang 0004,http://sei.pku.edu.cn/~zhangw/
 Wei Zhu,http://www.ams.stonybrook.edu/~zhu/
 Wei-Chung Hsu,http://www.csie.ntu.edu.tw/~hsuwc/
@@ -11435,7 +11417,6 @@ Xiaoli Li 0001,http://www1.i2r.a-star.edu.sg/~xlli/
 Xiaoli Z. Fern,http://web.engr.oregonstate.edu/~xfern/
 Xiaoli Zhang Fern,http://web.engr.oregonstate.edu/~xfern/
 Xiaolin Hu,http://www.xlhu.cn/
-Xiaolin Wang,https://www.usenix.org/conference/atc16/speaker-or-organizer/xiaolin-wang-peking-university
 Xiaolin Zheng,http://mypage.zju.edu.cn/xlzheng
 Xiaomin Sun,http://www.carch.ac.cn/~xmsun/xmsun.htm
 Xiaoming Li,http://net.pku.edu.cn/~lxm/
@@ -11920,7 +11901,6 @@ Zhi-hong Deng,http://www.cis.pku.edu.cn/faculty/system/dengzhihong/dengzhihong.h
 Zhi-hua Zhou,https://cs.nju.edu.cn/zhouzh/
 Zhibin Li,http://www.edinburgh-robotics.org/academics/zhibin-li/
 Zhidong Deng,http://www.tsinghua.edu.cn/publish/csen/4623/2010/20101224173318337163808/20101224173318337163808_.html
-Zhifang Sui,http://www.cipsc.org.cn/clp2014/webpage/en/program.htm
 Zhigang Deng,http://graphics.cs.uh.edu/zdeng/
 Zhigang Xiang,http://www.cs.qc.cuny.edu/xiang.html/
 Zhigang Zhu,http://www-cs.ccny.cuny.edu/~zhu/


### PR DESCRIPTION
Hello Professor Berger,

I found that the number of faculty of Peking University and their publication counts are aberrantly higher than other Chinese universities. The current database includes lots of ambigious dblp pages, which include publication of people who are not at PKU, and quite many of the faculty entries didn't come with valid proofs of appointment.

I validated quite many of them but gave up soon since there are too many bogus entries. Let me list a few which I removed here.

Entries which are tied with ambiguous dblp pages, or with a different person's page:
Wei Chen
Wen Gao
Chao Zhang
Lu Zhang
Feng Chen
Chao Xu
Ning Zhang
Jian Wang
Wei Zhang
Gang Huang
Jing Chen
Liwei Wang

Homepage URLs link to a page which we cannot verify his/her appointments (for example, facebook search pages, webpage not reachable, web pages in other institutions or colleges outside of engineering):
Wei Chen
Lu Zhang
Steven Feng Chen
Sujian Li
Baobao Chang
Houfeng Wang
Chao Xu
Ming Zhang 0004
Ning Zhang
Zhifang Sui
Wensheng Wei
Xiaolin Wang
Wei Zhang
Heng Wang
Gang Huang
Jing Chen
Tengjiao Wang

I suggest either updating them with my commits or just revert some recent commits regarding PKU. The previous commit updating PKU faculty doesn't seem to be verified well. 