### PR TITLE
Remove wrong DBLP aliases

### DIFF
--- a/dblp-aliases.csv
+++ b/dblp-aliases.csv
@@ -32494,14 +32494,3 @@ Oliver Matias van Kaick,Oliver van Kaick
 David Kaeli,David R. Kaeli
 Hankyong Kim,Hankyoung Kim
 Yuanyuan Zhou 0001,Yuanyuan Zhou
-Chao Xu 0006,Chao Xu
-Chao Zhang 0001,Chao Zhang
-Gang Huang 0001,Gang Huang
-Jing Chen 0002,Jing Chen
-Lijun Chen 0002,Lijun Chen
-Lu Zhang 0023,Lu Zhang
-Ning Zhang 0003,Ning Zhang
-Wei Chen 0021,Wei Chen
-Wei Zhang 0004,Wei Zhang
-Wen Gao 0001,Wen Gao
-Yu Huang 0004,Yu Huang

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -4363,6 +4363,7 @@ Bin Cui , Peking University
 Bin Sun , Peking University
 Bing Xie , Peking University
 Bingfeng Zhou , Peking University
+Chao Zhang 0001 , Peking University
 Chenren Xu , Peking University
 Dan Hao , Peking University
 Daqing Zhang , Peking University
@@ -4404,6 +4405,7 @@ Junfeng Hu , Peking University
 Junfeng Zhao , Peking University
 Kaigui Bian , Peking University
 Kunqing Xie , Peking University
+Lei Zou , Peking University
 Liangcai Gao , Peking University
 Lifu Wang , Peking University
 Ling-Yu Duan , Peking University
@@ -4429,6 +4431,7 @@ Tong Yang , Peking University
 Tong Zhao , Peking University
 Wei Yan , Peking University
 Wei Zeng , Peking University
+Wei Zhang 0004 , Peking University
 Weiping Huang , Peking University
 Weiwei Sun , Peking University
 Weizhong Shao , Peking University

--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -4363,8 +4363,6 @@ Bin Cui , Peking University
 Bin Sun , Peking University
 Bing Xie , Peking University
 Bingfeng Zhou , Peking University
-Chao Zhang , Peking University
-Chao Zhang 0001 , Peking University
 Chenren Xu , Peking University
 Dan Hao , Peking University
 Daqing Zhang , Peking University
@@ -4406,7 +4404,6 @@ Junfeng Hu , Peking University
 Junfeng Zhao , Peking University
 Kaigui Bian , Peking University
 Kunqing Xie , Peking University
-Lei Zou , Peking University
 Liangcai Gao , Peking University
 Lifu Wang , Peking University
 Ling-Yu Duan , Peking University
@@ -4452,7 +4449,6 @@ Xiaoru Yuan , Peking University
 Xihong Wu , Peking University
 Xinggong Zhang , Peking University
 Xingui He , Peking University
-Xinhui Han , Peking University
 Xiujun Ma , Peking University
 Xiuli Ma , Peking University
 Xu Sun , Peking University
@@ -4478,8 +4474,6 @@ Yizhou Wang , Peking University
 YongHong Tian , Peking University
 Yongtao Wang , Peking University
 Yongzhi Cao , Peking University
-Yu Huang , Peking University
-Yu Huang 0004 , Peking University
 Yun Liang 0001 , Peking University
 Yunfang Wu , Peking University
 Yunhai Tong , Peking University
@@ -7440,7 +7434,6 @@ William G. Griswold , University of California - San Diego
 Yannis Papakonstantinou , University of California - San Diego
 Yoav Freund , University of California - San Diego
 Yuanyuan Zhou , University of California - San Diego
-Yuanyuan Zhou 0001 , University of California - San Diego
 Zhuowen Tu , University of California - San Diego
 Ambuj K. Singh , University of California - Santa Barbara
 Amr El Abbadi , University of California - Santa Barbara
@@ -7810,7 +7803,6 @@ Kenneth M. Anderson , University of Colorado Boulder
 Kenneth Mark Anderson , University of Colorado Boulder
 Leysia Palen , University of Colorado Boulder
 Lijun Chen , University of Colorado Boulder
-Lijun Chen 0002 , University of Colorado Boulder
 Mark D. Gross , University of Colorado Boulder
 Martha Palmer , University of Colorado Boulder
 Martha Stone , University of Colorado Boulder

--- a/homepages.csv
+++ b/homepages.csv
@@ -1709,8 +1709,6 @@ Chanik Park,http://cpmi.postech.ac.kr/prof-chanik-park/
 Chao Li,http://www.cs.sjtu.edu.cn/~lichao/
 Chao Tian,http://www.eecs.utk.edu/people/faculty/ctian1/
 Chao Wang 0001,http://www-bcf.usc.edu/~wang626/
-Chao Zhang,http://chao.100871.net/
-Chao Zhang 0001,http://www.cis.pku.edu.cn/faculty/vision/zhangchao/zhangchao.htm
 Chaoli Wang,http://www3.nd.edu/~cwang11/about.html/
 Charalambos Poullis,http://www.poullis.org/
 Charalampos E. Tsourakakis,http://people.seas.harvard.edu/~babis/
@@ -5039,7 +5037,6 @@ Jinah Park,http://cgv.kaist.ac.kr/professor
 Jinbo Bi,http://www.engr.uconn.edu/~jinbo/
 Jinbo Xu,http://ttic.uchicago.edu/~jinbo/
 Jing Chen 0001,http://www3.cs.stonybrook.edu/~jingchen/
-Jing Chen 0002,http://www.cis.pku.edu.cn/auditory/Staff/chenj.htm
 Jing Gao,https://www.cse.buffalo.edu/~jing/
 Jing Jiang,http://www.mysmu.edu/faculty/jingjiang/
 Jing Kong,http://www.rle.mit.edu/nmeg/
@@ -6158,7 +6155,6 @@ Lei Xu 0001,http://www.phy.cuhk.edu.hk/people/xu.html
 Lei Yang,http://www.google.com/search?q=Lei%20Yang%20University%20of%20Nevada&btnI
 Lei Yang 0001,http://www.unr.edu/cse/people/faculty/yang/
 Lei Yu 0001,http://www.cs.binghamton.edu/~lyu/
-Lei Zou,http://www.icst.pku.edu.cn/intro/leizou/index.html
 Leif Kobbelt,https://www.graphics.rwth-aachen.de/
 Leila Kosseim,https://users.encs.concordia.ca/~kosseim/
 Leilah Lyons,https://www.cs.uic.edu/~llyons/
@@ -6247,7 +6243,6 @@ Lihi Zelnik-Manor,http://lihi.eew.technion.ac.il/
 Lihua Yue,http://www.jucs.org/jucs_articles_by_author/Yue_Lihua
 Lijun Chang,https://www.cse.unsw.edu.au/~ljchang/
 Lijun Chen,http://spot.colorado.edu/~lich1539/
-Lijun Chen 0002,https://www.researchgate.net/profile/Lijun_Chen2
 Lijun Yin,http://www.cs.binghamton.edu/~lijun/
 Lila Kari,https://cs.uwaterloo.ca/about/people/lila/
 Lila Santean,https://cs.uwaterloo.ca/about/people/lila/
@@ -6371,7 +6366,6 @@ Lu Hongtao,http://english.seiee.sjtu.edu.cn/english/detail/841_674.htm
 Lu Ruan,http://www.cs.iastate.edu/~ruan/
 Lu Su,http://www.cse.buffalo.edu/people/?u=lusu/
 Lu Wang,http://www.ccs.neu.edu/home/luwang/
-Lu Zhang 0023,http://sei.pku.edu.cn/~zhanglu/
 Luay Nakhleh,https://www.cs.rice.edu/~nakhleh/
 Lubomir Bic,http://www.ics.uci.edu/~bic/
 Lubomir F. Bic,http://www.ics.uci.edu/~bic/
@@ -7819,7 +7813,6 @@ Nima Honarmand,http://compas.cs.stonybrook.edu/~nhonarmand/
 Nina Amenta,http://www.cs.ucdavis.edu/~amenta/
 Nina S. T. Hirata,https://www.ime.usp.br/~nina/
 Nina Sumiko Tomita Hirata,http://www.ime.usp.br/~nina
-Ning Zhang 0003,https://www.morganlewis.com/bios/ningzhang
 Ninghui Li,https://www.cs.purdue.edu/homes/ninghui/
 Nir Ailon,http://nailon.net.technion.ac.il/
 Nir Bitansky,https://simons.berkeley.edu/people/nir-bitansky
@@ -11176,7 +11169,6 @@ Wei Xu 0004,https://cse.osu.edu/node/1671
 Wei Xue,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101224235122610366982/20101224235122610366982_.html
 Wei Yan,http://net.pku.edu.cn/~yw/
 Wei Zeng,http://biopic.pku.edu.cn/english/detail.aspx?id=44
-Wei Zhang 0004,http://sei.pku.edu.cn/~zhangw/
 Wei Zhu,http://www.ams.stonybrook.edu/~zhu/
 Wei-Chung Hsu,http://www.csie.ntu.edu.tw/~hsuwc/
 Wei-Ngan Chin,https://www.comp.nus.edu.sg/~chinwn/
@@ -11208,7 +11200,6 @@ Weiying Dai,https://www.binghamton.edu/cs/people/wdai.html/
 Weizhen Mao,http://www.cs.wm.edu/~wm/
 Weizhong Shao,http://www.sei.pku.edu.cn/people/shaowz/
 Wen Dong 0001,https://www.cse.buffalo.edu/~wendong/
-Wen Gao,http://www.jdl.ac.cn/htm-gaowen/en_main.htm
 Wen Gao 0001,http://www.jdl.ac.cn/htm-gaowen/
 Wen Hu,https://www.engineering.unsw.edu.au/computer-science-engineering/staff/wen-hu/
 Wen Zhang 0002,https://cecs.anu.edu.au/people/wen-zhang/
@@ -11479,7 +11470,6 @@ Xinggong Zhang,http://www.icst.pku.edu.cn/vip/people-zhangxg_en.html
 Xingui He,http://www.cis.pku.edu.cn/faculty/system/HeXinGui/Xingui_He.htm
 Xinguo Liu,http://mypage.zju.edu.cn/xgliu
 Xinhua Zhang,https://www.cs.uic.edu/~zhangx/
-Xinhui Han,http://162.105.163.117/index.php?s=/Home/Article/detail/id/557.html
 Xining Li,http://www.cis.uoguelph.ca/~xli/mainpage.html
 Xinming Ou,http://www.cse.usf.edu/~xou/
 Xinming Simon Ou,http://www.usf.edu/engineering/cse/people/ou-simon.aspx/
@@ -11759,8 +11749,6 @@ Yu Cao,https://www.uml.edu/Sciences/computer-science/faculty/Cao-Yu.aspx
 Yu Charlie Hu,https://engineering.purdue.edu/~ychu/
 Yu Chen,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101223231225900540687/20101223231225900540687_.html
 Yu David Liu,http://www.cs.binghamton.edu/~davidl/
-Yu Huang,http://www.scholarmate.com/scmwebsns/in/view;jsessionid=E42A2E2CFE6AD82775F707FA4BB97693.snsweb23501?des3PsnId=GtB%2BkSTEciI%3D
-Yu Huang 0004,http://www.phy.pku.edu.cn/~yeyu/index.html
 Yu Kai,http://speechlab.sjtu.edu.cn/~kyu/node/1
 Yu Lei,http://ranger.uta.edu/~ylei/
 Yu Long,https://www.facebook.com/public/Long-Yu/school/Shanghai-Jiao-Tong-University-109235979095677/
@@ -11781,7 +11769,6 @@ Yuanfang Cai,https://www.cs.drexel.edu/~yfcai/
 Yuanyuan Yang,https://www.cs.stonybrook.edu/people/faculty/YuanyuanYang
 Yuanyuan Zhang,https://loccs.sjtu.edu.cn/~yyzhang/
 Yuanyuan Zhou,https://cseweb.ucsd.edu/~yyzhou/
-Yuanyuan Zhou 0001,https://cseweb.ucsd.edu/~yyzhou/
 Yubin Xia,http://en.se.sjtu.edu.cn/teacher/teacherdetail.aspx?id=26
 Yubin Yang,https://cs.nju.edu.cn/yangyubin/
 Yubo Tao,http://www.cad.zju.edu.cn/home/ybtao

--- a/homepages.csv
+++ b/homepages.csv
@@ -1709,6 +1709,7 @@ Chanik Park,http://cpmi.postech.ac.kr/prof-chanik-park/
 Chao Li,http://www.cs.sjtu.edu.cn/~lichao/
 Chao Tian,http://www.eecs.utk.edu/people/faculty/ctian1/
 Chao Wang 0001,http://www-bcf.usc.edu/~wang626/
+Chao Zhang 0001,http://www.cis.pku.edu.cn/faculty/vision/zhangchao/zhangchao.htm
 Chaoli Wang,http://www3.nd.edu/~cwang11/about.html/
 Charalambos Poullis,http://www.poullis.org/
 Charalampos E. Tsourakakis,http://people.seas.harvard.edu/~babis/
@@ -6155,6 +6156,7 @@ Lei Xu 0001,http://www.phy.cuhk.edu.hk/people/xu.html
 Lei Yang,http://www.google.com/search?q=Lei%20Yang%20University%20of%20Nevada&btnI
 Lei Yang 0001,http://www.unr.edu/cse/people/faculty/yang/
 Lei Yu 0001,http://www.cs.binghamton.edu/~lyu/
+Lei Zou,http://www.icst.pku.edu.cn/intro/leizou/index.html
 Leif Kobbelt,https://www.graphics.rwth-aachen.de/
 Leila Kosseim,https://users.encs.concordia.ca/~kosseim/
 Leilah Lyons,https://www.cs.uic.edu/~llyons/
@@ -6366,6 +6368,7 @@ Lu Hongtao,http://english.seiee.sjtu.edu.cn/english/detail/841_674.htm
 Lu Ruan,http://www.cs.iastate.edu/~ruan/
 Lu Su,http://www.cse.buffalo.edu/people/?u=lusu/
 Lu Wang,http://www.ccs.neu.edu/home/luwang/
+Lu Zhang 0023,http://sei.pku.edu.cn/~zhanglu/
 Luay Nakhleh,https://www.cs.rice.edu/~nakhleh/
 Lubomir Bic,http://www.ics.uci.edu/~bic/
 Lubomir F. Bic,http://www.ics.uci.edu/~bic/
@@ -11169,6 +11172,7 @@ Wei Xu 0004,https://cse.osu.edu/node/1671
 Wei Xue,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101224235122610366982/20101224235122610366982_.html
 Wei Yan,http://net.pku.edu.cn/~yw/
 Wei Zeng,http://biopic.pku.edu.cn/english/detail.aspx?id=44
+Wei Zhang 0004,http://sei.pku.edu.cn/~zhangw/
 Wei Zhu,http://www.ams.stonybrook.edu/~zhu/
 Wei-Chung Hsu,http://www.csie.ntu.edu.tw/~hsuwc/
 Wei-Ngan Chin,https://www.comp.nus.edu.sg/~chinwn/


### PR DESCRIPTION
I found that some PKU faculty aliases are added so that ambiguous DBLP pages are automatically included to some of the faculty. I guess the contributor who committed that misunderstood the purpose of aliases file.

I removed some aliases and corresponding entries in the database so that ambiguous DBLP pages are not included automatically.