### PR TITLE
Updated affiliation.

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -760,6 +760,7 @@ Oliver Matias van Kaick , Carleton University
 Oliver van Kaick , Carleton University
 Pat Morin , Carleton University
 Paul C. van Oorschot , Carleton University
+Prosenjit Bose , Carleton University
 Robert Biddle , Carleton University
 Sonia Chiasson , Carleton University
 Tony White , Carleton University
@@ -8677,7 +8678,6 @@ Peter Graham , University of Manitoba
 Peter King , University of Manitoba
 Pourang Irani , University of Manitoba
 Pourang P. Irani , University of Manitoba
-Prosenjit Bose , University of Manitoba
 Rasit Eskicioglu , University of Manitoba
 Ruppa (Tulsi) Thulasiram , University of Manitoba
 Stephane Durocher , University of Manitoba


### PR DESCRIPTION
While Dr. Bose is an adjunct prof at the University of Manitoba, his main affiliation is Carleton University.