### PR TITLE
More U of T faculty in CS

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -788,6 +788,7 @@ Ann E. Nicholson,Monash University,http://monash.edu/research/explore/en/persons
 Ann Nicholson,Monash University,http://monash.edu/research/explore/en/persons/ann-nicholson(c9c984f3-4125-45fb-8e7f-773fedcda8a4).html/,NOSCHOLARPAGE
 Anna Bernasconi 0001,University of Pisa,http://www.di.unipi.it/~annab,rCnl9L4AAAAJ
 Anna Gál,University of Texas at Austin,https://www.cs.utexas.edu/~panni/,7079Jy8AAAAJ
+Anna Goldenberg,University of Toronto,http://goldenberglab.ca/,cEepZOEAAAAJ
 Anna Jordanous,University of Kent,https://www.cs.kent.ac.uk/people/staff/akj22/,NOSCHOLARPAGE
 Anna K. Jordanous,University of Kent,https://www.cs.kent.ac.uk/people/staff/akj22/,0OnhovsAAAAJ
 Anna Kicheva,IST Austria,https://ist.ac.at/research/research-groups/kicheva-group/,zBpAlHkAAAAJ
@@ -8323,6 +8324,7 @@ Qingling Duan,Queen’s University,https://dbms.queensu.ca/faculty/duan_qingling
 Qinming He,Zhejiang University,http://mypage.zju.edu.cn/0088262,NOSCHOLARPAGE
 Qiong Luo,HKUST,https://www.cse.ust.hk/~luo/,SqAsppUAAAAJ
 Qixing Huang,University of Texas at Austin,https://www.cs.utexas.edu/~huangqx/,NOSCHOLARPAGE
+Quaid Morris,University of Toronto,http://www.morrislab.ca/,bb_q7tYAAAAJ
 Quan Chen,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/~chen-quan/,3yBSdrsAAAAJ
 Quan Z. Sheng,University of Adelaide,https://cs.adelaide.edu.au/~qsheng/,lwy2C5YAAAAJ
 Quanquan Gu,University of Virginia,http://people.virginia.edu/~qg5w/,GU9HgNAAAAAJ


### PR DESCRIPTION
Two more machine learning CS (cross-appt/adjunct) faculty added who supervise graduate students.

See http://web.cs.toronto.edu/people/faculty.htm