### PR TITLE
Added Sean Follmer from Stanford University

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -9334,6 +9334,7 @@ Sean B. Holden,University of Cambridge,http://www.cl.cam.ac.uk/~sbh11/,NOSCHOLAR
 Sean B. Maynard,University of Melbourne,http://people.eng.unimelb.edu.au/seanbm/home.html/,OkNuF20AAAAJ
 Sean Bechhofer,University of Manchester,http://www.cs.man.ac.uk/~seanb/,XRzaza0AAAAJ
 Sean C. Warnick,Brigham Young University,https://cs.byu.edu/faculty/sean/,k7WBrxoAAAAJ
+Sean Follmer, Stanford University, http://shape.stanford.edu, f3g5oeEAAAAJ
 Sean Hallgren,Pennsylvania State University,http://www.cse.psu.edu/~sjh26/,NOSCHOLARPAGE
 Sean Holden,University of Cambridge,http://www.cl.cam.ac.uk/~sbh11/,NOSCHOLARPAGE
 Sean Luke,George Mason University,https://cs.gmu.edu/~sean/,jwxhFAQAAAAJ


### PR DESCRIPTION
Adding Sean Follmer to Stanford University listing. Sean Follmer is an Assistant Professor of Mechanical Engineering and Computer Science (By Courtesy). He is a researcher in the field of Human Computer Interaction and currently advises 2 CS PhD Students (along with other PhD Students in ME and EE). 