### PR TITLE
Remove INFOCOM from networks rankings, as it is not considered top-tier.

### DIFF
--- a/filter.xq
+++ b/filter.xq
@@ -84,7 +84,6 @@
 //inproceedings[booktitle="IMC"],
 //inproceedings[booktitle="Internet Measurement Conference"],
 //inproceedings[booktitle="SIGCOMM"],
-//inproceedings[booktitle="INFOCOM"],
 //inproceedings[booktitle="NSDI"],
 //article[journal="PACMPL"],
 //inproceedings[booktitle="POPL"],

--- a/index.html
+++ b/index.html
@@ -523,7 +523,6 @@
 			      <tr style="width:100%">
 				<td>
 				  <p class="text-muted" style="font-variant:small-caps;"><a href="http://sigcomm.org">acm sigcomm</a></p>
-				  <a href="http://dblp.uni-trier.de/db/conf/infocom/index.html">INFOCOM</a><br />
 				  <a href="http://dblp.uni-trier.de/db/conf/sigcomm/index.html">SIGCOMM</a><br />
 				  <a href="http://dblp.uni-trier.de/db/conf/nsdi/index.html">NSDI</a><br />
 				</td>

--- a/util/csrankings.py
+++ b/util/csrankings.py
@@ -75,7 +75,7 @@ areadict = {
     # SIGACT
     'act': ['STOC', 'FOCS', 'SODA'],
     # SIGCOMM
-    'comm': ['SIGCOMM', 'INFOCOM', 'NSDI'],
+    'comm': ['SIGCOMM', 'NSDI'],
     # SIGSAC
     # - USENIX Security listed twice to reflect variants in DBLP
     'sec': ['IEEE Symposium on Security and Privacy', 'ACM Conference on Computer and Communications Security', 'USENIX Security Symposium', 'USENIX Security'],

--- a/util/regenerate-data.py
+++ b/util/regenerate-data.py
@@ -27,7 +27,7 @@ areadict = {
     # SIGACT
     'act': ['STOC', 'FOCS', 'SODA'],
     # SIGCOMM
-    'comm': ['SIGCOMM', 'INFOCOM', 'NSDI'],
+    'comm': ['SIGCOMM', 'NSDI'],
     # SIGSAC
     # - USENIX Security listed twice to reflect variants in DBLP
     'sec': ['IEEE Symposium on Security and Privacy', 'ACM Conference on Computer and Communications Security', 'USENIX Security Symposium', 'USENIX Security', 'CCS'], # , 'NDSS'],

--- a/venues.csv
+++ b/venues.csv
@@ -25,7 +25,6 @@ area,canonical,alternate,default
 "chi","IMWUT","Proceedings of the ACM on Interactive, Mobile, Wearable and Ubiquitous Technologies",True
 "chi","UIST","UIST",True
 "comm","SIGCOMM","SIGCOMM",True
-"comm","INFOCOM","INFOCOM",True
 "comm","NSDI","NSDI",True
 "crypt","CRYPTO","CRYPTO",True
 "crypt","CRYPTO","CRYPTO (1)",True


### PR DESCRIPTION
Hi,
INFOCOM is not conisidered top-tier, and as it is a very large conference its inclusion skews rankings. This PR removes INFOCOM from the network/communications list.
