### PR TITLE
Changing the affiliation 'DIKU' to 'University of Copenhagen'

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -17,7 +17,7 @@ Chulalongkorn University,asia
 Concordia University,canada
 DAIICT,asia
 Dalhousie University,canada
-DIKU,europe
+University of Copenhagen,europe
 EPFL,europe
 ETH Zurich,europe
 Ecole Normale Superieure de Cachan,europe

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -40,7 +40,7 @@ Aaron Striegel,University of Notre Dame,https://engineering.nd.edu/profiles/astr
 Aaron Stump,University of Iowa,https://www.cs.uiowa.edu/~astump/,568MtVQAAAAJ
 Aarti Gupta,Princeton University,https://www.cs.princeton.edu/people/profile/aartig/,S_jYB2sAAAAJ
 Aarti Singh,Carnegie Mellon University,http://www.cs.cmu.edu/~aarti/,6jP3ZSEAAAAJ
-Aasa Feragen,DIKU,http://image.diku.dk/aasa/,MNDVpoUAAAAJ
+Aasa Feragen,University of Copenhagen,http://image.diku.dk/aasa/,MNDVpoUAAAAJ
 Abbas Edalat,Imperial College London,https://www.doc.ic.ac.uk/~ae/,KP1AXgwAAAAJ
 Abbas Heydarnoori,Sharif University of Technology,http://sharif.edu/~heydarnoori/,s5vgK3kAAAAJ
 Abbe Mowshowitz,CUNY,https://www.ccny.cuny.edu/profiles/abbe-mowshowitz/,KwmExSIAAAAJ
@@ -606,7 +606,7 @@ Anca D. Dragan,University of California - Berkeley,http://www.eecs.berkeley.edu/
 Anca Dragan,University of California - Berkeley,https://people.eecs.berkeley.edu/~anca/,UgHB5oAAAAAJ
 Anders Møller,Aarhus University,https://cs.au.dk/~amoeller/,0b1Q-3cAAAAJ
 Anders Robertsson,Lund University,http://www.control.lth.se/Staff/AndersRobertsson.html,YZNvXjAAAAAJ
-Anders Søgaard,DIKU,http://www.diku.dk/Ansatte/?pure=da/persons/221553,x3I4CrYAAAAJ
+Anders Søgaard,University of Copenhagen,http://www.diku.dk/Ansatte/?pure=da/persons/221553,x3I4CrYAAAAJ
 Anderson Rocha,University of Campinas,http://www.ic.unicamp.br/~rocha/,JX1fykMAAAAJ
 Anderson de Rezende Rocha,University of Campinas,http://www.ic.unicamp.br/~rocha/,NOSCHOLARPAGE
 Andranik Mirzaian,York University,http://www.eecs.yorku.ca/~andy/,NOSCHOLARPAGE
@@ -711,7 +711,7 @@ Andrew Warfield,University of British Columbia,http://www.cs.ubc.ca/~andy/,0Ypfg
 Andrian Marcus,University of Texas at Dallas,http://www.utdallas.edu/~amarcus/,ZZiaPdYAAAAJ
 Andries van Dam,Brown University,http://cs.brown.edu/~avd/,NOSCHOLARPAGE
 Andruid Kerne,Texas A&M University,https://engineering.tamu.edu/cse/people/akerne/,TD6dCG0AAAAJ
-Andrzej Filinski,DIKU,http://www.diku.dk/~andrzej/,Yh6akOEAAAAJ
+Andrzej Filinski,University of Copenhagen,http://www.diku.dk/~andrzej/,Yh6akOEAAAAJ
 Andrzej Janusz,University of Warsaw,https://ml.linkedin.com/in/andrzej-janusz-bb693a33/,QRGN2ywAAAAJ
 Andrzej Szalas,University of Warsaw,https://www.researchgate.net/profile/Andrzej_Szalas/citations?sorting=citationCount&page=2/,6nuzxuYAAAAJ
 Andrzej Tarlecki,University of Warsaw,http://www.mimuw.edu.pl/~tarlecki/,G3omKXoAAAAJ
@@ -1834,7 +1834,7 @@ Christian Blouin,Dalhousie University,https://www.dal.ca/faculty/computerscience
 Christian D. Newman,Rochester Institute of Technology,https://www.rit.edu/studentaffairs/religion/catholiccampusministry.php,hb_08rUAAAAJ
 Christian Darken,Naval Postgraduate School,http://faculty.nps.edu/cjdarken/,NOSCHOLARPAGE
 Christian Doerr,TU Delft,http://cybersecurity.tudelft.nl/users/christian-doerr/,NOSCHOLARPAGE
-Christian Igel,DIKU,http://image.diku.dk/igel/,d-jF4zIAAAAJ
+Christian Igel,University of Copenhagen,http://image.diku.dk/igel/,d-jF4zIAAAAJ
 Christian J. Darken,Naval Postgraduate School,http://faculty.nps.edu/cjdarken/,NOSCHOLARPAGE
 Christian Jacob,University of Calgary,http://www.cpsc.ucalgary.ca/~jacob/,DUxb0k0AAAAJ
 Christian Kästner,Carnegie Mellon University,https://www.cs.cmu.edu/~ckaestne/,PR-ZnJUAAAAJ
@@ -1849,7 +1849,7 @@ Christian S. Collberg,University of Arizona,http://www.cs.arizona.edu/people/col
 Christian Schindelhauer,University of Freiburg,http://cone.informatik.uni-freiburg.de/mitarbeiter/schindelhauer/adresse,TxVfH8QAAAAJ
 Christian Skalka,University of Vermont,http://www.cs.uvm.edu/~skalka/,XDj4RWQAAAAJ
 Christian Theobalt,Max Planck Institute,https://www.mpi-inf.mpg.de/~theobalt/,eIWg8NMAAAAJ
-Christian Wulff-Nilsen,DIKU,http://www.diku.dk/~koolooz/,y5cX8ekAAAAJ
+Christian Wulff-Nilsen,University of Copenhagen,http://www.diku.dk/~koolooz/,y5cX8ekAAAAJ
 Christiane Neme Campos,University of Campinas,http://www.ic.unicamp.br/~campos/,NOSCHOLARPAGE
 Christin Lindholm,Lund University,http://cs.lth.se/christin_lindholm,NOSCHOLARPAGE
 Christina Boucher,University of Florida,http://christinaboucher.com/,NOSCHOLARPAGE
@@ -1857,7 +1857,7 @@ Christina C. Christara,University of Toronto,http://www.cs.toronto.edu/~ccc/,-IA
 Christina Delimitrou,Cornell University,http://web.stanford.edu/~cdel/,OziQjUsAAAAJ
 Christina Gardner-McCune,University of Florida,https://www.cise.ufl.edu/people/faculty/gmccune/,qe2DVGEAAAAJ
 Christina Garman,Purdue University,https://www.cs.purdue.edu/people/faculty/clg/,r_GU-AwAAAAJ
-Christina Lioma,DIKU,http://www.diku.dk/~c.lioma/,dXkFCYoAAAAJ
+Christina Lioma,University of Copenhagen,http://www.diku.dk/~c.lioma/,dXkFCYoAAAAJ
 Christina Penner,University of Manitoba,http://umanitoba.ca/faculties/science/people/755.html,NOSCHOLARPAGE
 Christine Largeron,Université Jean Monnet,http://perso.univ-st-etienne.fr/largeron/,YgSSCaIAAAAJ
 Christine Largeron-Leténo,Université Jean Monnet,http://data.bnf.fr/12721328/christine_largeron/,NOSCHOLARPAGE
@@ -2042,8 +2042,8 @@ Corinne Fournier,Université Jean Monnet,https://laboratoirehubertcurien.univ-st
 Cormac Flanagan,University of California - Santa Cruz,https://users.soe.ucsc.edu/~cormac/,XkiApd4AAAAJ
 Cornelis Huizing,TU Eindhoven,https://www.win.tue.nl/~keesh/,j-Uuvt0AAAAJ
 Cory Barker,Brigham Young University,https://cs.byu.edu/faculty/barker/,iZfqmbMAAAAJ
-Cosmin E. Oancea,DIKU,http://www.diku.dk/~zgh600/,RpmM52IAAAAJ
-Cosmin Eugen Oancea,DIKU,http://diku.dk/english/staff/?pure=en/persons/421441/,NOSCHOLARPAGE
+Cosmin E. Oancea,University of Copenhagen,http://www.diku.dk/~zgh600/,RpmM52IAAAAJ
+Cosmin Eugen Oancea,University of Copenhagen,http://diku.dk/english/staff/?pure=en/persons/421441/,NOSCHOLARPAGE
 Costas J. Spanos,University of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/spanos.html/,90TaOdoAAAAJ
 Craig A. Shue,Worcester Polytechnic Institute,http://www.cs.wpi.edu/~cshue/,haHpARUAAAAJ
 Craig B. Zilles,University of Illinois at Urbana-Champaign,http://zilles.cs.illinois.edu/,V22Gj30AAAAJ
@@ -2685,7 +2685,7 @@ Dirk Arnold,Dalhousie University,https://www.cs.dal.ca/~dirk/,NsIbm80AAAAJ
 Dirk Englund,Massachusetts Institute of Technology,http://www.rle.mit.edu/qp/,ZFpENKoAAAAJ
 Dirk Fahland,TU Eindhoven,https://www.win.tue.nl/~dfahland/,qLkK5JAAAAAJ
 Dirk Grunwald,University of Colorado Boulder,http://systems.cs.colorado.edu/people/faculty/dirk-grunwald/,3Ws6G2AAAAAJ
-Dirk Hovy,DIKU,http://www.dirkhovy.com/,7xluaTAAAAAJ
+Dirk Hovy,University of Copenhagen,http://www.dirkhovy.com/,7xluaTAAAAAJ
 Dirk Oliver Theis,University of Tartu,http://ac.cs.ut.ee/people/dot/,b1nM_OUAAAAJ
 Dirk Pattinson,Australian National University,https://cs.anu.edu.au/people/dirk-pattinson/,_QbFzhkAAAAJ
 Dirk Van Gucht,Indiana University,https://www.cs.indiana.edu/~vgucht/,NCQuZX0AAAAJ
@@ -3078,7 +3078,7 @@ Erik B. Sudderth,University of California - Irvine,https://cs.brown.edu/people/s
 Erik Brunvand,University of Utah,https://www.cs.utah.edu/~elb/,Hkw7KOoAAAAJ
 Erik Cambria,Nanyang Technological University,http://research.ntu.edu.sg/expertise/academicprofile/Pages/StaffProfile.aspx?ST_EMAILID=CAMBRIA/,ilSYpW0AAAAJ
 Erik D. Demaine,Massachusetts Institute of Technology,http://erikdemaine.org/,6Ff2c8wAAAAJ
-Erik Frøkjær,DIKU,http://www.diku.dk/Ansatte/?pure=da/persons/113767/,N-445VIAAAAJ
+Erik Frøkjær,University of Copenhagen,http://www.diku.dk/Ansatte/?pure=da/persons/113767/,N-445VIAAAAJ
 Erik G. Learned-Miller,University of Massachusetts Amherst,http://people.cs.umass.edu/~elm/,Li-BrU4AAAAJ
 Erik G. Miller,University of Massachusetts Amherst,http://people.cs.umass.edu/~elm/,NOSCHOLARPAGE
 Erik Meijer,TU Delft,http://www.wis.ewi.tudelft.nl/meijer/,odFMpOYAAAAJ
@@ -3276,7 +3276,7 @@ Filomena De Santis,University of Salerno,http://www.unisa.it/docenti/filomenades
 Filomena Ferrucci,University of Salerno,http://salerno.academia.edu/FilomenaFerrucci/,6LDD4w0AAAAJ
 Finale Doshi,Harvard University,https://www.seas.harvard.edu/directory/finale/,NOSCHOLARPAGE
 Finale Doshi-Velez,Harvard University,https://www.seas.harvard.edu/directory/finale/,NOSCHOLARPAGE
-Finn Kensing,DIKU,http://www.diku.dk/Ansatte/?pure=da/persons/43656/,m_e3GYkAAAAJ
+Finn Kensing,University of Copenhagen,http://www.diku.dk/Ansatte/?pure=da/persons/43656/,m_e3GYkAAAAJ
 Fiona J. Beck,Australian National University,https://cecs.anu.edu.au/people/fiona-j-beck/,5PllF8QAAAAJ
 Flaminio Borgonovo,Politecnico di Milano,http://home.deib.polimi.it/borgonov/,NOSCHOLARPAGE
 Flavia Bonomo,University of Buenos Aires,http://mate.dm.uba.ar/~fbonomo/,6VEZpsYAAAAJ
@@ -3357,7 +3357,7 @@ François Baccelli,Ecole Normale Superieure,http://www.di.ens.fr/~baccelli/,NOSC
 François Guimbretière,Cornell University,https://www.cs.cornell.edu/~francois/,PxZT1sgAAAAJ
 François Gygi,University of California - Davis,http://faculty.engineering.ucdavis.edu/gygi/,NOSCHOLARPAGE
 François Jacquenet,Université Jean Monnet,http://perso.univ-st-etienne.fr/jacquene/,HPhooYQAAAAJ
-François Lauze,DIKU,http://image.diku.dk/francois/,nssvQ-UAAAAJ
+François Lauze,University of Copenhagen,http://image.diku.dk/francois/,nssvQ-UAAAAJ
 François Major,University of Montreal,http://www.iro.umontreal.ca/~major/,NOSCHOLARPAGE
 François Pitt,University of Toronto,http://www.cs.toronto.edu/~fpitt/,DnZw9asAAAAJ
 Frazer K. Noble,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=803250/,NOSCHOLARPAGE
@@ -3375,7 +3375,7 @@ Frederick H. Lochovsky,HKUST,https://www.cse.ust.hk/~fred/,eIm7hjkAAAAJ
 Frederick R. M. Barnes,University of Kent,https://www.cs.kent.ac.uk/~frmb/,NOSCHOLARPAGE
 Fredrik Milani,University of Tartu,http://www.ut.ee/en/fredrik-payman-milani/,Whhz1iUAAAAJ
 Friedemann Mattern,ETH Zurich,https://people.inf.ethz.ch/mattern/,rIdxtXsAAAAJ
-Fritz Henglein,DIKU,http://www.diku.dk/~henglein/,FOM81UEAAAAJ
+Fritz Henglein,University of Copenhagen,http://www.diku.dk/~henglein/,FOM81UEAAAAJ
 Frédo Durand,Massachusetts Institute of Technology,http://people.csail.mit.edu/fredo/,NJ9c4ygAAAAJ
 Frédéric Blanqui,Ecole Normale Superieure de Cachan,http://www.lsv.ens-cachan.fr/People/,PHpAzZ8AAAAJ
 Frédéric Desprez,Ecole Normale Superieure de Lyon,http://www.inria.fr/institut/organisation/adjoints-au-directeur-scientifique/frederic-desprez/,9KkV5HAAAAAJ
@@ -4345,7 +4345,7 @@ Isabel F. Cruz,University of Illinois at Chicago,https://www.cs.uic.edu/Cruz/,kd
 Isabel Maria Cacho Teixeira,Universidade de Lisboa,https://sotis.tecnico.ulisboa.pt/researcher/ist10780,NOSCHOLARPAGE
 Isabel Méndez-Díaz,University of Buenos Aires,https://www.dc.uba.ar/rrhh/profesores/mendezdiaz,NOSCHOLARPAGE
 Isabel Trancoso,Universidade de Lisboa,https://www.l2f.inesc-id.pt/wiki/index.php/Isabel_Trancoso,Auzu_DcAAAAJ
-Isabelle Augenstein,DIKU,http://isabelleaugenstein.github.io/,DjJp0dcAAAAJ
+Isabelle Augenstein,University of Copenhagen,http://isabelleaugenstein.github.io/,DjJp0dcAAAAJ
 Isambo Karali,University of Athens,http://cgi.di.uoa.gr/~izambo/ENG.html/,SYqu73cAAAAJ
 Isao Shimoyama,University of Tokyo,http://www.leopard.t.u-tokyo.ac.jp/intro.html,NOSCHOLARPAGE
 Ishfaq Ahmad,University of Texas at Arlington,http://ranger.uta.edu/~iahmad/,DPpfFp4AAAAJ
@@ -4472,7 +4472,7 @@ Jaime Ruiz,University of Florida,https://www.jaimeruiz.com/,K1O-ZPIAAAAJ
 Jaime Simao Sichman,University of São Paulo,https://www2.pcs.usp.br/pcsv6/index.php/131-docentes/223-jaime,rlSHIHIAAAAJ
 Jaime Viegas,Masdar Institute,https://www.masdar.ac.ae/aboutus/management/faculty-directory/item/5686-jaime-viegas,R97KDQ0AAAAJ
 Jakob Eriksson,University of Illinois at Chicago,https://www.cs.uic.edu/Jakob/,kLUW0psAAAAJ
-Jakob Grue Simonsen,DIKU,http://www.diku.dk/~simonsen/,JFhAzosAAAAJ
+Jakob Grue Simonsen,University of Copenhagen,http://www.diku.dk/~simonsen/,JFhAzosAAAAJ
 Jakub Kowalski,University of Wroclaw,http://ii.uni.wroc.pl/instytut/pracownicy/64,31AWuosAAAAJ
 Jakub Michaliszyn,University of Wroclaw,http://www.ii.uni.wroc.pl/~jmi/,KxpyIIYAAAAJ
 Jakub Pawlewicz,University of Warsaw,https://chessprogramming.wikispaces.com/Jakub+Pawlewicz/,95JYFDQAAAAJ
@@ -4717,7 +4717,7 @@ Jean-Pierre Hubaux,EPFL,https://people.epfl.ch/jean-pierre.hubaux/,W7YBLlEAAAAJ
 Jean-Sébastien Coron,University of Luxembourg,http://wwwen.uni.lu/recherche/fstc/laboratory_of_algorithmics_cryptology_and_security_lacs/members/jean_sebastien_coron/,NOSCHOLARPAGE
 Jean-Yves L'Excellent,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/jean-yves.l.excellent/,NOSCHOLARPAGE
 Jean-Yves Le Boudec,EPFL,https://people.epfl.ch/jean-yves.leboudec/,hLj70l8AAAAJ
-Jean-Yves Moyen,DIKU,https://lipn.univ-paris13.fr/~moyen/,PpkC9xUAAAAJ
+Jean-Yves Moyen,University of Copenhagen,https://lipn.univ-paris13.fr/~moyen/,PpkC9xUAAAAJ
 Jean-Yves Potvin,University of Montreal,http://www.iro.umontreal.ca/~potvin/,NOSCHOLARPAGE
 Jeanne Ferrante,University of California - San Diego,http://cseweb.ucsd.edu/~ferrante/,NOSCHOLARPAGE
 Jed Brown,University of Colorado Boulder,https://www.colorado.edu/cs/users/jeka2967/,x_9_NGwAAAAJ
@@ -5156,7 +5156,7 @@ Jon G. Rokne,University of Calgary,http://pages.cpsc.ucalgary.ca/~rokne/,NOSCHOL
 Jon M. Kleinberg,Cornell University,https://www.cs.cornell.edu/home/kleinber/,VX7d5EQAAAAJ
 Jon McCormack,Monash University,http://monash.edu/research/explore/en/persons/jon-mccormack(31d10cfb-858c-4a51-845e-7349899e9696).html/,nJDUC6cAAAAJ
 Jon Oberlander,University of Edinburgh,http://homepages.inf.ed.ac.uk/jon/,Sr4lD_YAAAAJ
-Jon Sporring,DIKU,http://image.diku.dk/sporring/,COP1HUwAAAAJ
+Jon Sporring,University of Copenhagen,http://image.diku.dk/sporring/,COP1HUwAAAAJ
 Jonathan Aldrich,Carnegie Mellon University,http://www.cs.cmu.edu/~./aldrich/,AzHmOtcAAAAJ
 Jonathan Appavoo,Boston University,http://www.cs.bu.edu/~jappavoo/,Z1Kl2REAAAAJ
 Jonathan Barrett,University of Oxford,https://www.cs.ox.ac.uk/people/jonathan.barrett/,rZefS0AAAAAJ
@@ -5209,7 +5209,7 @@ Jorge Fernandes,Universidade de Lisboa,http://fcsh.unl.pt/faculdade/docentes/pfe
 Jorge Garcia Vidal,Polytechnic University of Catalonia,http://people.ac.upc.edu/jorge/,NOSCHOLARPAGE
 Jorge Gonçalves,University of Melbourne,http://www.jorgegoncalves.com,dPnQIkEAAAAJ
 Jorge Stolfi,University of Campinas,https://twitter.com/jorgestolfi?lang=en,mLo7gCEAAAAJ
-Jorgen P. Bansler,DIKU,http://diku.dk/Ansatte/beskrivelse/?id=160232/,YuHIy0IAAAAJ
+Jorgen P. Bansler,University of Copenhagen,http://diku.dk/Ansatte/beskrivelse/?id=160232/,YuHIy0IAAAAJ
 Jorgen Peddersen,UNSW,https://www.engineering.unsw.edu.au/computer-science-engineering/staff/jorgen-peddersen/,NOSCHOLARPAGE
 Jose Joaquin Garcia-Luna-Aceves,University of California - Santa Cruz,https://users.soe.ucsc.edu/~jj/,NOSCHOLARPAGE
 Jose M. Carmena,University of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/carmena.html/,yTIIzd0AAAAJ
@@ -5449,7 +5449,7 @@ Jyh-Ming Lien,George Mason University,http://cs.gmu.edu/~jmlien/,EnrEVb0AAAAJ
 Jyh-Shing Roger Jang,National Taiwan University,https://mirlab.org/jang/,NOSCHOLARPAGE
 Jyh-haw Yeh,Boise State University,http://cs.boisestate.edu/~jhyeh/,NOSCHOLARPAGE
 Jyotsna Bapat,IIIT Bangalore,http://www.iiitb.ac.in/faculty_page.php?name=JyotsnaBapat/,NOSCHOLARPAGE
-Jyrki Katajainen,DIKU,http://www.diku.dk/~jyrki/,91jGnMUAAAAJ
+Jyrki Katajainen,University of Copenhagen,http://www.diku.dk/~jyrki/,91jGnMUAAAAJ
 Jérémy Barbay,Universidad de Chile,http://www.dcc.uchile.cl/~jbarbay/,x7L1W0rvHwsC
 Jérôme Feret,Ecole Normale Superieure,http://www.di.ens.fr/~feret/,TcO5mvwAAAAJ
 Jérôme Waldispühl,McGill University,http://www.cs.mcgill.ca/~jeromew/,IVZp2gQAAAAJ
@@ -5464,7 +5464,7 @@ Jörg Sander,University of Alberta,https://webdocs.cs.ualberta.ca/~joerg/,QzFTFL
 Jörg-Rüdiger Sack,Carleton University,http://www.scs.carleton.ca/~sack/,NOSCHOLARPAGE
 Jörn Diedrichsen,Western University,http://www.diedrichsenlab.org/,mF72dYoAAAAJ
 Jörn Janneck,Lund University,http://www.lunduniversity.lu.se/lucat/user/6d94f235ba6e4b38f5fbc1a7b0ed0c00,acaDIH8AAAAJ
-Jørgen P. Bansler,DIKU,http://diku.dk/Ansatte/beskrivelse/?id=160232/,NOSCHOLARPAGE
+Jørgen P. Bansler,University of Copenhagen,http://diku.dk/Ansatte/beskrivelse/?id=160232/,NOSCHOLARPAGE
 Jürgen Dingel,Queen’s University,http://www.cs.queensu.ca/~dingel/,MZggB6kAAAAJ
 Jürgen Giesl,RWTH Aachen,http://verify.rwth-aachen.de/giesl/,dh9YNEoAAAAJ
 Jürgen Sachau,University of Luxembourg,http://wwwen.uni.lu/snt/people/juergen_sachau/,NOSCHOLARPAGE
@@ -5585,11 +5585,11 @@ Kasim Selçuk Candan,Arizona State University,http://aria.asu.edu/candan/,NOSCHO
 Kasper Bonne Rasmussen,University of Oxford,http://www.cs.ox.ac.uk/people/kasper.rasmussen/,NOSCHOLARPAGE
 Kasper Dalgaard Larsen,Aarhus University,http://www.madalgo.au.dk/~larsen/,NOSCHOLARPAGE
 Kasper Green Larsen,Aarhus University,http://www.madalgo.au.dk/~larsen/,ZluoxUcAAAAJ
-Kasper Hornbæk,DIKU,http://diku.dk/Ansatte/?pure=da/persons/141851/,S6VMDA8AAAAJ
+Kasper Hornbæk,University of Copenhagen,http://diku.dk/Ansatte/?pure=da/persons/141851/,S6VMDA8AAAAJ
 Kasper Støy,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/kasper-stoey(2a9c0934-98ca-4101-b829-b88d77f6487e).html,NOSCHOLARPAGE
 Kasturi R. Varadarajan,University of Iowa,http://homepage.cs.uiowa.edu/~kvaradar/,UNxLPX8AAAAJ
 Katarzyna Paluch,University of Wroclaw,http://www.ii.uni.wroc.pl/~abraka/,NOSCHOLARPAGE
-Katarzyna Wac,DIKU,http://diku.dk/english/staff/vip/?pure=en/persons/501789/,GIejbKQAAAAJ
+Katarzyna Wac,University of Copenhagen,http://diku.dk/english/staff/vip/?pure=en/persons/501789/,GIejbKQAAAAJ
 Kate Booker,Australian National University,https://cecs.anu.edu.au/people/kate-booker/,NOSCHOLARPAGE
 Kate Larson,University of Waterloo,https://cs.uwaterloo.ca/~klarson/,QK-c5esAAAAJ
 Kate Saenko,Boston University,http://www.cs.uml.edu/~saenko/,9xDADY4AAAAJ
@@ -5655,7 +5655,7 @@ Kemao Qian,Nanyang Technological University,http://research.ntu.edu.sg/expertise
 Ken Baclawski,Northeastern University,http://www.ccs.neu.edu/home/kenb/,NOSCHOLARPAGE
 Ken Barker,University of Calgary,http://www.ucalgary.ca/kbarker/,jX6Svt4AAAAJ
 Ken Birman,Cornell University,http://www.cs.cornell.edu/ken/,I-rKkyEAAAAJ
-Ken Friis Larsen,DIKU,http://www.diku.dk/~kflarsen/,BcWkstQAAAAJ
+Ken Friis Larsen,University of Copenhagen,http://www.diku.dk/~kflarsen/,BcWkstQAAAAJ
 Ken Goldberg,University of California - Berkeley,http://goldberg.berkeley.edu/,NOSCHOLARPAGE
 Ken Koedinger,Carnegie Mellon University,http://pact.cs.cmu.edu/koedinger.html/,NOSCHOLARPAGE
 Ken Mercer,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=531330/,NOSCHOLARPAGE
@@ -5696,7 +5696,7 @@ Kenneth W. Regan,University at Buffalo,http://www.cse.buffalo.edu/~regan/,8nk9k5
 Kenneth Wai-Ting Leung,HKUST,https://www.cse.ust.hk/~kwtleung/,NOSCHOLARPAGE
 Kenneth Wingate Regan,University at Buffalo,https://chessprogramming.wikispaces.com/Kenneth+Wingate+Regan/,NOSCHOLARPAGE
 Kenneth Y. Goldberg,University of California - Berkeley,http://goldberg.berkeley.edu/,8fztli4AAAAJ
-Kenny Erleben,DIKU,http://www.diku.dk/~kenny/,CQkvlpUAAAAJ
+Kenny Erleben,University of Copenhagen,http://www.diku.dk/~kenny/,CQkvlpUAAAAJ
 Kenny Q. Zhu,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/~kzhu/,ZIRJ6lIAAAAJ
 Kenny Qili Zhu,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/~kzhu/,NOSCHOLARPAGE
 Kenny Wong,University of Alberta,https://webapps.cs.ualberta.ca/profile/,I__Yju4AAAAJ
@@ -5762,7 +5762,7 @@ Kihong Park,Purdue University,https://www.cs.purdue.edu/homes/park/,3sh3er0AAAAJ
 Kilian Q. Weinberger,Cornell University,http://www.cs.cornell.edu/~kilian/,jsxk8vsAAAAJ
 Kim Binsted,University of Hawaii at Manoa,http://www2.hawaii.edu/~binsted/,bd9-UG8AAAAJ
 Kim Marriott,Monash University,http://monash.edu/research/explore/en/persons/kimbal-marriott(7d023b2c-6774-452b-850c-a1c3ce23cb49).html/,sAjKW6oAAAAJ
-Kim Steenstrup Pedersen,DIKU,http://image.diku.dk/kimstp/,RzH2vKQAAAAJ
+Kim Steenstrup Pedersen,University of Copenhagen,http://image.diku.dk/kimstp/,RzH2vKQAAAAJ
 Kimmo Kaski,Aalto University,https://people.aalto.fi/kimmo_kaski,Cpay6fYAAAAJ
 Kin Hong Wong,Chinese University of Hong Kong,http://www.cse.cuhk.edu.hk/~khwong/,qTcmHIcAAAAJ
 Kin K. Leung,Imperial College London,http://www.commsp.ee.ic.ac.uk/~kkleung/,IpG80kwAAAAJ
@@ -5785,12 +5785,12 @@ Klara Nahrstedt,University of Illinois at Urbana-Champaign,https://cs.illinois.e
 Klas Nilsson,Lund University,http://cs.lth.se/klas_nilsson,NOSCHOLARPAGE
 Klaus Hildebrandt,TU Delft,https://graphics.tudelft.nl/klaus-hildebrandt/,qYZBq5cAAAAJ
 Klaus Kabitzsch,TU Dresden,https://tu-dresden.de/cdd/leitung_und_beteiligte/mitglieder/bereich-mathematik/Kabitzsch/,NOSCHOLARPAGE
-Klaus Marius Hansen,DIKU,http://www.diku.dk/~klausmh/,6yJ09KwAAAAJ
+Klaus Marius Hansen,University of Copenhagen,http://www.diku.dk/~klausmh/,6yJ09KwAAAAJ
 Klaus Meißner,TU Dresden,https://mmt.inf.tu-dresden.de/Team/mitarbeiter.xhtml?id=66/,NOSCHOLARPAGE
 Klaus Mueller,Stony Brook University,http://www3.cs.stonybrook.edu/~mueller/,jplQac8AAAAJ
 Klaus Weber,Australian National University,https://cecs.anu.edu.au/people/klaus-weber/,ZfCEt-4AAAAJ
 Klaus Wehrle,RWTH Aachen,https://www.comsys.rwth-aachen.de/team/klaus/,3jzgrIcAAAAJ
-Knud Henriksen,DIKU,http://diku.dk/english/staff/?pure=en%2Fpersons%2Fknud-henriksen(3aa8e9bd-9fc3-4f59-a679-3211d362871a).html/,dJvAmqwAAAAJ
+Knud Henriksen,University of Copenhagen,http://diku.dk/english/staff/?pure=en%2Fpersons%2Fknud-henriksen(3aa8e9bd-9fc3-4f59-a679-3211d362871a).html/,dJvAmqwAAAAJ
 Ko Nishino,Drexel University,https://www.cs.drexel.edu/~kon/,SXXEZhYAAAAJ
 Kobus Barnard,University of Arizona,http://kobus.ca/,fKESO6sAAAAJ
 Koby Crammer,Technion - Israel Institute of Technology,http://webee.technion.ac.il/people/koby/,NOSCHOLARPAGE
@@ -5961,7 +5961,7 @@ Laszlo Erdös,IST Austria,https://ist.ac.at/research/research-groups/erdoes-grou
 Lata Narayanan,Concordia University,http://www.cs.concordia.ca/~lata,sY3us-kAAAAJ
 Latifur Khan,University of Texas at Dallas,https://www.utdallas.edu/~lkhan/,7nERaWEAAAAJ
 Latifur R. Khan,University of Texas at Dallas,https://www.utdallas.edu/~lkhan/,NOSCHOLARPAGE
-Lauge Sørensen,DIKU,http://image.diku.dk/lauges/,ZWZ0yiEAAAAJ
+Lauge Sørensen,University of Copenhagen,http://image.diku.dk/lauges/,ZWZ0yiEAAAAJ
 Laura A. Dabbish,Carnegie Mellon University,http://www.lauradabbish.com/,DdNAgNwAAAAJ
 Laura Bocchi,University of Kent,https://www.cs.kent.ac.uk/people/staff/lb514/,R_QSej4AAAAJ
 Laura Dabbish,Carnegie Mellon University,http://www.lauradabbish.com/,NOSCHOLARPAGE
@@ -6323,7 +6323,7 @@ Madhu Sudan,Harvard University,http://madhu.seas.harvard.edu/,D-RwB3YAAAAJ
 Madhur Behl,University of Virginia,https://www.cs.virginia.edu/people/faculty/behl.html/,bj_imaYAAAAJ
 Madhur Tulsiani,Toyota Technological Institute at Chicago,http://ttic.uchicago.edu/~madhurt/,5ZTO0uMAAAAJ
 Madhusudhan Govindaraju,Binghamton University,http://www.cs.binghamton.edu/~mgovinda/,cuA3CkgAAAAJ
-Mads Nielsen,DIKU,http://www.diku.dk/Ansatte/?pure=da/persons/137906/,2QCJXEkAAAAJ
+Mads Nielsen,University of Copenhagen,http://www.diku.dk/Ansatte/?pure=da/persons/137906/,2QCJXEkAAAAJ
 Maen M. Al Assaf,University of Jordan,http://link.springer.com/article/10.1007/s11265-013-0787-6,eK4zRzwAAAAJ
 Magda El Zarki,University of California - Irvine,http://www.ics.uci.edu/~magda/,NOSCHOLARPAGE
 Magdalena Balazinska,University of Washington,http://www.cs.washington.edu/people/faculty/magda/,DDxFvcIAAAAJ
@@ -6647,7 +6647,7 @@ Markus Pauly,EPFL,http://lgg.epfl.ch/publications.php/,TSGyT-EAAAAJ
 Markus Püschel,ETH Zurich,https://www.inf.ethz.ch/personal/markusp/,az9ZryAAAAAJ
 Markus Schneider,University of Florida,http://www.cise.ufl.edu/~mschneid/,lOhijLUAAAAJ
 Markus Wagner 0007,University of Adelaide,https://cs.adelaide.edu.au/~markus/,DVbOu8MAAAAJ
-Marleen de Bruijne,DIKU,http://image.diku.dk/marleen/,7kTk3LUAAAAJ
+Marleen de Bruijne,University of Copenhagen,http://image.diku.dk/marleen/,7kTk3LUAAAAJ
 Marlon Dumas,University of Tartu,http://math.ut.ee/~dumas/,9lIttRkAAAAJ
 Marsette Vona,Northeastern University,http://www.ccs.neu.edu/research/gpc/vona.html/,0Y3rvXUAAAAJ
 Marsha Chechik,University of Toronto,http://www.cs.toronto.edu/~chechik/,CYfxRVIAAAAJ
@@ -6681,7 +6681,7 @@ Martin Bichler,TU Munich,http://dss.in.tum.de/staff/bichler.html/,gYRbZzIAAAAJ
 Martin Bouchard,University of Ottawa,http://www.site.uottawa.ca/~bouchard/,ufMGQ3MAAAAJ
 Martin C. Rinard,Massachusetts Institute of Technology,http://people.csail.mit.edu/rinard/,hxlxVEUAAAAJ
 Martin D. F. Wong,University of Illinois at Urbana-Champaign,https://www.ece.illinois.edu/directory/profile/mdfwong/,WPhoQiUAAAAJ
-Martin Elsman,DIKU,http://www.di.ku.dk/english/staff/?pure=en/persons/127388/,B_kB3DUAAAAJ
+Martin Elsman,University of Copenhagen,http://www.di.ku.dk/english/staff/?pure=en/persons/127388/,B_kB3DUAAAAJ
 Martin Erwig,Oregon State University,http://eecs.oregonstate.edu/~erwig/,KvfFlIMAAAAJ
 Martin Ester,Simon Fraser University,http://www.cs.sfu.ca/~ester/,ZYwC_CQAAAAJ
 Martin Farach,Rutgers University,http://www.cs.rutgers.edu/~farach/,NOSCHOLARPAGE
@@ -6700,7 +6700,7 @@ Martin Jägersand,University of Alberta,https://webdocs.cs.ualberta.ca/~jag/,kxA
 Martin Karsten,University of Waterloo,https://cs.uwaterloo.ca/~mkarsten/,ieXJpBkAAAAJ
 Martin Kreuzer,University of Passau,http://staff.fim.uni-passau.de/kreuzer/,0ZDLSpkAAAAJ
 Martin L. Kersten,CWI,http://homepages.cwi.nl/~mk/,Kr6jppsAAAAJ
-Martin Lillholm,DIKU,http://www.diku.dk/hjemmesider/studerende/grumse/,QLCX-88AAAAJ
+Martin Lillholm,University of Copenhagen,http://www.diku.dk/hjemmesider/studerende/grumse/,QLCX-88AAAAJ
 Martin Loose,IST Austria,https://ist.ac.at/research/research-groups/loose-group/,7or52IsAAAAJ
 Martin Müller 0003,University of Alberta,https://webdocs.cs.ualberta.ca/~mmueller/,UedjBD4AAAAJ
 Martin Odersky,EPFL,http://lampwww.epfl.ch/~odersky/,LbRD9tEAAAAJ
@@ -6799,7 +6799,7 @@ Matthew Doolan,Australian National University,https://cecs.anu.edu.au/people/mat
 Matthew Flatt,University of Utah,http://www.cs.utah.edu/~mflatt/,9sMIvdgAAAAJ
 Matthew Fluet,Rochester Institute of Technology,https://www.cs.rit.edu/~mtf/,8SmCkDQAAAAJ
 Matthew Fredrikson,Carnegie Mellon University,http://www.cs.cmu.edu/~mfredrik/,NOSCHOLARPAGE
-Matthew G. Liptrot,DIKU,http://ku-dk.academia.edu/MatthewLiptrot/,n0NYEY0AAAAJ
+Matthew G. Liptrot,University of Copenhagen,http://ku-dk.academia.edu/MatthewLiptrot/,n0NYEY0AAAAJ
 Matthew Green 0001,Johns Hopkins University,https://isi.jhu.edu/~mgreen/,X0XWAGkAAAAJ
 Matthew Hammer,University of Colorado Boulder,https://www.colorado.edu/cs/users/mhammer/,zVXQcSsAAAAJ
 Matthew Hicks,Virginia Tech,http://www.impedimenttoprogress.com/,_rJCgzIAAAAJ
@@ -7174,10 +7174,10 @@ Mikhail J. Atallah,Purdue University,https://www.cs.purdue.edu/people/mja/,uc8_e
 Mikhail Kapralov,EPFL,http://theory.epfl.ch/kapralov/,NOSCHOLARPAGE
 Mikhail Lemeshko,IST Austria,https://ist.ac.at/research/research-groups/lemeshko-group/,lxBCBfUAAAAJ
 Mikhailo Dokuchaev,University of São Paulo,http://www.ime.usp.br/~dokucha,BEi35iIAAAAJ
-Mikkel Abrahamsen,DIKU,http://www.diku.dk/Ansatte/forskere/?pure=da/persons/289414/,AYGv9T8AAAAJ
-Mikkel R. Jakobsen,DIKU,http://www.diku.dk/Ansatte/?pure=da/persons/147590/,NOSCHOLARPAGE
-Mikkel Rønne Jakobsen,DIKU,http://www.diku.dk/Ansatte/?pure=da/persons/147590/,NOSCHOLARPAGE
-Mikkel Thorup,DIKU,http://www.diku.dk/~mthorup/,UPBuOPIAAAAJ
+Mikkel Abrahamsen,University of Copenhagen,http://www.diku.dk/Ansatte/forskere/?pure=da/persons/289414/,AYGv9T8AAAAJ
+Mikkel R. Jakobsen,University of Copenhagen,http://www.diku.dk/Ansatte/?pure=da/persons/147590/,NOSCHOLARPAGE
+Mikkel Rønne Jakobsen,University of Copenhagen,http://www.diku.dk/Ansatte/?pure=da/persons/147590/,NOSCHOLARPAGE
+Mikkel Thorup,University of Copenhagen,http://www.diku.dk/~mthorup/,UPBuOPIAAAAJ
 Mikko Kivelä,Aalto University,https://people.aalto.fi/new/mikko.kivela,Z3913I0AAAAJ
 Miklós Csürös,University of Montreal,http://www.iro.umontreal.ca/~csuros/,NOSCHOLARPAGE
 Mikolaj Bojanczyk,University of Warsaw,http://www.mimuw.edu.pl/~bojan/,Rv0YwPAAAAAJ
@@ -7447,7 +7447,7 @@ Naghmeh Karimi,University of Maryland - Baltimore County,http://www.csee.umbc.ed
 Nagiza F. Samatova,North Carolina State University,https://www.csc.ncsu.edu/people/nfsamato/,vukA8JAAAAAJ
 Nagul Cooharojananone,Chulalongkorn University,http://pioneer.netserv.chula.ac.th/~cnagul/,NOSCHOLARPAGE
 Naijie Gu,USTC,http://dsxt.ustc.edu.cn/zj_ywjs.asp?zzid=745,NOSCHOLARPAGE
-Naja L. Holten Møller,DIKU,http://diku.dk/Ansatte/?pure=da/persons/340853/,NOSCHOLARPAGE
+Naja L. Holten Møller,University of Copenhagen,http://diku.dk/Ansatte/?pure=da/persons/340853/,NOSCHOLARPAGE
 Nalini Venkatasubramanian,University of California - Irvine,https://www.ics.uci.edu/~nalini/,qfCah3sAAAAJ
 Nam Sung Kim,University of Illinois at Urbana-Champaign,https://www.ece.illinois.edu/directory/profile/nskim/,iccBxJIAAAAJ
 Nan Yang,Australian National University,https://cecs.anu.edu.au/people/nan-yang/,ycwS45YAAAAJ
@@ -8028,7 +8028,7 @@ Pawel A. Dmochowski,Victoria University of Wellington,http://ecs.victoria.ac.nz/
 Pawel Gawrychowski,University of Wroclaw,http://www.ii.uni.wroc.pl/~gawry/,m-B6e-YAAAAJ
 Pawel Parys,University of Warsaw,http://www.mimuw.edu.pl/~parys/aboutme/,NOSCHOLARPAGE
 Pawel Urzyczyn,University of Warsaw,http://www.mimuw.edu.pl/~urzy/,NOSCHOLARPAGE
-Pawel Winter,DIKU,http://www.diku.dk/~pawel/,akQtjYcAAAAJ
+Pawel Winter,University of Copenhagen,http://www.diku.dk/~pawel/,akQtjYcAAAAJ
 Pawel Wocjan,University of Central Florida,http://www.cs.ucf.edu/~wocjan/,FcjgkmsAAAAJ
 Pawel Wozny,University of Wroclaw,https://www.ii.uni.wroc.pl/~pwo/,FjOm7C8AAAAJ
 Pearl Y. Wang,George Mason University,http://cs.gmu.edu/~pwang/,NOSCHOLARPAGE
@@ -8064,7 +8064,7 @@ Percy Liang,Stanford University,https://cs.stanford.edu/~pliang/,pouyVyUAAAAJ
 Perdita Stevens,University of Edinburgh,http://homepages.inf.ed.ac.uk/perdita/,KdBhbbYAAAAJ
 Pere Barlet-Ros,Polytechnic University of Catalonia,http://people.ac.upc.edu/pbarlet/,NOSCHOLARPAGE
 Periklis A. Papakonstantinou,Rutgers University,https://www.cs.rutgers.edu/people/faculty/affiliated-faculty,NOSCHOLARPAGE
-Pernille Bjørn,DIKU,http://diku.dk/english/staff/vip/?pure=en/persons/417695/,ZbzjucYAAAAJ
+Pernille Bjørn,University of Copenhagen,http://diku.dk/english/staff/vip/?pure=en/persons/417695/,ZbzjucYAAAAJ
 Perry Alexander,University of Kansas,http://perry.alexander.name/,X-WzDOYAAAAJ
 Perttu Hämäläinen,Aalto University,https://mediatech.aalto.fi/~phamalainen/,i90uqXUAAAAJ
 Pete Keleher,University of Maryland - College Park,https://www.cs.umd.edu/people/keleher/,NOSCHOLARPAGE
@@ -8837,7 +8837,7 @@ Robert G. Crawford,Queen’s University,http://research.cs.queensu.ca/home/rgc/,
 Robert G. Merkel,Monash University,http://monash.edu/research/explore/en/persons/robert-merkel(60ae5e11-1b74-4e46-bd00-0194549d414d).html/,n8wCPF4AAAAJ
 Robert G. Olsen,Washington State University,http://www.eecs.wsu.edu/~olsen/,UO6K1TkAAAAJ
 Robert Geist,Clemson University,https://people.cs.clemson.edu/~geist/homepage.html/,Ui2NKZUAAAAJ
-Robert Glück,DIKU,http://www.diku.dk/~glueck/,cGfKulEAAAAJ
+Robert Glück,University of Copenhagen,http://www.diku.dk/~glueck/,cGfKulEAAAAJ
 Robert H. Deng,Singapore Management University,https://www.smu.edu.sg/faculty/profile/9611/Robert-H-DENG,OPbZGPsAAAAJ
 Robert H. Sloan,University of Illinois at Chicago,https://www.cs.uic.edu/Sloan/,RiJSLsoAAAAJ
 Robert Harle,University of Cambridge,https://www.cl.cam.ac.uk/research/dtg/www/people/rkh23/,MUWnoZIAAAAJ
@@ -9394,7 +9394,7 @@ Sean Holden,University of Cambridge,http://www.cl.cam.ac.uk/~sbh11/,NOSCHOLARPAG
 Sean Luke,George Mason University,https://cs.gmu.edu/~sean/,jwxhFAQAAAAJ
 Sean W. Smith,Dartmouth College,http://www.cs.dartmouth.edu/~sws/,hjaMuwsAAAAJ
 Sean Warnick,Brigham Young University,https://cs.byu.edu/faculty/sean/,NOSCHOLARPAGE
-Sebastian Boring,DIKU,http://www.diku.dk/english/staff/?pure=en/persons/431157/,Y_QMLKAAAAAJ
+Sebastian Boring,University of Copenhagen,http://www.diku.dk/english/staff/?pure=en/persons/431157/,Y_QMLKAAAAAJ
 Sebastian Erdweg,TU Delft,http://www.informatik.uni-marburg.de/~seba/,2jCQrk4AAAAJ
 Sebastian Fischmeister,University of Waterloo,https://uwaterloo.ca/embedded-software-group/people-profiles/sebastian-fischmeister,NOSCHOLARPAGE
 Sebastian G. Elbaum,University of Nebraska,http://csce.unl.edu/~elbaum/,swPW5FYAAAAJ
@@ -9837,7 +9837,7 @@ Stefan Dziembowski,University of Warsaw,http://www.crypto.edu.pl/Dziembowski/,Vg
 Stefan Gumhold,TU Dresden,https://tu-dresden.de/ing/informatik/smt/cgv/,YH2WqxcAAAAJ
 Stefan Göller,Ecole Normale Superieure de Cachan,http://www.lsv.ens-cachan.fr/~goeller/,NOSCHOLARPAGE
 Stefan Haar,Ecole Normale Superieure de Cachan,http://www.lsv.ens-cachan.fr/~haar/,MgeEaDozUI8C
-Stefan Horst Sommer,DIKU,http://research.ku.dk/search/?pure=en/persons/254908/,NOSCHOLARPAGE
+Stefan Horst Sommer,University of Copenhagen,http://research.ku.dk/search/?pure=en/persons/254908/,NOSCHOLARPAGE
 Stefan Kahrs,University of Kent,https://www.cs.kent.ac.uk/~smk/,NOSCHOLARPAGE
 Stefan Katzenbeisser 0001,TU Darmstadt,http://www.seceng.informatik.tu-darmstadt.de/people/katzenbeisser/,NOSCHOLARPAGE
 Stefan Kiefer,University of Oxford,https://www.cs.ox.ac.uk/people/stefan.kiefer/,Kr0pjvwAAAAJ
@@ -9883,7 +9883,7 @@ Stephen A. Clark,University of Cambridge,https://sites.google.com/site/stephencl
 Stephen A. Edwards,Columbia University,http://www.cs.columbia.edu/~sedwards/,3aw_314AAAAJ
 Stephen A. Fenner,University of South Carolina,http://www.cse.sc.edu/~fenner/,NOSCHOLARPAGE
 Stephen A. Ward,Massachusetts Institute of Technology,https://www.csail.mit.edu/user/1517/,0iSggMcAAAAJ
-Stephen Alstrup,DIKU,http://diku.dk/Ansatte/?pure=da/persons/110448/,Agh-Q0IAAAAJ
+Stephen Alstrup,University of Copenhagen,http://diku.dk/Ansatte/?pure=da/persons/110448/,Agh-Q0IAAAAJ
 Stephen B. Furber,University of Manchester,https://www.research.manchester.ac.uk/portal/steve.furber.html,jLnsiBEAAAAJ
 Stephen Blackburn,Australian National University,http://users.cecs.anu.edu.au/~steveb/,HgSTO7oAAAAJ
 Stephen Brookes,Carnegie Mellon University,http://www.cs.cmu.edu/~brookes/,NOSCHOLARPAGE
@@ -10083,7 +10083,7 @@ Sundar Balasubramaniam,BITS Pilani,http://www.bits-pilani.ac.in/pilani/sundarb/p
 Sundar Vishwanathan,IIT Bombay,https://www.cse.iitb.ac.in/~sundar/,8CK3IY4AAAAJ
 Sundaram Suresh,Nanyang Technological University,http://www.ntu.edu.sg/home/ssundaram/,5iAMbhMAAAAJ
 Sundaresan Raman,BITS Pilani,http://www.bits-pilani.ac.in/pilani/sundaresanraman/profile/,NOSCHOLARPAGE
-Sune Darkner,DIKU,http://www.diku.dk/english/staff/?pure=en/persons/383640/,Z_bvPmcAAAAJ
+Sune Darkner,University of Copenhagen,http://www.diku.dk/english/staff/?pure=en/persons/383640/,Z_bvPmcAAAAJ
 Sung Yang Bang,POSTECH,http://imlab.postech.ac.kr/publications_IC.htm,NOSCHOLARPAGE
 Sung-Eui Yoon,KAIST,http://sglab.kaist.ac.kr/~sungeui/,uLQzQW4AAAAJ
 Sung-Hee Lee,KAIST,http://motionlab.kaist.ac.kr/?page_id=41,AVII4wsAAAAJ
@@ -10176,7 +10176,7 @@ Sébastien Roy,University of Montreal,http://www.iro.umontreal.ca/~roys/en_index
 Sérgio Vale Aguiar Campos,Universidade Federal de Minas Gerais,http://homepages.dcc.ufmg.br/~scampos,NOSCHOLARPAGE
 Sónia Ferreira Pinto,Universidade de Lisboa,https://sotis.tecnico.ulisboa.pt/keyword/0d0bf179-e55f-4b14-8c64-214087a98c3f,NOSCHOLARPAGE
 Søren Debois,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/soeren-debois(d3b41838-e2bf-4735-b1cd-03f60b49c7e5).html,okin7NMAAAAJ
-Søren Ingvor Olsen,DIKU,http://diku.dk/english/staff/?pure=en/persons/5264/,NOSCHOLARPAGE
+Søren Ingvor Olsen,University of Copenhagen,http://diku.dk/english/staff/?pure=en/persons/5264/,NOSCHOLARPAGE
 Søren Lauesen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/soeren-lauesen(ea6d10cf-6bb5-4414-8966-f1ed2591f794).html,NOSCHOLARPAGE
 Süleyman Cenk Sahinalp,Indiana University,https://www.soic.indiana.edu/all-people/profile.html?profile_id=291/,NOSCHOLARPAGE
 T. C. Chong,Australian National University,https://researchers.anu.edu.au/researchers/haberkorn-tc/,YOGnf60AAAAJ
@@ -10259,8 +10259,8 @@ Tapio Takala,Aalto University,https://people.aalto.fi/new/tapio.takala,NOSCHOLAR
 Tarek Elfouly,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/tarek.php,fItzV6EAAAAJ
 Tarek F. Abdelzaher,University of Illinois at Urbana-Champaign,http://web.engr.illinois.edu/~zaher/,cA28Zs0AAAAJ
 Tarek S. Abdelrahman,University of Toronto,http://www.eecg.toronto.edu/~tsa/,Tp5qZjsAAAAJ
-Tariq Andersen,DIKU,http://www.di.ku.dk/english/staff/?pure=en/persons/353044/,FMtPAZ0AAAAJ
-Tariq O. Andersen,DIKU,http://diku.dk/english/news/news2015/,FMtPAZ0AAAAJ
+Tariq Andersen,University of Copenhagen,http://www.di.ku.dk/english/staff/?pure=en/persons/353044/,FMtPAZ0AAAAJ
+Tariq O. Andersen,University of Copenhagen,http://diku.dk/english/news/news2015/,FMtPAZ0AAAAJ
 Tat Yung Kong,CUNY,http://www.tyungkong.us/,Hbb5UBgAAAAJ
 Tat-Jen Cham,Nanyang Technological University,http://www.ntu.edu.sg/home/astjcham/,Lx3X7W0AAAAJ
 Tat-Jun Chin,University of Adelaide,http://cs.adelaide.edu.au/~tjchin/,WyqGF10AAAAJ
@@ -10420,7 +10420,7 @@ Tien-Tsin Wong,Chinese University of Hong Kong,http://www.cse.cuhk.edu.hk/~ttwon
 Tiffani L. Williams,Texas A&M University,http://faculty.cs.tamu.edu/tlw/,HVQT4cAAAAAJ
 Tiffany Barnes,North Carolina State University,https://www.csc.ncsu.edu/people/tmbarnes/,2hemeGMAAAAJ
 Tijana Milenkovic,University of Notre Dame,http://www3.nd.edu/~tmilenko/,QrS2y5sAAAAJ
-Tijs Slaats,DIKU,http://diku.dk/english/staff/?pure=en/persons/561613/,c9fu-JIAAAAJ
+Tijs Slaats,University of Copenhagen,http://diku.dk/english/staff/?pure=en/persons/561613/,c9fu-JIAAAAJ
 Tijs van der Storm,CWI,http://homepages.cwi.nl/~storm/,yJ5PAekAAAAJ
 Tilo Burghardt,University of Bristol,http://www.cs.bris.ac.uk/~burghard/,NOSCHOLARPAGE
 Tim A. C. Willemse,TU Eindhoven,http://www.win.tue.nl/~timw/,NOSCHOLARPAGE
@@ -10554,8 +10554,8 @@ Tony Wirth,University of Melbourne,http://people.eng.unimelb.edu.au/awirth/,NOSC
 Tor M. Aamodt,University of British Columbia,https://www.ece.ubc.ca/~aamodt/,zCsB5XsAAAAJ
 Torben Amtoft,Kansas State University,http://cis.ksu.edu/~tamtoft/,NOSCHOLARPAGE
 Torben Amtoft Hansen,Kansas State University,http://cis.ksu.edu/~tamtoft/,NOSCHOLARPAGE
-Torben Æ. Mogensen,DIKU,http://www.diku.dk/~torbenm/,vjvvUioAAAAJ
-Torben Ægidius Mogensen,DIKU,http://www.diku.dk/~torbenm/,NOSCHOLARPAGE
+Torben Æ. Mogensen,University of Copenhagen,http://www.diku.dk/~torbenm/,vjvvUioAAAAJ
+Torben Ægidius Mogensen,University of Copenhagen,http://www.diku.dk/~torbenm/,NOSCHOLARPAGE
 Torsten Braun,University of Bern,http://www.iam.unibe.ch/~braun/,eL8OzgIAAAAJ
 Torsten Hoefler,ETH Zurich,https://htor.inf.ethz.ch/,DdBvcBEAAAAJ
 Torsten Höfler,ETH Zurich,https://htor.inf.ethz.ch/,NOSCHOLARPAGE
@@ -11392,7 +11392,7 @@ Yen-Jen Oyang,National Taiwan University,http://ah.ntu.edu.tw/web/Teacher!one.ac
 Yeongjin Jang,Oregon State University,http://people.oregonstate.edu/~jangye/,ID4dOvAAAAAJ
 Yevgeniy Dodis,New York University,http://www.cs.nyu.edu/~dodis/,3yPEc4YAAAAJ
 Yevgeniy Vorobeychik,Vanderbilt University,http://engineering.vanderbilt.edu/bio/eugene-vorobeychik/,ptI-HHkAAAAJ
-Yevgeny Seldin,DIKU,http://www.diku.dk/Ansatte/?pure=da/persons/500475/,fpWsD9oAAAAJ
+Yevgeny Seldin,University of Copenhagen,http://www.diku.dk/Ansatte/?pure=da/persons/500475/,fpWsD9oAAAAJ
 Yew-Soon Ong,Nanyang Technological University,http://www.ntu.edu.sg/home/asysong/,h9oWOsEAAAAJ
 Yexiang Xue,Purdue University,https://www.cs.purdue.edu/people/faculty/yexiang/,NOSCHOLARPAGE
 Yezhou Yang,Arizona State University,https://yezhouyang.engineering.asu.edu/,k2suuZgAAAAJ
@@ -11480,7 +11480,7 @@ Yonggang Wen,Nanyang Technological University,http://www.ntu.edu.sg/home/ygwen/,
 Yonghe Liu,University of Texas at Arlington,https://www.uta.edu/profiles/yonghe-liu/,NOSCHOLARPAGE
 Yongjin Liu,Tsinghua University,http://media.cs.tsinghua.edu.cn/en/liuyj,VB1GZgYAAAAJ
 Yongjun Liao,Ecole Normale Superieure de Lyon,http://www.ens-lyon.fr/annuaire/mme-yongjun-liao--269058.kjsp?RH=ENS-LYON-FR-ANNUAIRE/,NOSCHOLARPAGE
-Yongluan Zhou,DIKU,http://diku.dk/english/staff/?pure=en/persons/590429,Tqh1RIkAAAAJ
+Yongluan Zhou,University of Copenhagen,http://diku.dk/english/staff/?pure=en/persons/590429,Tqh1RIkAAAAJ
 Yongtao Wang,Peking University,http://ieeexplore.ieee.org/document/7333883/,Zna90HQAAAAJ
 Yongwei Wu,Tsinghua University,http://madsys.cs.tsinghua.edu.cn/~yongweiwu/,ld3axtkAAAAJ
 Yongyi Mao,University of Ottawa,http://www.site.uottawa.ca/~yymao/,jM5l70wAAAAJ
@@ -11604,8 +11604,8 @@ Yves-Stan Le Cornec,Ecole Normale Superieure de Lyon,http://www.ens-lyon.fr/m-yv
 Yvo Desmedt,University of Texas at Dallas,http://www.utdallas.edu/~Yvo.Desmedt/,NOSCHOLARPAGE
 Yvonne Coady,University of Victoria,http://www.cs.uvic.ca/~ycoady/,Z4GOmPMAAAAJ
 Yvonne Dittrich,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/yvonne-dittrich(f2136570-f73c-446f-9fb0-6d9e461e2124).html,K6o-8eEAAAAJ
-Yvonne J. F. M. Jansen,DIKU,http://www.plainsite.org/profiles/lewis-brisbois-bisgaard-and-smith-llp/,NOSCHOLARPAGE
-Yvonne Jansen,DIKU,http://www.diku.dk/Ansatte/?pure=da%2Fpersons%2Fyvonne-jansen(b7d34108-fa8c-4a46-9796-c572d2b4f27b).html/,WM1ClEoAAAAJ
+Yvonne J. F. M. Jansen,University of Copenhagen,http://www.plainsite.org/profiles/lewis-brisbois-bisgaard-and-smith-llp/,NOSCHOLARPAGE
+Yvonne Jansen,University of Copenhagen,http://www.diku.dk/Ansatte/?pure=da%2Fpersons%2Fyvonne-jansen(b7d34108-fa8c-4a46-9796-c572d2b4f27b).html/,WM1ClEoAAAAJ
 Yvonne Rogers,University College London,https://uclic.ucl.ac.uk/people/yvonne-rogers/,qzcYcEAAAAAJ
 Z. Meral Özsoyoglu,Case Western Reserve University,http://engineering.case.edu/eecs/faculty-staff,QRrrUU0AAAAJ
 Zac Friggstad,University of Alberta,https://webdocs.cs.ualberta.ca/~zacharyf/,NOSCHOLARPAGE


### PR DESCRIPTION
Changing the affiliation 'DIKU' (which is a department at the University of Copenhagen) to 'University of Copenhagen' to be in line with other institution entries