### PR TITLE
Added some missing faculty from various institutions.

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -391,6 +391,7 @@ Alexander Schliep,Rutgers University,http://www.cs.rutgers.edu/~schliep/,djKBKsw
 Alexander Schwarzmann,University of Connecticut,http://www.engr.uconn.edu/~aas/,gQo0AHYAAAAJ
 Alexander Serebrenik,TU Eindhoven,http://www.win.tue.nl/~aserebre/,Mcn2e18AAAAJ
 Alexander T. Ihler,University of California - Irvine,http://www.ics.uci.edu/~ihler/,ffdt7gMAAAAJ
+Alexander Tropsha,University of North Carolina,http://cs.unc.edu/people/alexander-tropsha/,inPIy48AAAAJ
 Alexander V. Veidenbaum,University of California - Irvine,http://www.ics.uci.edu/~alexv/,NOSCHOLARPAGE
 Alexandr Andoni,Columbia University,http://datascience.columbia.edu/alex-andoni/,Evgx6UkAAAAJ
 Alexandra Boldyreva,Georgia Institute of Technology,http://www.cc.gatech.edu/~aboldyre/,8mHLyRoAAAAJ
@@ -1930,6 +1931,7 @@ Chris Martens,North Carolina State University,http://www.cs.cmu.edu/~cmartens/,J
 Chris McDonald,University of Western Australia,http://staffhome.ecm.uwa.edu.au/~00014979/,8jUAxZkAAAAJ
 Chris Mears,Monash University,http://monash.edu/research/explore/en/persons/christopher-mears(30d78dbb-d26b-406c-b477-643e80c55394).html/,Om1UNQQAAAAJ
 Chris North,Virginia Tech,http://people.cs.vt.edu/north/,qdxUOhcAAAAJ
+Chris Pal,University of Montreal,http://en.diro.umontreal.ca/department-directory/vue/pal-christopher/,1ScWJOoAAAAJ
 Chris Parnin,North Carolina State University,https://www.csc.ncsu.edu/people/cjparnin/,Guzbr0kAAAAJ
 Chris Peikert,University of Michigan,http://web.eecs.umich.edu/~cpeikert/,PiZymREAAAAJ
 Chris Preist,University of Bristol,http://www.bristol.ac.uk/eng-systems-centre/people/chris-priest.html/,rfoJfMgAAAAJ
@@ -2026,6 +2028,8 @@ Christopher Hollitt,Victoria University of Wellington,http://ecs.victoria.ac.nz/
 Christopher Homan,Rochester Institute of Technology,https://www.cs.rit.edu/~cmh/,kU6puLcAAAAJ
 Christopher J. Bishop,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Christopher_Bishop.html/,gsr-K3ADUvAC
 Christopher J. Dutchyn,University of Saskatchewan,https://www.cs.usask.ca/faculty/cjd032/,NOSCHOLARPAGE
+Christopher J. Pal,University of Montreal,http://en.diro.umontreal.ca/department-directory/vue/pal-christopher/,1ScWJOoAAAAJ
+Christopher Joseph Pal,University of Montreal,http://en.diro.umontreal.ca/department-directory/vue/pal-christopher/,1ScWJOoAAAAJ
 Christopher J. Rossbach,University of Texas at Austin,http://www.cs.utexas.edu/~rossbach/,pPSWi5EAAAAJ
 Christopher J. Taylor,University of Manchester,https://www.research.manchester.ac.uk/portal/en/researchers/christopher-taylor(f11de136-9c92-4edd-b9ac-d33b8b7a5cfb).html,-GC04gUAAAAJ
 Christopher James Langmead,Carnegie Mellon University,http://www.cs.cmu.edu/~cjl/,NOSCHOLARPAGE
@@ -2826,6 +2830,7 @@ Dilvan de Abreu Moreira,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/dilvan/,y15
 Dima Alhadidi,University of New Brunswick,http://www.cs.unb.ca/people/dalhadid,AkMtNxcAAAAJ
 Dima Damen,University of Bristol,https://www.cs.bris.ac.uk/~damen/,OxL9Wn8AAAAJ
 Dimitri Theodoratos,NJIT,https://web.njit.edu/~dth/,FxSyhSgAAAAJ
+Dimitri Van De Ville,EPFL,https://miplab.epfl.ch/,kFz4LNMAAAAJ
 Dimitrios Damopoulos,Stevens Institute of Technology,https://web.stevens.edu/facultyprofile/?id=2162,PQ8eoRMAAAAJ
 Dimitrios Gunopulos,University of Athens,http://kddlab.di.uoa.gr/dg.html/,PHJokEQAAAAJ
 Dimitrios Koutsonikolas,University at Buffalo,http://www.cse.buffalo.edu/faculty/dimitrio/,o3ol4ZcAAAAJ
@@ -2856,6 +2861,7 @@ Dinesh K. Pai,University of British Columbia,https://www.cs.ubc.ca/~pai/,ZiON80c
 Dinesh Manocha,University of North Carolina,https://www.cs.unc.edu/~dm/,X08l_4IAAAAJ
 Dinesh Mehta,Colorado School of Mines,http://www.mines.edu/~dmehta,LhsmMqoAAAAJ
 Dinesh P. Mehta,Colorado School of Mines,http://www.mines.edu/~dmehta,LhsmMqoAAAAJ
+Dinggang Shen,University of North Carolina,http://cs.unc.edu/people/dinggang-shen/,v6VYQC8AAAAJ
 Ding Ye,UNSW,http://www.cse.unsw.edu.au/~dye/,FE3a7SUAAAAJ
 Ding Yuan,University of Toronto,http://www.eecg.toronto.edu/~yuan/Home.html,g7PHxIYAAAAJ
 Ding-Zhu Du,University of Texas at Dallas,http://www.utdallas.edu/~dxd056000/,oAaMfQsAAAAJ
@@ -2963,6 +2969,7 @@ Dorian Arnold,University of New Mexico,http://www.cs.unm.edu/directory/faculty-p
 Dorian C. Arnold,University of New Mexico,http://www.cs.unm.edu/~darnold/,2jEFz5EAAAAJ
 Dorien Herremans,SUTD,http://dorienherremans.com/,Hp5W5f0AAAAJ
 Dorit Aharonov,Hebrew University of Jerusalem,http://www.cs.huji.ac.il/~doria/,hTBcSYQAAAAJ
+Dorit Merhof,RWTH Aachen,http://www.lfb.rwth-aachen.de/en/institute/team/merhof/,JH5HObAAAAAJ
 Doron A. Peled,Bar-Ilan University,http://u.cs.biu.ac.il/~doronp/,XF61SSwAAAAJ
 Doron Drusinsky,Naval Postgraduate School,http://faculty.nps.edu/ddrusins/,hkCVPIEAAAAJ
 Doron Nussbaum,Carleton University,https://carleton.ca/scs/people/doron-nussbaum/,NOSCHOLARPAGE
@@ -4256,6 +4263,7 @@ Hassan Ghasemzadeh Mohammadi,Washington State University,http://eecs.wsu.edu/~ha
 Hassan Gomaa,George Mason University,http://mason.gmu.edu/~hgomaa/,YjPRWAEAAAAJ
 Hassan Hijazi,Australian National University,https://researchers.anu.edu.au/researchers/hijazi-h?term=hassan/,QelVlY0AAAAJ
 Hassan L. Hijazi,Australian National University,https://researchers.anu.edu.au/researchers/hijazi-h/,QelVlY0AAAAJ
+Hassan Rivaz,Concordia University,https://users.encs.concordia.ca/~hrivaz/,FWDzqVUAAAAJ
 Hassan Sajjad,Qatar Computing Research Institute,http://www.qcri.org/our-people/bio?pid=99&amp;par=acc&amp;name=HassanSajjad,t3BH6NkAAAAJ
 Hatice Gunes,University of Cambridge,https://www.cl.cam.ac.uk/~hg410/,2WkE1wYAAAAJ
 Hausi A. Müller,University of Victoria,http://webhome.cs.uvic.ca/~hausi/,8hyNFkYAAAAJ
@@ -4725,6 +4733,7 @@ J. P. Misra,BITS Pilani,http://www.bits-pilani.ac.in/pilani/computerscience/Facu
 J. Paul Siebert,University of Glasgow,http://www.dcs.gla.ac.uk/~psiebert,DoEOa80AAAAJ
 J. Robin B. Cockett,University of Calgary,http://www.cpsc.ucalgary.ca/~robin/,NOSCHOLARPAGE
 J. Ross Beveridge,Colorado State University,http://www.cs.colostate.edu/~ross/,pAI5S50AAAAJ
+J. S. Marron,University of North Carolina,http://cs.unc.edu/people/steve-marron/,Ft9MrIoAAAAJ
 J. Saketha Nath,IIT Bombay,https://www.cse.iitb.ac.in/~saketh/,k70LrvsAAAAJ
 J. Scott Hawker,Rochester Institute of Technology,http://www.se.rit.edu/~hawker/,NOSCHOLARPAGE
 J. Strother Moore,University of Texas at Austin,https://www.cs.utexas.edu/users/moore/,NOSCHOLARPAGE
@@ -4891,6 +4900,7 @@ James Richard Curran,University of Sydney,http://sydney.edu.au/arts/staff/profil
 James Rowland,University of Kansas,http://www.eecs.ku.edu/people/faculty/jrowland/,7OFub-oAAAAJ
 James S. Collofello,Arizona State University,https://cidse.engineering.asu.edu/directory/collofello-james/,NOSCHOLARPAGE
 James S. Plank,University of Tennessee,http://web.eecs.utk.edu/~plank/,pH3eZOQAAAAJ
+James Stephen Marron,University of North Carolina,http://cs.unc.edu/people/steve-marron/,Ft9MrIoAAAAJ
 James Stewart,Queen’s University,http://www.cs.queensu.ca/home/jstewart/,xQXd2pEAAAAJ
 James T. Canning,University of Massachusetts Lowell,https://www.uml.edu/About/leadership/Deans/Canning-James.aspx,1V__UcAAAAAJ
 James T. Kwok,HKUST,http://www.cse.ust.hk/~jamesk/,-oTraZ4AAAAJ
@@ -5627,6 +5637,7 @@ Joshua A. Levine,University of Arizona,http://hdc.cs.arizona.edu/,eYA1nLIAAAAJ
 Joshua Clifford Bongard,University of Vermont,http://www.cs.uvm.edu/~jbongard/,Dj-kPasAAAAJ
 Joshua D. Guttman,Worcester Polytechnic Institute,http://www.cs.wpi.edu/~guttman/,UgTnZDwAAAAJ
 Joshua R. Smith,University of Washington,https://sensor.cs.washington.edu/jrs.html/,DPxLTGgAAAAJ
+Joshua T. Vogelstein,Johns Hopkins University,https://www.bme.jhu.edu/faculty_staff/joshua-t-vogelstein-phd/,DWPfdT4AAAAJ
 Joshua Tanenbaum,University of California - Irvine,http://josh.thegeekmovement.com/,rRJ9wTJMUB8C
 Josiah D. Hester,Northwestern University,http://josiahhester.com/cv/,EMYV8cEAAAAJ
 Josiah Poon,University of Sydney,http://sydney.edu.au/engineering/people/josiah.poon.php/,Q7U0O0gAAAAJ
@@ -5748,6 +5759,7 @@ Julia Zhang,Oregon State University,http://eecs.oregonstate.edu/people/zhang-jul
 Julian A. Padget,University of Bath,http://www.bath.ac.uk/comp-sci/contacts/academics/julian_padget/,4rR5aQEAAAAJ
 Julian C. Bradfield,University of Edinburgh,http://homepages.inf.ed.ac.uk/jcb/,NOSCHOLARPAGE
 Julian Fischer,IST Austria,https://ist.ac.at/research/research-groups/fischer-group/,dj3-UisAAAAJ
+Julian G. Rosenman,University of North Carolina,http://cs.unc.edu/people/julian-rosenman/,NOSCHOLARPAGE
 Julian Garcia Gallego,Monash University,http://monash.edu/research/explore/en/persons/julian-garcia-gallego(e39a16b9-83dc-494c-a652-3ef23cebd1b4).html/,NOSCHOLARPAGE
 Julian Gough,University of Bristol,http://bioinformatics.bris.ac.uk/people/julian_gough.html/,7p6iOO4AAAAJ
 Julian J. McAuley,University of California - San Diego,http://cseweb.ucsd.edu/~jmcauley/,icbo4M0AAAAJ
@@ -6029,6 +6041,7 @@ Kay C. Wiese,Simon Fraser University,https://www.sfu.ca/computing/people/faculty
 Kay Connelly,Indiana University,http://wphomes.soic.indiana.edu/connelly/,uZZ7HtIAAAAJ
 Kay H. Connelly,Indiana University,http://wphomes.soic.indiana.edu/connelly/,uZZ7HtIAAAAJ
 Kay Robbins,University of Texas at San Antonio,http://www.cs.utsa.edu/~krobbins/,g0dz7JoAAAAJ
+Kayhan N. Batmanghelich,University of Pittsburgh,https://kayhan.dbmi.pitt.edu/,PvHFAfIAAAAJ
 Kayvon Fatahalian,Carnegie Mellon University,https://www.cs.cmu.edu/~kayvonf/,ZeG4wDgAAAAJ
 Kazuyuki Aihara,University of Tokyo,https://www.iis.u-tokyo.ac.jp/en/research/staff/kazuyuki-aihara/,NOSCHOLARPAGE
 Ke Chen 0005,Zhejiang University,http://mypage.zju.edu.cn/kechenpage,NOSCHOLARPAGE
@@ -6582,6 +6595,7 @@ Linh Thi Xuan Phan,University of Pennsylvania,http://www.cis.upenn.edu/~linhphan
 Linhai Song,Pennsylvania State University,https://ist.psu.edu/directory/faculty/lus401,RVQMz2sAAAAJ
 Linmi Tao,Tsinghua University,http://www.tsinghua.edu.cn/publish/csen/4623/2010/20101224172944081935675/20101224172944081935675_.html,NOSCHOLARPAGE
 Linpeng Huang,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/en/PeopleDetail.aspx?id=166,IC620Q4AAAAJ
+Linwei Wang,Rochester Institute of Technology,https://www.rit.edu/gccis/linwei-wang,CG56DzcAAAAJ
 Linzhang Wang,Nanjing University,http://cs.nju.edu.cn/lzwang/,3BoHCW8AAAAJ
 Lionel C. Briand,University of Luxembourg,http://wwwen.uni.lu/snt/people/lionel_briand/,Zj897NoAAAAJ
 Lionel M. Ni,HKUST,https://www.cse.ust.hk/~ni/,OzMYwDIAAAAJ
@@ -7183,6 +7197,8 @@ Marti A. Hearst,University of California - Berkeley,http://people.ischool.berkel
 Martial Hebert,Carnegie Mellon University,http://www.cs.cmu.edu/~./hebert/,0ytii2EAAAAJ
 Martijn Stam,University of Bristol,http://www.bristol.ac.uk/engineering/people/martijn-stam/index.html/,2uRr5-YAAAAJ
 Martin A. Siegel,Indiana University,https://www.soic.indiana.edu/all-people/profile.html?profile_id=298/,sZ_nSuIAAAAJ
+Martin A. Styner,University of North Carolina,http://www.cs.unc.edu/~styner/,waEzpjgAAAAJ
+Martin Andreas Styner,University of North Carolina,http://www.cs.unc.edu/~styner/,waEzpjgAAAAJ
 Martin Andrews,University of Oxford,https://www.cs.ox.ac.uk/andrew.martin/,si3UgDwAAAAJ
 Martin Berzins,University of Utah,https://faculty.utah.edu/u0028351-MARTIN_BERZINS/research/index.hml/,RjxJExgAAAAJ
 Martin Bichler,TU Munich,http://dss.in.tum.de/staff/bichler.html/,gYRbZzIAAAAJ
@@ -7216,6 +7232,7 @@ Martin P. Robillard,McGill University,http://www.cs.mcgill.ca/~martin/,XlDo0wgAA
 Martin R. Gibbs,University of Melbourne,http://people.eng.unimelb.edu.au/martinrg/recent_pubs.html/,1ewxP20AAAAJ
 Martin Rinard,Massachusetts Institute of Technology,http://people.csail.mit.edu/rinard/,hxlxVEUAAAAJ
 Martin Strauss,University of Michigan,http://web.eecs.umich.edu/~martinjs/,FTv-o-UAAAAJ
+Martin Styner,University of North Carolina,http://www.cs.unc.edu/~styner/,waEzpjgAAAAJ
 Martin Swany,Indiana University,http://www.cs.indiana.edu/~swany/,NOSCHOLARPAGE
 Martin T. Vechev,ETH Zurich,http://www.srl.inf.ethz.ch/vechev.php/,aZ1Rh50AAAAJ
 Martin Tompa,University of Washington,http://www.cs.washington.edu/people/faculty/tompa/,NOSCHOLARPAGE
@@ -8094,6 +8111,8 @@ Nelson Maculan Filho,UFRJ,http://www.cos.ufrj.br/index.php/pt-BR/pessoas/details
 Nelson Max,University of California - Davis,http://faculty.engineering.ucdavis.edu/max/,XXoJ5n4AAAAJ
 Nelson Wong,University of Calgary,http://contacts.ucalgary.ca/info/cpsc/profiles/102-2540/,v71Oi_EAAAAJ
 Nelson-Antranig Baloian Tataryan,Universidad de Chile,http://www.uchile.cl/portafolio-academico/impresion.jsf?username=nbaloian,NOSCHOLARPAGE
+Nematollah Batmanghelich,University of Pittsburgh,https://kayhan.dbmi.pitt.edu/,PvHFAfIAAAAJ
+Nematollah Kayhan Batmanghelich,University of Pittsburgh,https://kayhan.dbmi.pitt.edu/,PvHFAfIAAAAJ
 Nematollaah Shiri,Concordia University,http://www.cs.concordia.ca/~shiri,_Pj5xqQAAAAJ
 Neminath Hubballi,IIT Indore,http://iiti.ac.in/people/~neminath/,tER-kV0AAAAJ
 Nenad Medvidovic,University of Southern California,http://sunset.usc.edu/~neno/,kqW_-2gAAAAJ
@@ -8851,6 +8870,7 @@ Piyush Srivastava,Tata Institute of Fundamental Research,http://www.tifr.res.in/
 Po-Ling Loh,University of Wisconsin - Madison,http://homepages.cae.wisc.edu/~loh/,NOSCHOLARPAGE
 Pokhar Mal Jat,DAIICT,http://www.daiict.ac.in/daiict/people/faculty.html,NOSCHOLARPAGE
 Polepalli Krishna Reddy,IIIT Hyderabad,http://faculty.iiit.ac.in/~pkreddy/,XIgl8kUAAAAJ
+Polina Golland,Massachusetts Institute of Technology,https://www.csail.mit.edu/person/polina-golland,eeyDrJ8AAAAJ
 Pong C. Yuen,Hong Kong Baptist University,http://www.comp.hkbu.edu.hk/~pcyuen,CwhIcHkAAAAJ
 Pong Chi Yuen,Hong Kong Baptist University,http://www.comp.hkbu.edu.hk/~pcyuen,CwhIcHkAAAAJ
 Ponnurangam Kumaraguru,IIIT Delhi,https://www.iiitd.ac.in/pk/,MfzQyP8AAAAJ


### PR DESCRIPTION
I added a few missing faculty members from various institutions. All these institutions are already part of the system. All the added faculty members should fulfill the inclusion criteria. I.e., they are either tenured or tenure-track faculty in a CS department or can supervise PhD students in the CS department. For most of the additions this is clear from the specified webpages.

The three exceptions are the following:

1) Kayhan N. Batmanghelich, University of Pittsburgh. He is an adjunct faculty in the machine learning department which is part of CS: https://www.ml.cmu.edu/people/adjunct-faculty.html

2) Joshua T. Vogelstein, Johns Hopkins University is an adjunct faculty in computer science: https://www.cs.jhu.edu/people/cs-affiliates/

3) Dimitri Van De Ville, EPFL, can advise CS PhD students as verified here: https://ic.epfl.ch/semester_projects_by_laboratory 

All the necessary aliases for DBLP were already included in dblp-aliases.csv and hence did not require any modifications.

