### PR TITLE
Updated the faculty list of the Computer Science Department at NCSU

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -1486,6 +1486,7 @@ Boudewijn P. F. Lelieveldt,TU Delft,http://visionlab.tudelft.nl/users/boudewijn-
 Boyana Norris,University of Oregon,https://ix.cs.uoregon.edu/~norris/,prJFPwUAAAAJ
 Brad A. Myers,Carnegie Mellon University,http://www.cs.cmu.edu/~bam/,E1cp_aYAAAAJ
 Brad Karp,University College London,http://www0.cs.ucl.ac.uk/staff/B.Karp/,KmXVOQkAAAAJ
+Bradley Reaves,North Carolina State University,https://bradreaves.net,0Ugq1JgAAAAJ
 Brad T. Vander Zanden,University of Tennessee,http://web.eecs.utk.edu/~bvz/,NOSCHOLARPAGE
 Bradford Gregory John Heap,UNSW,https://www.unsw.edu.au/about-us/former-members-council/,gz14Sq8AAAAJ
 Bradford Heap,UNSW,http://www.cse.unsw.edu.au/~bradfordh/,gz14Sq8AAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -4632,7 +4632,6 @@ Ingolf Krueger,University of California - San Diego,http://jacobsschool.ucsd.edu
 Ingolf Krüger,University of California - San Diego,http://jacobsschool.ucsd.edu/faculty/faculty_bios/index.sfe?fmp_recid=199/,NOSCHOLARPAGE
 Ingrid Nunes,UFRGS,http://inf.ufrgs.br/~ingridnunes,NOSCHOLARPAGE
 Ingrid Zukerman,Monash University,http://users.monash.edu/~ingrid/,DFyOHW4AAAAJ
-Injong Rhee,North Carolina State University,http://www4.ncsu.edu/~rhee/,eJ5nA0kAAAAJ
 Inna Pivkina,New Mexico State University,http://www.cs.nmsu.edu/~ipivkina/,NOSCHOLARPAGE
 Insik Shin,KAIST,http://cps.kaist.ac.kr/~ishin/,FE04Zl8AAAAJ
 Inso Kweon,KAIST,http://rcv.kaist.ac.kr/,XA8EOlEAAAAJ
@@ -5188,7 +5187,6 @@ Jessica D. Bayliss,Rochester Institute of Technology,https://www.rit.edu/gccis/i
 Jessica Hammer,Carnegie Mellon University,https://www.hcii.cmu.edu/people/jessica-hammer/,vSvRUAkAAAAJ
 Jessica K. Hodgins,Carnegie Mellon University,http://www.cs.cmu.edu/~jkh/,vswo4rQAAAAJ
 Jessica Lin 0001,George Mason University,http://cs.gmu.edu/~jessica/,tRHOWkcAAAAJ
-Jessica Staddon,North Carolina State University,https://www.csc.ncsu.edu/people/jnstaddo/,FKinAAsAAAAJ
 Jesús A. Izaguirre,University of Notre Dame,https://engineering.nd.edu/profiles/jizaguirre/,CZi62U4AAAAJ
 Jesús Labarta,Polytechnic University of Catalonia,https://www.bsc.es/labarta-mancho-jesus/,6vj6TdsAAAAJ
 Ji Liu 0002,University of Rochester,http://www.cs.rochester.edu/u/jliu/,UpbJ4CMAAAAJ
@@ -10009,10 +10007,8 @@ Sara Cordeiro Madeira,Universidade de Lisboa,http://web.tecnico.ulisboa.pt/sara.
 Sara Khalifa,UNSW,https://www.engineering.unsw.edu.au/computer-science-engineering/staff/sara-khalifa/,51qUEL4AAAAJ
 Sara Shurin,Hebrew University of Jerusalem,http://www.cs.huji.ac.il/~sara/,J2sg9BwAAAAJ
 Sarah Clinch,University of Manchester,https://www.research.manchester.ac.uk/portal/sarah.clinch.html,JBwY2kAAAAAJ
-Sarah Heckman,North Carolina State University,https://www.csc.ncsu.edu/people/sesmith5/,NOSCHOLARPAGE
 Sarah Meiklejohn,University College London,http://www0.cs.ucl.ac.uk/staff/S.Meiklejohn/,GzV9aJkAAAAJ
 Sarah Nadi,University of Alberta,https://www.ualberta.ca/science/about-us/contact-us/faculty-directory/sarah-nadi/,PxNO2g8AAAAJ
-Sarah Smith Heckman,North Carolina State University,http://www4.ncsu.edu/~sesmith5/,NOSCHOLARPAGE
 Sarah Zelikovitz,CUNY,http://www.cs.csi.cuny.edu/~zelikovi/,JJvTMLsAAAAJ
 Saranya Maneeroj,Chulalongkorn University,http://www.math.sc.chula.ac.th/en/profile/saranya.m/,NOSCHOLARPAGE
 Sargur N. Srihari,University at Buffalo,http://www.cedar.buffalo.edu/~srihari/,tC7MXlwAAAAJ
@@ -11216,7 +11212,7 @@ Timothy Wood,George Washington University,http://faculty.cs.gwu.edu/~timwood/wik
 Tin Nguyen,University of Nevada,https://www.cse.unr.edu/~tinn/,WRyPP80AAAAJ
 Tina Eliassi-Rad,Northeastern University,http://www.ccis.northeastern.edu/people/tina-eliassi-rad/,TXb5Ym8AAAAJ
 Ting Chen,University of Southern California,http://web.cmb.usc.edu/people/tingchen/,GnoD6-gAAAAJ
-Ting Yu,North Carolina State University,http://www4.ncsu.edu/~tyu/,6filNLkAAAAJ
+Ting Yu,Qatar Computing Research Institute,http://www.qcri.org.qa/our-people/bio?pid=115&name=Ting_Yu,6filNLkAAAAJ
 Ting Zhu,University of Maryland - Baltimore County,https://www.csee.umbc.edu/~zt/index.html,BXp6PIIAAAAJ
 Ting-Chuen Pong,HKUST,https://www.cse.ust.hk/faculty/tcpong/,NOSCHOLARPAGE
 Ting-Zhu Huang,University of Maryland - Baltimore County,http://www.csee.umbc.edu/~zt/,H7El-ZkAAAAJ
@@ -12007,7 +12003,7 @@ Xiaoping Zhang,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/46
 Xiaoqing Lu,Peking University,https://www.researchgate.net/profile/Xiaoqing_Lu6,NOSCHOLARPAGE
 Xiaoqiu Huang,Iowa State University,http://www.cs.iastate.edu/~xqhuang/,h5gEfxsAAAAJ
 Xiaoru Yuan,Peking University,http://vis.pku.edu.cn/xiaoruyuan.html,mJJVqRYAAAAJ
-Xiaosong Ma,North Carolina State University,http://www4.ncsu.edu/~xma/,xcs5JDIAAAAJ
+Xiaosong Ma,Qatar Computing Research Institute,http://www.qcri.org.qa/page?name=Xiaosong_Ma&a=117&pid=154&lang=en-CA,xcs5JDIAAAAJ
 Xiaotie Deng,Shanghai Jiao Tong University,https://simons.berkeley.edu/people/xiaotie-deng,OBUwP_oAAAAJ
 Xiaowei Yang,Duke University,https://users.cs.duke.edu/~xwy/,cVTdh_sAAAAJ
 Xiaowen Chu,Hong Kong Baptist University,http://www.comp.hkbu.edu.hk/~chxw,v4rX24EAAAAJ
@@ -12077,7 +12073,6 @@ Xuhua Ding,Singapore Management University,https://www.smu.edu.sg/faculty/profil
 Xukai Zou,IUPUI,http://cs.iupui.edu/~xkzou/,NOSCHOLARPAGE
 Xumin Liu,Rochester Institute of Technology,https://www.cs.rit.edu/people/faculty/xl/,2Qq9lnUAAAAJ
 Xun Jian,Virginia Tech,http://people.cs.vt.edu/xunj/profile.html,m8ihzWwAAAAJ
-Xuxian Jiang,North Carolina State University,https://www.csc.ncsu.edu/faculty/jiang/,8fHNKl4AAAAJ
 Y. C. Tay,National University of Singapore,http://www.math.nus.edu.sg/~mattyc/,qAalyGsAAAAJ
 Y. Charlie Hu,Purdue University,https://engineering.purdue.edu/~ychu/,r1Z8YhQAAAAJ
 Y. Narahari,IISc Bangalore,http://www.csa.iisc.ac.in/~hari/,NOSCHOLARPAGE


### PR DESCRIPTION
Updated the faculty list of the Computer Science Department at North Carolina State University (NCSU):

* Changed the affiliations of Xiaosong Ma and Ting Yu to Qatar
  Computing Research Institution.

* Removed the entry of Xuxian Jiang, who left NCSU and joined a startup company.

* Removed the entry of Injooong Rhee, who left NCSU and joined
  Samsung.

* Removed the entries of Sarah Heckman and Sarah Smith Heckman---which
  are actually the same person---who is a teach professor and cannot
  advise Ph.D. students.

* Removed the entry of Jessica Staddon, who left NCSU and joined
  Google.


