### PR TITLE
Updated Xiaokui Xiao

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -12255,7 +12255,7 @@ Xiaojuan Ma,HKUST,https://www.cse.ust.hk/~mxj/,TN0zm80AAAAJ
 Xiaojun Bi,Stony Brook University,https://www.cs.stonybrook.edu/people/faculty/XiaojunBi/,V9VBMa8AAAAJ
 Xiaojun Wan 0001,Peking University,http://www.icst.pku.edu.cn/lcwm/wanxj/,lTTeBdkAAAAJ
 Xiaojun Ye,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2010/20101219111626359565665/20101219111626359565665_.html,NOSCHOLARPAGE
-Xiaokui Xiao,Nanyang Technological University,http://www3.ntu.edu.sg/home/xkxiao/,BpgsGX0AAAAJ
+Xiaokui Xiao,National University of Singapore,http://www.comp.nus.edu.sg/~xiaoxk/,BpgsGX0AAAAJ
 Xiaolei Hou,Australian National University,https://cecs.anu.edu.au/people/xiaolei-hou/,Oc04rKwAAAAJ
 Xiaoli Fern,Oregon State University,http://web.engr.oregonstate.edu/~xfern/,rnDD_oEAAAAJ
 Xiaoli Li 0001,Nanyang Technological University,http://www1.i2r.a-star.edu.sg/~xlli/,CpU2wL0AAAAJ


### PR DESCRIPTION
Xiaokui Xiao, who was a faculty member at the Nanyang Technological University, joined National University of Singapore in 2018. Updated his homepage and affiliation.