### PR TITLE
Update penn faculty

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -1,4 +1,4 @@
-name , institution
+﻿name , institution
 Adam Doupé , Arizona State University
 Andréa W. Richa , Arizona State University
 Arunabha Sen , Arizona State University
@@ -2179,6 +2179,7 @@ Andreas Haeberlen , University of Pennsylvania
 Ani Nenkova , University of Pennsylvania
 Benjamin C. Pierce , University of Pennsylvania
 Boon Thau Loo , University of Pennsylvania
+Brett Hemenway , University of Pennsylvania
 Camillo J. Taylor , University of Pennsylvania
 Chris Callison-Burch , University of Pennsylvania
 Insup Lee , University of Pennsylvania
@@ -2186,6 +2187,7 @@ Jean Gallier , University of Pennsylvania
 Jean H. Gallier , University of Pennsylvania
 Jianbo Shi , University of Pennsylvania
 Joseph Devietti , University of Pennsylvania
+Konrad P. Körding , University of Pennsylvania
 Kostas Daniilidis , University of Pennsylvania
 Lyle H. Ungar , University of Pennsylvania
 Matt Blaze , University of Pennsylvania


### PR DESCRIPTION
Added secondary faculty with PhD advising privileges.

# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [ ] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [ ] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [ ] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

