### PR TITLE
Penn affiliations

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -1,4 +1,4 @@
-name,affiliation,homepage,scholarid
+﻿name,affiliation,homepage,scholarid
 A. Aldo Faisal,Imperial College London,https://www.imperial.ac.uk/people/a.faisal,WjHjbrwAAAAJ
 A. Antony Franklin,IIT Hyderabad,http://newslab.iith.ac.in/AntonyFranklin/,LVfqLuoAAAAJ
 A. C. W. Finkelstein,University College London,http://www0.cs.ucl.ac.uk/staff/a.finkelstein/,n8xuCVkAAAAJ
@@ -1572,6 +1572,7 @@ Brent Hecht,Northwestern University,http://www.brenthecht.com/,6IinLVUAAAAJ
 Brent R. Waters,University of Texas at Austin,http://www.cs.utexas.edu/~bwaters/,VEKxHOAAAAAJ
 Brent Waters,University of Texas at Austin,http://www.cs.utexas.edu/~bwaters/,VEKxHOAAAAAJ
 Bret Michael,Naval Postgraduate School,http://faculty.nps.edu/vitae/cgi-bin/vita.cgi?p=display_vita&id=1023567701/,JYxa6eYAAAAJ
+Brett Hemenway,University of Pennsylvania,http://www.cis.upenn.edu/~fbrett/,ahCv50cAAAAJ
 Brian A. Barsky,University of California - Berkeley,http://www.cs.berkeley.edu/~barsky/,
 Brian A. Malloy,Clemson University,http://www.brianmalloy.com/,NOSCHOLARPAGE
 Brian Beckage,University of Vermont,http://www.uvm.edu/~bbeckage/,NOSCHOLARPAGE
@@ -6455,6 +6456,7 @@ Koiti Hasida,University of Tokyo,http://www.i.u-tokyo.ac.jp/edu/course/ice/membe
 Kok-Ming Leung,New York University,http://engineering.nyu.edu/people/kok-ming-leung/,NOSCHOLARPAGE
 Kolin Paul,IIT Delhi,http://www.cse.iitd.ernet.in/~kolin/,6TWEO3IAAAAJ
 Konrad Iwanicki,University of Warsaw,http://www.mimuw.edu.pl/~iwanicki/,ALTjvpMAAAAJ
+Konrad P. Körding,University of Pennsylvania,http://koerding.com/,MiFqJGcAAAAJ
 Konstantin Korovin,University of Manchester,http://www.cs.manchester.ac.uk/about-us/staff/profile/?ea=Konstantin.Korovin,NCNsDlYAAAAJ
 Konstantin Makarychev,Northwestern University,http://www.mccormick.northwestern.edu/research-faculty/directory/profiles/makarychev-konstantin.html/,-E3hYj8AAAAJ
 Konstantinos Daniilidis,University of Pennsylvania,http://www.cis.upenn.edu/~kostas/,dGs2BcIAAAAJ


### PR DESCRIPTION
Adding secondary faculty with PhD advising privileges

# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [ ] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [ ] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [ ] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

