### PR TITLE
A few updates regarding Univ. Edinburgh, and UCL

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -3640,7 +3640,7 @@ Fernando Castor Filho,UFPE,http://www.cin.ufpe.br/~fjclf,c_egjh0AAAAJ
 Fernando Castor,UFPE,http://www.cin.ufpe.br/~fjclf,c_egjh0AAAAJ
 Fernando E. B. Otero,University of Kent,https://www.cs.kent.ac.uk/people/staff/febo/,pEa-vucAAAAJ
 Fernando Esteban Barril Otero,University of Kent,https://www.cs.kent.ac.uk/people/staff/febo/,pEa-vucAAAAJ
-Fernando G. S. L. Brandão,University College London,http://fernandobrandao.org/,zmDJrh0AAAAJ
+Fernando G. S. L. Brandão,California Institute of Technology,http://fernandobrandao.org/,zmDJrh0AAAAJ
 Fernando Gehm Moraes,PUC-RS,http://www.inf.pucrs.br/moraes/,XNjum_8AAAAJ
 Fernando Jiménez,University of Murcia,http://webs.um.es/fernan/miwiki/doku.php?id=english,CWgxQY8AAAAJ
 Fernando José Castor de Lima Filho,UFPE,http://www.cin.ufpe.br/~fjclf,c_egjh0AAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -4430,7 +4430,7 @@ Hazem Hiary,University of Jordan,http://www.gju.edu.jo/content/dr-hazem-kaylani-
 Hazem M. Hajj,American University of Beirut,http://feaweb.aub.edu.lb/personalwebsites/hhajj/,QidtvQgAAAAJ
 Hazem N. Nounou,Texas A&M at Qatar,https://www.qatar.tamu.edu/programs/ecen/faculty-and-staff/duplicate-of-dr.-ioannis-economou,lTlbcSUAAAAJ
 Haïdar Safa,American University of Beirut,https://www.aub.edu.lb/fas/cs/people/Pages/hs33.aspx,THYMTJMAAAAJ
-He Sun 0001,University of Bristol,http://seis.bris.ac.uk/~hs15417/,r-HWoCgAAAAJ
+He Sun 0001,University of Edinburgh,http://homepages.inf.ed.ac.uk/hsun4/,NOSCHOLARPAGE
 He Wang,Purdue University,https://www.cs.purdue.edu/homes/hw/,CL1vEJcAAAAJ
 Heather Zheng,University of Chicago,http://www.cs.ucsb.edu/~htzheng/,XrIr0nYAAAAJ
 Heba Saadeh,University of Jordan,http://eacademic.ju.edu.jo/Heba.saadeh/,ctbGyYUAAAAJ
@@ -4469,6 +4469,7 @@ Hemant Kumar Mulmudi,Australian National University,https://cecs.anu.edu.au/peop
 Hemanta K. Maji,Purdue University,https://www.cs.purdue.edu/homes/hmaji/,sCL2jBcAAAAJ
 Hemanta Kumar Maji,Purdue University,https://www.cs.purdue.edu/homes/hmaji/,sCL2jBcAAAAJ
 Hendrik Blockeel,KU Leuven,https://people.cs.kuleuven.be/~hendrik.blockeel/,Eq5sUNpp0gwC
+Heng Guo,University of Edinburgh,http://homepages.inf.ed.ac.uk/hguo/,993eudcAAAAJ
 Heng Huang,University of Pittsburgh,http://www.pitt.edu/~heh45/,JfGT-1kAAAAJ
 Heng Ji,Rensselaer Polytechnic Institute,http://nlp.cs.rpi.edu/hengji.html/,z7GCqT4AAAAJ
 Heng Tao Shen,University of Queensland,http://staff.itee.uq.edu.au/shenht/,NOSCHOLARPAGE


### PR DESCRIPTION
Heng Guo joined Univ. Edinburgh, as a lecturer.
He Sun moved from Univ. Bristol to Univ. Edinburgh, as a senior lecturer.
Fernando G.S.L. Brandão moved from UCL to Caltech.
