### PR TITLE
adding Michael Hilton at CMU

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -7825,6 +7825,7 @@ Michael Henry Albert,University of Otago,http://www.cs.otago.ac.nz/staff/michael
 Michael Herrmann,University of Edinburgh,http://www.research.ed.ac.uk/portal/en/persons/michael-herrmann(cf1b7c31-3a87-4812-bf0a-05cf49b0120e).html/,MJiOEy0AAAAJ
 Michael Hicks 0001,University of Maryland - College Park,http://www.cs.umd.edu/~mwh/,I9Vzs-4AAAAJ
 Michael Hicks,University of Maryland - College Park,http://www.cs.umd.edu/~mwh/,I9Vzs-4AAAAJ
+Michael Hilton,Carnegie Mellon University,https://www.cs.cmu.edu/~mhilton/,g4Au-T0AAAAJ
 Michael Homer,Victoria University of Wellington,https://ecs.victoria.ac.nz/Main/MichaelHomer/,ss2RKjoAAAAJ
 Michael Horsch,University of Saskatchewan,http://artsandscience.usask.ca/profile/MHorsch,NOSCHOLARPAGE
 Michael Huth,Imperial College London,http://www.doc.ic.ac.uk/~mrh/,ZBlUaIAAAAAJ


### PR DESCRIPTION
NOTE: At Carnegie Mellon, Teaching Track faculty are full time faculty members, and can advise PhD students.  

# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [ ] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [ ] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [ ] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

