### PR TITLE
update shenzhen tsinghua

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -13059,3 +13059,26 @@ Terence Soule,University of Idaho,http://www.uidaho.edu/engr/departments/cs/our-
 Min Xian,University of Idaho,http://www.uidaho.edu/engr/our-people/min-xian,NOSCHOLARPAGE
 Changshui Zhang,Tsinghua University,http://bigeye.au.tsinghua.edu.cn/english/Introduction.html,GL9M37YAAAAJ
 Xiaoyun Wang,Tsinghua University,http://www.tsinghua.edu.cn/publish/casen/1695/2010/20101224093253705266640/20101224093253705266640_.html,5pUP56sAAAAJ
+Qingmin Liao,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/szen/113/2011/20110110105023518139832/20110110105023518139832_.html,NOSCHOLARPAGE
+Shu-Tao Xia,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/szen/113/2011/20110107140252657484321/20110107140252657484321_.html,koAXTXgAAAAJ
+Xin Jin 0002,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/szen/113/2012/20120425165610024876921/20120425165610024876921_.html,NOSCHOLARPAGE
+Houde Liu,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/szen/113/2017/20170417151709946425020/20170417151709946425020_.html,NOSCHOLARPAGE
+Zhiyong Wu,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/szen/113/2011/20110107141540008446966/20110107141540008446966_.html,7Xl6KdkAAAAJ
+Xiu Li,Tsinghua University,http://www.tsinghua.edu.cn/publish/csen/4623/2010/20101224001632440223805/20101224001632440223805_.html,Xrh1OIUAAAAJ
+Lu Fang,Tsinghua University,http://www.luvision.net/,C1YeBLMAAAAJ
+Qi Li,Tsinghua University,http://ics.netlab.edu.cn/~qli/,NOSCHOLARPAGE
+Haoqian Wang,Tsinghua University,http://medialab.sz.tsinghua.edu.cn/people/HaoqianWang.html,NOSCHOLARPAGE
+Wenming Yang,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/szen/113/2017/20170417151802065765700/20170417151802065765700_.html,NOSCHOLARPAGE
+Chun Yuan,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/szen/113/2010/20101217151348647267126/20101217151348647267126_.html,NOSCHOLARPAGE
+Zhi Wang 0001,Tsinghua University,http://media.cs.tsinghua.edu.cn/~wangzhi,PK8BtpwAAAAJ
+Yong Jiang 0001,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/sz/139/2010/20101218141241447905144/20101218141241447905144_.html,NOSCHOLARPAGE
+Xingjun Wang,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/sz/139/2010/20101218140507157809423/20101218140507157809423_.html,NOSCHOLARPAGE
+Zhenhua Guo,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/sz/139/2012/20120420104947649501973/20120420104947649501973_.html,dbR6bD0AAAAJ
+Weifeng Li,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/sz/139/2012/20121023155658163353790/20121023155658163353790_.html,NOSCHOLARPAGE
+Yongbing Zhang,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/sz/139/2013/20130712170817703523468/20130712170817703523468_.html,0KlvTEYAAAAJ
+Bo Yuan,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/sz/139/2011/20110407103542448480685/20110407103542448480685_.html,FMiooBoAAAAJ&hl=zh-CN
+Yujiu Yang,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/sz/139/2011/20110407110432867305723/20110407110432867305723_.html,NOSCHOLARPAGE
+Xueqian Wang,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/sz/139/2014/20140318152802581307699/20140318152802581307699_.html,NOSCHOLARPAGE
+Xingzheng Wang,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/sz/139/2017/20171117101631213775717/20171117101631213775717_.html,-2_P9-QAAAAJ
+Zongqing Lu,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/sz/139/2013/20130417105142051500706/20130417105142051500706_.html,NOSCHOLARPAGE
+Wenhuang Liu,Tsinghua University,http://www.sz.tsinghua.edu.cn/publish/sz/139/2010/20101218140701952724178/20101218140701952724178_.html,NOSCHOLARPAGE


### PR DESCRIPTION
The Graduate School at Shenzhen, Tsinghua University, was jointly founded by Tsinghua University and the Shenzhen Municipal Government in 2010. This school is directly affiliated with Tsinghua University in Beijing and the faculty members are affiliated with different departments of Tsinghua University as well. The major functionality of this school is providing a high-level research platform to train PhD students as well as Master students.

In this pull request, we collect the faculty members affiliated with the graduate school at Shenzhen, Tsinghua university who can supervise CS PhD students.

[Overview of the graduate school at Shenzhen, Tsinghua University](http://www.tsinghua.edu.cn/publish/szen/5033/index.html)