### PR TITLE
added new faculty to Binghamton

### DIFF
--- a/faculty-affiliations.csv
+++ b/faculty-affiliations.csv
@@ -429,9 +429,12 @@ Michael J. Lewis , Binghamton University
 Mo Sha 0001 , Binghamton University
 Patrick H. Madden , Binghamton University
 Ping Yang 0002 , Binghamton University
+Seunghee Shin , Binghamton University
+Shiqi Zhang , Binghamton University
 Timothy N. Miller , Binghamton University
 Weiyi Meng , Binghamton University
 Weiying Dai , Binghamton University
+Xi Peng 0005 , Binghamton University
 Yan Wang 0003 , Binghamton University
 Yao Liu 0001 , Binghamton University
 Yifan Zhang 0002 , Binghamton University


### PR DESCRIPTION
# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [ ] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [ ] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [ ] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

