### PR TITLE
Added some missing Cornell faculty that can advise CIS PhD students

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -13272,3 +13272,27 @@ Alex Mihailidis,University of Toronto,http://www.iatsl.org/people/amihailidis.ht
 Alan M. Moses,University of Toronto,http://www.moseslab.csb.utoronto.ca/,o5gmOHMAAAAJ
 John Thangarajah,RMIT University,http://john.agentprojects.com/,bGu9cEsAAAAJ
 Farhana Murtaza Choudhury,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/c/choudhury-dr-farhana,8hh5de8AAAAJ
+John M. Abowd,Cornell University,https://blogs.cornell.edu/abowd/,u0pd464AAAAJ
+Solon Barocas,Cornell University,http://solon.barocas.org/,rEjgIskAAAAJ
+Natalya N. Bazarova,Cornell University,https://sml.comm.cornell.edu/,g_ayYI0AAAAJ
+Lawrence E. Blume,Cornell University,http://tuvalu.santafe.edu/~leb/,EPQuuHMAAAAJ
+Morten H. Christiansen,Cornell University,http://cnl.psych.cornell.edu/people.html,_0jbd88AAAAJ
+David Easley,Cornell University,https://easley.economics.cornell.edu/,ZKeyKNgAAAAJ
+Susan R. Fussell,Cornell University,http://sfussell.hci.cornell.edu/index.shtml,QpG20J0AAAAJ
+Geri Gay,Cornell University,http://infosci.cornell.edu/faculty/geri-gay,uJ4q1wcAAAAJ
+Paul Ginsparg,Cornell University,http://www.infosci.cornell.edu/faculty/paul-ginsparg,NONE
+Haym Hirsh,Cornell University,http://www.infosci.cornell.edu/forward-thinking-people/field-faculty/haym-hirsh,NONE
+Guy Hoffman,Cornell University,http://guyhoffman.com/,ZocLOAMAAAAJ
+Lee Humphreys,Cornell University,http://blogs.cornell.edu/humphreys/,waote-8AAAAJ
+Steven J. Jackson,Cornell University,https://sjackson.infosci.cornell.edu/,KRLB84YAAAAJ
+Wendy Ju,Cornell University,http://www.wendyju.com/,kjYhZYwAAAAJ
+Gilly Leshed,Cornell University,http://leshed.infosci.cornell.edu/,DDbtd6AAAAAJ
+Karen Levy,Cornell University,http://www.karen-levy.net/,lNM0S1kAAAAJ
+Michael W. Macy,Cornell University,https://sites.google.com/site/michaelmacy14/home,7OW6weoAAAAJ
+Drew Margolin,Cornell University,http://blogs.cornell.edu/margolin/,iQPFZ_sAAAAJ
+Mats Rooth,Cornell University,http://conf.ling.cornell.edu/mr249/,jjr9RaUAAAAJ
+Jeffrey M. Rzeszotarski,Cornell University,http://jeffrz.com/,W3hgmHoAAAAJ
+Andrea Stevenson Won,Cornell University,https://communication.cals.cornell.edu/people/andrea-won,Z8rD3GcAAAAJ
+Stephen B. Wicker,Cornell University,http://wisl.ece.cornell.edu/wicker/,HbFGylgAAAAJ
+Y. Connie Yuan,Cornell University,http://connieyuan.comm.cornell.edu/,CQtD1LgAAAAJ
+Malte Ziewitz,Cornell University,http://zwtz.org/,bVVMm9UAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -13280,8 +13280,8 @@ Morten H. Christiansen,Cornell University,http://cnl.psych.cornell.edu/people.ht
 David Easley,Cornell University,https://easley.economics.cornell.edu/,ZKeyKNgAAAAJ
 Susan R. Fussell,Cornell University,http://sfussell.hci.cornell.edu/index.shtml,QpG20J0AAAAJ
 Geri Gay,Cornell University,http://infosci.cornell.edu/faculty/geri-gay,uJ4q1wcAAAAJ
-Paul Ginsparg,Cornell University,http://www.infosci.cornell.edu/faculty/paul-ginsparg,NONE
-Haym Hirsh,Cornell University,http://www.infosci.cornell.edu/forward-thinking-people/field-faculty/haym-hirsh,NONE
+Paul Ginsparg,Cornell University,http://www.infosci.cornell.edu/faculty/paul-ginsparg,NOSCHOLARPAGE
+Haym Hirsh,Cornell University,http://www.infosci.cornell.edu/forward-thinking-people/field-faculty/haym-hirsh,NOSCHOLARPAGE
 Guy Hoffman,Cornell University,http://guyhoffman.com/,ZocLOAMAAAAJ
 Lee Humphreys,Cornell University,http://blogs.cornell.edu/humphreys/,waote-8AAAAJ
 Steven J. Jackson,Cornell University,https://sjackson.infosci.cornell.edu/,KRLB84YAAAAJ


### PR DESCRIPTION
# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

