### PR TITLE
Add Adam M. Smith from UC Santa Cruz

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -111,6 +111,7 @@ Adam Klivans,University of Texas at Austin,https://www.cs.utexas.edu/~klivans/,N
 Adam Krzyzak,Concordia University,http://users.encs.concordia.ca/~krzyzak/,fYbg3F8AAAAJ
 Adam Lopez,University of Edinburgh,http://alopez.github.io/,u4sxKZwAAAAJ
 Adam M. Bates,Univ. of Illinois at Urbana-Champaign,http://adambates.org/,IIKFMKoAAAAJ
+Adam M. Smith,University of California - Santa Cruz,https://adamsmith.as/,78OLNd4AAAAJ
 Adam Morrison 0001,Tel Aviv University,http://www.cs.tau.ac.il/~mad/,GMEoZR0AAAAJ
 Adam O'Neill,Georgetown University,http://people.cs.georgetown.edu/~adam/,SIFRrBIAAAAJ
 Adam R. Klivans,University of Texas at Austin,https://www.cs.utexas.edu/~klivans/,NOSCHOLARPAGE


### PR DESCRIPTION
I'm in the department of Computational Media, but, yes, I can be the sole advisor of CS PhD students.