### PR TITLE
Added "NAACL-HLT" as alias to NAACL

### DIFF
--- a/util/csrankings.py
+++ b/util/csrankings.py
@@ -93,7 +93,7 @@ areadict = {
     'ir': ['WWW', 'SIGIR'],
     # SIGCHI
     'chi': ['CHI', 'UbiComp', 'Ubicomp', 'UIST'],
-    'nlp': ['EMNLP', 'ACL', 'ACL (1)', 'ACL (2)', 'NAACL', 'HLT-NAACL',
+    'nlp': ['EMNLP', 'ACL', 'ACL (1)', 'ACL (2)', 'NAACL', 'HLT-NAACL', 'NAACL-HLT',
             'ACL/IJCNLP',  # -- in 2009 was joint
             'COLING-ACL',  # -- in 1998 was joint
             'EMNLP-CoNLL',  # -- in 2012 was joint

--- a/util/regenerate-data.py
+++ b/util/regenerate-data.py
@@ -112,7 +112,7 @@ areadict = {
     'chiconf' : ['CHI'],
     'ubicomp' : ['UbiComp', 'Ubicomp', 'IMWUT', 'Pervasive'],
     'uist' : ['UIST'],
-#    'nlp': ['EMNLP', 'ACL', 'ACL (1)', 'ACL (2)', 'NAACL', 'HLT-NAACL',
+#    'nlp': ['EMNLP', 'ACL', 'ACL (1)', 'ACL (2)', 'NAACL', 'HLT-NAACL', 'NAACL-HLT',
 #            'ACL/IJCNLP',  # -- in 2009 was joint
 #            'COLING-ACL',  # -- in 1998 was joint
 #            'EMNLP-CoNLL',  # -- in 2012 was joint
@@ -120,7 +120,7 @@ areadict = {
 #            ],
     'emnlp': ['EMNLP', 'EMNLP-CoNLL', 'HLT/EMNLP'],
     'acl' : ['ACL', 'ACL (1)', 'ACL (2)', 'ACL/IJCNLP', 'COLING-ACL'],
-    'naacl' : ['NAACL', 'HLT-NAACL'],
+    'naacl' : ['NAACL', 'HLT-NAACL', 'NAACL-HLT'],
 #    'vision': ['CVPR', 'CVPR (1)', 'CVPR (2)', 'ICCV', 'ECCV', 'ECCV (1)', 'ECCV (2)', 'ECCV (3)', 'ECCV (4)', 'ECCV (5)', 'ECCV (6)', 'ECCV (7)'],
     'cvpr': ['CVPR', 'CVPR (1)', 'CVPR (2)'],
     'iccv': ['ICCV'],

--- a/venues.csv
+++ b/venues.csv
@@ -72,6 +72,7 @@ area,canonical,alternate,default
 "nlp","ACL","ACL (2)",True
 "nlp","NAACL","NAACL",True
 "nlp","NAACL","HLT-NAACL",True
+"nlp","NAACL","NAACL-HLT",True
 "nlp","ACL","ACL/IJCNLP",True
 "nlp","ACL","COLING-ACL",True
 "nlp","EMNLP","EMNLP-CoNLL",True


### PR DESCRIPTION
In 2018, NAACL is listed in dblp as "NAACL-HLT":
http://dblp.uni-trier.de/search?q=NAACL-HLT%20venue%3ANAACL-HLT%3A

This adds an alias to catch this.