### PR TITLE
add new faculty

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -13299,3 +13299,6 @@ Zhisheng Yan,Georgia State University,https://grid.cs.gsu.edu/~zyan/,i6ePuTMAAAA
 Alex Zelikovsky,Georgia State University,http://cs.gsu.edu/profile/alex-zelikovsky/,UzCRNJwAAAAJ
 Yanqing Zhang,Georgia State University,https://grid.cs.gsu.edu/zhang/,NOSCHOLARPAGE
 Ying Zhu,Georgia State University,https://sites.google.com/site/yingzhugsu/,sz_Z3igAAAAJ
+Zhenhui Li,Pennsylvania State University,https://faculty.ist.psu.edu/jessieli/,r0nnyGYAAAAJ
+Weinan Zhang,Shanghai Jiaotong University,http://wnzhang.net,Qzss0GEAAAAJ
+Chao Li,Shanghai Jiaotong University,http://www.cs.sjtu.edu.cn/~lichao/,Yy-wQg4AAAAJ


### PR DESCRIPTION
# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [ ] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [ ] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

=======================

3 new faculties added in the end of the `csrankings.csv`. 

Zhenhui Li,Pennsylvania State University
Weinan Zhang,Shanghai Jiaotong University
Chao Li,Shanghai Jiaotong University