### PR TITLE
Faculty Update for University of Edinburgh

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -11844,6 +11844,7 @@ Timothy J. Hickey,Brandeis University,http://www.cs.brandeis.edu/~tim/,APFVA6sAA
 Timothy L. Andersen,Boise State University,http://cs.boisestate.edu/~tim/,mTErwxgAAAAJ
 Timothy Lethbridge,University of Ottawa,http://www.site.uottawa.ca/~tcl/,PQ9tLbUAAAAJ
 Timothy M. Chan,Univ. of Illinois at Urbana-Champaign,http://tmc.web.engr.illinois.edu/,NOSCHOLARPAGE
+Timothy M. Hospedales,University of Edinburgh,http://homepages.inf.ed.ac.uk/thospeda/,nHhtvqkAAAAJ
 Timothy M. Jones,University of Cambridge,http://www.cl.cam.ac.uk/~tmj32/,XpbRPyIAAAAJ
 Timothy N. Miller,Binghamton University,http://www.cs.binghamton.edu/~millerti/,NgEPEgEAAAAJ
 Timothy Ravasi,KAUST,https://www.kaust.edu.sa/en/study/faculty/timothy-ravasi,UR9EUP8AAAAJ


### PR DESCRIPTION
# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [ ] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

