### PR TITLE
update Daniel Lee's affiliation

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -2498,7 +2498,7 @@ Daniel Cohen-Or,Tel Aviv University,http://www.cs.tau.ac.il/~dcor/,fAxws1sAAAAJ
 Daniel Conte de Leon,University of Idaho,http://www.uidaho.edu/engr/departments/cs/our-people/faculty/conte-de-leon,aLH-yuoAAAAJ
 Daniel Costinett,University of Tennessee,https://www.eecs.utk.edu/people/faculty/dcostine/,7c5zd_4AAAAJ
 Daniel Cremers,TU Munich,http://vision.in.tum.de/members/cremers/,cXQciMEAAAAJ
-Daniel D. Lee,University of Pennsylvania,http://www.seas.upenn.edu/~ddlee/,-oS9Tm8AAAAJ
+Daniel D. Lee,Cornell University,http://www.seas.upenn.edu/~ddlee/,-oS9Tm8AAAAJ
 Daniel D. Suthers,University of Hawaii at Manoa,http://www2.hawaii.edu/~suthers/,8rEj1jIAAAAJ
 Daniel Deutch,Tel Aviv University,https://www.cs.tau.ac.il/~danielde/,KvIYIokAAAAJ
 Daniel Dominic Kaplan Sleator,Carnegie Mellon University,http://www.cs.cmu.edu/~sleator/,NOSCHOLARPAGE


### PR DESCRIPTION
Updated Daniel Lee's affiliation from UPenn to Cornell: https://tech.cornell.edu/news/two-distinguished-professors-join-cornell-tech-faculty/