### PR TITLE
New faculty@concordia

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -13304,4 +13304,4 @@ Zhenhui Li,Pennsylvania State University,https://faculty.ist.psu.edu/jessieli/,r
 Weinan Zhang,Shanghai Jiaotong University,http://wnzhang.net,Qzss0GEAAAAJ
 Chao Li,Shanghai Jiaotong University,http://www.cs.sjtu.edu.cn/~lichao/,Yy-wQg4AAAAJ
 Wensheng Dou,Chinese Academy of Sciences,http://www.tcse.cn/~wsdou/,NYHyagEAAAAJ
-Jinqiu Yang, Concordia University,https://ece.uwaterloo.ca/~j223yang/,DpY9rhEAAAAJ
+Jinqiu Yang,Concordia University,https://ece.uwaterloo.ca/~j223yang/,DpY9rhEAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -13304,3 +13304,4 @@ Zhenhui Li,Pennsylvania State University,https://faculty.ist.psu.edu/jessieli/,r
 Weinan Zhang,Shanghai Jiaotong University,http://wnzhang.net,Qzss0GEAAAAJ
 Chao Li,Shanghai Jiaotong University,http://www.cs.sjtu.edu.cn/~lichao/,Yy-wQg4AAAAJ
 Wensheng Dou,Chinese Academy of Sciences,http://www.tcse.cn/~wsdou/,NYHyagEAAAAJ
+Jinqiu Yang, Concordia University,https://ece.uwaterloo.ca/~j223yang/,DpY9rhEAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -13304,4 +13304,4 @@ Zhenhui Li,Pennsylvania State University,https://faculty.ist.psu.edu/jessieli/,r
 Weinan Zhang,Shanghai Jiaotong University,http://wnzhang.net,Qzss0GEAAAAJ
 Chao Li,Shanghai Jiaotong University,http://www.cs.sjtu.edu.cn/~lichao/,Yy-wQg4AAAAJ
 Wensheng Dou,Chinese Academy of Sciences,http://www.tcse.cn/~wsdou/,NYHyagEAAAAJ
-Jinqiu Yang,Concordia University,https://ece.uwaterloo.ca/~j223yang/,DpY9rhEAAAAJ
+Jinqiu Yang,Concordia University,https://ece.uwaterloo.ca/~j223yang,DpY9rhEAAAAJ


### PR DESCRIPTION
Adding a new faculty member at Concordia University.

**Inclusion criteria**

- [X] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [X] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.
