### PR TITLE
Add "NAACL-HLT (2)" as alias for NAACL

### DIFF
--- a/filter.xq
+++ b/filter.xq
@@ -11,6 +11,7 @@
 //inproceedings[booktitle="ACL (2)"],
 //inproceedings[booktitle="NAACL"],
 //inproceedings[booktitle="NAACL-HLT"],
+//inproceedings[booktitle="NAACL-HLT (2)"],
 //inproceedings[booktitle="HLT-NAACL"],
 //inproceedings[booktitle="ACL/IJCNLP"],
 //inproceedings[booktitle="COLING-ACL"],

--- a/util/csrankings.py
+++ b/util/csrankings.py
@@ -93,7 +93,7 @@ areadict = {
     'ir': ['WWW', 'SIGIR'],
     # SIGCHI
     'chi': ['CHI', 'UbiComp', 'Ubicomp', 'UIST'],
-    'nlp': ['EMNLP', 'ACL', 'ACL (1)', 'ACL (2)', 'NAACL', 'HLT-NAACL', 'NAACL-HLT',
+    'nlp': ['EMNLP', 'ACL', 'ACL (1)', 'ACL (2)', 'NAACL', 'HLT-NAACL', 'NAACL-HLT', 'NAACL-HLT (2)',
             'ACL/IJCNLP',  # -- in 2009 was joint
             'COLING-ACL',  # -- in 1998 was joint
             'EMNLP-CoNLL',  # -- in 2012 was joint

--- a/util/regenerate-data.py
+++ b/util/regenerate-data.py
@@ -112,7 +112,7 @@ areadict = {
     'chiconf' : ['CHI'],
     'ubicomp' : ['UbiComp', 'Ubicomp', 'IMWUT', 'Pervasive'],
     'uist' : ['UIST'],
-#    'nlp': ['EMNLP', 'ACL', 'ACL (1)', 'ACL (2)', 'NAACL', 'HLT-NAACL', 'NAACL-HLT',
+#    'nlp': ['EMNLP', 'ACL', 'ACL (1)', 'ACL (2)', 'NAACL', 'HLT-NAACL', 'NAACL-HLT', 'NAACL-HLT (2)',
 #            'ACL/IJCNLP',  # -- in 2009 was joint
 #            'COLING-ACL',  # -- in 1998 was joint
 #            'EMNLP-CoNLL',  # -- in 2012 was joint
@@ -120,7 +120,7 @@ areadict = {
 #            ],
     'emnlp': ['EMNLP', 'EMNLP-CoNLL', 'HLT/EMNLP'],
     'acl' : ['ACL', 'ACL (1)', 'ACL (2)', 'ACL/IJCNLP', 'COLING-ACL'],
-    'naacl' : ['NAACL', 'HLT-NAACL', 'NAACL-HLT'],
+    'naacl' : ['NAACL', 'HLT-NAACL', 'NAACL-HLT', 'NAACL-HLT (2)'],
 #    'vision': ['CVPR', 'CVPR (1)', 'CVPR (2)', 'ICCV', 'ECCV', 'ECCV (1)', 'ECCV (2)', 'ECCV (3)', 'ECCV (4)', 'ECCV (5)', 'ECCV (6)', 'ECCV (7)'],
     'cvpr': ['CVPR', 'CVPR (1)', 'CVPR (2)'],
     'iccv': ['ICCV'],

--- a/venues.csv
+++ b/venues.csv
@@ -73,6 +73,7 @@ area,canonical,alternate,default
 "nlp","NAACL","NAACL",True
 "nlp","NAACL","HLT-NAACL",True
 "nlp","NAACL","NAACL-HLT",True
+"nlp","NAACL","NAACL-HLT (2)",True
 "nlp","ACL","ACL/IJCNLP",True
 "nlp","ACL","COLING-ACL",True
 "nlp","EMNLP","EMNLP-CoNLL",True


### PR DESCRIPTION
NAACL 2018 has another alias, "NAACL-HLT (2)". See [its dblp link](https://dblp.uni-trier.de/db/conf/naacl/naacl2018-2.html). This is the issue for short papers. Since this name is not recorded, it is not counted in [current CSRankings](http://csrankings.org/#/fromyear/2017/toyear/2018/index?none).

This commit add the name "NAACL-HLT (2)" to all the places mentioning the aliases, to keep the consistency. Though I think only the change in utils/regenerate-data.py would be in effect.

Another side note: although paper published in NAACL-HLT (2) is not counted in NAACL entry, it is mistakenly counted in ACL. I think this might be due to a partial string matching of "ACL".

Examples of DBLP entries of professors who published NAACL-HLT (2) in 2018:
- https://dblp.uni-trier.de/pers/hd/b/Bao:Forrest_Sheng
- https://dblp.uni-trier.de/pers/hd/s/Salakhutdinov:Ruslan
