### PR TITLE
typo in Ahmet Erdem Sariyuce's name

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -194,7 +194,7 @@ Ahmed Karmouch,University of Ottawa,http://www.site.uottawa.ca/~karmouch,kQpPzdg
 Ahmed M. Elgammal,Rutgers University,http://www.cs.rutgers.edu/~elgammal/Home.html,DxQiCiIAAAAJ
 Ahmed Sameh,Purdue University,https://www.cs.purdue.edu/people/sameh,tk2gySEAAAAJ
 Ahmet Burak Can,Hacettepe University,https://web.cs.hacettepe.edu.tr/~abc,NOSCHOLARPAGE
-Ahmet Erdem Sariyuce,University at Buffalo,http://sariyuce.com,sK4Ck6gAAAAJ
+Ahmet Erdem Sariyüce,University at Buffalo,http://sariyuce.com,sK4Ck6gAAAAJ
 Ahti Peder,University of Tartu,http://www.ut.ee/en/ahti-peder,NOSCHOLARPAGE
 Ai-Chun Pang,National Taiwan University,https://www.csie.ntu.edu.tw/~acpang,NOSCHOLARPAGE
 Aidan Hogan,Universidad de Chile,http://aidanhogan.com,CP-fgY4AAAAJ


### PR DESCRIPTION
To get the correct DBLP link.