### PR TITLE
Added new GMU CS professor Eric Osterweil

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -3562,6 +3562,7 @@ Eric Mercer,Brigham Young University,https://cs.byu.edu/faculty/egm,FbUhdYYAAAAJ
 Eric Mjolsness,University of California - Irvine,http://emj.ics.uci.edu,tqF2ld4AAAAJ
 Eric Neufeld,University of Saskatchewan,https://www.cs.usask.ca/faculty/eric,mEQZrhcAAAAJ
 Eric Nyberg,Carnegie Mellon University,http://www.cs.cmu.edu/~ehn,G6XN5cRm0FIJ
+Eric Osterweil,George Mason University,https://cs.gmu.edu/directory/,Jw1ccPYAAAAJ
 Eric P. Xing,Carnegie Mellon University,http://www.cs.cmu.edu/~epxing,5pKTRxEAAAAJ
 Eric Patterson,Clemson University,https://people.cs.clemson.edu/~ekp,Avto8CcAAAAJ
 Eric Paulos,University of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/paulos.html,K__JmtcAAAAJ


### PR DESCRIPTION
Added new GMU CS professor Eric Osterweil.