### PR TITLE
Added colleagues at University of Copenhagen + additional alias for ACL

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -1593,6 +1593,7 @@ Bogdan Warinschi,University of Bristol,http://www.bris.ac.uk/engineering/people/
 Bohyung Han,POSTECH,http://cvlab.postech.ac.kr/~bhhan,9aaeCToAAAAJ
 Boi Faltings,EPFL,http://liawww.epfl.ch/~faltings,X21nbgcAAAAJ
 Boleslaw K. Szymanski,Rensselaer Polytechnic Institute,http://www.cs.rpi.edu/~szymansk,2OJOZTUAAAAJ
+Bolette Sanford Pedersen,University of Copenhagen,https://nors.ku.dk/english/staff/?pure=en/persons/134967,NOSCHOLARPAGE
 Bolong Zeng,Washington State University,https://school.eecs.wsu.edu/people/faculty/bolong-zeng,kp0baVYAAAAJ
 Bon K. Sy,CUNY,https://www.gc.cuny.edu/Page-Elements/Academics-Research-Centers-Initiatives/Doctoral-Programs/Computer-Science/Faculty-Bios/Bon-K-Sy,GLjNiI4AAAAJ
 Bonnie A. Nardi,University of California - Irvine,http://www.artifex.org/~bonnie,hwc6A1MAAAAJ
@@ -9336,6 +9337,7 @@ Patrick W. Dymond,York University,http://eecs.lassonde.yorku.ca/faculty/patrick-
 Patrick Yin Chiang,Oregon State University,http://eecs.oregonstate.edu/people/chiang-patrick,4nYbZ0YAAAAJ
 Patrick van der Smagt,TU Munich,https://brml.org/people/smagt,5ybzvbsAAAAJ
 Patrik Haslum,Australian National University,https://cs.anu.edu.au/people/patrik-haslum,XqbCCJIAAAAJ
+Patrizia Paggio,University of Copenhagen,https://cst.ku.dk/english/ansatte/?pure=en/persons/7206,gSqyTW8AAAAJ
 Pattarasinee Bhattarakosol,Chulalongkorn University,http://www.math.sc.chula.ac.th/en/profile/pattarasinee.b,WeFVkqAAAAAJ
 Paul A. Fishwick,University of Texas at Dallas,http://www.utdallas.edu/atec/fishwick,NOSCHOLARPAGE
 Paul Amer,University of Delaware,https://www.eecis.udel.edu/~amer,CNjiRFQAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -3020,6 +3020,7 @@ Derick Wood,HKUST,https://www.cse.ust.hk/derickwood,KVpdzBkAAAAJ
 Desh Ranjan,Old Dominion University,http://odu.edu/directory/people/d/dranjan,NOSCHOLARPAGE
 Desheng Zhang,Rutgers University,https://www.cs.rutgers.edu/~dz220,cyEM2BoAAAAJ
 Deshun Yang,Peking University,http://www.icst.pku.edu.cn/audioLab/researchgroup.htm,NOSCHOLARPAGE
+Desmond Elliott,University of Copenhagen,https://elliottd.github.io/,OjYpMi4AAAAJ
 Despina Michael,Cyprus University of Technology,https://www.cut.ac.cy/faculties/aac/mga/staff/elected-staff/despina.michael/?languageId=1,mPuIqtAAAAA
 Deuk Heo,Washington State University,https://school.eecs.wsu.edu/people/faculty/deuk-heo,NOSCHOLARPAGE
 Deva Ramanan,Carnegie Mellon University,http://www.cs.cmu.edu/~deva,9B8PoXUAAAAJ

--- a/venues.csv
+++ b/venues.csv
@@ -70,6 +70,7 @@ area,canonical,alternate,default
 "nlp","ACL","ACL",True
 "nlp","ACL","ACL (1)",True
 "nlp","ACL","ACL (2)",True
+"nlp","ACL","ACL (4)",True
 "nlp","NAACL","NAACL",True
 "nlp","NAACL","HLT-NAACL",True
 "nlp","NAACL","NAACL-HLT",True


### PR DESCRIPTION
- Added Desmond Elliott as new faculty member at the University of Copenhagen from September 2018 (see https://di.ku.dk/english/research/imagesection/nlp/)
- Added another alias for ACL
- Added Bolette Sanford Pedersen and Patrizia Paggio from the Centre for Language Technology, University of Copenhagen