### PR TITLE
Update faculty affiliation of Indiana University

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -3826,7 +3826,7 @@ Feng Gu,CUNY,http://www.cs.csi.cuny.edu/~gu,6JuoIAUAAAAJ
 Feng Liu,University of Queensland,http://researchers.uq.edu.au/researcher/951,NOSCHOLARPAGE
 Feng Lu 0005,Beihang University,http://shi.buaa.edu.cn/lufeng,NOSCHOLARPAGE
 Feng Luo,Clemson University,https://people.cs.clemson.edu/~luofeng,joROlFwAAAAJ
-Feng Qian 0001,Indiana University,https://www.cs.indiana.edu/~fengqian,NOSCHOLARPAGE
+Feng Qian 0001,University of Minnesota,https://www-users.cs.umn.edu/~fengqian/,NOSCHOLARPAGE
 Feng Qin,Ohio State University,http://web.cse.ohio-state.edu/~qin,kTh5nIIAAAAJ
 Feng Xu 0005,Tsinghua University,http://cgcad.thss.tsinghua.edu.cn/xufeng,OqNQnTkAAAAJ
 Feng Yan 0001,University of Nevada,http://www.unr.edu/cse/people/faculty/yan,Qdn7MgUAAAAJ
@@ -13817,3 +13817,7 @@ Zygmunt J. Haas,University of Texas at Dallas,http://www.utdallas.edu/~zjh130030
 Özgür Simsek,University of Bath,https://www.mpib-berlin.mpg.de/en/staff/oezguer-simsek,z1BYZG0AAAAJ
 Öznur Özkasap,Koç University,http://home.ku.edu.tr/~oozkasap,v2WiJeIAAAAJ
 Ümit V. Çatalyürek,Georgia Institute of Technology,https://www.cc.gatech.edu/~umit,OLDMURQAAAAJ
+Shuang Wang 0002,Indiana University,http://www.shuangwang.org/,GnDGqKQAAAAJ
+Volker Brendel,Indiana University,http://brendelgroup.org/,w9oekBcAAAAJ
+Matthew W. Hahn,Indiana University,https://www.informatics.indiana.edu/dalkilic/,ShySYTIAAAAJ
+Michael A. McRobbie,Indiana University,https://www.sice.indiana.edu/all-people/profile.html?profile_id=254,NOSCHOLARPAGE


### PR DESCRIPTION
# Contributing to CSrankings
* Prof. Feng Qian moved to University of Minnesota
* Add Prof. Shuang Wang, Prof. Volker Brendel, Prof. Matthew W. Hahn, Prof. Michael A. McRobbie

**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [x] If the institution you are adding is not in the US,
update `country-info.csv`.

