### PR TITLE
New Rutgers CS faculty – Fall 2018

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -28,6 +28,7 @@ Aamena Alshamsi,Masdar Institute,https://www.masdar.ac.ae/aboutus/management/fac
 Aamir Cheema,Monash University,http://www.aamircheema.com,chWbG70AAAAJ
 Aanjhan Ranganathan,Northeastern University,https://www.aanjhan.com,Jid_EAkAAAAJ
 Aaram Yun,UNIST,http://aaramyun.unist.ac.kr,NOSCHOLARPAGE
+Aaron Bernstein,Rutgers University,http://bernsteinaaron.com/,NOSCHOLARPAGE
 Aaron Bobick,Washington University in St. Louis,https://www.cc.gatech.edu/~afb,rynvwScAAAAJ
 Aaron C. Courville,University of Montreal,https://aaroncourville.wordpress.com,km6CP8cAAAAJ
 Aaron Clauset,University of Colorado Boulder,https://www.colorado.edu/cs/users/aacl0007,e7VI_HcAAAAJ
@@ -11569,6 +11570,7 @@ Srini Srinivasan,University College London,http://www0.cs.ucl.ac.uk/people/S.Sri
 Srinivas Aluru,Georgia Institute of Technology,http://www.cc.gatech.edu/~saluru,YOGOScoAAAAJ
 Srinivas Devadas,Massachusetts Institute of Technology,https://people.csail.mit.edu/devadas,NOSCHOLARPAGE
 Srinivas Katkoori,University of South Florida,http://vcapp.cse.usf.edu/~katkoori,LBBlksAAAAAJ
+Srinivas Narayana,Rutgers University,https://www.cs.rutgers.edu/faculty/srinivas-narayana,SIoEl8oAAAAJ
 Srinivas Sampalli,Dalhousie University,https://web.cs.dal.ca/~srini,NOSCHOLARPAGE
 Srinivasa G. Narasimhan,Carnegie Mellon University,http://www.cs.cmu.edu/~srinivas,MhYrLJAAAAAJ
 Srinivasan Keshav,University of Waterloo,http://blizzard.cs.uwaterloo.ca/keshav,NOSCHOLARPAGE
@@ -11900,6 +11902,7 @@ Sunghee Choi,KAIST,http://gclab.kaist.ac.kr/sunghee.html,JX6jaiUAAAAJ
 Sungho Jo,KAIST,http://isnl.kaist.ac.kr,NOSCHOLARPAGE
 Sunghoon Ivan Lee,University of Massachusetts Amherst,http://www.sunghoonivanlee.com,NOSCHOLARPAGE
 Sunghun Kim 0001,HKUST,https://www.cse.ust.hk/~hunkim,dQM6NLgAAAAJ
+Sungjin Ahn,Rutgers University,http://www.sungjinahn.com/,nfHyDeUAAAAJ
 Sungwon Kang,KAIST,https://cs.kaist.ac.kr/people/view?idx=368&kind=faculty&menu=167,agu-mFoAAAAJ
 Sungwoo Park,POSTECH,http://pl.postech.ac.kr/~gla,Y91RynEAAAAJ
 Sunil Arya,HKUST,https://www.cse.ust.hk/~arya,Azu2w_MAAAAJ


### PR DESCRIPTION
This PR adds new CS faculty members that started at Rutgers University in Fall 2018.
