### PR TITLE
Fix homepage links of Masaryk University faculty

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -100,7 +100,7 @@ Abtin Rahimian,University of Colorado Boulder,http://home.cs.colorado.edu/~abra3
 Abusayeed Saifullah,Wayne State University,http://www.cs.wayne.edu/saifullah,CYwffSUAAAAJ
 Abyayananda Maiti,IIT Patna,https://iitp.ac.in/index.php/departments/computer-center/people/head/1095-dr-abyayananda-maiti.html,N49XT94AAAAJ
 Achille Pattavina,Politecnico di Milano,http://home.deib.polimi.it/pattavina,NOSCHOLARPAGE
-Achim Blumensath,Masaryk University,https://www.muni.cz/lide/237782,NOSCHOLARPAGE
+Achim Blumensath,Masaryk University,https://www.muni.cz/en/people/237782,NOSCHOLARPAGE
 Achutavarrier Prasad Vinod,Nanyang Technological University,http://www.ntu.edu.sg/home/asvinod,NOSCHOLARPAGE
 Ada Gavrilovska,Georgia Institute of Technology,http://www.cc.gatech.edu/home/ada,OlRjTCIAAAAJ
 Ada Wai-Chee Fu,Chinese University of Hong Kong,http://www.cse.cuhk.edu.hk/~adafu,tcwyqtUAAAAJ
@@ -336,7 +336,7 @@ Aleksandar Nikolov,University of Toronto,http://www.cs.toronto.edu/~anikolov,glV
 Aleksander Madry,Massachusetts Institute of Technology,https://people.csail.mit.edu/madry,SupjsEUAAAAJ
 Aleksandra Korolova,University of Southern California,http://informatics.usc.edu/people/aleksandra-korolova.htm,oK_XUmsAAAAJ
 Aleksy Schubert,University of Warsaw,http://www.mimuw.edu.pl/~alx,0vbRwBQAAAAJ
-Ales Horák,Masaryk University,https://www.muni.cz/lide/1648,lBJuYA8AAAAJ
+Ales Horák,Masaryk University,https://www.muni.cz/en/people/1648,lBJuYA8AAAAJ
 Alessandra Cavarra,University of Oxford,http://www.cs.ox.ac.uk/people/alessandra.cavarra,NOSCHOLARPAGE
 Alessandra Gorla,IMDEA Software Institute,http://software.imdea.org/~alessandra.gorla,6uUwTrwAAAAJ
 Alessandra Russo,Imperial College London,http://www.imperial.ac.uk/people/a.russo,_6zceo4AAAAJ
@@ -1049,7 +1049,7 @@ Antonis M. Paschalis,University of Athens,http://www.di.uoa.gr/eng/staff/999,q8L
 Antoniu Pop,University of Manchester,https://www.research.manchester.ac.uk/portal/antoniu.pop.html,A2aGvWcAAAAJ
 Antony Hosking,Australian National University,https://cecs.anu.edu.au/people/tony-hosking,NOSCHOLARPAGE
 Antony L. Hosking,Australian National University,https://cs.anu.edu.au/people/tony-hosking,NOSCHOLARPAGE
-Antonín Kucera,Masaryk University,https://www.muni.cz/lide/2508,HxIvytQAAAAJ
+Antonín Kucera,Masaryk University,https://www.muni.cz/en/people/2508,HxIvytQAAAAJ
 Antti Oulasvirta,Aalto University,http://users.comnet.aalto.fi/oulasvir,_z41TLwAAAAJ
 Antti Ylä-Jääski,Aalto University,http://cse.aalto.fi/en/personnel/antti-yla-jaaski,ojkArgn5IlAC
 António Grilo,Universidade de Lisboa,http://www.demi.fct.unl.pt/en/pessoas/docentes/antonio-carlos-barbara-grilo,G6nldpYAAAAJ
@@ -1326,9 +1326,9 @@ Barbara Pernici,Politecnico di Milano,http://home.deib.polimi.it/pernici,r-f9TQE
 Barbara Plank,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/barbara-plank(f073ebac-704d-4236-9206-d1d2ef2be9c3).html,5nGlwIQAAAAJ
 Barbara Poblete,Universidad de Chile,https://www.dcc.uchile.cl/barbara_poblete,eZBFWGEAAAAJ
 Barbara Webb,University of Edinburgh,http://homepages.inf.ed.ac.uk/bwebb,k9T3V7EAAAAJ
-Barbora Buhnova,Masaryk University,https://www.muni.cz/lide/39394,3J7jHK4AAAAJ
-Barbora Kozlíková,Masaryk University,https://www.muni.cz/lide/60850,0hMZracAAAAJ
-Barbora Zimmerova,Masaryk University,https://www.muni.cz/lide/39394,3J7jHK4AAAAJ
+Barbora Buhnova,Masaryk University,https://www.muni.cz/en/people/39394,3J7jHK4AAAAJ
+Barbora Kozlíková,Masaryk University,https://www.muni.cz/en/people/60850,0hMZracAAAAJ
+Barbora Zimmerova,Masaryk University,https://www.muni.cz/en/people/39394,3J7jHK4AAAAJ
 Baris Akgun,Koç University,https://mysite.ku.edu.tr/baakgun,5sL0xZ4AAAAJ
 Baris Akgün,Koç University,https://mysite.ku.edu.tr/baakgun,5sL0xZ4AAAAJ
 Baris Kasikci,University of Michigan,http://www.bariskasikci.org,y5J0h7gAAAAJ
@@ -2642,8 +2642,8 @@ Daniel Jorge Viegas Gonçalves,Universidade de Lisboa,https://fenix.tecnico.ulis
 Daniel Jurafsky,Stanford University,http://web.stanford.edu/~jurafsky,uZg9l58AAAAJ
 Daniel Kifer,Pennsylvania State University,http://www.cse.psu.edu/~duk17,7PQN6r4AAAAJ
 Daniel Kroening,University of Oxford,https://www.cs.ox.ac.uk/people/daniel.kroening,DHddutUAAAAJ
-Daniel Král,Masaryk University,https://www.muni.cz/lide/44742,crv1hRwAAAAJ
-Daniel Král',Masaryk University,https://www.muni.cz/lide/44742,crv1hRwAAAAJ
+Daniel Král,Masaryk University,https://www.muni.cz/en/people/44742,crv1hRwAAAAJ
+Daniel Král',Masaryk University,https://www.muni.cz/en/people/44742,crv1hRwAAAAJ
 Daniel Kröning,University of Oxford,https://www.cs.ox.ac.uk/people/daniel.kroening,DHddutUAAAAJ
 Daniel L. Chester,University of Delaware,https://www.eecis.udel.edu/~chester,f1rXXY8AAAAJ
 Daniel L. Pimentel-Alarcón,Georgia State University,https://danielpimentel.github.io/index.html,NOSCHOLARPAGE
@@ -2924,7 +2924,7 @@ David Schwartz,Rochester Institute of Technology,http://igm.rit.edu/~dis,Aob433g
 David Scott,Northern Arizona University,https://nau.edu/siccs/faculty/david-scott,vgRGifIAAAAJ
 David Scuse,University of Manitoba,http://www.cs.umanitoba.ca/~scuse,jeiSmwYAAAAJ
 David Shmoys,Cornell University,https://people.orie.cornell.edu/shmoys,rD8a4hQAAAAJ
-David Smahel,Masaryk University,https://www.muni.cz/lide/3068,LKs73BQAAAAJ
+David Smahel,Masaryk University,https://www.muni.cz/en/people/3068,LKs73BQAAAAJ
 David Sontag,Massachusetts Institute of Technology,http://cs.nyu.edu/~dsontag,LfcroyAAAAAJ
 David Squire,Monash University,https://www.researchgate.net/profile/David_Squire,NOSCHOLARPAGE
 David Starobinski,Boston University,http://people.bu.edu/staro,C0ddY2kAAAAJ
@@ -2933,7 +2933,7 @@ David Stotts,University of North Carolina,http://www.cs.unc.edu/~stotts,NOSCHOLA
 David Streader,Victoria University of Wellington,https://ecs.victoria.ac.nz/Main/DavidStreader,NOSCHOLARPAGE
 David Sturgill,North Carolina State University,https://www.csc.ncsu.edu/people/dbsturgi,NOSCHOLARPAGE
 David Suter,University of Adelaide,https://cs.adelaide.edu.au/~dsuter,moJRxjoAAAAJ
-David Svoboda,Masaryk University,https://www.muni.cz/lide/2824,NOSCHOLARPAGE
+David Svoboda,Masaryk University,https://www.muni.cz/en/people/2824,NOSCHOLARPAGE
 David T. Blaauw,University of Michigan,http://web.eecs.umich.edu/faculty/blaauw,P3JdmqAAAAAJ
 David Taniar,Monash University,http://users.monash.edu/~dtaniar,M1acg20AAAAJ
 David Toman,University of Waterloo,https://cs.uwaterloo.ca/~david,cCoKzk8AAAAJ
@@ -3707,7 +3707,7 @@ Eusebius J. Doedel,Concordia University,http://cmvl.cs.concordia.ca/doedel.html,
 Eva Benkova,IST Austria,https://ist.ac.at/research/research-groups/benkova-group,NOSCHOLARPAGE
 Eva Darulova,Max Planck Institute,http://www.mpi-sws.org/~eva,GrC1RcEAAAAJ
 Eva Heinrich,Massey University,http://www.massey.ac.nz/massey/learning/colleges/college-of-sciences/staff-profile.cfm?stref=474230,yYMCSSwAAAAJ
-Eva Hladká,Masaryk University,https://www.muni.cz/lide/2053,8cg5zgYAAAAJ
+Eva Hladká,Masaryk University,https://www.muni.cz/en/people/2053,8cg5zgYAAAAJ
 Eva M. Navarro-Lopez,University of Manchester,http://www.cs.man.ac.uk/~navarroe,1IDSDUwAAAAJ
 Eva Marín-Tordera,Polytechnic University of Catalonia,https://craax.upc.edu/eva,NOSCHOLARPAGE
 Eva Rodriguez,Polytechnic University of Catalonia,http://www.crcsi.com.au/about/our-people/eva-rodriguez-rodriguez,6-ZbUAoAAAAJ
@@ -3917,7 +3917,7 @@ Flávio Rech Wagner,UFRGS,http://www.inf.ufrgs.br/~flavio,NOSCHOLARPAGE
 Flávio de Oliveira Silva,UFU,http://www.facom.ufu.br/~flavio,SW_VMq4AAAAJ
 Forrest Sheng Bao,Iowa State University,https://www.cs.iastate.edu/people/forrest-sheng-bao,XWpFf0IAAAAJ
 Foteini Baldimtsi,George Mason University,http://www.baldimtsi.com,Wrx-9LUAAAAJ
-Fotis Liarokapis,Masaryk University,https://www.muni.cz/lide/235197,snY7XXkAAAAJ
+Fotis Liarokapis,Masaryk University,https://www.muni.cz/en/people/235197,snY7XXkAAAAJ
 Fow-Sen Choa,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/people/faculty/fow-sen-choa,NOSCHOLARPAGE
 Frada Burstein,Monash University,http://www.sims.monash.edu.au/staff/fb,h2soBioAAAAJ
 Fragkiskos Papadopoulos,Cyprus University of Technology,https://www.cut.ac.cy/faculties/fet/eecei/staff/f.papadopoulos/?languageId=1,ib8q0gUAAAAJ
@@ -4599,7 +4599,7 @@ Han Yu,Nanyang Technological University,https://sites.google.com/site/hanyushome
 Han la Poutré,CWI,http://homepages.cwi.nl/~hlp,NOSCHOLARPAGE
 Han-Wei Shen,Ohio State University,http://web.cse.ohio-state.edu/~hwshen,95Z6-isAAAAJ
 Hana Abdullah Al-Nuaim,King Abdulaziz University,http://hnuaim.kau.edu.sa/Default.aspx?Site_ID=0002344&lng=EN,NOSCHOLARPAGE
-Hana Rudová,Masaryk University,https://www.muni.cz/lide/3840,wuykjtQAAAAJ
+Hana Rudová,Masaryk University,https://www.muni.cz/en/people/3840,wuykjtQAAAAJ
 Hanan Lutfi Lutfiyya,Western University,http://www.csd.uwo.ca/faculty/hanan,NOSCHOLARPAGE
 Hanan Lutfiyya,Western University,http://www.csd.uwo.ca/faculty/hanan,NOSCHOLARPAGE
 Hanan Samet,University of Maryland - College Park,https://www.cs.umd.edu/people/hjs,ATOfqHEAAAAJ
@@ -5187,8 +5187,8 @@ Ivan Laptev,Ecole Normale Superieure,https://www.di.ens.fr/~laptev,-9ifK0cAAAAJ
 Ivan Martinovic,University of Oxford,https://www.cs.ox.ac.uk/people/ivan.martinovic,CDK6C2cAAAAJ
 Ivan Titov,University of Edinburgh,http://ivan-titov.org,FKUc3vsAAAAJ
 Ivan Visconti,University of Salerno,http://docenti.unisa.it/004312/home,QEairGEAAAAJ
-Ivana Cerna,Masaryk University,https://www.muni.cz/lide/1419,ktCv0pkAAAAJ
-Ivana Cerná,Masaryk University,https://www.muni.cz/lide/1419,ktCv0pkAAAAJ
+Ivana Cerna,Masaryk University,https://www.muni.cz/en/people/1419,ktCv0pkAAAAJ
+Ivana Cerná,Masaryk University,https://www.muni.cz/en/people/1419,ktCv0pkAAAAJ
 Ivana Drobnjak,University College London,http://www0.cs.ucl.ac.uk/people/I.Drobnjak.html,55BI2VIICu8C
 Ivano Malavolta,VU Amsterdam,http://www.ivanomalavolta.com,ya3htIoAAAAJ
 Ivo F. Sbalzarini,TU Dresden,http://mosaic.mpi-cbg.de/?q=people/ivo_sbalzarini,KPdbUktu0hkC
@@ -5426,7 +5426,7 @@ Jamie Callan,Carnegie Mellon University,http://www.cs.cmu.edu/~callan,Un5KXJ4AAA
 Jamie Payton,Temple University,https://cis.temple.edu/~payton,dIbeva0AAAAJ
 Jan Allebach,Purdue University,https://engineering.purdue.edu/ECE/People/ptProfile?resource_id=3043,NOSCHOLARPAGE
 Jan Bender,RWTH Aachen,https://www.animation.rwth-aachen.de,POEoFagAAAAJ
-Jan Bouda,Masaryk University,https://www.muni.cz/lide/3717,To23LQMAAAAJ
+Jan Bouda,Masaryk University,https://www.muni.cz/en/people/3717,To23LQMAAAAJ
 Jan C. A. van der Lubbe,TU Delft,http://cybersecurity.tudelft.nl/users/jan-van-der-lubbe,NOSCHOLARPAGE
 Jan C. van Gemert,TU Delft,http://visionlab.tudelft.nl/users/jan-van-gemert,JUdMRGcAAAAJ
 Jan Carlo Barca,Monash University,http://monash.edu/research/explore/en/persons/jan-barca(b809a264-a966-4c49-b3b3-1425a47f97ee).html,bZQ0r6YAAAAJ
@@ -5442,7 +5442,7 @@ Jan M. Rabaey,University of California - Berkeley,https://www2.eecs.berkeley.edu
 Jan Maas,IST Austria,https://ist.ac.at/research/research-groups/maas-group,Cm3vCpUAAAAJ
 Jan Madey,University of Warsaw,http://www.eunis.org/organization/jan-madey-bio,NOSCHOLARPAGE
 Jan O. Borchers,RWTH Aachen,https://hci.rwth-aachen.de/borchers,BN5-ACgAAAAJ
-Jan Obdrzálek,Masaryk University,https://www.muni.cz/lide/1552,x9S-uaAAAAAJ
+Jan Obdrzálek,Masaryk University,https://www.muni.cz/en/people/1552,x9S-uaAAAAAJ
 Jan Oliver Borchers,RWTH Aachen,https://hci.rwth-aachen.de/borchers,BN5-ACgAAAAJ
 Jan Otop,University of Wroclaw,http://popl16.sigplan.org/profile/janotop,EueQHIgAAAAJ
 Jan P. H. van Santen,OHSU,http://cslu.ohsu.edu/~vansanten,NOSCHOLARPAGE
@@ -5455,7 +5455,7 @@ Jan Rutten,CWI,https://www.cwi.nl/people/127,NOSCHOLARPAGE
 Jan S. Rellermeyer,TU Delft,https://www.tudelft.nl/en/staff/j.s.rellermeyer,hnCSi8gAAAAJ
 Jan Schröder,University of Melbourne,https://www.findanexpert.unimelb.edu.au/display/person304961,EoQ2NZsAAAAJ
 Jan Stelovsky,University of Hawaii at Manoa,http://www2.hawaii.edu/~janst,NOSCHOLARPAGE
-Jan Strejcek,Masaryk University,https://www.muni.cz/lide/3366,2Bdz-iAAAAAJ
+Jan Strejcek,Masaryk University,https://www.muni.cz/en/people/3366,2Bdz-iAAAAAJ
 Jan Treur,VU Amsterdam,http://www.cs.vu.nl/~treur,2NzjnkYAAAAJ
 Jan Vitek,Northeastern University,http://janvitek.org,Ws0GjboAAAAJ
 Jan van Eijck,CWI,http://homepages.cwi.nl/~jve,ptYHch4AAAAJ
@@ -5896,11 +5896,11 @@ Jinyang Li 0001,New York University,http://www.cs.nyu.edu/~jinyang,MrWIWNwAAAAJ
 Jinyuan Stella Sun,University of Tennessee,http://web.eecs.utk.edu/~jysun,gqGfIIsAAAAJ
 Jinyuan Sun,University of Tennessee,http://web.eecs.utk.edu/~jysun,gqGfIIsAAAAJ
 Jinze Liu,University of Kentucky,http://www.netlab.uky.edu/u/liuj/home,NOSCHOLARPAGE
-Jiri Barnat,Masaryk University,https://www.muni.cz/lide/3496,Z9ZkOdcAAAAJ
+Jiri Barnat,Masaryk University,https://www.muni.cz/en/people/3496,Z9ZkOdcAAAAJ
 Jiri Friml,IST Austria,https://ist.ac.at/research/research-groups/friml-group,NOSCHOLARPAGE
-Jiri Sochor,Masaryk University,https://www.muni.cz/lide/2446,kd3m5-4AAAAJ
-Jirí Sochor,Masaryk University,https://www.muni.cz/lide/2446,kd3m5-4AAAAJ
-Jirí Zlatuska,Masaryk University,https://www.muni.cz/lide/1777,NOSCHOLARPAGE
+Jiri Sochor,Masaryk University,https://www.muni.cz/en/people/2446,kd3m5-4AAAAJ
+Jirí Sochor,Masaryk University,https://www.muni.cz/en/people/2446,kd3m5-4AAAAJ
+Jirí Zlatuska,Masaryk University,https://www.muni.cz/en/people/1777,NOSCHOLARPAGE
 Jishen Zhao,University of California - San Diego,https://users.soe.ucsc.edu/~jzhao,MtkNrygAAAAJ
 Jitender S. Deogun,University of Nebraska,http://cse.unl.edu/~deogun,QpLZdfoAAAAJ
 Jiwu Shu,Tsinghua University,http://storage.cs.tsinghua.edu.cn/~jiwu-shu,VccUDSgAAAAJ
@@ -6282,7 +6282,7 @@ Joyce Y. Chai,Michigan State University,http://www.cse.msu.edu/~jchai,NOSCHOLARP
 Joyce Yue Chai,Michigan State University,http://www.cse.msu.edu/~jchai,NOSCHOLARPAGE
 Joydeep Biswas,University of Massachusetts Amherst,https://www.cics.umass.edu/person/biswas-joydeep,f28F1YUAAAAJ
 Joydeep Chandra,IIT Patna,https://iitp.ac.in/index.php/departments/computer-center/people/head/705-dr-joydeep-chandra.html,_MaLUpIAAAAJ
-Jozef Gruska,Masaryk University,https://www.muni.cz/lide/3026,NOSCHOLARPAGE
+Jozef Gruska,Masaryk University,https://www.muni.cz/en/people/3026,NOSCHOLARPAGE
 Jozsef Csicsvari,IST Austria,https://ist.ac.at/research/research-groups/csicsvari-group,NOSCHOLARPAGE
 João Batista Neto,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/jbatista,NOSCHOLARPAGE
 João Comba,UFRGS,http://www.inf.ufrgs.br/~comba,NOSCHOLARPAGE
@@ -6594,7 +6594,7 @@ Kaoru Sezaki,University of Tokyo,https://www.k.u-tokyo.ac.jp/pros-e/person/kaoru
 Kapil Ahuja,IIT Indore,http://www.iiti.ac.in/~kahuja,l2ySGVcAAAAJ
 Karan Singh,University of Toronto,http://www.dgp.toronto.edu/~karan,hy6wONIAAAAJ
 Kareem Darwish,Qatar Computing Research Institute,http://www.qcri.org/our-people/bio?pid=23&amp;par=acc&amp;name=KareemDarwish,y7tlR6UAAAAJ
-Karel Pala,Masaryk University,https://www.muni.cz/lide/455,BMgQNWMAAAAJ
+Karel Pala,Masaryk University,https://www.muni.cz/en/people/455,BMgQNWMAAAAJ
 Karem A. Sakallah,University of Michigan,http://web.eecs.umich.edu/~karem,M441iZ8AAAAJ
 Karen Daniels,University of Massachusetts Lowell,http://www.cs.uml.edu/~kdaniels,NOSCHOLARPAGE
 Karen E. Petrie,University of Dundee,https://www.computing.dundee.ac.uk/about/staff/23,pJB7cjoAAAAJ
@@ -7389,9 +7389,9 @@ Lu Zhang 0023,Peking University,http://sei.pku.edu.cn/~zhanglu,JUnz2VcAAAAJ
 Luay Nakhleh,Rice University,https://www.cs.rice.edu/~nakhleh,46HLWf8AAAAJ
 Lubomir Bic,University of California - Irvine,http://www.ics.uci.edu/~bic,NOSCHOLARPAGE
 Lubomir F. Bic,University of California - Irvine,http://www.ics.uci.edu/~bic,NOSCHOLARPAGE
-Lubomír Popelínský,Masaryk University,https://www.muni.cz/lide/1945,NOSCHOLARPAGE
-Lubos Brim,Masaryk University,https://www.muni.cz/lide/197,-EvkffIAAAAJ
-Lubos Popelínský,Masaryk University,https://www.muni.cz/lide/1945,NOSCHOLARPAGE
+Lubomír Popelínský,Masaryk University,https://www.muni.cz/en/people/1945,NOSCHOLARPAGE
+Lubos Brim,Masaryk University,https://www.muni.cz/en/people/197,-EvkffIAAAAJ
+Lubos Popelínský,Masaryk University,https://www.muni.cz/en/people/1945,NOSCHOLARPAGE
 Luc Berthouze,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/201607,WvYeh5IAAAAJ
 Luc De Raedt,KU Leuven,https://people.cs.kuleuven.be/~luc.deraedt,dgobB6AAAAAJ
 Luc Devroye,McGill University,http://luc.devroye.org,DC_7koIAAAAJ
@@ -7422,7 +7422,7 @@ Luciano Paschoal Gaspary,UFRGS,http://www.inf.ufrgs.br/~paschoal,SnT7z5wAAAAJ
 Lucinéia Heloisa Thom,UFRGS,http://inf.ufrgs.br/~lucineia,MTLCh6oAAAAJ
 Lucinéia Thom,UFRGS,http://inf.ufrgs.br/~lucineia,MTLCh6oAAAAJ
 Lucio Mauro Duarte,UFRGS,http://inf.ufrgs.br/~lmduarte,NOSCHOLARPAGE
-Ludek Matyska,Masaryk University,https://www.muni.cz/lide/1904,XA85OFQAAAAJ
+Ludek Matyska,Masaryk University,https://www.muni.cz/en/people/1904,XA85OFQAAAAJ
 Lui Sha,Univ. of Illinois at Urbana-Champaign,https://cs.illinois.edu/directory/profile/lrs,SlXqNooAAAAJ
 Luidi Gelabert Simonetti,UFRJ,http://www.cos.ufrj.br/~luidi,xOugM_4AAAAJ
 Luidi Simonetti,UFRJ,http://www.cos.ufrj.br/~luidi,xOugM_4AAAAJ
@@ -8444,9 +8444,9 @@ Michael Wybrow,Monash University,http://monash.edu/research/explore/en/persons/m
 Michael Yacci,Rochester Institute of Technology,https://www.rit.edu/gccis/michael-yacci,NOSCHOLARPAGE
 Michael Zapp,University of Manitoba,http://cs.umanitoba.ca/people,pN2BYuIAAAAJ
 Michael Zink,University of Massachusetts Amherst,http://www.ecs.umass.edu/ece/zink,iVck6WIAAAAJ
-Michal Brandejs,Masaryk University,https://www.muni.cz/lide/2116,NOSCHOLARPAGE
+Michal Brandejs,Masaryk University,https://www.muni.cz/en/people/2116,NOSCHOLARPAGE
 Michal Feldman,Tel Aviv University,https://www.cs.tau.ac.il/~mfeldman,IKjIhTwAAAAJ
-Michal Kozubek,Masaryk University,https://www.muni.cz/lide/3740,y-Vc8W4AAAAJ
+Michal Kozubek,Masaryk University,https://www.muni.cz/en/people/3740,y-Vc8W4AAAAJ
 Michal Pilipczuk,University of Warsaw,http://www.mimuw.edu.pl/~mp248287,RPD8Up0AAAAJ
 Michal Skrzypczak,University of Warsaw,http://www.mimuw.edu.pl/~mskrzypczak,StdzCQUAAAAJ
 Michal Young,University of Oregon,http://ix.cs.uoregon.edu/~michal,7LTGov4AAAAJ
@@ -8697,7 +8697,7 @@ Moi-Tin Chew,Massey University,https://www.massey.ac.nz/massey/learning/colleges
 Moira C. Norrie,ETH Zurich,https://globis.ethz.ch/person/moira-c-norrie,NOSCHOLARPAGE
 Moisés Piedade,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist11049,NOSCHOLARPAGE
 Moisés Simões Piedade,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist11049,NOSCHOLARPAGE
-Mojmír Kretínský,Masaryk University,https://www.muni.cz/lide/631,CcXNE7YAAAAJ
+Mojmír Kretínský,Masaryk University,https://www.muni.cz/en/people/631,CcXNE7YAAAAJ
 Mokhtar Aboelaze,York University,http://www.cs.yorku.ca/~aboelaze,NOSCHOLARPAGE
 Momotaz Begum,University of New Hampshire,http://www.cs.unh.edu/~mbegum,YP9KtBQAAAAJ
 Mona Singh,Princeton University,https://www.cs.princeton.edu/~mona,JpAehzgAAAAJ
@@ -9526,11 +9526,11 @@ Paulo S. L. Souza,USP-ICMC,http://icmc.usp.br/pessoas?id=3258655,epwMhL4AAAAJ
 Paulo Sergio Lopes de Souza,USP-ICMC,http://icmc.usp.br/pessoas?id=3258655,epwMhL4AAAAJ
 Paulo Veríssimo,University of Luxembourg,http://wwwen.uni.lu/snt/people/paulo_esteves_verissimo,aMHx8aUAAAAJ
 Pavel A. Pevzner,University of California - San Diego,http://cseweb.ucsd.edu/~ppevzner,0fq5QeIAAAAJ
-Pavel Celeda,Masaryk University,https://www.muni.cz/lide/206086,19TG5q8AAAAJ
-Pavel Matula,Masaryk University,https://www.muni.cz/lide/2927,NOSCHOLARPAGE
-Pavel Rychlý,Masaryk University,https://www.muni.cz/lide/3692,AQJK5pMAAAAJ
+Pavel Celeda,Masaryk University,https://www.muni.cz/en/people/206086,19TG5q8AAAAJ
+Pavel Matula,Masaryk University,https://www.muni.cz/en/people/2927,NOSCHOLARPAGE
+Pavel Rychlý,Masaryk University,https://www.muni.cz/en/people/3692,AQJK5pMAAAAJ
 Pavel Skums,Georgia State University,http://alan.cs.gsu.edu/compbel,h5ZxsFAAAAAJ
-Pavel Zezula,Masaryk University,https://www.muni.cz/lide/47485,EHIdRAYAAAAJ
+Pavel Zezula,Masaryk University,https://www.muni.cz/en/people/47485,EHIdRAYAAAAJ
 Pavithra Prabhakar,Kansas State University,http://people.cs.ksu.edu/~pprabhakar/home.html,og6bNK0qJtkC
 Pavol Cerný,University of Colorado Boulder,http://ecee.colorado.edu/pavol,FQm9ZGgAAAAJ
 Pavol Federl,University of Calgary,http://contacts.ucalgary.ca/info/cpsc/profiles/102-12711,euyKfgUAAAAJ
@@ -9696,10 +9696,10 @@ Peter Y. A. Ryan,University of Luxembourg,http://wwwen.uni.lu/snt/research/apsia
 Peter Z. Revesz,University of Nebraska,http://cse.unl.edu/~revesz,dDwXNpYAAAAJ
 Peter van Beek,University of Waterloo,https://cs.uwaterloo.ca/~vanbeek,MP_l6fsAAAAJ
 Peter-Michael Seidel,University of Hawaii at Manoa,http://www.asecolab.org/people/pseidel,NOSCHOLARPAGE
-Petr Hlinený,Masaryk University,https://www.muni.cz/lide/168881,6gR2tBkAAAAJ
-Petr Holub,Masaryk University,https://www.muni.cz/lide/3248,NOSCHOLARPAGE
-Petr Matula,Masaryk University,https://www.muni.cz/lide/3019,_J1EjksAAAAJ
-Petr Sojka,Masaryk University,https://www.muni.cz/lide/2378,9piza88AAAAJ
+Petr Hlinený,Masaryk University,https://www.muni.cz/en/people/168881,6gR2tBkAAAAJ
+Petr Holub,Masaryk University,https://www.muni.cz/en/people/3248,NOSCHOLARPAGE
+Petr Matula,Masaryk University,https://www.muni.cz/en/people/3019,_J1EjksAAAAJ
+Petr Sojka,Masaryk University,https://www.muni.cz/en/people/2378,9piza88AAAAJ
 Petra Berenbrink,Simon Fraser University,http://www.cs.sfu.ca/~petra,NOSCHOLARPAGE
 Petri Vuorimaa,Aalto University,https://people.aalto.fi/petri_vuorimaa,Bcg93pAAAAAJ
 Petros Drineas,Purdue University,http://www.drineas.org,Yw2PquQAAAAJ
@@ -9986,7 +9986,7 @@ Rada Chirkova,North Carolina State University,https://www.csc.ncsu.edu/people/ry
 Rada Flavia Mihalcea,University of Michigan,https://web.eecs.umich.edu/~mihalcea,UetM7FgAAAAJ
 Rada Mihalcea,University of Michigan,https://web.eecs.umich.edu/~mihalcea,UetM7FgAAAAJ
 Rade Kutil,University of Salzburg,https://www.cosy.sbg.ac.at/~rkutil,NOSCHOLARPAGE
-Radek Pelánek,Masaryk University,https://www.muni.cz/lide/4297,Q5pgzoUAAAAJ
+Radek Pelánek,Masaryk University,https://www.muni.cz/en/people/4297,Q5pgzoUAAAAJ
 Radhika Mamidi,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/radhikamamidi,DsIpZR0AAAAJ
 Radhika Nagpal,Harvard University,http://www.radhikanagpal.org,NOSCHOLARPAGE
 Radim Bartos,University of New Hampshire,http://www.cs.unh.edu/~rbartos,VgGq9i0AAAAJ
@@ -12453,10 +12453,10 @@ Tommy Thorne,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Thoma
 Tomofumi Yuki,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/tomofumi.yuki,SV9UUhYAAAAJ
 Tomohiro Tanikawa,University of Tokyo,http://www.cyber.t.u-tokyo.ac.jp,NOSCHOLARPAGE
 Tomoyuki Takahata,University of Tokyo,http://www.leopard.t.u-tokyo.ac.jp/~takahata,NOSCHOLARPAGE
-Tomás Brázdil,Masaryk University,https://www.muni.cz/lide/4074,4Mp6OSYAAAAJ
+Tomás Brázdil,Masaryk University,https://www.muni.cz/en/people/4074,4Mp6OSYAAAAJ
 Tomás García Ferrari,University of Waikato,http://www.cms.waikato.ac.nz/people/tomasgf,U5v_QA0AAAAJ
 Tomás Lozano-Pérez,Massachusetts Institute of Technology,http://people.csail.mit.edu/tlp,NOSCHOLARPAGE
-Tomás Pitner,Masaryk University,https://www.muni.cz/lide/94,bX-cpaoAAAAJ
+Tomás Pitner,Masaryk University,https://www.muni.cz/en/people/94,bX-cpaoAAAAJ
 Tona Henderson,Rochester Institute of Technology,https://www.rit.edu/gccis/igm/tona-henderson,NOSCHOLARPAGE
 Tong Lin,Peking University,http://www.cis.pku.edu.cn/faculty/vision/lintong/default.htm,NOSCHOLARPAGE
 Tong Yang 0003,Peking University,http://net.pku.edu.cn/~yangtong,zYDaX-4AAAAJ
@@ -12621,7 +12621,7 @@ V. Susheela Devi,IISc Bangalore,http://www.csa.iisc.ac.in/~susheela,NOSCHOLARPAG
 V. Vijaya Saradhi,IIT Guwahati,https://www.iitg.ernet.in/saradhi,1DpQo5AAAAAJ
 V. Vinod,Massachusetts Institute of Technology,http://www.mit.edu/~vinodv,a8jIPIkAAAAJ
 V. Wiktor Marek,University of Kentucky,https://www.cs.uky.edu/~marek,NOSCHOLARPAGE
-Vaclav Prenosil,Masaryk University,https://www.muni.cz/lide/169249,DFSqdsEAAAAJ
+Vaclav Prenosil,Masaryk University,https://www.muni.cz/en/people/169249,DFSqdsEAAAAJ
 Vaclav Rajlich,Wayne State University,http://www.cs.wayne.edu/~vip,HgNTSYAAAAAJ
 Vadim Bulitko,University of Alberta,http://ircl.cs.ualberta.ca,a93MQNQAAAAJ
 Vadim E. Levit,Ariel University,http://ariel.academia.edu/VadimLevit,iAIwEeAAAAAJ
@@ -12660,8 +12660,8 @@ Varun Chandola,University at Buffalo,http://www.cse.buffalo.edu/~chandola,07Z4HA
 Varun Dutt,IIT Mandi,https://faculty.iitmandi.ac.in/~varun,jly9u8AAAAAJ
 Varun Kanade,University of Oxford,http://www.cs.ox.ac.uk/people/varun.kanade,NOSCHOLARPAGE
 Vasco M. Manquinho,Universidade de Lisboa,http://sat.inesc-id.pt/~vmm,vG7Gj6QAAAAJ
-Vashek Matyas,Masaryk University,https://www.muni.cz/lide/344,x6uv-rkAAAAJ
-Vashek Matyás,Masaryk University,https://www.muni.cz/lide/344,x6uv-rkAAAAJ
+Vashek Matyas,Masaryk University,https://www.muni.cz/en/people/344,x6uv-rkAAAAJ
+Vashek Matyás,Masaryk University,https://www.muni.cz/en/people/344,x6uv-rkAAAAJ
 Vasileios P. Kemerlis,Brown University,https://cs.brown.edu/~vpk,tkb2YWQAAAAJ
 Vasilios A. Siris,AUEB,http://www.aueb.gr/users/vsiris,Vj3O0cEAAAAJ
 Vasilis Gkatzelis,Drexel University,https://www.cs.drexel.edu/~gkatz,0VBRRRoAAAAJ
@@ -12847,7 +12847,7 @@ Vladimir Stojanovic,University of California - Berkeley,https://www2.eecs.berkel
 Vladimir Vapnik,Columbia University,http://datascience.columbia.edu/vladimir-vapnik,NOSCHOLARPAGE
 Vlado Keselj,Dalhousie University,https://www.cs.dal.ca/~vlado,uDKsmuIAAAAJ
 Vlado Menkovski,TU Eindhoven,https://www.tue.nl/en/university/departments/mathematics-and-computer-science/the-department/staff/detail/ep/e/d/ep-uid/20093057,2s9HUEMAAAAJ
-Vlastislav Dohnal,Masaryk University,https://www.muni.cz/lide/2952,Vmj26i4AAAAJ
+Vlastislav Dohnal,Masaryk University,https://www.muni.cz/en/people/2952,Vmj26i4AAAAJ
 Voicu Groza,University of Ottawa,http://www.eecs.uottawa.ca/~groza,OwLP6fkAAAAJ
 Voicu Popescu,Purdue University,https://www.cs.purdue.edu/homes/popescu,NOSCHOLARPAGE
 Voicu Z. Groza,University of Ottawa,http://www.eecs.uottawa.ca/~groza,OwLP6fkAAAAJ


### PR DESCRIPTION
I checked the names and links online and realized the university profile pages do not take up the browser language by default as I thought. I adjusted the links to display the English version by default.

Sorry for the inconvenience of the separate pull request!
(And thanks for the super-fast reaction of the initial pull request 👍)