### PR TITLE
Updated KangKang Yin(SFU) forbidden homepage URL.

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -6584,7 +6584,7 @@ Kang Chen,Tsinghua University,http://madsys.cs.tsinghua.edu.cn/~kangchen,fXtFkIo
 Kang G. Shin,University of Michigan,http://web.eecs.umich.edu/~kgshin,vY7MdLYAAAAJ
 Kang Li 0001,University of Georgia,http://cobweb.cs.uga.edu/~kangli,LLcNeeYAAAAJ
 Kang Zhang,University of Texas at Dallas,http://www.utdallas.edu/~kzhang,cdzVY_QAAAAJ
-KangKang Yin,Simon Fraser University,http://www.comp.nus.edu.sg/~kkyin,5P2jxPQAAAAJ
+KangKang Yin,Simon Fraser University,https://www.cs.sfu.ca/~kkyin,5P2jxPQAAAAJ
 Kangjie Lu,University of Minnesota,https://www.cs.umn.edu/people/kangjie-lu,1F9N6icAAAAJ
 Kannan Ramchandran,University of California - Berkeley,https://www.eecs.berkeley.edu/~kannanr,DcV-5RAAAAAJ
 Kannan Srinathan,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/srinathan,NOSCHOLARPAGE


### PR DESCRIPTION
Updating KangKang Yin's' hompage from NUS forbidden webpage to working Simon Fraser University's page.

# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [ ] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [ ] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

