### PR TITLE
Added Florida International University CS faculty

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -398,6 +398,7 @@ Alex Waibel,Carnegie Mellon University,http://www.cs.cmu.edu/~ahw,uHwTzpYAAAAJ
 Alex Zelikovsky,Georgia State University,http://cs.gsu.edu/profile/alex-zelikovsky,UzCRNJwAAAAJ
 Alexander A. Razborov,University of Chicago,https://people.cs.uchicago.edu/~razborov,NOSCHOLARPAGE
 Alexander A. Sherstov,University of California - Los Angeles,http://www.cs.ucla.edu/~sherstov,JinbAIQAAAAJ
+Alexander Afanasyev,Florida International University,https://users.cs.fiu.edu/~afanasyev,goyNhdoAAAAJ
 Alexander Aiken,Stanford University,https://theory.stanford.edu/~aiken,3vKjkoQAAAAJ
 Alexander Binder,SUTD,https://istd.sutd.edu.sg/people/faculty/alexander-binder,5B8CTlEAAAAJ
 Alexander Borgida,Rutgers University,https://www.cs.rutgers.edu/~borgida,S5AaMfgAAAAJ
@@ -1583,6 +1584,7 @@ Blair Nonnecke,University of Guelph,https://www.uoguelph.ca/computing/people/bla
 Blanca Rodríguez Bravo,University of Oxford,http://www.cs.ox.ac.uk/people/blanca.rodriguez,NOSCHOLARPAGE
 Blase Ur,University of Chicago,http://www.blaseur.com,3Xql0fwAAAAJ
 Bo An,Nanyang Technological University,http://www.ntu.edu.sg/home/boan,CvdNmi0AAAAJ
+Bogdan Carbunar,Florida International University,https://users.cs.fiu.edu/~carbunar,B7BCFdoAAAAJ
 Bo Ji,Temple University,https://cis.temple.edu/~boji,VO8vrxEAAAAJ
 Bo Lang,Beihang University,http://scse.buaa.edu.cn/info/1078/2660.htm,NOSCHOLARPAGE
 Bo Li 0001,HKUST,https://www.cse.ust.hk/~bli,BMkV-YoAAAAJ
@@ -2175,6 +2177,7 @@ Christian J. Darken,Naval Postgraduate School,http://faculty.nps.edu/cjdarken,NO
 Christian Jacob,University of Calgary,http://www.cpsc.ucalgary.ca/~jacob,DUxb0k0AAAAJ
 Christian Kästner,Carnegie Mellon University,https://www.cs.cmu.edu/~ckaestne,PR-ZnJUAAAAJ
 Christian Lengauer,University of Passau,http://www.infosun.fmi.uni-passau.de/cl/staff/lengauer,He31yBEAAAAJ
+Christine L. Lisetti,Florida International University,http://www.cis.fiu.edu/~lisetti,NOSCHOLARPAGE
 Christian N. S. Pedersen,Aarhus University,http://users-birc.au.dk/cstorm,RHtkRKwAAAAJ
 Christian Nørgaard Storm Pedersen,Aarhus University,http://users-birc.au.dk/cstorm,RHtkRKwAAAAJ
 Christian Poellabauer,University of Notre Dame,http://www3.nd.edu/~cpoellab,7anf7aEAAAAJ
@@ -3017,6 +3020,7 @@ Demetrios Achlioptas,University of California - Santa Cruz,https://www.soe.ucsc.
 Deming Chen,Univ. of Illinois at Urbana-Champaign,https://www.ece.illinois.edu/directory/profile/dchen,A_A_LrsAAAAJ
 Demosthenis Teneketzis,University of Michigan,http://web.eecs.umich.edu/~teneket,NOSCHOLARPAGE
 Deng Cai,Zhejiang University,http://www.cad.zju.edu.cn/home/dengcai,vzxDyJoAAAAJ
+Deng Pan,Florida International University,http://www.cs.fiu.edu/~pand,o0lXy-UAAAAJ
 Denilson Barbosa,University of Alberta,https://www.ualberta.ca/~denilson,usr3H7gAAAAJ
 Denis Deratani Mauá,USP,http://www.ime.usp.br/~ddm,NOSCHOLARPAGE
 Denis F. Wolf,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/denis,ncy_2xUAAAAJ
@@ -3774,6 +3778,7 @@ Fadi A. Zaraket,American University of Beirut,http://research-fadi.aub.edu.lb,1e
 Fadi N. Karameh,American University of Beirut,https://website.aub.edu.lb/fea/publicprofile/Pages/profile.aspx?memberid=fk14,1e2w_FoAAAAJ
 Fahad R. Dogar,Tufts University,http://www.cs.tufts.edu/Faculty/fahad-dogar.html,KPjFQ4AAAAAJ
 Fahad Rafique Dogar,Tufts University,http://www.cs.tufts.edu/Faculty/fahad-dogar.html,KPjFQ4AAAAAJ
+Fahad Saeed,Florida International University,http://www.saeedfahad.com,NOSCHOLARPAGE
 Fahiem Bacchus,University of Toronto,http://www.cs.toronto.edu/~fbacchus,Yy4QD_AAAAAJ
 Fahim Dalvi,Qatar Computing Research Institute,http://www.qcri.org/our-people/bio?pid=248&amp;par=acc&amp;name=FahimDalvi,uQGCv10AAAAJ
 Fahrad Arbab,CWI,http://homepages.cwi.nl/~farhad,GTW3mJ4AAAAJ
@@ -4162,6 +4167,7 @@ Geoffrey I. Webb,Monash University,http://i.giwebb.com,NOSCHOLARPAGE
 Geoffrey J. Gordon,Carnegie Mellon University,http://www.cs.cmu.edu/~ggordon,0OY5L3UAAAAJ
 Geoffrey M. Voelker,University of California - San Diego,http://cseweb.ucsd.edu/~voelker,ZfDtNpUAAAAJ
 Geoffrey Mainland,Drexel University,https://www.cs.drexel.edu/~mainland,jjWDm9wAAAAJ
+Geoffrey Smith,Florida International University,http://www.cis.fiu.edu/~smithg,OCmc_bYAAAAJ
 Geoffrey Werner Challen,University at Buffalo,https://blue.cse.buffalo.edu/people/gwa,lR34_8YAAAAJ
 Georg Carle,TU Munich,https://www.net.in.tum.de/members/carle,l5xqmTIAAAAJ
 Georg Danzl,IST Austria,http://ist.ac.at/research/physical-sciences/danzl-group,NOSCHOLARPAGE
@@ -4327,6 +4333,7 @@ Giovanni S. Moretti,Massey University,http://www.massey.ac.nz/massey/expertise/p
 Giovanni Samaey,KU Leuven,https://giovannisamaey.wordpress.com,t9FNZpsAAAAJ
 Giovanni Vigna,University of California - Santa Barbara,https://www.cs.ucsb.edu/~vigna,2eM6GocAAAAJ
 Girish Varma,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/girish.varma,YLlRCu4AAAAJ
+Giri Narasimhan,Florida International University,http://www.cs.fiu.edu/~giri,Q9PwPo8AAAAJ
 Gisele L. Pappa,UFMG,http://homepages.dcc.ufmg.br/~glpappa,C_0ZLuYAAAAJ
 Gisele Lobo Pappa,UFMG,http://homepages.dcc.ufmg.br/~glpappa,C_0ZLuYAAAAJ
 Gita Reese Sukthankar,University of Central Florida,http://www.eecs.ucf.edu/~gitars,NOSCHOLARPAGE
@@ -5303,6 +5310,7 @@ Jaime G. Carbonell,Carnegie Mellon University,https://www.cs.cmu.edu/~jgc,uSfaEg
 Jaime Ruiz,University of Florida,https://www.jaimeruiz.com,K1O-ZPIAAAAJ
 Jaime Simao Sichman,USP,https://www2.pcs.usp.br/pcsv6/index.php/131-docentes/223-jaime,rlSHIHIAAAAJ
 Jaime Viegas,Masdar Institute,https://www.masdar.ac.ae/aboutus/management/faculty-directory/item/5686-jaime-viegas,R97KDQ0AAAAJ
+Jainendra K. Navlakha,Florida International University,https://www.cis.fiu.edu/faculty-staff/navlakha-jainendra-k,NOSCHOLARPAGE
 Jakob Eriksson,University of Illinois at Chicago,https://www.cs.uic.edu/Jakob,kLUW0psAAAAJ
 Jakob Grue Simonsen,University of Copenhagen,http://www.diku.dk/~simonsen,JFhAzosAAAAJ
 Jakob Nordström,KTH Royal Institute of Technology,http://www.csc.kth.se/~jakobn,YSFwWNIAAAAJ
@@ -5510,6 +5518,7 @@ Jason I. Hong,Carnegie Mellon University,http://www.cs.cmu.edu/~jasonh,MoFbcc0AA
 Jason J. Corso,University of Michigan,http://web.eecs.umich.edu/~jjcorso,g9bV-_sAAAAJ
 Jason Jue,University of Texas at Dallas,http://www.utdallas.edu/~jjue,8EDESdwAAAAJ
 Jason Leigh,University of Hawaii at Manoa,http://www2.hawaii.edu/~leighj,5KgriYAAAAAJ
+Jason Liu,Florida International University,http://www.cis.fiu.edu/~liux,l8b0bfcAAAAJ
 Jason Lowe-Power,University of California - Davis,https://faculty.engineering.ucdavis.edu/lowepower,7m7TYQsAAAAJ
 Jason M. O'Kane,University of South Carolina,http://www.cse.sc.edu/~jokane,ETFTMZMAAAAJ
 Jason Mars,University of Michigan,http://jasonmars.org,Fn5PadcAAAAJ
@@ -7178,6 +7187,7 @@ Leonard McMillan,University of North Carolina,http://www.cs.unc.edu/~mcmillan,z6
 Leonard Pitt,Univ. of Illinois at Urbana-Champaign,https://cs.illinois.edu/directory/profile/pitt,GdYYuwoAAAAJ
 Leonardo B. Oliveira,UFMG,http://homepages.dcc.ufmg.br/~leob,YTEzpH0AAAAJ
 Leonardo Barbosa e Oliveira,UFMG,http://homepages.dcc.ufmg.br/~leob,YTEzpH0AAAAJ
+Leonardo Bobadilla,Florida International University,http://users.cis.fiu.edu/~jabobadi,-lKA19EAAAAJ
 Leonardo G. P. Murta,UFF,http://www2.ic.uff.br/~leomurta,VEbJeB8AAAAJ
 Leonardo Gresta Paulino Murta,UFF,http://www2.ic.uff.br/~leomurta,VEbJeB8AAAAJ
 Leonardo Murta,UFF,http://www2.ic.uff.br/~leomurta,VEbJeB8AAAAJ
@@ -7318,6 +7328,7 @@ Lisa Singh,Georgetown University,http://people.cs.georgetown.edu/~singh,NOSCHOLA
 Lisandro Zambenedetti Granville,UFRGS,http://www.inf.ufrgs.br/granville,v9JjkyYAAAAJ
 Lise Getoor,University of California - Santa Cruz,https://www.soe.ucsc.edu/people/getoor,Y8-xGncAAAAJ
 Lisong Xu,University of Nebraska,http://cse.unl.edu/~xu,ns_6BgMAAAAJ
+Liting Hu,Florida International University,http://users.cis.fiu.edu/~lhu,jG2EBooAAAAJ
 Liuba Shrira,Brandeis University,http://www.cs.brandeis.edu/~liuba,tyUShkAAAAAJ
 Liusheng Huang,USTC,http://dsxt.ustc.edu.cn/zj_ywjs.asp?zzid=36,1XHpROsAAAAJ
 Liwei Wang 0001,Peking University,http://www.cis.pku.edu.cn/faculty/vision/wangliwei,NOSCHOLARPAGE
@@ -7497,6 +7508,7 @@ M. Frans Kaashoek,Massachusetts Institute of Technology,https://pdos.csail.mit.e
 M. G. J. van den Brand,TU Eindhoven,http://www.win.tue.nl/~mvdbrand,CZt-AsoAAAAJ
 M. Gopi,University of California - Irvine,http://www.ics.uci.edu/~gopi,DI8bU-0AAAAJ
 M. Kemal Sönmez,OHSU,http://www.ohsu.edu/xd/education/schools/school-of-medicine/departments/basic-science-departments/csee/csee-people/sonmez.cfm,NOSCHOLARPAGE
+M. Mondal Ananda,Florida International University,https://www.cis.fiu.edu/faculty-staff/mondal-ananda,NOSCHOLARPAGE
 M. Narasimha Murty,IISc Bangalore,http://www.csa.iisc.ac.in/~mnm,VQZTmpcAAAAJ
 M. Praveen,CMI,http://www.cmi.ac.in/~praveenm,xDgt2Z8AAAAJ
 M. S. Ryoo,Indiana University,http://michaelryoo.com,vcw0TJIAAAAJ
@@ -7830,10 +7842,12 @@ Maristella Matera,Politecnico di Milano,http://home.deib.polimi.it/matera,NScXYC
 Marius Portmann,University of Queensland,http://staff.itee.uq.edu.au/marius,hiYVpa0AAAAJ
 Marius Ungarish,Technion,http://www.cs.technion.ac.il/people/unga,NOSCHOLARPAGE
 Marjo Kauppinen,Aalto University,https://people.aalto.fi/new/marjo.kauppinen,Wo8x6EUAAAAJ
+Mark A. Finlayson,Florida International University,http://cs.fiu.edu/~markaf,X8peo3AAAAAJ
 Mark A. Hasegawa-Johnson,Univ. of Illinois at Urbana-Champaign,http://www.ifp.illinois.edu/~hasegawa,18O0OAwAAAAJ
 Mark A. Horowitz,Stanford University,http://stanford.edu/~horowitz,e7V7-gEAAAAJ
 Mark A. Neerincx,TU Delft,https://ii.tudelft.nl/?q=node/4467,rwBWbFAAAAAJ
 Mark Alexander Reynolds,University of Western Australia,http://uwa.edu.au/people/mark.reynolds,2VbIrLMAAAAJ
+Mark Allen Weiss,Florida International University,http://www.cis.fiu.edu/~weiss,gfYCK9gAAAAJ
 Mark B. Sandler,Queen Mary University of London,http://www.eecs.qmul.ac.uk/profiles/sandlermark.html,W-gexv0AAAAJ
 Mark Batty,University of Kent,https://www.cs.kent.ac.uk/people/staff/mjb211,MnDiDMcAAAAJ
 Mark Braverman,Princeton University,https://www.cs.princeton.edu/people/profile/mbraverm,NOSCHOLARPAGE
@@ -8034,6 +8048,7 @@ Masashi Toyoda,University of Tokyo,https://www.iis.u-tokyo.ac.jp/en/research/sta
 Masatoshi Ishikawa,University of Tokyo,http://www.k2.t.u-tokyo.ac.jp/members/ishikawa/ishikawa-e.html,MPwVuGwAAAAJ
 Masayuki Inaba,University of Tokyo,http://www.jsk.t.u-tokyo.ac.jp/~inaba,NOSCHOLARPAGE
 Mashael AlSabah,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/mashael.php,rGIv25EAAAAJ
+Masoud Milani,Florida International University,https://www.cis.fiu.edu/faculty-staff/milani-masoud,NOSCHOLARPAGE
 Massimiliano Pierobon,University of Nebraska,http://cse.unl.edu/~pierobon,Rhu5LQIAAAAJ
 Massimiliano Pontil,University College London,http://www0.cs.ucl.ac.uk/staff/M.Pontil,lcOacs8AAAAJ
 Massimiliano de Leoni,TU Eindhoven,http://www.win.tue.nl/~mdeleoni,OejM6_AAAAAJ
@@ -8170,6 +8185,7 @@ Mayank Vatsa,IIIT Delhi,https://www.iiitd.edu.in/~mayank,NOSCHOLARPAGE
 Mayur Naik,University of Pennsylvania,http://www.cis.upenn.edu/~mhnaik,fmsV6nEAAAAJ
 Maziar Goudarzi,Sharif University of Technology,http://sharif.edu/~goudarzi,qAJqk9IAAAAJ
 Md. Khaled Khan,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/khaled_khan.php,SpQmNnoAAAAJ
+Md. Endadul Hoque,Florida International University,https://users.cs.fiu.edu/~ehoque,dSLXaKUAAAAJ
 Mea Wang,University of Calgary,http://networks.cpsc.ucalgary.ca/mea,CgdJUiMAAAAJ
 Medha Atre,IIT Kanpur,http://www.cse.iitk.ac.in/users/atrem,N_manZoAAAAJ
 Meelis Kull,University of Tartu,https://www.ut.ee/en/meelis-kull,yJwctG4AAAAJ
@@ -8707,6 +8723,7 @@ Monica Brockmeyer,Wayne State University,http://engineering.wayne.edu/profile/ag
 Monica N. Nicolescu,University of Nevada,https://www.cse.unr.edu/~monica,CjRSS8MAAAAJ
 Monica S. Lam,Stanford University,https://suif.stanford.edu/~lam,fVaS7a8AAAAJ
 Monica Sebillo,University of Salerno,http://www.unisa.it/docenti/monicamariasebillo/index,NOSCHOLARPAGE
+Monique Ross,Florida International University,https://www.cis.fiu.edu/faculty-staff/ross-monique,LtfU7CgAAAAJ
 Montek Singh,University of North Carolina,https://www.cs.unc.edu/~montek,NOSCHOLARPAGE
 Mooly Sagiv,Tel Aviv University,http://www.cs.tau.ac.il/~msagiv,j4UuW80AAAAJ
 Moonzoo Kim,KAIST,http://swtv.kaist.ac.kr/~moonzoo,HPB-yOEAAAAJ
@@ -8840,6 +8857,7 @@ Naftaly Minsky,Rutgers University,https://www.cs.rutgers.edu/~minsky,VLgJXtQAAAA
 Naghmeh Karimi,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/people/faculty/naghmeh-karimi,M-Z7bAIAAAAJ
 Nagiza F. Samatova,North Carolina State University,https://www.csc.ncsu.edu/people/nfsamato,vukA8JAAAAAJ
 Nagul Cooharojananone,Chulalongkorn University,http://pioneer.netserv.chula.ac.th/~cnagul,NOSCHOLARPAGE
+Nagarajan Prabakar,Florida International University,http://www.cis.fiu.edu/~prabakar,NOSCHOLARPAGE
 Nahri Moreano,UFMS,https://www.facom.ufms.br/~nahri,NOSCHOLARPAGE
 Naijie Gu,USTC,http://dsxt.ustc.edu.cn/zj_ywjs.asp?zzid=745,NOSCHOLARPAGE
 Naja L. Holten Møller,University of Copenhagen,http://diku.dk/Ansatte/?pure=da/persons/340853,NOSCHOLARPAGE
@@ -8867,6 +8885,7 @@ Naomi Ehrich Leonard,Princeton University,https://www.princeton.edu/~naomi,NOSCH
 Naomi Feldman,University of Maryland - College Park,http://legacydirs.umiacs.umd.edu/~nhf/index.html,FvRFQZ8AAAAJ
 Naomi H. Feldman,University of Maryland - College Park,http://legacydirs.umiacs.umd.edu/~nhf/index.html,FvRFQZ8AAAAJ
 Naomi Nishimura,University of Waterloo,https://cs.uwaterloo.ca/~nishi,SO3M2JwAAAAJ
+Naphtali Rishe,Florida International University,http://cake.fiu.edu/Rishe,bA1-qT0AAAAJ
 Narain Gehani,NJIT,http://cs.njit.edu/~gehani,NOSCHOLARPAGE
 Narain H. Gehani,NJIT,http://cs.njit.edu/~gehani,NOSCHOLARPAGE
 Naranker Dulay,Imperial College London,http://wp.doc.ic.ac.uk/nd,KXfVZq0AAAAJ
@@ -9057,6 +9076,7 @@ Nigel Topham,University of Edinburgh,http://homepages.inf.ed.ac.uk/npt,NOSCHOLAR
 Nihal P. Jayamaha,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=416150,NOSCHOLARPAGE
 Nihar B. Shah,Carnegie Mellon University,http://www.cs.cmu.edu/~nihars,BF39lMQAAAAJ
 Niki Kittur,Carnegie Mellon University,https://www.hcii.cmu.edu/people/aniket-kittur,2vZ5zRQAAAAJ
+Niki Pissinou,Florida International University,https://www.cis.fiu.edu/faculty-staff/pissinou-niki,NOSCHOLARPAGE
 Niki Trigoni,University of Oxford,https://www.cs.ox.ac.uk/niki.trigoni,NOSCHOLARPAGE
 Nikil D. Dutt,University of California - Irvine,http://www.ics.uci.edu/~dutt,CpBXPVoAAAAJ
 Nikil Dutt,University of California - Irvine,http://www.ics.uci.edu/~dutt,CpBXPVoAAAAJ
@@ -9097,6 +9117,7 @@ Nina S. T. Hirata,USP,http://www.ime.usp.br/~nina,NOSCHOLARPAGE
 Nina Sumiko Tomita,USP,http://www.ime.usp.br/~nina,NOSCHOLARPAGE
 Nina Sumiko Tomita Hirata,USP,http://www.ime.usp.br/~nina,NOSCHOLARPAGE
 Ning Zhang 0017,Washington University in St. Louis,https://n1ngz.github.io,gwB_pJcAAAAJ
+Ning Xie 0002,Florida International University,http://www.cs.fiu.edu/~nxie,H9x5YXkAAAAJ
 Ninghui Li,Purdue University,https://www.cs.purdue.edu/homes/ninghui,Qc_4yiYAAAAJ
 Nir Ailon,Technion,http://nailon.net.technion.ac.il,NOSCHOLARPAGE
 Nir Bitansky,Tel Aviv University,https://simons.berkeley.edu/people/nir-bitansky,XBk56N0AAAAJ
@@ -9626,6 +9647,7 @@ Peter H. Welch,University of Kent,https://www.cs.kent.ac.uk/~phw,hd1j2w0AAAAJ
 Peter Hubwieser,TU Munich,http://www.professoren.tum.de/en/hubwieser-peter,YuvySKkAAAAJ
 Peter Høyer,University of Calgary,http://www.cpsc.ucalgary.ca/~hoyer,NOSCHOLARPAGE
 Peter J. Bentley,University College London,http://www0.cs.ucl.ac.uk/staff/p.bentley,9DHkQbYAAAAJ
+Peter J. Clarke,Florida International University,http://www.cis.fiu.edu/~clarkep,dOIx9wcAAAAJ
 Peter J. Denning,Naval Postgraduate School,http://faculty.nps.edu/vitae/cgi-bin/vita.cgi?p=display_vita&id=1074712364,bfs3-ZoAAAAJ
 Peter J. Downey,University of Arizona,https://www.cs.arizona.edu/~pete,NOSCHOLARPAGE
 Peter J. Haas,University of Massachusetts Amherst,http://researcher.watson.ibm.com/researcher/view.php?person=us-phaas,PeCI8KcAAAAJ
@@ -10082,6 +10104,7 @@ Rajmohan Rajaraman,Northeastern University,http://www.ccs.neu.edu/home/rraj,QZrx
 Rajsekar Manokaran,IIT Madras,http://www.cse.iitm.ac.in/~rajsekar,NOSCHOLARPAGE
 Rajshekhar Sunderraman,Georgia State University,http://tinman.cs.gsu.edu/~raj,pXsiqKwAAAAJ
 Raju Halder,IIT Patna,https://iitp.ac.in/~halder,mA0HQJEAAAAJ
+Raju Rangaswami,Florida International University,http://www.cis.fiu.edu/~raju,-Y_xfI8AAAAJ
 Raju S. Bapi,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/rajubapi,bbSYyiAAAAAJ
 Rakesh B. Bobba,Oregon State University,http://eecs.oregonstate.edu/people/bobba-rakesh,_0x5unAAAAAJ
 Rakesh Bobba,Oregon State University,http://eecs.oregonstate.edu/people/bobba-rakesh,_0x5unAAAAAJ
@@ -10855,6 +10878,7 @@ S. Q. Zheng,University of Texas at Dallas,http://www.utdallas.edu/~sizheng,NOSCH
 S. R. S. Iyengar,IIT Ropar,http://sudarshaniyengar.com,NOSCHOLARPAGE
 S. Rao Kosaraju,Johns Hopkins University,http://www.cs.jhu.edu/~kosaraju,NOSCHOLARPAGE
 S. Shankar Sastry,University of California - Berkeley,http://robotics.eecs.berkeley.edu/~sastry,KgZxzjsAAAAJ
+S. Sitharama Iyengar,Florida International University,http://users.cis.fiu.edu/~iyengar,eNONM8AAAAAJ
 S. Sudarshan 0001,IIT Bombay,https://www.cse.iitb.ac.in/~sudarsha,KVbazsEAAAAJ
 S. V. N. Vishwanathan,University of California - Santa Cruz,https://www.soe.ucsc.edu/people/vishy,tqcSvFIAAAAJ
 S. V. Rao,IIT Guwahati,https://www.iitg.ernet.in/svrao,4NoqGCEAAAAJ
@@ -11224,6 +11248,7 @@ Seyed Hamed Hassani,University of Pennsylvania,https://www.seas.upenn.edu/~hassa
 Seyed Hassan Mirian,Sharif University of Technology,http://ce.sharif.edu/~mirian,NOSCHOLARPAGE
 Seyed-Hassan Mirian-Hosseinabadi,Sharif University of Technology,http://ce.sharif.edu/~mirian,NOSCHOLARPAGE
 Seyed-Mehdi-Reza Beheshti,UNSW,http://www.cse.unsw.edu.au/~sbeheshti,NOSCHOLARPAGE
+Seyed Masoud Sadjadi,Florida International University,http://www.cis.fiu.edu/~sadjadi,NOSCHOLARPAGE
 Seymour E. Goodman,Georgia Institute of Technology,http://www.iac.gatech.edu/people/faculty/goodman,U6OVPVMAAAAJ
 Seyoung Kim,Carnegie Mellon University,http://www.cs.cmu.edu/~sssykim,G99KBM8AAAAJ
 Shaahin Hessabi,Sharif University of Technology,http://sharif.edu/~hessabi,upXLWZEAAAAJ
@@ -11413,6 +11438,7 @@ Shuangshuang Jin,Clemson University,https://sjinwsu.wixsite.com/jin6,bYSZ-egAAAA
 Shubham Jain,Old Dominion University,http://www.cs.odu.edu/~jain,P9Z011YAAAAJ
 Shubhangi Saraf,Rutgers University,https://www.math.rutgers.edu/~ss1984,NiRqwkcAAAAJ
 Shuchi Chawla 0001,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~shuchi,Znp3UkEAAAAJ
+Shu-Ching Chen,Florida International University,https://www.cs.fiu.edu/~chens,NOSCHOLARPAGE
 Shueng-Han Gary Chan,HKUST,https://home.cse.ust.hk/~gchan,uiCSOycAAAAJ
 Shuhui Wang,Chinese Academy of Sciences,http://vipl.ict.ac.cn/view_people.php?url=&id=62,h-JxBSYAAAAJ
 ShuiGuang Deng,Zhejiang University,http://mypage.zju.edu.cn/shuiguang,txbuN0YAAAAJ
@@ -12959,6 +12985,7 @@ Wei Xu 0005,Tsinghua University,http://iiis.tsinghua.edu.cn/~weixu,6jN5vScAAAAJ
 Wei Xue,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101224235122610366982/20101224235122610366982_.html,iaziYXMAAAAJ
 Wei Yan,Peking University,https://chinamedicalboard.org/news/cmb-profile-jian-weiyan,NOSCHOLARPAGE
 Wei Yang 0013,University of Texas at Dallas,http://web.engr.illinois.edu/~weiyang3,CEVHpQUAAAAJ
+Wei Zeng,Florida International University,http://cis.fiu.edu/~wzeng,yKYRdd0AAAAJ
 Wei Zhang 0004,Peking University,http://sei.pku.edu.cn/~zhangw,NOSCHOLARPAGE
 Wei Zhu,Stony Brook University,http://www.ams.stonybrook.edu/~zhu,9jshr6QAAAAJ
 Wei-Chung Hsu,National Taiwan University,http://www.csie.ntu.edu.tw/~hsuwc,NOSCHOLARPAGE


### PR DESCRIPTION
- All added faculty are full time, tenure-track at Florida International University(FIU).
Department webpage: https://www.cis.fiu.edu/people/faculty/
- FIU CS dept was not listed in CSrankings before.
