### PR TITLE
Add faculties from UVA

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -29,6 +29,7 @@ Aamir Cheema,Monash University,http://www.aamircheema.com,chWbG70AAAAJ
 Aanjhan Ranganathan,Northeastern University,https://www.aanjhan.com,Jid_EAkAAAAJ
 Aaram Yun,UNIST,http://aaramyun.unist.ac.kr,NOSCHOLARPAGE
 Aaron Bernstein,Rutgers University,http://bernsteinaaron.com,NOSCHOLARPAGE
+Aaron Bloomfield,University of Virginia,https://engineering.virginia.edu/faculty/aaron-bloomfield,NOSCHOLARPAGE
 Aaron Bobick,Washington University in St. Louis,https://www.cc.gatech.edu/~afb,rynvwScAAAAJ
 Aaron C. Courville,University of Montreal,https://aaroncourville.wordpress.com,km6CP8cAAAAJ
 Aaron Clauset,University of Colorado Boulder,https://www.colorado.edu/cs/users/aacl0007,e7VI_HcAAAAJ
@@ -7563,6 +7564,7 @@ Majid Komeili,Carleton University,http://people.scs.carleton.ca/~majidkomeili,AI
 Majid Mirmehdi,University of Bristol,http://www.cs.bris.ac.uk/~majid,NsW3yAwAAAAJ
 Majid Sarrafzadeh,University of California - Los Angeles,http://www.cs.ucla.edu/~majid,LYt_4uIAAAAJ
 Maksim Serbyn,IST Austria,https://ist.ac.at/research/physical_sciences,NOSCHOLARPAGE
+Malathi Veeraraghavan,University of Virginia,https://engineering.virginia.edu/faculty/malathi-veeraraghavan,ieNQogYAAAAJ
 Malcolm D. Atkinson,University of Edinburgh,http://www.research.ed.ac.uk/portal/en/persons/malcolm-atkinson(8e51eafb-dd78-468b-8970-ec2349e92305).html,NOSCHOLARPAGE
 Malcolm Heywood,Dalhousie University,https://www.dal.ca/faculty/computerscience/faculty-staff/malcolm-heywood.html,_d-AGjUAAAAJ
 Malcolm P. Atkinson,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Malcolm_Atkinson.html,NOSCHOLARPAGE
@@ -8899,6 +8901,7 @@ Nate Foster,Cornell University,http://www.cs.cornell.edu/~jnfoster,AH5j40kAAAAJ
 Nathalie Revol,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/nathalie.revol,f00lNLUAAAAJ
 Nathaly Verwaal,University of Calgary,http://contacts.ucalgary.ca/info/cpsc/profiles/102-3419,NOSCHOLARPAGE
 Nathan Beckmann,Carnegie Mellon University,http://www.cs.cmu.edu/~beckmann,zkdjit0AAAAJ
+Nathan Brunelle,University of Virginia,https://engineering.virginia.edu/faculty/nathan-brunelle,NOSCHOLARPAGE
 Nathan D. Cahill,Rochester Institute of Technology,https://people.rit.edu/ndcsma,NOSCHOLARPAGE
 Nathan Fisher,Wayne State University,http://www.cs.wayne.edu/~fishern,30pCSfEAAAAJ
 Nathan Friedman,McGill University,https://www.cs.mcgill.ca/academic/undergrad/advising,NOSCHOLARPAGE
@@ -9304,6 +9307,7 @@ Pamela J. Wisniewski,University of Central Florida,http://www.pamspam.com,3JZB10
 Pamela Karr,University of Central Florida,http://www.pamspam.com,3JZB10QAAAAJ
 Pamela Karr Wisniewski,University of Central Florida,http://www.pamspam.com,3JZB10QAAAAJ
 Pan Hui,HKUST,http://www.cse.ust.hk/~panhui,dcDrhzMAAAAJ
+Panagiotis Apostolellis,https://engineering.virginia.edu/faculty/panagiotis-apostolellis,r_1LwogAAAAJ
 Panagiotis Karras,Aarhus University,http://cs.au.dk/~karras,B6C4aBoAAAAJ
 Panagiotis Manolios,Northeastern University,http://www.ccs.neu.edu/home/pete,NOSCHOLARPAGE
 Panagiotis Rondogiannis,University of Athens,http://cgi.di.uoa.gr/~prondo,a6x5amYAAAAJ
@@ -10980,6 +10984,7 @@ Sandro Rigo,UNICAMP,http://www.ic.unicamp.br/~sandro,Bkd9ZXkAAAAJ
 Sandy Garner,University of Otago,http://www.cs.otago.ac.nz/staff/Sandy_Garner,NOSCHOLARPAGE
 Sandy Irani,University of California - Irvine,https://www.ics.uci.edu/~irani,NOSCHOLARPAGE
 Sang Kil Cha,KAIST,http://softsec.kaist.ac.kr/~sangkilc,kV40DzcAAAAJ
+Sang Hyuk Son,University of Virginia,http://www.cs.virginia.edu/~son/,pHox8i0AAAAJ
 Sang Won Lee 0002,Virginia Tech,http://people.cs.vt.edu/sangwonlee,II2NGWIAAAAJ
 Sang Woo Jun,University of California - Irvine,https://www.ics.uci.edu/~swjun/,l9zZMOYAAAAJ
 Sangjin Hong,Stony Brook University,http://www.stonybrook.edu/commcms/electrical/people/Hong_Sangjin.html,NOSCHOLARPAGE

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -7564,7 +7564,6 @@ Majid Komeili,Carleton University,http://people.scs.carleton.ca/~majidkomeili,AI
 Majid Mirmehdi,University of Bristol,http://www.cs.bris.ac.uk/~majid,NsW3yAwAAAAJ
 Majid Sarrafzadeh,University of California - Los Angeles,http://www.cs.ucla.edu/~majid,LYt_4uIAAAAJ
 Maksim Serbyn,IST Austria,https://ist.ac.at/research/physical_sciences,NOSCHOLARPAGE
-Malathi Veeraraghavan,University of Virginia,https://engineering.virginia.edu/faculty/malathi-veeraraghavan,ieNQogYAAAAJ
 Malcolm D. Atkinson,University of Edinburgh,http://www.research.ed.ac.uk/portal/en/persons/malcolm-atkinson(8e51eafb-dd78-468b-8970-ec2349e92305).html,NOSCHOLARPAGE
 Malcolm Heywood,Dalhousie University,https://www.dal.ca/faculty/computerscience/faculty-staff/malcolm-heywood.html,_d-AGjUAAAAJ
 Malcolm P. Atkinson,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Malcolm_Atkinson.html,NOSCHOLARPAGE
@@ -10984,7 +10983,6 @@ Sandro Rigo,UNICAMP,http://www.ic.unicamp.br/~sandro,Bkd9ZXkAAAAJ
 Sandy Garner,University of Otago,http://www.cs.otago.ac.nz/staff/Sandy_Garner,NOSCHOLARPAGE
 Sandy Irani,University of California - Irvine,https://www.ics.uci.edu/~irani,NOSCHOLARPAGE
 Sang Kil Cha,KAIST,http://softsec.kaist.ac.kr/~sangkilc,kV40DzcAAAAJ
-Sang Hyuk Son,University of Virginia,http://www.cs.virginia.edu/~son/,pHox8i0AAAAJ
 Sang Won Lee 0002,Virginia Tech,http://people.cs.vt.edu/sangwonlee,II2NGWIAAAAJ
 Sang Woo Jun,University of California - Irvine,https://www.ics.uci.edu/~swjun/,l9zZMOYAAAAJ
 Sangjin Hong,Stony Brook University,http://www.stonybrook.edu/commcms/electrical/people/Hong_Sangjin.html,NOSCHOLARPAGE


### PR DESCRIPTION
# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [ ] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [ ] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [ ] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

