### PR TITLE
Added two new UHM faculty

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -9631,6 +9631,7 @@ Peter J. Haas,University of Massachusetts Amherst,http://researcher.watson.ibm.c
 Peter J. Keleher,University of Maryland - College Park,https://www.cs.umd.edu/people/keleher,NOSCHOLARPAGE
 Peter J. Ramadge,Princeton University,http://ee.princeton.edu/people/faculty/peter-j-ramadge,BOMboVoAAAAJ
 Peter J. Rodgers,University of Kent,https://www.cs.kent.ac.uk/people/staff/pjr,wu6mHBsAAAAJ
+Peter J. Sadowski,University of Hawaii at Manoa,https://www2.hawaii.edu/~psadow,5-s3bS8AAAAJ
 Peter J. Stuckey,University of Melbourne,http://people.eng.unimelb.edu.au/pstuckey,tvFekxwAAAAJ
 Peter J. Varman,Rice University,http://varman.rice.edu,c56AFDoAAAAJ
 Peter James Stuckey,University of Melbourne,http://people.eng.unimelb.edu.au/pstuckey,tvFekxwAAAAJ
@@ -10392,6 +10393,7 @@ Richard Wildes,York University,http://www.cse.yorku.ca/~wildes,1vEw_kgAAAAJ
 Richard Wolski,University of California - Santa Barbara,https://www.cs.ucsb.edu/~rich,NOSCHOLARPAGE
 Richard Zanibbi,Rochester Institute of Technology,https://www.cs.rit.edu/~rlaz,k6xVb1QAAAAJ
 Rick Alterman,Brandeis University,http://www.brandeis.edu/facultyguide/person.html?emplid=4a09ce0d1a4b429db8f07e9e0210e5e2e7ab094b,NOSCHOLARPAGE
+Rick Kazman,University of Hawaii at Manoa,http://shidler.hawaii.edu/directory/rick-kazman/itm,fWHdqsUAAAAJ
 Rick L. Stevens,University of Chicago,https://cs.uchicago.edu/directory/rick-stevens,2oSSsLYAAAAJ
 Rick Stevens,University of Chicago,https://cs.uchicago.edu/directory/rick-stevens,2oSSsLYAAAAJ
 Rickard Ewetz,University of Central Florida,http://www.ece.ucf.edu/~ewetz,NOSCHOLARPAGE


### PR DESCRIPTION
Peter Sadowski is a new full-time tenure track faculty member in the Computer Science Department.

Rick Kazman, a full-time tenured faculty member from another department at this University, has just been approved as a cooperating graduate faculty member in the Computer Science. This means that he can advise graduate students and serve as chair on graduate student committees in Computer Science.