### PR TITLE
Fix broken homepage link for Chengyu Song

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -2083,7 +2083,7 @@ Chengkai Li,University of Texas at Arlington,http://ranger.uta.edu/~cli,v8ZQDf8A
 Chengnian Sun,University of Waterloo,https://chengniansun.bitbucket.io,rwbI5qAAAAAJ
 Chengqing Zong,Chinese Academy of Sciences,http://www.nlpr.ia.ac.cn/cip/english/zong.htm,l8lvKOQAAAAJ
 Chengxiang Zhai,Univ. of Illinois at Urbana-Champaign,http://czhai.cs.illinois.edu,YU-baPIAAAAJ
-Chengyu Song,University of California - Riverside,http://www.cc.gatech.edu/grads/c/csong43,EoypoXAAAAAJ
+Chengyu Song,University of California - Riverside,https://www.cs.ucr.edu/~csong,EoypoXAAAAAJ
 Chengzheng Sun,Nanyang Technological University,http://www.ntu.edu.sg/home/czsun,eBpYUn4AAAAJ
 Chenhao Tan,University of Colorado Boulder,https://chenhaot.com,KGMaP18AAAAJ
 Chenliang Xu,University of Rochester,https://www.cs.rochester.edu/~cxu22,54HfyDIAAAAJ


### PR DESCRIPTION
**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

