### PR TITLE
Update affiliation for Douglas Stebila

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -3329,7 +3329,7 @@ Douglas Lawrence,Ohio University,https://www.ohio.edu/engineering/about/people/p
 Douglas Leslie Maskell,Nanyang Technological University,http://www.ntu.edu.sg/home/asdouglas,o_roEHkAAAAJ
 Douglas R. Stinson,University of Waterloo,http://cacr.uwaterloo.ca/~dstinson,kFbFJqIAAAAJ
 Douglas S. Reeves,North Carolina State University,http://reeves.csc.ncsu.edu,UUAn_V8AAAAJ
-Douglas Stebila,McMaster University,https://www.douglas.stebila.ca,b1DDIcYAAAAJ
+Douglas Stebila,University of Waterloo,https://www.douglas.stebila.ca,b1DDIcYAAAAJ
 Douglas Thain,University of Notre Dame,http://www3.nd.edu/~dthain,53RlhUcAAAAJ
 Douglas Troeger,CUNY,https://www.ccny.cuny.edu/profiles/douglas-troeger,NOSCHOLARPAGE
 Douglas W. Jones,University of Iowa,https://www.cs.uiowa.edu/~jones,gX8LBfgAAAAJ


### PR DESCRIPTION
**Inclusion criteria**

- [X] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [X] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.
