### PR TITLE
Add new faculty member of Queen's University

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -14052,6 +14052,7 @@ Yuan Lin 0003,Shanghai Univ. of Finance and Economics,http://itcs.shufe.edu.cn/y
 Yuan Luo,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/en/PeopleDetail.aspx?id=155,NOSCHOLARPAGE
 Yuan Tian,University of Virginia,https://www.yuantiancmu.com,ja0GtqgAAAAJ
 Yuan Tian 0001,University of Virginia,https://engineering.virginia.edu/faculty/yuan-tian,ja0GtqgAAAAJ
+Yuan Tian 0008,Queen’s University,http://sophiaytian.com/,wX4le_QAAAAJ
 Yuan Xie 0001,University of California - Santa Barbara,http://www.ece.ucsb.edu/~yuanxie,dK2ZuDcAAAAJ
 Yuan Zhou,Indiana University,https://www.soic.indiana.edu/all-people/profile.html?profile_id=442,aR34e1gAAAAJ
 Yuan-Fang Li,Monash University,http://monash.edu/research/explore/en/persons/yuanfang-li(45cfb4c4-99f3-4880-a1fd-b353372086b6).html,wufXO1kAAAAJ


### PR DESCRIPTION
# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [ ] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [ ] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [ ] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

