### PR TITLE
Fix homepage and google scholar links for Hao Chen at UC Davis

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -4828,7 +4828,7 @@ Hantao Zhang,University of Iowa,https://www.cs.uiowa.edu/~hzhang,NOSCHOLARPAGE
 Hany Farid,Dartmouth College,http://www.cs.dartmouth.edu/farid,VEdybxgAAAAJ
 Hao (Richard) Zhang,Simon Fraser University,http://www.cs.sfu.ca/~haoz,FtryeKoAAAAJ
 Hao Che,University of Texas at Arlington,http://crystal.uta.edu/~hche,Vyrg19YAAAAJ
-Hao Chen 0003,University of California - Davis,https://anson.ucdavis.edu/~haochen,1G6oaRwAAAAJ
+Hao Chen,University of California - Davis,http://web.cs.ucdavis.edu/~hchen,1Aa3qxIAAAAJ
 Hao Huang,Nanjing University,http://www.mathcs.emory.edu/~hhuan30,bTTwjj8AAAAJ
 Hao Su,University of California - San Diego,http://ai.ucsd.edu/~haosu,1P8Zu04AAAAJ
 Hao Zhang 0002,Simon Fraser University,http://www.cs.sfu.ca/~haoz,FtryeKoAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -4828,7 +4828,7 @@ Hantao Zhang,University of Iowa,https://www.cs.uiowa.edu/~hzhang,NOSCHOLARPAGE
 Hany Farid,Dartmouth College,http://www.cs.dartmouth.edu/farid,VEdybxgAAAAJ
 Hao (Richard) Zhang,Simon Fraser University,http://www.cs.sfu.ca/~haoz,FtryeKoAAAAJ
 Hao Che,University of Texas at Arlington,http://crystal.uta.edu/~hche,Vyrg19YAAAAJ
-Hao Chen,University of California - Davis,http://web.cs.ucdavis.edu/~hchen,1Aa3qxIAAAAJ
+Hao Chen 0003,University of California - Davis,http://web.cs.ucdavis.edu/~hchen,1Aa3qxIAAAAJ
 Hao Huang,Nanjing University,http://www.mathcs.emory.edu/~hhuan30,bTTwjj8AAAAJ
 Hao Su,University of California - San Diego,http://ai.ucsd.edu/~haosu,1P8Zu04AAAAJ
 Hao Zhang 0002,Simon Fraser University,http://www.cs.sfu.ca/~haoz,FtryeKoAAAAJ


### PR DESCRIPTION
1. Fixed the homepage link as it was pointing to the wrong professor (not in CS department).
2. Fixed the google scholar link was pointing to the wrong person.
3. Removed the disambiguation suffixes as there is no duplication of names.