### PR TITLE
Fixed google scholar link for Jimmy Lin (Waterloo), the former link w…

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -6117,7 +6117,7 @@ Jiming Liu 0001,Hong Kong Baptist University,http://www.comp.hkbu.edu.hk/~jiming
 Jimmy Ba,University of Toronto,https://jimmylba.github.io,ymzxRhAAAAAJ
 Jimmy H. M. Lee,Chinese University of Hong Kong,https://www.coursera.org/instructor/jlee,NOSCHOLARPAGE
 Jimmy Ho-Man Lee,Chinese University of Hong Kong,https://www.coursera.org/instructor/jlee,NOSCHOLARPAGE
-Jimmy J. Lin,University of Waterloo,https://cs.uwaterloo.ca/~jimmylin,iOuvnPMAAAAJ
+Jimmy J. Lin,University of Waterloo,https://cs.uwaterloo.ca/~jimmylin,0EWw1z8AAAAJ
 Jimson Mathew,IIT Patna,https://iitp.ac.in/index.php/departments/engineering/computer-science-a-engineering/people/faculty/1502-dr-jimson-mathew.html,NOSCHOLARPAGE
 Jin Huang 0001,Zhejiang University,http://www.cad.zju.edu.cn/home/hj/index.xml,KLgK108AAAAJ
 Jin Huang 0002,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2017/20170413095136757222879/20170413095136757222879_.html,NOSCHOLARPAGE


### PR DESCRIPTION
Fixed google scholar link for Jimmy J Lin (Waterloo), the former link was for a Jimmy C Lin at Johns Hopkins

# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [ ] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [ ] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [ ] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

