### PR TITLE
Add University of York details

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -216,3 +216,4 @@ Seoul National University,asia
 Middlesex University,europe
 Newcastle University,australasia
 University of Surrey,europe
+University of York,europe

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -14705,3 +14705,56 @@ Zygmunt J. Haas,University of Texas at Dallas,http://www.utdallas.edu/~zjh130030
 Öznur Özkasap,Koç University,http://home.ku.edu.tr/~oozkasap,v2WiJeIAAAAJ
 Øystein Nytrø,Norwegian University of Science and Technology,https://www.ntnu.edu/employees/nytroe,-Zavs80AAAAJ
 Ümit V. Çatalyürek,Georgia Institute of Technology,https://www.cc.gatech.edu/~umit,OLDMURQAAAAJ
+Robert I. Davis,University of York,https://www-users.cs.york.ac.uk/~robdavis/,xjVBcr4AAAAJ
+Iain Bate,University of York,https://www-user.cs.york.ac.uk/~ijb/,dE_ooMIAAAAJ
+Leandro Soares Indrusiak,University of York,https://www-users.cs.york.ac.uk/~lsi/,f1PUDsEAAAAJ
+Wanli Chang,University of York,https://www-users.cs.york.ac.uk/~wanli/,OYcT_B4AAAAJ
+Andy J. Wellings,University of York,https://www-users.cs.york.ac.uk/~andy/,yPa4QrkAAAAJ
+Neil C. Audsley,University of York,https://www-users.cs.york.ac.uk/~neil/,D65ZWSgAAAAJ
+Ian Gray,University of York,https://www-users.cs.york.ac.uk/~iang/,HloK4CAAAAAJ
+Alan Burns,University of York,https://www-users.cs.york.ac.uk/~burns/,Io7KbYcAAAAJ
+Ibrahim Habli,University of York,https://www-users.cs.york.ac.uk/~ihabli/,U9j-FS8AAAAJ
+Tangming Yuan,University of York,https://www-users.cs.york.ac.uk/~tommy/,1fzy4fsAAAAJ
+Lilian Blot,University of York,https://www-users.cs.york.ac.uk/~lblot,Enkx56UAAAAJ
+Radu Calinescu,University of York,https://www-users.cs.york.ac.uk/raduc/,NLiNqPwAAAAJ
+Daniel Kudenko,University of York,http://www.cs.york.ac.uk/~kudenko,uUXUMukAAAAJ
+Daniel W Franks,University of York,https://danfranks.weebly.com,Zpo8koYAAAAJ
+Javier Cámara,University of York,http://www.javicamara.com/,iMMncw8AAAAJ
+Tim P. Kelly,University of York,www-users.cs.york.ac.uk/~tpk,cNeDb_8AAAAJ
+Dimitar Kazakov,University of York,https://www-users.cs.york.ac.uk/~kazakov/,CLI_4LYAAAAJ
+Stefano Pirandola,University of York,https://www-users.cs.york.ac.uk/~pirs/,bV8llfkAAAAJ
+Christopher Power,University of York,https://www-users.cs.york.ac.uk/~cpower/,1ZA0JtcAAAAJ
+Paul Cairns,University of York,https://www-users.cs.york.ac.uk/~pcairns/,cNVmuG0AAAAJ
+Helen Petrie,University of York,https://www-users.cs.york.ac.uk/~petrie/,xhkqoGAAAAAJ
+Suresh Manandhar,University of York,https://www-users.cs.york.ac.uk/~suresh/,5iH8GVIAAAAJ
+Simon O'Keefe,University of York,https://www-users.cs.york.ac.uk/~sok/,QL1JHlUAAAAJ
+Ana Cavalcanti,University of York,https://www-users.cs.york.ac.uk/~alcc/,fu6TM4wAAAAJ
+Siamak F. Shahandashti,University of York,https://www-users.cs.york.ac.uk/~siamak,CZTajNQAAAAJ
+Susan Stepney,University of York,https://www-users.cs.york.ac.uk/~susan/,rD32w_EAAAAJ
+Edwin R. Hancock,University of York,https://www-users.cs.york.ac.uk/~erh/,EjDU2ncAAAAJ
+Adrian G. Bors,University of York,https://www-users.cs.york.ac.uk/adrian/,cvdyalUAAAAJ
+Detlef Plump,University of York,https://www-users.cs.york.ac.uk/~det/,nh6AHbIAAAAJ
+Nicholas Drivalos Matragkas,University of York,http://www-users.cs.york.ac.uk/~nikos/,Dvp7fNoAAAAJ
+John A McDermid,University of York,https://www-users.cs.york.ac.uk/~jam/,REscLkoAAAAJ
+William A. P. Smith,University of York,https://www-users.cs.york.ac.uk/wsmith/,o2z0h6MAAAAJ
+Anders Drachen,University of York,https://www.cs.york.ac.uk/people/~adrachen,rOcL0NgAAAAJ
+Samuel L. Braunstein,University of York,https://www-users.cs.york.ac.uk/~schmuel/,jh-mlXoAAAAJ
+Angus M Marshall,University of York,http://www-users.york.ac.uk/~amm616/,RV4F9n8AAAAJ
+Chris Bailey,University of York,www.cs.york.ac.uk/~chrisb,QQ_dWtcAAAAJ
+Steven A. Wright,University of York,https://www-users.cs.york.ac.uk/~saw/,uh1UaD4AAAAJ
+Dimitrios S. Kolovos,University of York,https://www-users.cs.york.ac.uk/~dkolovos/,aRd1i6UAAAAJ
+James Cussens,University of York,https://www-users.cs.york.ac.uk/~jc,OEFkOR0AAAAJ
+Steve King,University of York,https://www-users.cs.york.ac.uk/~king/,Q75-BIgAAAAJ
+Rob Alexander,University of York,https://www-users.cs.york.ac.uk/~rda/,DFdBpC0AAAAJ
+Richard C. Wilson,University of York,https://www-users.cs.york.ac.uk/~wilson/,o4Sq5yMAAAAJ
+Nick Pears,University of York,https://www-users.cs.york.ac.uk/nep/,U_hUs6wzw_AC
+Vassilios G. Vassilakis,University of York,https://www-users.cs.york.ac.uk/~vv/,-OzxgUwAAAAJ
+Siyuan Ji,University of York,https://www-users.cs.york.ac.uk/~siyuan/,oZdrNNwAAAAJ
+Jim Woodcock,University of York,https://www-users.cs.york.ac.uk/~jim/,bO-FeTIAAAAJ
+Peter Nightingale,University of York,https://www-users.cs.york.ac.uk/pwn503/,Msh14AUAAAAJ 
+Ioanna Iacovides,University of York,http://www-users.york.ac.uk/~ii560/,LuBaasYAAAAJ
+Richard F. Paige,University of York,http://www-users.york.ac.uk/~paige/,HzFjuyUAAAAJ
+Peter I. Cowling,University of York,http://www-users.york.ac.uk/~cowling/,xQ7IpL8AAAAJ
+Delaram Kahrobaei,University of York,http://www-users.york.ac.uk/~kahrobaei/,ScTS9PkAAAAJ
+Jim Austin,University of York,http://www-users.york.ac.uk/~austin/,xpZL8d8AAAAJ
+James Alfred Walker,University of York,https://www.cs.york.ac.uk/~jawalker/,Yl5OycsAAAAJ


### PR DESCRIPTION
# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [ ] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [ ] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [ ] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

