### PR TITLE
Add a faculty [Yusuke Miyao] from University of Tokyo

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -100,8 +100,10 @@ Shanghai Univ. of Finance and Economics,asia
 Sharif University of Technology,asia
 Simon Fraser University,canada
 Singapore Management University,asia
+Sun Yat-Sen University,asia
 SUTD,asia
 Tata Institute of Fundamental Research,asia
+Tokyo Institute of Technology,asia
 Tsinghua University,asia
 TU Berlin,europe
 TU Braunschweig,europe

--- a/country-info.csv
+++ b/country-info.csv
@@ -100,10 +100,8 @@ Shanghai Univ. of Finance and Economics,asia
 Sharif University of Technology,asia
 Simon Fraser University,canada
 Singapore Management University,asia
-Sun Yat-Sen University,asia
 SUTD,asia
 Tata Institute of Fundamental Research,asia
-Tokyo Institute of Technology,asia
 Tsinghua University,asia
 TU Berlin,europe
 TU Braunschweig,europe

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -14511,6 +14511,7 @@ Yusu Wang,Ohio State University,http://web.cse.ohio-state.edu/~yusu,L7jhqMIAAAAJ
 Yusuf Murat Erten,Izmir Institute of Technology,http://ceng.iyte.edu.tr/people/murat-erten,XY_kpWgAAAAJ
 Yusuf Sahillioglu,Middle East Technical University,http://user.ceng.metu.edu.tr/~ys,1bu8cjoAAAAJ
 Yusuf Yaslan,Istanbul Technical University,https://web.itu.edu.tr/yyaslan,0GSCY28AAAAJ
+Yusuke Miyao,University of Tokyo,https://mynlp.github.io/en
 Yuting Chen,Shanghai Jiao Tong University,http://en.se.sjtu.edu.cn/teacher/teacherdetail.aspx?id=31,2AjR92EAAAAJ
 Yuval Emek,Technion,https://yemek.net.technion.ac.il,q2WvHtkAAAAJ
 Yuval Filmus,Technion,http://www.cs.technion.ac.il/people/yuvalfi,TFvs8NgAAAAJ


### PR DESCRIPTION
Add one professor newly come into University of Tokyo.

Detail: Prof. Miyao was worked in National Institute of Informatics and SOKENDAI (The Graduate University for Advanced Studies) before, but this year he has joined into the University of Tokyo.

Other useful information: https://researchmap.jp/yusuke/?lang=english

Hope these can help you to conveniently confirm it somehow.