### PR TITLE
Add Yusuke Miyao from University of Tokyo

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -14515,6 +14515,7 @@ Yusu Wang,Ohio State University,http://web.cse.ohio-state.edu/~yusu,L7jhqMIAAAAJ
 Yusuf Murat Erten,Izmir Institute of Technology,http://ceng.iyte.edu.tr/people/murat-erten,XY_kpWgAAAAJ
 Yusuf Sahillioglu,Middle East Technical University,http://user.ceng.metu.edu.tr/~ys,1bu8cjoAAAAJ
 Yusuf Yaslan,Istanbul Technical University,https://web.itu.edu.tr/yyaslan,0GSCY28AAAAJ
+Yusuke Miyao,University of Tokyo,https://mynlp.github.io/en
 Yuting Chen,Shanghai Jiao Tong University,http://en.se.sjtu.edu.cn/teacher/teacherdetail.aspx?id=31,2AjR92EAAAAJ
 Yuval Emek,Technion,https://yemek.net.technion.ac.il,q2WvHtkAAAAJ
 Yuval Filmus,Technion,http://www.cs.technion.ac.il/people/yuvalfi,TFvs8NgAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -14515,7 +14515,7 @@ Yusu Wang,Ohio State University,http://web.cse.ohio-state.edu/~yusu,L7jhqMIAAAAJ
 Yusuf Murat Erten,Izmir Institute of Technology,http://ceng.iyte.edu.tr/people/murat-erten,XY_kpWgAAAAJ
 Yusuf Sahillioglu,Middle East Technical University,http://user.ceng.metu.edu.tr/~ys,1bu8cjoAAAAJ
 Yusuf Yaslan,Istanbul Technical University,https://web.itu.edu.tr/yyaslan,0GSCY28AAAAJ
-Yusuke Miyao,University of Tokyo,https://mynlp.github.io/en
+Yusuke Miyao,University of Tokyo,https://mynlp.github.io/en,NOSCHOLARPAGE
 Yuting Chen,Shanghai Jiao Tong University,http://en.se.sjtu.edu.cn/teacher/teacherdetail.aspx?id=31,2AjR92EAAAAJ
 Yuval Emek,Technion,https://yemek.net.technion.ac.il,q2WvHtkAAAAJ
 Yuval Filmus,Technion,http://www.cs.technion.ac.il/people/yuvalfi,TFvs8NgAAAAJ


### PR DESCRIPTION
Just add one professor newly come into University of Tokyo in August.

Detail: Prof. Miyao was worked in National Institute of Informatics and SOKENDAI (The Graduate University for Advanced Studies) before, but this year he has joined into the University of Tokyo.

Other useful information: https://researchmap.jp/yusuke/?lang=english

Hope these can help you to conveniently confirm it somehow.