### PR TITLE
faculty that have moved

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -2245,7 +2245,6 @@ Chongjun Wang,Nanjing University,https://hpi.de/en/research/research-school/inte
 Choonhwa Lee,Hanyang University,http://dcc.hanyang.ac.kr/members.htm,NOSCHOLARPAGE
 Chris Bailey-Kellogg,Dartmouth College,http://www.cs.dartmouth.edu/~cbk,NOSCHOLARPAGE
 Chris Bartone,Ohio University,https://www.ohio.edu/engineering/about/people/profiles.cfm?profile=bartone,NOSCHOLARPAGE
-Chris Biemann,TU Darmstadt,https://www.lt.tu-darmstadt.de/de/people/prof-dr-chris-biemann,NOSCHOLARPAGE
 Chris Bystroff,Rensselaer Polytechnic Institute,http://www.bioinfo.rpi.edu/bystrc,ZHK-ewYAAAAJ
 Chris Callison-Burch,University of Pennsylvania,http://www.cis.upenn.edu/~ccb,nv-MV58AAAAJ
 Chris Chitty,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=106050,NOSCHOLARPAGE
@@ -7202,7 +7201,6 @@ Kevin Gimpel,TTI Chicago,http://ttic.uchicago.edu/~kgimpel,kDHs7DYAAAAJ
 Kevin J. Compton,University of Michigan,http://web.eecs.umich.edu/~kjc,NOSCHOLARPAGE
 Kevin Jeffay,University of North Carolina,http://jeffay.web.unc.edu,J12C3nYAAAAJ
 Kevin K. Y. Kuan,University of Sydney,http://sydney.edu.au/engineering/people/kevin.kuan.php,nxiGa3EAAAAJ
-Kevin Knight,University of Southern California,http://www.isi.edu/~knight,d7PTaOYAAAAJ
 Kevin Leyton-Brown,University of British Columbia,http://www.cs.ubc.ca/~kevinlb,_4dnp0IAAAAJ
 Kevin Liu,Michigan State University,http://www.cse.msu.edu/~kjl,6xDUqM0AAAAJ
 Kevin R. B. Butler,University of Florida,http://cise.ufl.edu/~butler,gvo0nMsAAAAJ


### PR DESCRIPTION
Knight moved to industry, Biemann to Hamburg (which is not currently covered)