### PR TITLE
Changes to the University of Cambridge to reflect current faculty

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -8861,7 +8861,6 @@ Michael I. Shamos,Carnegie Mellon University,http://euro.ecom.cmu.edu/shamos.htm
 Michael Ian Shamos,Carnegie Mellon University,http://euro.ecom.cmu.edu/shamos.html,NOSCHOLARPAGE
 Michael J. Black,Max Planck Institute,https://ps.is.tuebingen.mpg.de/person/black,6NjbexEAAAAJ
 Michael J. Brooks,University of Adelaide,http://www.adelaide.edu.au/directory/michael.brooks,IRsRrroAAAAJ
-Michael J. C. Gordon,University of Cambridge,http://www.cl.cam.ac.uk/~mjcg/colour-index.html,ED-qvWkAAAAJ
 Michael J. Cafarella,University of Michigan,http://web.eecs.umich.edu/~michjc,r1quzEkAAAAJ
 Michael J. Carey 0001,University of California - Irvine,http://www.ics.uci.edu/~mjcarey,qqiZTS8AAAAJ
 Michael J. Dinneen,University of Auckland,https://www.cs.auckland.ac.nz/~mjd,NspX1ZIAAAAJ
@@ -9060,7 +9059,6 @@ Mike Domaratzki,University of Manitoba,http://www.cs.umanitoba.ca/~mdomarat,W5Gc
 Mike Feeley,University of British Columbia,https://www.cs.ubc.ca/people/mike-feeley,g93mhb4AAAAJ
 Mike Franklin,University of Chicago,https://cs.uchicago.edu/directory/michael-franklin,qvH-ATcAAAAJ
 Mike Fraser,University of Bristol,http://www.bristol.ac.uk/engineering/people/mike-c-fraser/index.html,0fMpFU8AAAAJ
-Mike Gordon,University of Cambridge,http://www.cl.cam.ac.uk/~mjcg/colour-index.html,ED-qvWkAAAAJ
 Mike H. MacGregor,University of Alberta,https://webdocs.cs.ualberta.ca/~macg,uUWOJvkAAAAJ
 Mike Hicks,University of Maryland - College Park,http://www.cs.umd.edu/~mwh,I9Vzs-4AAAAJ
 Mike Holenderski,TU Eindhoven,https://www.tue.nl/en/university/departments/mathematics-and-computer-science/the-department/staff/detail/ep/e/d/ep-uid/20000748,NOSCHOLARPAGE
@@ -11021,7 +11019,6 @@ Richard Hughey,University of California - Santa Cruz,https://www.soe.ucsc.edu/pe
 Richard I. Hartley,Australian National University,http://axiom.anu.edu.au/~hartley,cHia5p0AAAAJ
 Richard J. Anderson,University of Washington,http://www.cs.washington.edu/people/faculty/anderson,uLsDDUMAAAAJ
 Richard J. Enbody,Michigan State University,http://www.cse.msu.edu/~enbody,QR4VpsIAAAAJ
-Richard J. Gibbens,University of Cambridge,http://www.cl.cam.ac.uk/~rg31,AAWOlNUAAAAJ
 Richard J. Lipton,Georgia Institute of Technology,http://www.cc.gatech.edu/people/richard-lipton,f8B4yewAAAAJ
 Richard J. Trefler,University of Waterloo,https://cs.uwaterloo.ca/~trefler,NOSCHOLARPAGE
 Richard Jay Lipton,Georgia Institute of Technology,http://www.cc.gatech.edu/people/richard-lipton,f8B4yewAAAAJ
@@ -12460,7 +12457,6 @@ Stephanie Forrest,University of New Mexico,https://www.cs.unm.edu/~forrest,rx56n
 Stephanie Ludi,University of North Texas,http://www.cse.unt.edu/~ludi,wV2jzL8AAAAJ
 Stephanie Weirich,University of Pennsylvania,https://www.cis.upenn.edu/~sweirich,NOSCHOLARPAGE
 Stephen A. Brewster,University of Glasgow,http://www.dcs.gla.ac.uk/~stephen,uu7LudIAAAAJ
-Stephen A. Clark,University of Cambridge,https://sites.google.com/site/stephenclark609,aXP4XuoAAAAJ
 Stephen A. Edwards,Columbia University,http://www.cs.columbia.edu/~sedwards,3aw_314AAAAJ
 Stephen A. Fenner,University of South Carolina,http://www.cse.sc.edu/~fenner,NOSCHOLARPAGE
 Stephen A. Ward,Massachusetts Institute of Technology,https://www.csail.mit.edu/user/1517,0iSggMcAAAAJ
@@ -12472,7 +12468,6 @@ Stephen Brooks,Dalhousie University,https://web.cs.dal.ca/~sbrooks,mR2jMNUAAAAJ
 Stephen C. Y. Lu,University of Southern California,http://ise.usc.edu/directory/stephen_lu.htm,N4TZNVoAAAAJ
 Stephen Cameron,University of Oxford,http://www.cs.ox.ac.uk/stephen.cameron,mssbQTEAAAAJ
 Stephen Chong,Harvard University,http://people.seas.harvard.edu/~chong,5bxyMBwAAAAJ
-Stephen Clark,University of Cambridge,https://sites.google.com/site/stephenclark609,qr7zUMAAAAAJ
 Stephen Cooper,University of Nebraska,http://cse.unl.edu/~scooper,8Hfi_iUAAAAJ
 Stephen D. Brookes,Carnegie Mellon University,http://www.cs.cmu.edu/~brookes,yBq9ovYAAAAJ
 Stephen E. Reichenbach,University of Nebraska,http://cse.unl.edu/~reich,GDQ7k80AAAAJ
@@ -13152,7 +13147,6 @@ Timothy Bourke,Ecole Normale Superieure,http://www.di.ens.fr/~bourke,XOi6VWwAAAA
 Timothy Bretl,Univ. of Illinois at Urbana-Champaign,http://bretl.csl.illinois.edu,ab_0lGcAAAAJ
 Timothy C. Bell,University of Canterbury,http://www.cosc.canterbury.ac.nz/tim.bell,NOSCHOLARPAGE
 Timothy C. Lethbridge,University of Ottawa,http://www.site.uottawa.ca/~tcl,PQ9tLbUAAAAJ
-Timothy David Jones,University of Cambridge,http://www.cl.cam.ac.uk/~tmj32,NOSCHOLARPAGE
 Timothy G. Griffin,University of Cambridge,https://www.cl.cam.ac.uk/~tgg22,bNZfDVgAAAAJ
 Timothy Graham,Australian National University,http://anu-au.academia.edu/TimothyGraham,xbDCsowAAAAJ
 Timothy J. Hickey,Brandeis University,http://www.cs.brandeis.edu/~tim,APFVA6sAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -262,7 +262,6 @@ Alain J. Martin,California Institute of Technology,http://www.eas.caltech.edu/pe
 Alain Tapp,University of Montreal,http://diro.umontreal.ca/repertoire-departement/vue/tapp-alain,tAM57M8AAAAJ
 Alain Trémeau,Université Jean Monnet,http://www.create.uwe.ac.uk/membership/tremeau.htm,NOSCHOLARPAGE
 Alain Wegmann,EPFL,https://people.epfl.ch/alain.wegmann,NOSCHOLARPAGE
-Alan Blackwell,University of Cambridge,http://www.cl.cam.ac.uk/~afb21,0kWwkEUAAAAJ
 Alan Blair,UNSW,http://www.cse.unsw.edu.au/~blair,oYi8fBIAAAAJ
 Alan Borning,University of Washington,http://www.cs.washington.edu/people/faculty/borning,NOSCHOLARPAGE
 Alan Bundy,University of Edinburgh,https://sweb.inf.ed.ac.uk/bundy,n7STZEYAAAAJ
@@ -295,7 +294,6 @@ Alan Mycroft,University of Cambridge,https://www.cl.cam.ac.uk/~am21,0ycSEz8AAAAJ
 Alan Paul Fern,Oregon State University,http://eecs.oregonstate.edu/~afern,GaKxFrcAAAAJ
 Alan Richard Bundy,University of Edinburgh,https://sweb.inf.ed.ac.uk/bundy,n7STZEYAAAAJ
 Alan Ritter,Ohio State University,https://cse.osu.edu/people/ritter.1492,unXtH3IAAAAJ
-Alan Ross Anderson,University of Cambridge,https://www.jstor.org/stable/3129910,NOSCHOLARPAGE
 Alan S. Willsky,Massachusetts Institute of Technology,http://ssg.mit.edu/~willsky,XYy_Nm4AAAAJ
 Alan Smaill,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Alan_Smaill.html,NOSCHOLARPAGE
 Alan Sussman,University of Maryland - College Park,https://www.cs.umd.edu/~als,4Ts9jNQAAAAJ
@@ -570,6 +568,7 @@ Ali Taylan Cemgil,Boğaziçi University,https://www.cmpe.boun.edu.tr/~cemgil,X3Z
 Alice A. Miller,University of Glasgow,http://www.dcs.gla.ac.uk/~alice,aqR9WqQAAAAJ
 Alice H. Oh,KAIST,http://uilab.kaist.ac.kr/members/aliceoh,KcB5NH4AAAAJ
 Alice Haeyun Oh,KAIST,http://uilab.kaist.ac.kr/members/aliceoh,KcB5NH4AAAAJ
+Alice Hutchings,University of Cambridge,https://www.cl.cam.ac.uk/~ah793,kITQ0T8AAAAJ
 Alice Miller,University of Glasgow,http://www.dcs.gla.ac.uk/~alice,aqR9WqQAAAAJ
 Alin Albu-Schäffer,TU Munich,https://www.professoren.tum.de/en/albu-schaeffer-alin,yP_zL3gAAAAJ
 Alin Deutsch,University of California - San Diego,http://db.ucsd.edu/People/alin,2lZr6WsAAAAJ
@@ -633,6 +632,7 @@ Amal J. Ahmed,Northeastern University,http://www.ccs.neu.edu/home/amal,Y1C007wAA
 Amali Weerasinghe,University of Adelaide,http://www.adelaide.edu.au/directory/amali.weerasinghe,cW9YyJAAAAAJ
 Aman Parnami,IIIT Delhi,https://www.iiitd.ac.in/aman,PI30hN8AAAAJ
 Amanda Lazar,University of Maryland - College Park,https://ischool.umd.edu/faculty-staff/amanda-lazar,WrnEVwQAAAAJ
+Amanda Prorok,University of Cambridge,https://www.proroklab.org,o7xMDgEAAAAJ
 Amarda Shehu,George Mason University,https://cs.gmu.edu/~ashehu,HkB_Gz0AAAAJ
 Amarjeet Singh 0001,IIIT Delhi,https://www.iiitd.ac.in/amarjeet,cZhWKd0AAAAJ
 Amaury Habrard,Université Jean Monnet,http://perso.univ-st-etienne.fr/habrarda,oPemAuMAAAAJ
@@ -807,6 +807,7 @@ Andreas R. Pfenning,Carnegie Mellon University,http://people.csail.mit.edu/apfen
 Andreas S. Andreou,Cyprus University of Technology,https://www.cut.ac.cy/faculties/fet/eecei/staff/andreas.andreou/?languageId=1,CqlJG_IAAAAJ
 Andreas Stathopoulos,College of William and Mary,http://www.cs.wm.edu/~andreas,2M8BWDkAAAAJ
 Andreas Uhl,University of Salzburg,https://www.cosy.sbg.ac.at/~uhl,NOSCHOLARPAGE
+Andreas Vlachos,University of Cambridge,https://www.cl.cam.ac.uk/~av308,XjWnyM4AAAAJ
 Andreas Vogelsang,TU Berlin,https://www.aset.tu-berlin.de/menue/team/andreas_vogelsang,knNRUtEAAAAJ
 Andreas Weisshaar,Oregon State University,http://eecs.oregonstate.edu/people/weisshaar-andreas,NOSCHOLARPAGE
 Andreas Wichert,Universidade de Lisboa,http://web.tecnico.ulisboa.pt/~andreas.wichert,yHp58QgAAAAJ
@@ -829,12 +830,11 @@ Andrew Blakers,Australian National University,https://researchers.anu.edu.au/res
 Andrew C. Doxey,University of Waterloo,http://doxey.uwaterloo.ca,NOSCHOLARPAGE
 Andrew C. Gordon,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Andrew_Gordon.html,h-GK55oAAAAJ
 Andrew C. Myers,Cornell University,http://www.cs.cornell.edu/andru,ovlpa_IAAAAJ
-Andrew C. Rice,University of Cambridge,https://www.cl.cam.ac.uk/~acr31,5qyXpx4AAAAJ
+Andrew C. Rice,University of Cambridge,https://www.cl.cam.ac.uk/~acr31,bxvOPw8AAAAJ
 Andrew C. Simpson,University of Oxford,http://www.cs.ox.ac.uk/andrew.simpson,rrydyHwAAAAJ
 Andrew C. Yao,Tsinghua University,http://iiis.tsinghua.edu.cn/yao,NOSCHOLARPAGE
 Andrew Calway,University of Bristol,http://www.bris.ac.uk/engineering/people/andrew-d-calway/index.html,zMXplXcAAAAJ
 Andrew Chi-Chih Yao,Tsinghua University,http://iiis.tsinghua.edu.cn/yao,NOSCHOLARPAGE
-Andrew Colin Rice,University of Cambridge,https://www.cl.cam.ac.uk/~acr31,5qyXpx4AAAAJ
 Andrew D. Calway,University of Bristol,http://www.bris.ac.uk/engineering/people/andrew-d-calway/index.html,zMXplXcAAAAJ
 Andrew D. Ker,University of Oxford,http://www.cs.ox.ac.uk/andrew.ker/home.html,9fTPyU0AAAAJ
 Andrew D. Richardson,Northern Arizona University,https://nau.edu/siccs/faculty,GlGy7vgAAAAJ
@@ -847,7 +847,6 @@ Andrew F. Thomson,Australian National University,https://cecs.anu.edu.au/people/
 Andrew Gordon Wilson,Cornell University,https://people.orie.cornell.edu/andrew,twWX2LIAAAAJ
 Andrew Grimshaw,University of Virginia,http://www.cs.virginia.edu/~grimshaw,T_O6pjEAAAAJ
 Andrew Hamilton-Wright,University of Guelph,https://www.uoguelph.ca/computing/people/andrew-hamilton-wright,nWoiQrQAAAAJ
-Andrew Hopper,University of Cambridge,https://www.cl.cam.ac.uk/~ah12,WBr_GXUAAAAJ
 Andrew J. Davison,Imperial College London,https://www.doc.ic.ac.uk/~ajd,SNQFnBEAAAAJ
 Andrew J. Ko,University of Washington,http://faculty.washington.edu/ajko,otmdDLoAAAAJ
 Andrew J. McAllister,University of New Brunswick,http://www.cs.unb.ca/~andrewm,d1yVDNgAAAAJ
@@ -857,7 +856,7 @@ Andrew Lo,Massachusetts Institute of Technology,http://alo.mit.edu,4M-iGXMAAAAJ
 Andrew Lukefahr,Indiana University,http://homes.sice.indiana.edu/lukefahr,tZ4fdX0AAAAJ
 Andrew Luxton-Reilly,University of Auckland,https://www.cs.auckland.ac.nz/~andrew-l,3nuHa7IAAAAJ
 Andrew M. Childs,University of Maryland - College Park,https://www.cs.umd.edu/~amchilds,7MOW-j4AAAAJ
-Andrew M. Pitts,University of Cambridge,http://www.cl.cam.ac.uk/~amp12,J1wRn3oAAAAJ
+Andrew M. Pitts,University of Cambridge,https://www.cl.cam.ac.uk/~amp12,J1wRn3oAAAAJ
 Andrew Markham,University of Oxford,https://www.cs.ox.ac.uk/people/andrew.markham,g3JTO9EAAAAJ
 Andrew McCallum,University of Massachusetts Amherst,https://people.cs.umass.edu/~mccallum,yILa1y0AAAAJ
 Andrew McGregor 0001,University of Massachusetts Amherst,http://people.cs.umass.edu/~mcgregor,IpBjTKQAAAAJ
@@ -885,9 +884,8 @@ Andrew Trotman,University of Otago,http://www.cs.otago.ac.nz/homepages/andrew,Yi
 Andrew Turpin,University of Melbourne,http://people.eng.unimelb.edu.au/aturpin,lCZblDwAAAAJ
 Andrew W. Appel,Princeton University,https://www.cs.princeton.edu/~appel,wC_ntLYAAAAJ
 Andrew W. Lo,Massachusetts Institute of Technology,http://alo.mit.edu,4M-iGXMAAAAJ
-Andrew W. Moore 0001,Carnegie Mellon University,http://www.cs.cmu.edu/~awm,lSWWr04AAAAJ
-Andrew W. Moore 0002,University of Cambridge,http://www.cl.cam.ac.uk/~awm22,PbfkKLcAAAAJ
-Andrew William Moore,University of Cambridge,http://www.cl.cam.ac.uk/~awm22,PbfkKLcAAAAJ
+Andrew W. Moore 0001,Carnegie Mellon University,http://www.cs.cmu.edu/~awm,PbfkKLcAAAAJ
+Andrew W. Moore 0002,University of Cambridge,https://www.cl.cam.ac.uk/~awm22,lSWWr04AAAAJ
 Andrey N. Chernikov,Old Dominion University,http://www.cs.odu.edu/~achernik,DJ-5kAcAAAAJ
 Andri Ioannou,Cyprus University of Technology,http://www.cut.ac.cy/faculties/aac/mga/staff/elected-staff/andri.i.ioannou,RT7cgC8AAAAJ
 Andri Ioannou-Nicolaou,Cyprus University of Technology,http://www.cut.ac.cy/faculties/aac/mga/staff/elected-staff/andri.i.ioannou,RT7cgC8AAAAJ
@@ -968,7 +966,7 @@ Anil Kumar Sao,IIT Mandi,http://faculty.iitmandi.ac.in/~anil,4ya5wyQAAAAJ
 Anil Kumar Singh,IIT (BHU) Varanasi,http://www.iitbhu.ac.in/cse/index.php/people/faculty/37.html,2IaFZuMAAAAJ
 Anil Kumar Tripathi,IIT (BHU) Varanasi,http://www.iitbhu.ac.in/cse/index.php/people/faculty/34.html,MeBbV48AAAAJ
 Anil Kumar Vuppala,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/anilvuppala,VEx1PN4AAAAJ
-Anil Madhavapeddy,University of Cambridge,http://anil.recoil.org,u2nZ7F8AAAAJ
+Anil Madhavapeddy,University of Cambridge,https://anil.recoil.org,u2nZ7F8AAAAJ
 Anil Maheshwari,Carleton University,http://www.scs.carleton.ca/~maheshwa,-6ZbKwoAAAAJ
 Anil N. Hirani,Univ. of Illinois at Urbana-Champaign,http://www.math.uiuc.edu/~hirani,2FlUClkAAAAJ
 Anil Seth,IIT Kanpur,https://www.cse.iitk.ac.in/users/seth,3eJCZCkAAAAJ
@@ -1123,7 +1121,7 @@ António Rito Silva,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/home
 Antônio Marinho Pilla Barcellos,UFRGS,http://www.inf.ufrgs.br/~marinho,NOSCHOLARPAGE
 Anu G. Bourgeois,Georgia State University,https://grid.cs.gsu.edu/bourgeois,qsAUgQ8AAAAJ
 Anubha Gupta,IIIT Delhi,http://faculty.iiitd.ac.in/~anubha,VWCf3JEAAAAJ
-Anuj Dawar,University of Cambridge,http://www.cl.cam.ac.uk/~ad260,xdOimF8AAAAJ
+Anuj Dawar,University of Cambridge,https://www.cl.cam.ac.uk/~ad260,xdOimF8AAAAJ
 Anuj Karpatne,Virginia Tech,https://people.cs.vt.edu/karpatne,aJdbHAoAAAAJ
 Anujan Varma,University of California - Santa Cruz,https://www.soe.ucsc.edu/people/varma,z9lI9VIAAAAJ
 Anup Basu,University of Alberta,https://webdocs.cs.ualberta.ca/~anup,x8Nn-jQAAAAJ
@@ -2056,7 +2054,7 @@ Cathy Wu,University of Delaware,http://bioinformatics.udel.edu/people/personnel/
 Cauligi S. Raghavendra,University of Southern California,http://ceng.usc.edu/~raghu,GM-hJhQAAAAJ
 Ce Zhang,ETH Zurich,https://www.inf.ethz.ch/personal/ce.zhang,GkXqbmMAAAAJ
 Ce Zhu,UESTC,http://www.avc2-lab.net/~eczhu,C7iZbYMAAAAJ
-Cecilia Mascolo,University of Cambridge,http://www.cl.cam.ac.uk/~cm542,Ej4BNaQAAAAJ
+Cecilia Mascolo,University of Cambridge,https://www.cl.cam.ac.uk/~cm542,Ej4BNaQAAAAJ
 Cecilia R. Aragon,University of Washington,http://faculty.washington.edu/aragon,BM_qLgYAAAAJ
 Cecília Baranauskas,UNICAMP,http://bv.fapesp.br/pt/pesquisador/3391/maria-cecilia-calani-baranauskas,NOSCHOLARPAGE
 Cecília M. F. Rubira,UNICAMP,http://www.bv.fapesp.br/en/pesquisador/8092/cecilia-mary-fischer-rubira,NOSCHOLARPAGE
@@ -2699,6 +2697,7 @@ Damith Chinthana Ranasinghe,University of Adelaide,http://www.adelaide.edu.au/di
 Damla Turgut,University of Central Florida,http://www.cs.ucf.edu/~turgut,bjX4jCkAAAAJ
 Damon L. Woodard,University of Florida,https://www.ece.ufl.edu/user/1469,hhBx6TMAAAAJ
 Damon McCoy,New York University,http://engineering.nyu.edu/people/damon-mccoy,pT8-2f0AAAAJ
+Damon Wischik,University of Cambridge,https://www.cl.cam.ac.uk/~djw1005,NOSCHOLARPAGE
 Dan Alistarh,IST Austria,https://ist.ac.at/research/research-groups/alistarh-group,75q-6ZQAAAAJ
 Dan Boneh,Stanford University,http://crypto.stanford.edu/~dabo,MwLqCs4AAAAJ
 Dan C. Marinescu,University of Central Florida,https://www.cs.ucf.edu/~dcm,YoLdEIIAAAAJ
@@ -3010,7 +3009,7 @@ David J. Barnes,University of Kent,https://www.cs.kent.ac.uk/~djb,r1wpO3AAAAAJ
 David J. Crandall,Indiana University,http://www.cs.indiana.edu/~djcran,8bQRH5YAAAAJ
 David J. Fleet,University of Toronto,http://www.cs.toronto.edu/~fleet,njOmQFsAAAAJ
 David J. Gavaghan,University of Oxford,http://www.cs.ox.ac.uk/david.gavaghan,riGX3YsAAAAJ
-David J. Greaves,University of Cambridge,http://www.cl.cam.ac.uk/~djg11,WStMFkYAAAAJ
+David J. Greaves,University of Cambridge,https://www.cl.cam.ac.uk/~djg11,WStMFkYAAAAJ
 David J. Hawkes,University College London,http://cmic.cs.ucl.ac.uk/staff/dave_hawkes,O42T24CT_GwC
 David J. Kriegman,University of California - San Diego,http://cseweb.ucsd.edu/~kriegman,EqetexsAAAAJ
 David J. Mostow,Carnegie Mellon University,http://www.cs.cmu.edu/~mostow,P0Mv6pIAAAAJ
@@ -3605,7 +3604,6 @@ Edward D. Lazowska,University of Washington,http://www.cs.washington.edu/people/
 Edward F. Gehringer,North Carolina State University,http://www4.ncsu.edu/~efg,IEHo6YcAAAAJ
 Edward Hermann Haeusler,PUC-RIO,http://www-di.inf.puc-rio.br/~hermann,eQP-Ez8AAAAJ
 Edward Holden,Rochester Institute of Technology,http://www.ist.rit.edu/~eph,NOSCHOLARPAGE
-Edward John Briscoe,University of Cambridge,https://www.cl.cam.ac.uk/~ejb1,qNP6lAwAAAAJ
 Edward K. Wong,New York University,http://engineering.nyu.edu/people/edward-k-wong,f7laURkAAAAJ
 Edward Lank,University of Waterloo,https://cs.uwaterloo.ca/~lank,e7P8IwgAAAAJ
 Edward M. Reingold,Illinois Institute of Technology,https://science.iit.edu/people/faculty/edward-reingold,UlQeH7AAAAAJ
@@ -3932,6 +3930,7 @@ Evan Barba,Georgetown University,http://explore.georgetown.edu/people/eb892,mecU
 Evan Drumwright,George Washington University,https://www.seas.gwu.edu/evan-drumwright,pC92XmQAAAAJ
 Evan Franklin,Australian National University,https://cecs.anu.edu.au/people/evan-franklin,s0zK0k4AAAAJ
 Evan M. Drumwright,George Washington University,https://www.seas.gwu.edu/evan-drumwright,pC92XmQAAAAJ
+Evangelia Kalyvianaki,University of Cambridge,https://www.cl.cam.ac.uk/~ek264,8nhT3JAAAAAJ
 Evangeline F. Y. Young,Chinese University of Hong Kong,http://www.cse.cuhk.edu.hk/~fyyoung,NOSCHOLARPAGE
 Evangelos E. Milios,Dalhousie University,https://www.cs.dal.ca/~eem,ME8aQywAAAAJ
 Evangelos E. Papalexakis,University of California - Riverside,https://www.cs.cmu.edu/~epapalex,2P1kinAAAAAJ
@@ -4216,7 +4215,7 @@ Frank Rudzicz,University of Toronto,http://www.cs.toronto.edu/~frank,elXOB1sAAAA
 Frank Ruskey,University of Victoria,http://www.cs.uvic.ca/~ruskey,z81N4kUAAAAJ
 Frank S. de Boer,CWI,http://homepages.cwi.nl/~frb,5EtjjF8AAAAJ
 Frank Shipman,Texas A&M University,http://www.csdl.tamu.edu/~shipman,NOSCHOLARPAGE
-Frank Stajano,University of Cambridge,http://www.cl.cam.ac.uk/~fms27,NOSCHOLARPAGE
+Frank Stajano,University of Cambridge,https://www.cl.cam.ac.uk/~fms27,gpmtO_gAAAAJ
 Frank Stephan,National University of Singapore,https://www.comp.nus.edu.sg/~fstephan,m32l0cMAAAAJ
 Frank Thuijsman,Maastricht University,https://dke.maastrichtuniversity.nl/f.thuijsman/site,OxPUGmwAAAAJ
 Frank Tip,Northeastern University,http://www.franktip.org,siQDY4gAAAAJ
@@ -5375,9 +5374,8 @@ Ian Horrocks,University of Oxford,http://www.cs.ox.ac.uk/ian.horrocks,0ypdmcYAAA
 Ian Horswill,Northwestern University,http://www.cs.northwestern.edu/~ian,YZesz7sAAAAJ
 Ian J. Hayes,University of Queensland,http://researchers.uq.edu.au/researcher/211,fRdQiZcAAAAJ
 Ian J. Wassell,University of Cambridge,https://www.cl.cam.ac.uk/research/dtg/www/people/ijw24,jHRJWk8AAAAJ
-Ian James Wassell,University of Cambridge,https://www.cl.cam.ac.uk/research/dtg/www/people/ijw24,NOSCHOLARPAGE
 Ian M. Hodkinson,Imperial College London,http://www.doc.ic.ac.uk/~imh,dNFiqhoAAAAJ
-Ian M. Leslie,University of Cambridge,https://www.cl.cam.ac.uk/~iml1,40Y8NUsAAAAJ
+Ian M. Leslie,University of Cambridge,https://www.cl.cam.ac.uk/~iml1,NOSCHOLARPAGE
 Ian M. Mitchell,University of British Columbia,https://www.cs.ubc.ca/~mitchell,bTG82acAAAAJ
 Ian Mackie,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/212026,NOSCHOLARPAGE
 Ian McKillop,University of Waterloo,https://uwaterloo.ca/public-health-and-health-systems/people-profiles/ian-mckillop,NOSCHOLARPAGE
@@ -5394,7 +5392,6 @@ Ian Utting,University of Kent,https://www.cs.kent.ac.uk/~iau,j32IMCEAAAAJ
 Ian Vince McLoughlin,University of Kent,http://kent.academia.edu/IanMcLoughlin,mcnKgPoAAAAJ
 Ian Wakeman,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/10651,NXsakW8AAAAJ
 Ian Warren,University of Auckland,https://www.cs.auckland.ac.nz/people/i-warren,X12wTvkAAAAJ
-Ian Wassell,University of Cambridge,https://www.cl.cam.ac.uk/research/dtg/www/people/ijw24,jHRJWk8AAAAJ
 Ian Welch,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/IanWelch,EBgB5LwAAAAJ
 Iasonas Polakis,University of Illinois at Chicago,https://www.cs.uic.edu/~polakis,OgJKomcAAAAJ
 Ibrahim Abe M. Elfadel,Masdar Institute,https://www.masdar.ac.ae/aboutus/management/faculty-directory/item/5680-ibrahim-elfadel,NOSCHOLARPAGE
@@ -6411,7 +6408,7 @@ John Criswell,University of Rochester,https://www.cs.rochester.edu/u/criswell,jG
 John D. Kececioglu,University of Arizona,https://www.cs.arizona.edu/~kece,SKXmmxIAAAAJ
 John D. Lafferty,Yale University,https://statistics.yale.edu/people/john-lafferty,NOSCHOLARPAGE
 John Darlington,Imperial College London,http://www.imperial.ac.uk/people/j.darlington,WzMgfywAAAAJ
-John Daugman,University of Cambridge,http://www.cl.cam.ac.uk/~jgd1000,NOSCHOLARPAGE
+John Daugman,University of Cambridge,https://www.cl.cam.ac.uk/~jgd1000,D0Q3owUAAAAJ
 John Dowell,University College London,http://www0.cs.ucl.ac.uk/people/J.Dowell.html,NOSCHOLARPAGE
 John E. Hopcroft,Cornell University,http://www.cs.cornell.edu/jeh,NOSCHOLARPAGE
 John E. Laird,University of Michigan,http://ai.eecs.umich.edu/people/laird,ea6cjVUAAAAJ
@@ -6419,7 +6416,6 @@ John E. Savage,Brown University,http://cs.brown.edu/~jes,1lHqK_4AAAAJ
 John Edwin Laird,University of Michigan,http://ai.eecs.umich.edu/people/laird,ea6cjVUAAAAJ
 John F. Canny,University of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/canny.html,LAv0HTEAAAAJ
 John F. Hughes,Brown University,http://cs.brown.edu/~jfh,ege5vzMAAAAJ
-John G. Daugman,University of Cambridge,http://www.cl.cam.ac.uk/~jgd1000,NOSCHOLARPAGE
 John G. Wager,Oregon State University,http://eecs.oregonstate.edu/people/wager-john,ZgUfjxcsQU4C
 John Georgas,Northern Arizona University,https://www.cefns.nau.edu/~jg455,NOSCHOLARPAGE
 John Grundy,Monash University,https://sites.google.com/site/johncgrundy,bbEQGY8AAAAJ
@@ -6508,7 +6504,7 @@ Joke G. Blom,CWI,http://homepages.cwi.nl/~gollum,Za0-ttMAAAAJ
 Jon A. Solworth,University of Illinois at Chicago,http://parsys.eecs.uic.edu/~solworth,NOSCHOLARPAGE
 Jon Atle Gulla,Norwegian University of Science and Technology,https://www.ntnu.edu/employees/jon.atle.gulla,lq5InSEAAAAJ
 Jon B. Weissman,University of Minnesota,http://www-users.cs.umn.edu/~jon,ouY9ypcAAAAJ
-Jon Crowcroft,University of Cambridge,http://www.cl.cam.ac.uk/~jac22,qnMs-XYAAAAJ
+Jon Crowcroft,University of Cambridge,https://www.cl.cam.ac.uk/~jac22,qnMs-XYAAAAJ
 Jon Doyle,North Carolina State University,https://www.csc.ncsu.edu/faculty/doyle,C6DtGmMAAAAJ
 Jon E. Froehlich,University of Washington,http://www.cs.umd.edu/~jonf,nExKrpsAAAAJ
 Jon Froehlich,University of Washington,http://www.cs.umd.edu/~jonf,nExKrpsAAAAJ
@@ -7569,7 +7565,7 @@ Laurie Williams,North Carolina State University,http://collaboration.csc.ncsu.ed
 Lav R. Varshney,Univ. of Illinois at Urbana-Champaign,http://varshney.web.engr.illinois.edu,JIJGu30AAAAJ
 Lavika Goel,BITS Pilani,http://www.bits-pilani.ac.in/pilani/lavikagoel/profile,S9hsnNoAAAAJ
 Lawrence Birnbaum,Northwestern University,http://www.mccormick.northwestern.edu/research-faculty/directory/profiles/birnbaum-larry.html,vxmUoXEAAAAJ
-Lawrence C. Paulson,University of Cambridge,http://www.cl.cam.ac.uk/~lp15,Sv1hcjEAAAAJ
+Lawrence C. Paulson,University of Cambridge,https://www.cl.cam.ac.uk/~lp15,Sv1hcjEAAAAJ
 Lawrence Cavedon,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/c/cavedon-associate-professor-lawrence,ZAEiiEUAAAAJ
 Lawrence Chung,University of Texas at Dallas,http://www.utdallas.edu/~chung,pFRPgsIAAAAJ
 Lawrence Hall,University of South Florida,http://www.usf.edu/engineering/cse/people/hall-lawrence.aspx,AKHplAUAAAAJ
@@ -8173,7 +8169,7 @@ Marcelo Gattass,PUC-RIO,http://webserver2.tecgraf.puc-rio.br/~mgattass,zrRqeM8AA
 Marcelo Gomes de Queiroz,USP,http://www.ime.usp.br/~mqz,NOSCHOLARPAGE
 Marcelo H. de Carvalho,UFMS,https://www.facom.ufms.br/~mhc,Q_F5v5wAAAAJ
 Marcelo Keese Albertini,UFU,http://www.facom.ufu.br/~albertini,NOSCHOLARPAGE
-Marcelo P. Fiore,University of Cambridge,http://www.cl.cam.ac.uk/~mpf23,yTiYbvcAAAAJ
+Marcelo P. Fiore,University of Cambridge,https://www.cl.cam.ac.uk/~mpf23,NOSCHOLARPAGE
 Marcelo Pias,FURG Federal University of Rio Grande,https://sites.google.com/site/piasmarcelo,X_zoltAAAAAJ
 Marcelo Pimenta,UFRGS,http://inf.ufrgs.br/~mpimenta,NOSCHOLARPAGE
 Marcelo Risk,University of Buenos Aires,https://www.dc.uba.ar/rrhh/profesores/risk,NOSCHOLARPAGE
@@ -8430,10 +8426,9 @@ Markulf Kohlweiss,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/
 Markus Brill,TU Berlin,https://www.algo.tu-berlin.de/menue/people/markus_brill,LeFkVsYAAAAJ
 Markus Dürmuth,Ruhr-University Bochum,http://mobsec.rub.de/group/people/duermuth_markus,4Gu4Zx4AAAAJ
 Markus Endler,PUC-RIO,http://www.inf.puc-rio.br/~endler,QpN9ae8AAAAJ
-Markus G. Kuhn,University of Cambridge,http://www.cl.cam.ac.uk/~mgk25,4FSAZOsAAAAJ
+Markus G. Kuhn,University of Cambridge,https://www.cl.cam.ac.uk/~mgk25,4FSAZOsAAAAJ
 Markus H. Gross,ETH Zurich,https://graphics.ethz.ch/~grossm,uxk0GmUAAAAJ
 Markus Hadwiger,KAUST,https://www.kaust.edu.sa/en/study/faculty/markus-hadwiger,wmx7KVUAAAAJ
-Markus Kuhn,University of Cambridge,http://www.cl.cam.ac.uk/~mgk25,4FSAZOsAAAAJ
 Markus Nebel,Bielefeld University,https://ekvv.uni-bielefeld.de/pers_publ/publ/PersonDetail.jsp?personId=71594916&lang=en,NOSCHOLARPAGE
 Markus Pauly,EPFL,http://lgg.epfl.ch/publications.php,TSGyT-EAAAAJ
 Markus Püschel,ETH Zurich,https://www.inf.ethz.ch/personal/markusp,az9ZryAAAAAJ
@@ -9393,7 +9388,7 @@ N. Zincir-Heywood,Dalhousie University,https://www.cs.dal.ca/~zincir,F9nG0F4AAAA
 Na Liu,University of Sydney,https://sydney.edu.au/engineering/people/liu.na.php,NOSCHOLARPAGE
 Na Meng,Virginia Tech,http://people.cs.vt.edu/nm8247,d-VnBn8AAAAJ
 Nachum Dershowitz,Tel Aviv University,http://www.cs.tau.ac.il/~nachumd,NOSCHOLARPAGE
-Nada Amin,Harvard University,http://namin.net,9cGEmcgAAAAJ
+Nada Amin,University of Cambridge,http://namin.net,9cGEmcgAAAAJ
 Nadarajah Mithulananthan,University of Queensland,http://researchers.uq.edu.au/researcher/2221,0edDWSQAAAAJ
 Nadeem Jamali,University of Saskatchewan,http://agents.usask.ca/Agents_Lab/Nadeem_Jamali.html,NOSCHOLARPAGE
 Nader H. Bshouty,Technion,http://www.cs.technion.ac.il/~bshouty,NOSCHOLARPAGE
@@ -9517,6 +9512,7 @@ Ndapandula Nakashole,University of California - San Diego,http://nakashole.com,N
 Neal E. Young,University of California - Riverside,http://www.cs.ucr.edu/~neal,_nyTrU0AAAAJ
 Neda Aboutorab,Australian National University,https://cecs.anu.edu.au/people/neda-aboutorab,yelZOQIAAAAJ
 Nedialko S. Nedialkov,McMaster University,https://www.cas.mcmaster.ca/~nedialk,mVEWNfgAAAAJ
+Neelakantan R. Krishnaswami,University of Cambridge,https://www.cl.cam.ac.uk/~nk480,qCE8eVcAAAAJ
 Neelam Sinha,IIIT Bangalore,http://www.iiitb.ac.in/faculty_page.php?name=NeelamSinha,6A_OhfoAAAAJ
 Neelam Soundarajan,Ohio State University,https://cse.osu.edu/people/soundarajan.1,fasXmPQAAAAJ
 Neeldhara Misra,IIT Gandhinagar,http://www.iitgn.ac.in/faculty/comp/neeldhara.htm,XFgieDYAAAAJ
@@ -10119,6 +10115,7 @@ Paul Valiant,Brown University,http://cs.brown.edu/~pvaliant,NOSCHOLARPAGE
 Paul W. Goldberg,University of Oxford,https://www.cs.ox.ac.uk/people/paul.goldberg,Ai3fEfQAAAAJ
 Paul W. Purdom,Indiana University,http://www.cs.indiana.edu/~pwp,h6Z8WS0AAAAJ
 Paula A. Whitlock,CUNY,http://www.sci.brooklyn.cuny.edu/~whitlock,NOSCHOLARPAGE
+Paula Buttery,University of Cambridge,https://www.cl.cam.ac.uk/~pjb48,NOSCHOLARPAGE
 Paula Zabala,University of Buenos Aires,https://www.dc.uba.ar/materias/aed3/2013/2c/docentes/zabala,Zxmyb4MAAAAJ
 Pauline C Haddow,Norwegian University of Science and Technology,https://www.ntnu.edu/employees/pauline,HIHxCNAAAAAJ
 Paulo A. Pagliosa,UFMS,https://www.facom.ufms.br/~pagliosa,lNUJYtwAAAAJ
@@ -10295,7 +10292,7 @@ Peter Pietzuch,Imperial College London,https://www.doc.ic.ac.uk/~prp,vYcHYoYAAAA
 Peter R. Cappello,University of California - Santa Barbara,https://www.cs.ucsb.edu/~cappello,8fudeRAAAAAJ
 Peter R. Pietzuch,Imperial College London,https://www.doc.ic.ac.uk/~prp,vYcHYoYAAAAJ
 Peter R. Sutton,University of Queensland,http://researchers.uq.edu.au/researcher/70,dRo61oUAAAAJ
-Peter Robinson 0001,University of Cambridge,http://www.cl.cam.ac.uk/~pr10,psbDs9oAAAAJ
+Peter Robinson 0001,University of Cambridge,https://www.cl.cam.ac.uk/~pr10,91NxdC4AAAAJ
 Peter Rodgers,University of Kent,https://www.cs.kent.ac.uk/people/staff/pjr,wu6mHBsAAAAJ
 Peter Rodgers 0001,University of Kent,https://www.cs.kent.ac.uk/people/staff/pjr,wu6mHBsAAAAJ
 Peter Rossmanith,RWTH Aachen,http://tcs.rwth-aachen.de/~rossmani,NOSCHOLARPAGE
@@ -10305,7 +10302,7 @@ Peter Scheuermann,Northwestern University,http://www.ece.northwestern.edu/~peter
 Peter Schrammel,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/384323,JCU-scYAAAAJ
 Peter Schröder,California Institute of Technology,http://www.cs.caltech.edu/~ps,t3TgxNwAAAAJ
 Peter Sestoft,IT University of Copenhagen,http://www.itu.dk/people/sestoft,qz1BCu8AAAAJ
-Peter Sewell,University of Cambridge,http://www.cl.cam.ac.uk/~pes20,NOSCHOLARPAGE
+Peter Sewell,University of Cambridge,https://www.cl.cam.ac.uk/~pes20,NOSCHOLARPAGE
 Peter Sheridan Dodds,University of Vermont,http://www.uvm.edu/pdodds,xK3kOxQAAAAJ
 Peter Steenkiste,Carnegie Mellon University,http://www.cs.cmu.edu/~prs,DK7TEvkAAAAJ
 Peter Stone,University of Texas at Austin,https://www.cs.utexas.edu/~pstone,qnwjcfAAAAAJ
@@ -10417,7 +10414,7 @@ Pieter J. Toussaint,Norwegian University of Science and Technology,https://www.n
 Pieter Jelle Toussaint,Norwegian University of Science and Technology,https://www.ntnu.edu/employees/pieter,NOSCHOLARPAGE
 Pieter Peers,College of William and Mary,http://www.cs.wm.edu/~ppeers,We8Oy0EAAAAJ
 Pietro Bonizzi,Maastricht University,https://www.maastrichtuniversity.nl/pietro.bonizzi,Y-zKXgsAAAAJ
-Pietro Liò,University of Cambridge,https://www.cl.cam.ac.uk/~pl219,NOSCHOLARPAGE
+Pietro Liò,University of Cambridge,https://www.cl.cam.ac.uk/~pl219,3YrWf7EAAAAJ
 Pietro Michiardi,EURECOM,http://www.eurecom.fr/~michiard,mlx1eCgAAAAJ
 Pietro Perona,California Institute of Technology,https://www.vision.caltech.edu/Perona.html,j29kMCwAAAAJ
 Pin Tao,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101224173206168406028/20101224173206168406028_.html,NOSCHOLARPAGE
@@ -10658,7 +10655,6 @@ Rafael Prikladnicki,PUC-RS,http://www.inf.pucrs.br/~rafael,_W9zu7sAAAAJ
 Rafael Valencia-García,University of Murcia,http://webs.um.es/valencia/miwiki/doku.php,GLpBPNMAAAAJ
 Rafail Ostrovsky,University of California - Los Angeles,http://www.cs.ucla.edu/~rafail,UvFrX04AAAAJ
 Rafal A. Angryk,Georgia State University,https://grid.cs.gsu.edu/~rangryk,Phw2RfEAAAAJ
-Rafal K. Mantiuk,University of Cambridge,https://www.cl.cam.ac.uk/~rkm38,pJEb8x4AAAAJ
 Rafal Mantiuk,University of Cambridge,https://www.cl.cam.ac.uk/~rkm38,pJEb8x4AAAAJ
 Raffaella Mirandola,Politecnico di Milano,http://home.deib.polimi.it/mirandol,_NqFoiYAAAAJ
 Ragesh Jaiswal,IIT Delhi,http://www.cse.iitd.ernet.in/~rjaiswal,hrbj92oAAAAJ
@@ -11034,7 +11030,7 @@ Richard M. Karp,University of California - Berkeley,https://www.eecs.berkeley.ed
 Richard M. Stern,Carnegie Mellon University,http://www.cs.cmu.edu/~rms,ffUu1PcAAAAJ
 Richard Mann,University of Waterloo,https://cs.uwaterloo.ca/~mannr,NOSCHOLARPAGE
 Richard Mayr,University of Edinburgh,http://homepages.inf.ed.ac.uk/rmayr,o5doXYoAAAAJ
-Richard Mortier,University of Cambridge,http://www.csap.cam.ac.uk/network/richard-mortier,9LJgRFAAAAAJ
+Richard Mortier,University of Cambridge,http://mort.io,9LJgRFAAAAAJ
 Richard N. Taylor,University of California - Irvine,https://www.ics.uci.edu/~taylor,h9t7KCcAAAAJ
 Richard N. Thomas,University of Queensland,https://communication-arts.uq.edu.au/tutor-contact-details,RYlsfBQAAAAJ
 Richard Nelson,University of Waikato,http://www.cms.waikato.ac.nz/people/richardn,18npA5wAAAAJ
@@ -11119,7 +11115,6 @@ Robert Cartwright,Rice University,https://www.cs.rice.edu/~cork/index.shtml,TtJe
 Robert Craig Holte,University of Alberta,https://webdocs.cs.ualberta.ca/~holte,CXPlI08AAAAJ
 Robert D. Cameron,Simon Fraser University,http://www.cs.sfu.ca/~cameron,NOSCHOLARPAGE
 Robert D. Kleinberg,Cornell University,http://www.cs.cornell.edu/~rdk,zkvW8FQAAAAJ
-Robert D. Mullins,University of Cambridge,http://www.csap.cam.ac.uk/network/robert-mullins,i_Fn85MAAAAJ
 Robert D. Nowak,University of Wisconsin - Madison,http://nowak.ece.wisc.edu,fn13u8IAAAAJ
 Robert D. Rodman,North Carolina State University,https://www.csc.ncsu.edu/people/rodman,NOSCHOLARPAGE
 Robert D. Skeel,Purdue University,https://www.cs.purdue.edu/people/skeel,NOSCHOLARPAGE
@@ -11150,7 +11145,6 @@ Robert Gene Reynolds,Wayne State University,http://ai.cs.wayne.edu/ai/member%20w
 Robert Glück,University of Copenhagen,http://www.diku.dk/~glueck,cGfKulEAAAAJ
 Robert H. Deng,Singapore Management University,https://www.smu.edu.sg/faculty/profile/9611/Robert-H-DENG,OPbZGPsAAAAJ
 Robert H. Sloan,University of Illinois at Chicago,https://www.cs.uic.edu/Sloan,RiJSLsoAAAAJ
-Robert Harle,University of Cambridge,https://www.cl.cam.ac.uk/research/dtg/www/people/rkh23,MUWnoZIAAAAJ
 Robert Harper 0001,Carnegie Mellon University,http://www.cs.cmu.edu/~rwh,zLfuPQcAAAAJ
 Robert Hoehndorf,KAUST,https://www.kaust.edu.sa/en/study/faculty/robert-hoehndorf,4vVGk3kAAAAJ
 Robert Holte,University of Alberta,https://webdocs.cs.ualberta.ca/~holte,CXPlI08AAAAJ
@@ -11166,7 +11160,7 @@ Robert J. K. Jacob,Tufts University,http://www.cs.tufts.edu/~jacob,NOSCHOLARPAGE
 Robert J. Renka,University of North Texas,http://www.cse.unt.edu/~renka,XzNYtXMAAAAJ
 Robert J. Sheehan,University of Auckland,https://www.cs.auckland.ac.nz/people/r-sheehan,h44VIt4AAAAJ
 Robert J. Walker,University of Calgary,http://lsmr.org/walker,lvXu4XcAAAAJ
-Robert K. Harle,University of Cambridge,https://www.cl.cam.ac.uk/research/dtg/www/people/rkh23,MUWnoZIAAAAJ
+Robert K. Harle,University of Cambridge,https://www.cl.cam.ac.uk/~rkh23,MUWnoZIAAAAJ
 Robert Kleinberg,Cornell University,http://www.cs.cornell.edu/~rdk,zkvW8FQAAAAJ
 Robert Kowalski,Imperial College London,http://www.doc.ic.ac.uk/~rak,pvkQAj0AAAAJ
 Robert Kraut,Carnegie Mellon University,http://kraut.hciresearch.org,HKGYvu4AAAAJ
@@ -11187,10 +11181,9 @@ Robert Michael Lewis,College of William and Mary,http://www.wm.edu/as/computersc
 Robert Michael Young,University of Utah,https://faculty.utah.edu/u6006841-ROBERT_MICHAEL_YOUNG/research/index.hml,HS-NvpIAAAAJ
 Robert Moll,University of Massachusetts Amherst,https://www.cics.umass.edu/faculty/directory/moll_robert,NOSCHOLARPAGE
 Robert Muller,Boston College,http://www.cs.bc.edu/~muller,jplQac8AAAAJ
-Robert Mullins,University of Cambridge,http://www.cl.cam.ac.uk/~rdm34,i_Fn85MAAAAJ
-Robert N. M. Watson,University of Cambridge,http://www.cl.cam.ac.uk/~rnw24,wAO9FfoAAAAJ
+Robert Mullins,University of Cambridge,https://www.cl.cam.ac.uk/~rdm34,zjXO2HMAAAAJ
+Robert N. M. Watson,University of Cambridge,https://www.cl.cam.ac.uk/~rnw24,wAO9FfoAAAAJ
 Robert N. Moll,University of Massachusetts Amherst,https://www.cics.umass.edu/faculty/directory/moll_robert,NOSCHOLARPAGE
-Robert Nicholas Maxwell Watson,University of Cambridge,http://www.cl.cam.ac.uk/~rnw24,wAO9FfoAAAAJ
 Robert P. Burton,Brigham Young University,https://cs.byu.edu/faculty/rpburton,0NKgxEEAAAAJ
 Robert Patro,Stony Brook University,https://www.cs.stonybrook.edu/people/faculty/RobertPatro,H36hOqEAAAAJ
 Robert Platt,Northeastern University,http://www.ccs.neu.edu/home/rplatt,NOSCHOLARPAGE
@@ -11407,7 +11400,7 @@ Roseli A. Francelin Romero,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/rafrance
 Roseli Aparecida Francelin Romero,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/rafrance,pdtTa-8AAAAJ
 Ross A. Knepper,Cornell University,http://www.cs.cornell.edu/~rak,dgBh0UMAAAAJ
 Ross D. King,University of Manchester,https://www.research.manchester.ac.uk/portal/ross.king.html,BgZp7XcAAAAJ
-Ross J. Anderson,University of Cambridge,https://www.cl.cam.ac.uk/~rja14,iAJav9YAAAAJ
+Ross J. Anderson,University of Cambridge,https://www.cl.cam.ac.uk/~rja14,WgyDcoUAAAAJ
 Ross M. McConnell,Colorado State University,http://www.cs.colostate.edu/~rmm,JXsWja0AAAAJ
 Ross Maciejewski,Arizona State University,http://rmaciejewski.faculty.asu.edu,nChgOjEAAAAJ
 Ross T. Whitaker,University of Utah,http://www.cs.utah.edu/~whitaker,FaOZ6EMAAAAJ
@@ -11484,6 +11477,7 @@ Ruzena Bajcsy,University of California - Berkeley,https://www.eecs.berkeley.edu/
 Ruzica Piskac,Yale University,http://www.cs.yale.edu/~piskac,71RQt3sAAAAJ
 Ryan B. Hayward,University of Alberta,https://webdocs.cs.ualberta.ca/~hayward,h-VFYuUAAAAJ
 Ryan C. N. D'Arcy,Simon Fraser University,http://www.sfu.ca/engineering/people/faculty/ryan_darcy.html,APPBnh4AAAAJ
+Ryan Cotterell,University of Cambridge,https://ryancotterell.github.io/,DexOqtoAAAAJ
 Ryan Farrell,Brigham Young University,https://faculty.cs.byu.edu/~farrell,56EZh6YAAAAJ
 Ryan Hayward,University of Alberta,https://webdocs.cs.ualberta.ca/~hayward,h-VFYuUAAAAJ
 Ryan Henry,University of Calgary,http://homes.soic.indiana.edu/henry,kj6ctNwAAAAJ
@@ -11817,13 +11811,12 @@ Scott Shenker,University of California - Berkeley,https://www.eecs.berkeley.edu/
 Se Young Chun,UNIST,http://seyoungchun.wordpress.com,ntw4vH4AAAAJ
 Sea Ling,Monash University,http://monash.edu/research/explore/en/persons/chris-ling(12fc1dc1-ee0e-4294-a74d-7b6f2218dc2a).html,16YOBUgAAAAJ
 Seah Hock Soon,Nanyang Technological University,http://www.ntu.edu.sg/home/ashsseah,NOSCHOLARPAGE
-Sean B. Holden,University of Cambridge,http://www.cl.cam.ac.uk/~sbh11,NOSCHOLARPAGE
+Sean B. Holden,University of Cambridge,https://www.cl.cam.ac.uk/~sbh11,NOSCHOLARPAGE
 Sean B. Maynard,University of Melbourne,http://people.eng.unimelb.edu.au/seanbm/home.html,OkNuF20AAAAJ
 Sean Bechhofer,University of Manchester,http://www.cs.man.ac.uk/~seanb,XRzaza0AAAAJ
 Sean C. Warnick,Brigham Young University,https://cs.byu.edu/faculty/sean,k7WBrxoAAAAJ
 Sean Follmer,Stanford University,http://shape.stanford.edu,f3g5oeEAAAAJ
 Sean Hallgren,Pennsylvania State University,http://www.cse.psu.edu/~sjh26,NOSCHOLARPAGE
-Sean Holden,University of Cambridge,http://www.cl.cam.ac.uk/~sbh11,NOSCHOLARPAGE
 Sean Luke,George Mason University,https://cs.gmu.edu/~sean,jwxhFAQAAAAJ
 Sean P. Engelson,Illinois Institute of Technology,https://science.iit.edu/people/faculty/shlomo-argamon,mjsJxhQAAAAJ
 Sean W. Smith,Dartmouth College,http://www.cs.dartmouth.edu/~sws,hjaMuwsAAAAJ
@@ -12223,7 +12216,7 @@ Simon Peter,University of Texas at Austin,http://www.cs.utexas.edu/~simon,6fllVQ
 Simon R. Arridge,University College London,http://cmic.cs.ucl.ac.uk/staff/simon_arridge,UKy9ejwAAAAJ
 Simon Rogers,University of Glasgow,http://www.dcs.gla.ac.uk/~srogers,5EiC_wEAAAAJ
 Simon S. Lam,University of Texas at Austin,https://www.cs.utexas.edu/users/lam,0XV1sFsAAAAJ
-Simon W. Moore,University of Cambridge,http://www.cl.cam.ac.uk/~swm11,hPhDxHwAAAAJ
+Simon W. Moore,University of Cambridge,https://www.cl.cam.ac.uk/~swm11,hPhDxHwAAAAJ
 Simone Campanoni,Northwestern University,http://www.mccormick.northwestern.edu/research-faculty/directory/profiles/campanoni-simone.html,bY5WiJIAAAAJ
 Simone D. J. Barbosa,PUC-RIO,http://www-di.inf.puc-rio.br/~simone,DEayOYgAAAAJ
 Simone Diniz Junqueira Barbosa,PUC-RIO,http://www-di.inf.puc-rio.br/~simone,DEayOYgAAAAJ
@@ -12231,7 +12224,7 @@ Simone L. Martins,UFF,http://www2.ic.uff.br/~simone,oEIT_KQAAAAJ
 Simone Linz,University of Auckland,https://unidirectory.auckland.ac.nz/profile/slin498,9lCabZsAAAAJ
 Simone R. S. Souza,USP-ICMC,http://icmc.usp.br/pessoas?id=3685313,EhrqxfYAAAAJ
 Simone Severini,University College London,http://www.ucl.ac.uk/~ucapsse,NOSCHOLARPAGE
-Simone Teufel,University of Cambridge,http://www.cl.cam.ac.uk/~sht25,GnKIYCcAAAAJ
+Simone Teufel,University of Cambridge,https://www.cl.cam.ac.uk/~sht25,GnKIYCcAAAAJ
 Simone do Rocio Senger de Souza,USP-ICMC,http://icmc.usp.br/pessoas?id=3685313,EhrqxfYAAAAJ
 Sin'ichi Satoh,University of Tokyo,http://research.nii.ac.jp/~satoh,NOSCHOLARPAGE
 Sinai Robins,USP,http://www.ime.usp.br/~sinai,PRi_2KEAAAAJ
@@ -13069,7 +13062,7 @@ Thomas Rose,RWTH Aachen,http://dbis.rwth-aachen.de/cms/staff/rose,dR-qbA4AAAAJ
 Thomas Rothvoss,University of Washington,https://www.math.washington.edu/~rothvoss,Ad-hkLEAAAAJ
 Thomas Rothvoß,University of Washington,https://www.math.washington.edu/~rothvoss,Ad-hkLEAAAAJ
 Thomas S. E. Maibaum,McMaster University,http://www.cas.mcmaster.ca/~maibaum,NOSCHOLARPAGE
-Thomas Sauerwald,University of Cambridge,http://www.cl.cam.ac.uk/~tms41,lidwLWIAAAAJ
+Thomas Sauerwald,University of Cambridge,https://www.cl.cam.ac.uk/~tms41,lidwLWIAAAAJ
 Thomas Schmid,University of Utah,https://faculty.utah.edu/u0729347-Thomas_Schmid/biography/index.hml,puOEoqoAAAAJ
 Thomas Schneider 0003,TU Darmstadt,https://www.thomaschneider.de,E31PR1oAAAAJ
 Thomas Schwarz,University of California - Santa Cruz,http://www.ssrc.ucsc.edu/person/tschwarz.html,BF_pzdoAAAAJ
@@ -13160,15 +13153,14 @@ Timothy Bretl,Univ. of Illinois at Urbana-Champaign,http://bretl.csl.illinois.ed
 Timothy C. Bell,University of Canterbury,http://www.cosc.canterbury.ac.nz/tim.bell,NOSCHOLARPAGE
 Timothy C. Lethbridge,University of Ottawa,http://www.site.uottawa.ca/~tcl,PQ9tLbUAAAAJ
 Timothy David Jones,University of Cambridge,http://www.cl.cam.ac.uk/~tmj32,NOSCHOLARPAGE
-Timothy G. Griffin,University of Cambridge,http://www.cl.cam.ac.uk/~tgg22,bNZfDVgAAAAJ
+Timothy G. Griffin,University of Cambridge,https://www.cl.cam.ac.uk/~tgg22,bNZfDVgAAAAJ
 Timothy Graham,Australian National University,http://anu-au.academia.edu/TimothyGraham,xbDCsowAAAAJ
-Timothy Griffin,University of Cambridge,http://www.cl.cam.ac.uk/~tgg22,bNZfDVgAAAAJ
 Timothy J. Hickey,Brandeis University,http://www.cs.brandeis.edu/~tim,APFVA6sAAAAJ
 Timothy L. Andersen,Boise State University,http://cs.boisestate.edu/~tim,mTErwxgAAAAJ
 Timothy Lethbridge,University of Ottawa,http://www.site.uottawa.ca/~tcl,PQ9tLbUAAAAJ
 Timothy M. Chan,Univ. of Illinois at Urbana-Champaign,http://tmc.web.engr.illinois.edu,NOSCHOLARPAGE
 Timothy M. Hospedales,University of Edinburgh,http://homepages.inf.ed.ac.uk/thospeda,nHhtvqkAAAAJ
-Timothy M. Jones 0001,University of Cambridge,http://www.cl.cam.ac.uk/~tmj32,qnn3-gMAAAAJ
+Timothy M. Jones 0001,University of Cambridge,https://www.cl.cam.ac.uk/~tmj32,qnn3-gMAAAAJ
 Timothy Ravasi,KAUST,https://www.kaust.edu.sa/en/study/faculty/timothy-ravasi,UR9EUP8AAAAJ
 Timothy Roscoe,ETH Zurich,http://people.inf.ethz.ch/troscoe,NOSCHOLARPAGE
 Timothy Sherwood,University of California - Santa Barbara,https://www.cs.ucsb.edu/~sherwood,nLuHfy4AAAAJ

--- a/dblp-aliases.csv
+++ b/dblp-aliases.csv
@@ -814,6 +814,7 @@ Alain Tierry Chamaken Kamde,Alain Chamaken
 Alair Do Lago,Alair Pereira do Lago
 Alaitz Zabala-Torres,Alaitz Zabala
 Alam Bolhassan,Noor Alamshah Bolhassan
+Alan Blackwell,Alan F. Blackwell
 Alan Bowling,Alan P. Bowling
 Alan Chi Hung Ling,Alan C. H. Ling
 Alan Chin-Chen Chang,Chin-Chen Chang
@@ -6795,6 +6796,7 @@ David Gonzalo Muñoz Medina,David Gonzalo Muñoz
 David González G.,David González González
 David Gordon Cameron,David G. Cameron
 David Gozalvez,David Gozalvez Serrano
+David Greaves,David J. Greaves
 David Gross,David Gross-Amblard
 David Gustav Wagner,David G. Wagner
 David Gérault,David Gerault
@@ -12312,6 +12314,7 @@ Ian Douglas Horswill,Ian Horswill
 Ian E. Pratt,Ian Pratt-Hartmann
 Ian Henning,Ian D. Henning
 Ian J. Gerard,Ian Gerard
+Ian James Wassell,Ian J. Wassell
 Ian Jermyn,Ian H. Jermyn
 Ian M. Molloy,Ian Molloy
 Ian Michael O'Neill,Ian M. O'Neill
@@ -14563,6 +14566,7 @@ John F. Timms,John Timms
 John F. Tripp,John Tripp
 John Francis Leys,John F. Leys
 John Furunäs,Johan Furunäs
+John G. Daugman,John Daugman
 John Galen Buckwalter,J. Galen Buckwalter
 John Gathegi,John Ng'ang'a Gathegi
 John Gerdes Jr.,John H. Gerdes Jr.
@@ -25861,6 +25865,7 @@ Robert Cerveny,Robert P. Cerveny
 Robert Cloutier,Robert J. Cloutier
 Robert Cohn,Robert S. Cohn
 Robert Craig Holte,Robert C. Holte
+Robert D. Mullins,Robert Mullins
 Robert D. Stevens,Robert Stevens
 Robert Duncan Macredie,Robert D. Macredie
 Robert E. Bodenheimer,Bobby Bodenheimer
@@ -26337,6 +26342,7 @@ Rosina Weber,Rosina O. Weber
 Rosina Weber-Lee,Rosina O. Weber
 Rosli Bin Salleh,Rosli Salleh
 Ross A. Lippert,Ross Lippert
+Ross Anderson,Ross J. Anderson
 Ross D. Tredinnick,Ross Tredinnick
 Ross F. Hayward,Ross Hayward
 Ross J. Bille,Ross Bille
@@ -27293,6 +27299,7 @@ Sea-Nae Park,Seanae Park
 Seak-Weng Vong,Seakweng Vong
 Sean C. Kerman,Sean Kerman
 Sean G. Maher,Sean Maher
+Sean Holden,Sean B. Holden
 Sean M. Fitzhugh,Sean Fitzhugh
 Sean Megason,Sean G. Megason
 Sean Munson,Sean A. Munson


### PR DESCRIPTION
Added and removed people and fixed duplicates to reflect current faculty and an additional related faculty in a different department:

https://www.cl.cam.ac.uk/people/academic.html
