### PR TITLE
tim roughgarden to columbia

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -13133,7 +13133,7 @@ Tim McInerney,Ryerson University,www.scs.ryerson.ca/~tmcinern,4jp8rwgAAAAJ
 Tim Menzies,North Carolina State University,http://menzies.us,7htTUTgmLtUC
 Tim Miller,University of Melbourne,http://people.eng.unimelb.edu.au/tmiller,D3m499MAAAAJ
 Tim Oates,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/people/faculty/tim-oates,NOSCHOLARPAGE
-Tim Roughgarden,Stanford University,http://theory.stanford.edu/~tim,0lcJYs8AAAAJ
+Tim Roughgarden,Columbia University,http://timroughgarden.org,0lcJYs8AAAAJ
 Tim Sherwood,University of California - Santa Barbara,https://www.cs.ucsb.edu/~sherwood,nLuHfy4AAAAJ
 Tim Storer,University of Glasgow,http://www.dcs.gla.ac.uk/~tws,vxlepBgAAAAJ
 Tim W. Nattkemper,Bielefeld University,http://ekvv.uni-bielefeld.de/pers_publ/publ/PersonDetail.jsp?personId=11602,8SR1jMcAAAAJ


### PR DESCRIPTION
Also listed at this URL
http://www.cs.columbia.edu/theory/ 


# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [x] If the institution you are adding is not in the US,
update `country-info.csv`.

