### PR TITLE
Add the faculty related to AI at Korea University

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -218,3 +218,5 @@ Seoul National University,asia
 Middlesex University,europe
 Newcastle University,australasia
 University of Surrey,europe
+Korea University,asia
+

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -14793,3 +14793,10 @@ Zygmunt J. Haas,University of Texas at Dallas,http://www.utdallas.edu/~zjh130030
 Øystein Nytrø,Norwegian University of Science and Technology,https://www.ntnu.edu/employees/nytroe,-Zavs80AAAAJ
 Ümit V. Çatalyürek,Georgia Institute of Technology,https://www.cc.gatech.edu/~umit,OLDMURQAAAAJ
 Andrea Bianchi,KAIST,http://alsoplantsfly.com,wVDtZB0AAAAJ
+Jaegul Choo,Korea University,https://sites.google.com/site/jaegulchoo,GHJYsLEAAAAJ
+Chang-Su Kim,Korea University,https://mcl.korea.ac.kr/people/professor,KOdKwNsAAAAJ
+Jaewoo Kang,Korea University,http://dmis.korea.ac.kr/people,iiIxp8cAAAA
+Seong-Whan Lee,Korea University,http://pr.korea.ac.kr/sub2_1.php?code=LSW,5yNbjSoAAAAJ
+SangKeun Lee,Korea University,http://dilab.korea.ac.kr/?page_id=658,BGSUpLgAAAAJ
+Christian Wallraven,Korea University,http://cogsys.korea.ac.kr/People.html,VJuuzLwAAAAJ
+Klaus-Robert Müller,Korea University,https://www.ml.tu-berlin.de/menue/mitglieder/klaus-robert_mueller,jplQac8AAAAJ


### PR DESCRIPTION
**Added the professors who are related to the AI area (AI, Vision, ML, NLP, Data mining & Retrieval) at Korea University in South Korea. Each faculty member belongs to a different department at Korea University.**

# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [x] If the institution you are adding is not in the US,
update `country-info.csv`.

