### PR TITLE
Added Manmohan Chandraker by Rui Zhu (rzhu@eng.ucsd.edu)

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -8179,6 +8179,7 @@ Manish Parashar,Rutgers University,http://parashar.rutgers.edu,SCM35lMAAAAJ
 Manish Shrivastava,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/m.shrivastava,DKC3xNYAAAAJ
 Manish Singh,Rutgers University,https://www.cs.rutgers.edu/people/faculty/affiliated-faculty,9XRvM88AAAAJ
 Manjunath V. Joshi,DAIICT,http://www.daiict.ac.in/daiict/people/faculty.html,iDqnnKkAAAAJ
+Manmohan Krishna Chandraker,University of California - San Diego,http://cseweb.ucsd.edu/~mkchandraker,oPFCNk4AAAAJ
 Manohar Kaul,IIT Hyderabad,http://www.iith.ac.in/~mkaul,jNroyK4AAAAJ
 Manoj Gupta,IIT Gandhinagar,http://www.iitgn.ac.in/faculty/comp/manoj.htm,PGzgTLoAAAAJ
 Manoj M. Prabhakaran,IIT Bombay,http://mmp.cs.illinois.edu,FANRIhwAAAAJ


### PR DESCRIPTION
# Pull request info

Rui Zhu, PhD student at UC San Diego adds his advisor Manmohan Chandraker to the database. The new entry meets all the requirements on the contribution guidelines. Thank you!

-- Rui

# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [ ] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [ ] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [ ] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

