### PR TITLE
Adding missing Penn faculty

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -9625,7 +9625,7 @@ Michael P. Fourman,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff
 Michael P. Friedlander,University of British Columbia,http://www.cs.ubc.ca/~mpf,mOgIIH4AAAAJ
 Michael P. Wellman,University of Michigan,http://www.eecs.umich.edu/ai/people/wellman,UruIct4AAAAJ
 Michael Paul Fourman,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Michael_Fourman.html,psO0rckAAAAJ
-Michael Posa,https://dair.seas.upenn.edu/michael-posa/,DCSFMuAAAAAJ
+Michael Posa,University of Pennsylvania,https://dair.seas.upenn.edu/michael-posa/,DCSFMuAAAAAJ
 Michael Pradel,TU Darmstadt,http://mp.binaervarianz.de,V-850TAAAAAJ
 Michael R. Berthold,University of Konstanz,https://www.bison.uni-konstanz.de/members/prof-dr-m-berthold,NOSCHOLARPAGE
 Michael R. Brent,Washington University in St. Louis,http://mblab.wustl.edu,YE2tPHQAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -2840,6 +2840,7 @@ Cynthia Liem,TU Delft,http://mmc.tudelft.nl/users/cynthia-liem,BFhUNNEAAAAJ
 Cynthia Matuszek,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~cmat,C3NuO-AAAAAJ
 Cynthia Putnam,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/FacultyInfo.aspx?fid=1001,NOSCHOLARPAGE
 Cynthia R. Marling,Ohio University,http://oucsace.cs.ohiou.edu/~marling,zeBniq4AAAAJ
+Cynthia R. Sung,University of Pennsylvania,https://www.seas.upenn.edu/~crsung/,NOSCHOLARPAGE
 Cynthia Rudin,Duke University,https://users.cs.duke.edu/~cynthia/home.html,mezKJyoAAAAJ
 Cynthia Sturton,University of North Carolina,http://cs.unc.edu/~csturton,hOlkT4sAAAAJ
 Cyriac Aiswarya,CMI,http://www.cmi.ac.in/~aiswarya,NLwqvCwAAAAJ
@@ -6181,6 +6182,7 @@ James H. Davenport,University of Bath,http://people.bath.ac.uk/masjhd,dy5hIhAAAA
 James H. Hill,IUPUI,http://sebox.cs.iupui.edu,NOSCHOLARPAGE
 James H. Martin,University of Colorado Boulder,http://www.cs.colorado.edu/~martin,ZVxO6IIAAAAJ
 James H. Morris,Carnegie Mellon University,http://www.cs.cmu.edu/~jhm,Y9cRdbIAAAAJ
+James H. Moore,University of Pennsylvania,http://epistasis.org/jason-h-moore-phd/,mE1Te78AAAAJ
 James Harland,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/h/harland-associate-professor-james,46pt7TgAAAAJ
 James Harold Davenport,University of Bath,http://people.bath.ac.uk/masjhd,dy5hIhAAAAAJ
 James Hays,Georgia Institute of Technology,http://www.cc.gatech.edu/~hays,vjZrDKQAAAAJ
@@ -12372,6 +12374,7 @@ Ryan R. Newton,Indiana University,http://www.cs.indiana.edu/~rrnewton/homepage.h
 Ryan Riley,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/ryan.php,75JB_d0AAAAJ
 Ryan Robucci,Univ. of Maryland - Baltimore County,https://eclipse.umbc.edu/robucci.html,Kdw47AcAAAAJ
 Ryan Shea,Simon Fraser University,http://www.sfu.ca/~rws1,rOPt1L4AAAAJ
+Ryan Shaun Joazeiro de Baker,University of Pennsylvania,http://www.upenn.edu/learninganalytics/ryanbaker/index.html,hvs8PEoAAAAJ
 Ryan Stansifer,Florida Institute of Technology,https://cs.fit.edu/~ryan,NOSCHOLARPAGE
 Ryan Stutsman,University of Utah,https://faculty.utah.edu/u0982239-Ryan_Stutsman/teaching/index.hml,pyZ_FH4AAAAJ
 Ryan Tibshirani,Carnegie Mellon University,http://www.stat.cmu.edu/~ryantibs,cQ1P1qoAAAAJ
@@ -12396,7 +12399,6 @@ S. C. Cheung,HKUST,https://www.cse.ust.hk/~scc,5RIgb3wAAAAJ
 S. C. Mukhopadhyay,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=265530,fsu2yL8AAAAJ
 S. Dov Gordon,George Mason University,http://cs.gmu.edu/~gordon,NOSCHOLARPAGE
 S. E. M. O'Keefe,University of York,https://www-users.cs.york.ac.uk/~sok,QL1JHlUAAAAJ
-S. Hamed Hassani,University of Pennsylvania,https://www.seas.upenn.edu/~hassani,NOSCHOLARPAGE
 S. J. Creese,University of Oxford,http://www.cs.ox.ac.uk/sadie.creese,NOSCHOLARPAGE
 S. J. Wright,Monash University,http://monash.edu/research/explore/en/persons/steven-wright(40be3258-c026-4e34-a74d-08837c38344b).html,icJpxpMAAAAJ
 S. Lakshmivarahan,University of Oklahoma,http://www.ou.edu/coe/cs/people/varahan,NOSCHOLARPAGE
@@ -15620,6 +15622,7 @@ Yoonsik Cheon,University of Texas - El Paso,http://www.cs.utep.edu/cheon,NOSCHOL
 Yoonsuck Choe,Texas A&M University,http://faculty.cs.tamu.edu/choe,nFb_T4wAAAAJ
 Yoram Moses,Technion,http://moses.eew.technion.ac.il,X90c-SYAAAAJ
 Yoram Singer,Princeton University,http://www.cs.princeton.edu/~ysinger,NOSCHOLARPAGE
+Yoseph Barash,University of Pennsylvania,https://www.biociphers.org/yosephb,NOSCHOLARPAGE
 Yoshiharu Kohayakawa,USP,http://www.ime.usp.br/~yk,EC6p9kIAAAAJ
 Yoshihide Yoshimoto,University of Tokyo,http://www.s.u-tokyo.ac.jp/en/people/yoshimoto_yoshihide,NOSCHOLARPAGE
 Yoshihiko Hasegawa,University of Tokyo,http://www.i.u-tokyo.ac.jp/edu/course/ice/members_e.shtml,NOSCHOLARPAGE

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -9625,6 +9625,7 @@ Michael P. Fourman,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff
 Michael P. Friedlander,University of British Columbia,http://www.cs.ubc.ca/~mpf,mOgIIH4AAAAJ
 Michael P. Wellman,University of Michigan,http://www.eecs.umich.edu/ai/people/wellman,UruIct4AAAAJ
 Michael Paul Fourman,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Michael_Fourman.html,psO0rckAAAAJ
+Michael Posa,https://dair.seas.upenn.edu/michael-posa/,DCSFMuAAAAAJ
 Michael Pradel,TU Darmstadt,http://mp.binaervarianz.de,V-850TAAAAAJ
 Michael R. Berthold,University of Konstanz,https://www.bison.uni-konstanz.de/members/prof-dr-m-berthold,NOSCHOLARPAGE
 Michael R. Brent,Washington University in St. Louis,http://mblab.wustl.edu,YE2tPHQAAAAJ


### PR DESCRIPTION
# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [x] If the institution you are adding is not in the US,
update `country-info.csv`.

