### PR TITLE
Add two SFU faculty

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -1001,6 +1001,7 @@ Andy Zaidman,TU Delft,http://www.st.ewi.tudelft.nl/~zaidman,CDTfcG4AAAAJ
 Andy van Dam,Brown University,http://cs.brown.edu/~avd,NOSCHOLARPAGE
 Anelis Kaiser,University of Freiburg,http://gmint.informatik.uni-freiburg.de/kaiser,NOSCHOLARPAGE
 Ang Chen,Rice University,https://www.cs.rice.edu/~angchen,8Y4dDxkAAAAJ&hl
+Angel X. Chang,Simon Fraser University,http://www.sfu.ca/computing/people/faculty/angelchang11111111.html,8gfs8XIAAAAJ
 Angela Arapoyanni,University of Athens,http://www.di.uoa.gr/eng/staff/1012,NOSCHOLARPAGE
 Angela Demke Brown,University of Toronto,http://www.cs.toronto.edu/~demke,xicy8QcAAAAJ
 Angela Finlayson,UNSW,https://www.engineering.unsw.edu.au/computer-science-engineering/staff/angela-finlayson,NOSCHOLARPAGE
@@ -8751,6 +8752,7 @@ Manoj Prabhakaran,IIT Bombay,http://mmp.cs.illinois.edu,FANRIhwAAAAJ
 Manolis Katevenis,University of Crete,http://users.ics.forth.gr/~kateveni,E2-GshsAAAAJ
 Manolis Kellis,Massachusetts Institute of Technology,http://mit.edu/manoli,lsYXBx8AAAAJ
 Manolis Koubarakis,University of Athens,http://cgi.di.uoa.gr/~koubarak,FKy2868AAAAJ
+Manolis Savva,Simon Fraser University,http://www.sfu.ca/computing/people/faculty/manolissavva1111111.html,4D2vsdYAAAAJ
 Manos Antonakakis,Georgia Institute of Technology,https://sites.google.com/site/antonakakis,P6VJcVIAAAAJ
 Manos Athanassoulis,Boston University,http://manos.athanassoulis.net,RyXHY68AAAAJ
 Manos Kapritsos,University of Michigan,http://web.eecs.umich.edu/~manosk,65VCOs0AAAAJ


### PR DESCRIPTION
# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [X] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [X] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [X] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [X] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [X] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [X] If the institution you are adding is not in the US,
update `country-info.csv`.

