### PR TITLE
add missing EPFL faculty

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -4044,7 +4044,7 @@ Emma Brunskill,Stanford University,http://www.cs.cmu.edu/~ebrun,HaN8b2YAAAAJ
 Emma Frejinger,University of Montreal,http://en.diro.umontreal.ca/department-directory/vue/frejinger-emma,PBOoXfwAAAAJ
 Emmanouel A. Giakoumakis,AUEB,https://www-1.aueb.gr/en/content/new-rector-athens-university-economics-and-business,NOSCHOLARPAGE
 Emmanouil Benetos,Queen Mary University of London,http://www.eecs.qmul.ac.uk/~emmanouilb,Wg49oI4AAAAJ
-Emmanuel Abbe,Princeton University,http://www.ee.princeton.edu/research/eabbe/?q=node/1,NOSCHOLARPAGE
+Emmanuel Abbe,EPFL,https://people.epfl.ch/emmanuel.abbe,NOSCHOLARPAGE
 Emmanuel Agu,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/eoa.html,Ke6ex0wAAAAJ
 Emmanuel Beffara,Ecole Normale Superieure de Lyon,http://www.ens-lyon.fr/annuaire/m-beffara-emmanuel-145623.kjsp?RH=ENS-LYON,NOSCHOLARPAGE
 Emmanuel Filiot,Université libre de Bruxelles,http://www.ulb.ac.be/di/ssd/filiot,EPCJ1lQAAAAJ
@@ -16127,4 +16127,3 @@ François Fleuret,EPFL,https://people.epfl.ch/francois.fleuret,Bj1tRlsAAAAJ
 Alexandre Alahi,EPFL,https://people.epfl.ch/alexandre.alahi,UIhXQ64AAAAJ
 Pierre Vandergheynst,EPFL,https://people.epfl.ch/pierre.vandergheynst,1p9NOFEAAAAJ
 Ali H. Sayed,EPFL,https://people.epfl.ch/ali.sayed,uDG9sXQAAAAJ
-Emmanuel Abbe,EPFL,https://people.epfl.ch/emmanuel.abbe,NOSCHOLARPAGE

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -16127,3 +16127,4 @@ François Fleuret,EPFL,https://people.epfl.ch/francois.fleuret,Bj1tRlsAAAAJ
 Alexandre Alahi,EPFL,https://people.epfl.ch/alexandre.alahi,UIhXQ64AAAAJ
 Pierre Vandergheynst,EPFL,https://people.epfl.ch/pierre.vandergheynst,1p9NOFEAAAAJ
 Ali H. Sayed,EPFL,https://people.epfl.ch/ali.sayed,uDG9sXQAAAAJ
+Emmanuel Abbe,EPFL,https://people.epfl.ch/emmanuel.abbe,NOSCHOLARPAGE

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -16126,3 +16126,4 @@ Volkan Cevher,EPFL,https://people.epfl.ch/volkan.cevher,hlWhzU8AAAAJ
 François Fleuret,EPFL,https://people.epfl.ch/francois.fleuret,Bj1tRlsAAAAJ
 Alexandre Alahi,EPFL,https://people.epfl.ch/alexandre.alahi,UIhXQ64AAAAJ
 Pierre Vandergheynst,EPFL,https://people.epfl.ch/pierre.vandergheynst,1p9NOFEAAAAJ
+Ali H. Sayed,EPFL,https://people.epfl.ch/ali.sayed,uDG9sXQAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -16121,3 +16121,8 @@ Benjamin Peherstorfer,New York University,https://cims.nyu.edu/~pehersto/,C81Whl
 Daniel B. Neill,New York University,https://cs.nyu.edu/~neill/,zSqlq00AAAAJ
 He He,New York University,https://hhexiy.github.io/,K-isjagAAAAJ
 Christopher Musco,New York University,https://www.chrismusco.com/,HXXSrNMAAAAJ
+Pascal Frossard,EPFL,https://people.epfl.ch/pascal.frossard,-Ve9sJ0AAAAJ
+Volkan Cevher,EPFL,https://people.epfl.ch/volkan.cevher,hlWhzU8AAAAJ
+François Fleuret,EPFL,https://people.epfl.ch/francois.fleuret,Bj1tRlsAAAAJ
+Alexandre Alahi,EPFL,https://people.epfl.ch/alexandre.alahi,UIhXQ64AAAAJ
+Pierre Vandergheynst,EPFL,https://people.epfl.ch/pierre.vandergheynst,1p9NOFEAAAAJ


### PR DESCRIPTION
These 7 were missing and are officially part of our CS doctoral school = EDIC

can be confirmed here 
https://www.epfl.ch/education/phd/programs/edic-computer-and-communication-sciences/
under affiliated labs (scroll down)

# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [X] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.


**Adding one or more faculty members (including an entire department)**

- [X] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.
