### PR TITLE
Add Aalborg University to CS ranking

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -1,6 +1,7 @@
 institution,region
 Aalto University,europe
 Aarhus University,europe
+Aalborg University,europe
 American University of Beirut,asia
 Ariel University,europe
 AUEB,europe

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -16154,7 +16154,7 @@ Alexandre Alahi,EPFL,https://people.epfl.ch/alexandre.alahi,UIhXQ64AAAAJ
 Pierre Vandergheynst,EPFL,https://people.epfl.ch/pierre.vandergheynst,1p9NOFEAAAAJ
 Ali H. Sayed,EPFL,https://people.epfl.ch/ali.sayed,uDG9sXQAAAAJ
 Christian S. Jensen,Aalborg University,http://people.cs.aau.dk/~csj/,wo20cPYAAAAJ
-Kim G. Larsen,Aalborg University,www.cs.aau.dk/~kgl,neDFD60AAAAJ
+Kim G. Larsen,Aalborg University,http://www.cs.aau.dk/~kgl,neDFD60AAAAJ
 Torben Bach Pedersen,Aalborg University,http://people.cs.aau.dk/~tbp/,XGzPuKEAAAAJ
 Jesper Kjeldskov,Aalborg University,http://people.cs.aau.dk/~jesper/,pD3nfeAAAAAJ
 Hua Lu 0001,Aalborg University,http://people.cs.aau.dk/~luhua/,h1mExmcAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -16153,3 +16153,37 @@ François Fleuret,EPFL,https://people.epfl.ch/francois.fleuret,Bj1tRlsAAAAJ
 Alexandre Alahi,EPFL,https://people.epfl.ch/alexandre.alahi,UIhXQ64AAAAJ
 Pierre Vandergheynst,EPFL,https://people.epfl.ch/pierre.vandergheynst,1p9NOFEAAAAJ
 Ali H. Sayed,EPFL,https://people.epfl.ch/ali.sayed,uDG9sXQAAAAJ
+Christian S. Jensen,Aalborg University,http://people.cs.aau.dk/~csj/,wo20cPYAAAAJ
+Kim G. Larsen,Aalborg University,www.cs.aau.dk/~kgl,neDFD60AAAAJ
+Torben Bach Pedersen,Aalborg University,http://people.cs.aau.dk/~tbp/,XGzPuKEAAAAJ
+Jesper Kjeldskov,Aalborg University,http://people.cs.aau.dk/~jesper/,pD3nfeAAAAAJ
+Hua Lu 0001,Aalborg University,http://people.cs.aau.dk/~luhua/,h1mExmcAAAAJ
+Peter Dolog,Aalborg University,https://peterdolog.wordpress.com/,gCafUI0AAAAJ
+Bin Yang 0002,Aalborg University,http://people.cs.aau.dk/~byang/,qjBQhoUAAAAJ
+Jirí Srba,Aalborg University,http://people.cs.aau.dk/~srba/,PYmuJQoAAAAJ
+Jan Stage,Aalborg University,http://people.cs.aau.dk/~jans/,6fgR7XcAAAAJ
+Mikael B. Skov,Aalborg University,http://people.cs.aau.dk/~dubois/,sivdLnwAAAAJ
+Kristian G. Olesen,Aalborg University,http://people.cs.aau.dk/~kgo/cv.html,qrPdfAcAAAAJ
+Simonas Saltenis,Aalborg University,http://people.cs.aau.dk/~simas/,K0l79_wAAAAJ
+Peter Axel Nielsen,Aalborg University,http://people.cs.aau.dk/~pan/,l2VkFywAAAAJ
+Bent Thomsen,Aalborg University,http://people.cs.aau.dk/~bt/,mhyMmZoAAAAJ
+Brian Nielsen,Aalborg University,http://people.cs.aau.dk/~bnielsen/,iAgWGgwAAAAJ
+Arne Skou,Aalborg University,http://people.cs.aau.dk/~ask/,qIjjvXwAAAAJ
+Thomas D. Nielsen,Aalborg University,http://people.cs.aau.dk/~tdn/,6fWF0CgAAAAJ
+Katja Hose,Aalborg University,http://people.cs.aau.dk/~khose/,LbXvZUoAAAAJ
+Jeni Paay,Aalborg University,http://people.cs.aau.dk/~jeni/jeni_homepage/home.html,-4miticAAAAJ
+Manfred Jaeger,Aalborg University,http://people.cs.aau.dk/~jaeger/,1E085gUAAAAJ,
+Hans Hüttel,Aalborg University,http://people.cs.aau.dk/~hans/index-eng.html,Wf7-agQAAAAJ
+René Rydhof Hansen,Aalborg University,http://people.cs.aau.dk/~rrh/,MGLEvwkAAAAJ
+Ulrik Nyman,Aalborg University,http://ulrik.blog.aau.dk/,Z3FXuI0AAAAJ
+Christian Thomsen,Aalborg University,http://personprofil.aau.dk/111293?lang=en,Y7i1yN4AAAAJ
+Lone Leth Thomsen,Aalborg University,http://people.cs.aau.dk/~lone/,vyYcihcAAAAJ
+Ivan Aaen,Aalborg University,http://people.cs.aau.dk/~ivan/,-8-9oRgAAAAJ
+Kristian Torp,Aalborg University,http://people.cs.aau.dk/~torp/,EusRZN0AAAAJ
+Kurt Nørmark,Aalborg University,http://people.cs.aau.dk/~normark/,5L7St-cAAAAJ
+Giorgio Bacci,Aalborg University,http://people.cs.aau.dk/~grbacci/,y2Q3kK8AAAAJ
+Anders Bruun,Aalborg University,http://personprofil.aau.dk/120220,X32A-C4AAAAJ
+John Stouby Persson,Aalborg University,http://people.cs.aau.dk/~john/,2uofkmkAAAAJ
+Radu Mardare,Aalborg University,http://people.cs.aau.dk/~mardare/,NOSCHOLARPAGE
+Josva Kleist,Aalborg University,http://personprofil.aau.dk/104832?lang=en,NOSCHOLARPAGE
+Uffe Kjærulff,Aalborg University,http://personprofil.aau.dk/102267?lang=en,NOSCHOLARPAGE


### PR DESCRIPTION
Here is an update for Department of Computer Science at Aalborg University, Denmark. In this update I have included almost all professors and associate professors in csrankings.csv. Since our department is not in this ranking before, I have included "Aalborg University" in country-info.csv. 

