### PR TITLE
Added Bundeswehr University Munich

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -10,6 +10,7 @@ BITS Pilani,asia
 Bar-Ilan University,europe
 Beihang University,asia
 Ben-Gurion University of the Negev,europe
+Bundeswehr University Munich,europe
 CMI,asia
 CWI,europe
 Carleton University,canada

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -5160,7 +5160,7 @@ Gultekin Özsoyoglu,Case Western Reserve University,http://engineering.case.edu/
 Gunhee Kim,Seoul National University,http://vision.snu.ac.kr/~gunhee,CiSdOV0AAAAJ
 Gunnar Gotshalks,York University,http://www.cse.yorku.ca/~gunnar,NOSCHOLARPAGE
 Gunnar Rätsch,ETH Zurich,http://bmi.inf.ethz.ch/personnel/gunnar-ratsch,tQuQ1FwAAAAJ
-Gunnar Teege,Bundeswehr University Munich,https://www.unibw.de/technische-informatik/mitarbeiter/professoren/univ-prof-dr-gunnar-teege,NOSCHOLARPAGE
+Gunnar Teege,Bundeswehr University Munich,http://www.unibw.de/gunnar.teege,NOSCHOLARPAGE
 Gunnar Tufte,NTNU,https://www.ntnu.edu/employees/gunnar.tufte,85QJtE0AAAAJ
 Guo Freeman,Clemson University,http://guof.people.clemson.edu,eRQZhUAAAAAJ
 Guo-Hui Lin,University of Alberta,https://webdocs.cs.ualberta.ca/~ghlin,XSgTV7gAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -854,6 +854,7 @@ Andreas Fell,Australian National University,https://cs.anu.edu.au/people/andreas
 Andreas G. Veneris,University of Toronto,http://www.eecg.utoronto.ca/~veneris/AndreasVeneris.htm,NOSCHOLARPAGE
 Andreas Haeberlen,University of Pennsylvania,http://www.cis.upenn.edu/~ahae,kqPhodQAAAAJ
 Andreas Henschel,Masdar Institute,https://www2.masdar.ac.ae/aboutus/management/faculty-directory/item/5665-andreas-henschel,jenl24IAAAAJ
+Andreas Karcher,Bundeswehr University Munich,https://www.unibw.de/ia,NOSCHOLARPAGE
 Andreas Klappenecker,Texas A&M University,http://faculty.cs.tamu.edu/klappi,QKzwvNgAAAAJ
 Andreas Klöckner,Univ. of Illinois at Urbana-Champaign,https://mathema.tician.de/aboutme,n5dYy5sAAAAJ
 Andreas Koch,TU Darmstadt,http://www.esa.informatik.tu-darmstadt.de/twiki/bin/view/Staff/AndreasKochEn.html,_AvdpMgAAAAJ
@@ -1304,6 +1305,7 @@ Arndt Bode,TU Munich,https://www.lrr.in.tum.de/mitarbeiter/bode,NOSCHOLARPAGE
 Arndt von Staa,PUC-RIO,http://www.inf.puc-rio.br/blog/professor/arndt-von-staa,NOSCHOLARPAGE
 Arne Skou,Aalborg University,http://people.cs.aau.dk/~ask,qIjjvXwAAAAJ
 Arne Storjohann,University of Waterloo,https://cs.uwaterloo.ca/~astorjoh,NOSCHOLARPAGE
+Arno Wacker,Bundeswehr University Munich,https://www.unibw.de/anwendungssicherheit/univ-prof-dr-arno-wacker,zq79YP0AAAAJ
 Arnon Avron,Tel Aviv University,http://www.cs.tau.ac.il/~aa,NOSCHOLARPAGE
 Arnulfo P. Azcarraga,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742696277&command=GETPROFILE,dBYuhB4AAAAJ
 Arobinda Gupta,IIT Kharagpur,http://cse.iitkgp.ac.in/~agupta,NOSCHOLARPAGE
@@ -2813,6 +2815,7 @@ Cormac Flanagan,University of California - Santa Cruz,https://users.soe.ucsc.edu
 Cornelia Caragea,University of Illinois at Chicago,https://www.cs.uic.edu/~cornelia,vkX6VV4AAAAJ
 Cornelia Verspoor,University of Melbourne,http://findanexpert.unimelb.edu.au/display/person458973,dUxHnbcAAAAJ
 Cornelis Huizing,TU Eindhoven,https://www.win.tue.nl/~keesh,j-Uuvt0AAAAJ
+Cornelius Greither,Bundeswehr University Munich,https://www.unibw.de/timor/mitarbeiter/greither/univ-prof-dr-cornelius-greither,NOSCHOLARPAGE
 Corrado Aaron Visaggio,University of Sannio,https://www.unisannio.it/it/users/corrado-aaron-visaggio,bNMLhsIAAAAJ
 Cory Barker,Brigham Young University,https://cs.byu.edu/faculty/barker,iZfqmbMAAAAJ
 Cory Beard,University of Missouri - Kansas City,http://sce2.umkc.edu/csee/beardc/Beard_CV.pdf,-0KiLnsAAAAJ
@@ -4500,6 +4503,7 @@ Flora Dilys Salim,RMIT University,http://florasalim.com,Yz35RSYAAAAJ
 Flora Salim,RMIT University,http://florasalim.com,Yz35RSYAAAAJ
 Florante R. Salvador,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742700878&command=GETPROFILE,2waSM7YAAAAJ
 Florante Salvador,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742700878&command=GETPROFILE,2waSM7YAAAAJ
+Florian Alt,Bundeswehr University Munich,https://www.unibw.de/usable-security-and-privacy/team/univ-prof-dr-florian-alt,wf3Muy8AAAAJ
 Florian Daniel,Politecnico di Milano,http://home.deib.polimi.it/daniel,wF6n9-0AAAAJ
 Florian Kaltenberger,EURECOM,http://www.eurecom.fr/~kaltenbe,R1R9668AAAAJ
 Florian Kammueller,Middlesex University,http://www.cs.mdx.ac.uk/people/florian-kammueller,DaQ8dGMAAAAJ
@@ -4678,6 +4682,7 @@ G. Sivakumar,IIT Bombay,https://www.cse.iitb.ac.in/~siva,gqHcbCkAAAAJ
 G. Srinivasaraghavan,IIIT Bangalore,http://www.iiitb.ac.in/faculty_page.php?name=GSrinivasaraghavan,NOSCHOLARPAGE
 G. Stefano Sukhatme,University of Southern California,http://www-robotics.usc.edu/~gaurav,lRUi-A8AAAAJ
 Gabe Sibley,University of Colorado Boulder,https://www.colorado.edu/cs/users/gasi6462,MNp5hwoAAAAJ
+Gabi Dreo Rodosek,Bundeswehr University Munich,https://www.unibw.de/technische-informatik/mitarbeiter/professoren/univ-prof-in-dr-gabi-dreo-rodosek,NOSCHOLARPAGE
 Gabor C. Temes,Oregon State University,http://eecs.oregonstate.edu/people/temes-gabor,NOSCHOLARPAGE
 Gabor Fichtinger,Queen’s University,http://www.cs.queensu.ca/~gabor,_KxkI6UAAAAJ
 Gabor Karsai,Vanderbilt University,http://engineering.vanderbilt.edu/bio/gabor-karsai,dShqnssAAAAJ
@@ -5155,6 +5160,7 @@ Gultekin Özsoyoglu,Case Western Reserve University,http://engineering.case.edu/
 Gunhee Kim,Seoul National University,http://vision.snu.ac.kr/~gunhee,CiSdOV0AAAAJ
 Gunnar Gotshalks,York University,http://www.cse.yorku.ca/~gunnar,NOSCHOLARPAGE
 Gunnar Rätsch,ETH Zurich,http://bmi.inf.ethz.ch/personnel/gunnar-ratsch,tQuQ1FwAAAAJ
+Gunnar Teege,Bundeswehr University Munich,https://www.unibw.de/technische-informatik/mitarbeiter/professoren/univ-prof-dr-gunnar-teege,NOSCHOLARPAGE
 Gunnar Tufte,NTNU,https://www.ntnu.edu/employees/gunnar.tufte,85QJtE0AAAAJ
 Guo Freeman,Clemson University,http://guof.people.clemson.edu,eRQZhUAAAAAJ
 Guo-Hui Lin,University of Alberta,https://webdocs.cs.ualberta.ca/~ghlin,XSgTV7gAAAAJ
@@ -5508,6 +5514,7 @@ Helle Hein,University of Tartu,http://www.ut.ee/en/kontakt/arvutiteaduse-institu
 Helmut A. Mayer,University of Salzburg,https://www.cosy.sbg.ac.at/~helmut/helmut.html,NOSCHOLARPAGE
 Helmut Hlavacs,University of Vienna,https://cs.univie.ac.at/helmut.hlavacs,I6E7smMAAAAJ
 Helmut Krcmar,TU Munich,http://www.professoren.tum.de/en/krcmar-helmut,zwax5qkAAAAJ
+Helmut Mayer 0001,Bundeswehr University Munich,https://www.unibw.de/inf4/mitarbeiter/univ-prof-dr-ing-helmut-mayer,f_n9lOIAAAAJ
 Helmut Seidl,TU Munich,http://www2.in.tum.de/~seidl,cWGEU94AAAAJ
 Hema A. Murthy,IIT Madras,http://www.cse.iitm.ac.in/~hema,AQ8w2uEAAAAJ
 Hemangee K. Kapoor,IIT Guwahati,http://www.iitg.ac.in/hemangee,9TsaEbMAAAAJ
@@ -6935,6 +6942,7 @@ Johannes A. Buchmann,TU Darmstadt,https://www.cdc.informatik.tu-darmstadt.de/de/
 Johannes C. van Vliet,VU Amsterdam,http://www.cs.vu.nl/~hans,4YAdfEsAAAAJ
 Johannes Fink,IST Austria,https://ist.ac.at/research/research-groups/fink-group,4Ot68t8AAAAJ
 Johannes Fürnkranz,TU Darmstadt,http://www.ke.tu-darmstadt.de/staff/juffi,sfTn4wEAAAAJ
+Johannes Kinder,Bundeswehr University Munich,https://www.unibw.de/systemsicherheit/kinder,rnDHTKYAAAAJ
 Johannes Köbler,Humboldt University of Berlin,https://www.informatik.hu-berlin.de/forschung/gebiete/algorithmenII,NOSCHOLARPAGE
 John (Jack) Morgan Sampson,Pennsylvania State University,http://www.cse.psu.edu/~jms1257,fSQCT0YAAAAJ
 John (Juyang) Weng,Michigan State University,http://www.cse.msu.edu/~weng,HnQ2gqMAAAAJ
@@ -7977,6 +7985,7 @@ Kiyoung Choi,Seoul National University,http://dal.snu.ac.kr/members/professor,_S
 Kjetil Nørvåg,NTNU,http://www.idi.ntnu.no/~noervaag,mADR4AYAAAAJ
 Klara Nahrstedt,Univ. of Illinois at Urbana-Champaign,https://cs.illinois.edu/directory/profile/klara,CUO0vDcAAAAJ
 Klas Nilsson,Lund University,http://cs.lth.se/klas_nilsson,NOSCHOLARPAGE
+Klaus Buchenrieder,Bundeswehr University Munich,https://www.unibw.de/technische-informatik/mitarbeiter/professoren/univ-prof-ph-d-klaus-buchenrieder,NOSCHOLARPAGE
 Klaus Diller,University of Koblenz-Landau,https://www.uni-koblenz-landau.de/de/koblenz/fb4/ifm/agdiller/team/diller/klaus-diller,NOSCHOLARPAGE
 Klaus Hildebrandt,TU Delft,https://graphics.tudelft.nl/klaus-hildebrandt,qYZBq5cAAAAJ
 Klaus Kabitzsch,TU Dresden,https://tu-dresden.de/cdd/leitung_und_beteiligte/mitglieder/bereich-mathematik/Kabitzsch,NOSCHOLARPAGE
@@ -9145,6 +9154,7 @@ Mark Lanthier,Carleton University,https://carleton.ca/scs/people/mark-lanthier,N
 Mark Lawford,McMaster University,https://www.cas.mcmaster.ca/~lawford,7v2eN0cAAAAJ
 Mark Liberman,University of Pennsylvania,http://www.ling.upenn.edu/~myl,R--JjPoAAAAJ
 Mark Manulis,University of Surrey,http://manulis.eu,MdmQAVkAAAAJ
+Mark Minas,Bundeswehr University Munich,https://www.unibw.de/inf2/personen/professoren/minas,NOSCHOLARPAGE
 Mark O. Riedl,Georgia Institute of Technology,https://research.cc.gatech.edu/inc/mark-riedl,Yg_QjxcAAAAJ
 Mark Oskin,University of Washington,http://homes.cs.washington.edu/~oskin,gHfzsl4AAAAJ
 Mark Owen Riedl,Georgia Institute of Technology,https://research.cc.gatech.edu/inc/mark-riedl,Yg_QjxcAAAAJ
@@ -9188,6 +9198,7 @@ Markus Nebel,Bielefeld University,https://ekvv.uni-bielefeld.de/pers_publ/publ/P
 Markus Pauly,EPFL,http://lgg.epfl.ch/publications.php,TSGyT-EAAAAJ
 Markus Püschel,ETH Zurich,https://www.inf.ethz.ch/personal/markusp,az9ZryAAAAAJ
 Markus Schneider,University of Florida,http://www.cise.ufl.edu/~mschneid,lOhijLUAAAAJ
+Markus Siegle,Bundeswehr University Munich,https://www.unibw.de/technische-informatik/mitarbeiter/professoren/siegle/entwurf-von-rechen-und-kommunikationssystemen,Sdh-toEAAAAJ
 Markus Steinberger,Graz University of Technology,https://www.markussteinberger.net,meRwdycAAAAJ
 Markus Wagner 0007,University of Adelaide,https://cs.adelaide.edu.au/~markus,DVbOu8MAAAAJ
 Marleen de Bruijne,University of Copenhagen,http://image.diku.dk/marleen,7kTk3LUAAAAJ
@@ -9705,6 +9716,7 @@ Michael Kearns,University of Pennsylvania,http://www.cis.upenn.edu/~mkearns,8iQk
 Michael Kifer,Stony Brook University,http://www3.cs.stonybrook.edu/~kifer,HIOYWhYAAAAJ
 Michael King,Florida Institute of Technology,https://www.fit.edu/faculty-profiles/5/michael-king,NOSCHOLARPAGE
 Michael Kirley,University of Melbourne,http://people.eng.unimelb.edu.au/mkirley,te9wVHwAAAAJ
+Michael Koch 0001,Bundeswehr University Munich,http://www.unibw.de/michael.koch,knY18cEAAAAJ
 Michael Kwok-Po Ng,Hong Kong Baptist University,http://www.math.hkbu.edu.hk/~mng,BBpjLiIAAAAJ
 Michael Kölling,University of Kent,https://www.cs.kent.ac.uk/people/staff/mik,NOSCHOLARPAGE
 Michael L. Best,Georgia Institute of Technology,http://mikeb.inta.gatech.edu,gLLhIb8AAAAJ
@@ -10704,6 +10716,7 @@ Oliver Eulenstein,Iowa State University,http://www.cs.iastate.edu/~oeulenst,HWF6
 Oliver Kennedy,University at Buffalo,http://www.cse.buffalo.edu/people/?u=okennedy,9Q9tiCsAAAAJ
 Oliver Matias van Kaick,Carleton University,http://people.scs.carleton.ca/~olivervankaick,IfvyBBUAAAAJ
 Oliver Ray,University of Bristol,https://www.cs.bris.ac.uk/~oray,3vwgzlUAAAAJ
+Oliver Rose,Bundeswehr University Munich,https://www.unibw.de/technische-informatik/mitarbeiter/professoren/univ-prof-dr-oliver-rose,CJqlQKQAAAAJ
 Oliver S. Cossairt,Northwestern University,http://compphotolab.northwestern.edu,QxxseqsAAAAJ
 Oliver Schulte,Simon Fraser University,http://www.cs.sfu.ca/~oschulte,NOSCHOLARPAGE
 Oliver W. W. Yang,University of Ottawa,http://www.site.uottawa.ca/~yang,NOSCHOLARPAGE
@@ -11175,6 +11188,7 @@ Peter Grunwald,CWI,http://homepages.cwi.nl/~pdg,wItp6h8AAAAJ
 Peter Grünwald,CWI,http://homepages.cwi.nl/~pdg,wItp6h8AAAAJ
 Peter H. Welch,University of Kent,https://www.cs.kent.ac.uk/~phw,hd1j2w0AAAAJ
 Peter Hastings,DePaul University,http://reed.cs.depaul.edu/peterh,r-U50JwAAAAJ
+Peter Hertling,Bundeswehr University Munich,https://www.unibw.de/timor/mitarbeiter/hertling/univ-prof-dr-peter-hertling,NOSCHOLARPAGE
 Peter Hubwieser,TU Munich,http://www.professoren.tum.de/en/hubwieser-peter,YuvySKkAAAAJ
 Peter Høyer,University of Calgary,http://www.cpsc.ucalgary.ca/~hoyer,NOSCHOLARPAGE
 Peter I. Cowling,University of York,https://www-users.cs.york.ac.uk/~pic,xQ7IpL8AAAAJ
@@ -13495,6 +13509,7 @@ Stavros G. Kolliopoulos,University of Athens,http://cgi.di.uoa.gr/~sgk,1jZJgWQAA
 Stavros Toumpis,AUEB,https://195.251.255.130/en/faculty/toumpis-stavros,LyiVPKEAAAAJ
 Stavros Tripakis,Northeastern University,https://www.ccis.northeastern.edu/people/stavros-tripakis,xmdNUEcAAAAJ
 Stefan Arnborg,KTH Royal Institute of Technology,http://www.csc.kth.se/~stefana,NOSCHOLARPAGE
+Stefan Brunthaler,Bundeswehr University Munich,https://www.unibw.de/systemsicherheit/univ-prof-dr-stefan-brunthaler,8PPYUEQAAAAJ
 Stefan C. Kremer,University of Guelph,https://www.uoguelph.ca/computing/people/stefan-kremer,ECQMeb0AAAAJ
 Stefan Decker,RWTH Aachen,http://www.stefandecker.org,uhVkSswAAAAJ
 Stefan Dziembowski,University of Warsaw,http://www.crypto.edu.pl/Dziembowski,VgiXQ2YAAAAJ
@@ -13520,6 +13535,7 @@ Stefan Monnier,University of Montreal,https://www.iro.umontreal.ca/~monnier,NOSC
 Stefan Müller 0002,University of Koblenz-Landau,https://www.uni-koblenz-landau.de/de/koblenz/fb4/icv/agmueller/personen/stefanm/stefanm,NOSCHOLARPAGE
 Stefan Nilsson,KTH Royal Institute of Technology,http://www.csc.kth.se/~snilsson,NOSCHOLARPAGE
 Stefan Nürnberger,CISPA Helmholtz Center,https://infsec.cs.uni-saarland.de/~nuernberger,hk15WDAAAAAJ
+Stefan Pickl,Bundeswehr University Munich,https://www.unibw.de/comtessa,NOSCHOLARPAGE
 Stefan Resmerita,University of Salzburg,http://cs.uni-salzburg.at/~stefan.resmerita,NOSCHOLARPAGE
 Stefan Roth 0001,TU Darmstadt,http://www.visinf.tu-darmstadt.de/team_members/sroth/sroth.en.jsp,0yDoR0AAAAAJ
 Stefan Savage,University of California - San Diego,http://cseweb.ucsd.edu/~savage,_JhgbioAAAAJ
@@ -14582,6 +14598,7 @@ Ulrich Sorger,University of Luxembourg,http://wwwen.uni.lu/recherche/fstc/comput
 Ulrich Speidel,University of Auckland,http://www.tcs.auckland.ac.nz/~ulrich,NOSCHOLARPAGE
 Ulrik Nyman,Aalborg University,http://ulrik.blog.aau.dk,Z3FXuI0AAAAJ
 Ulrik Schroeder,RWTH Aachen,http://learntech.rwth-aachen.de/schroeder,8EYyC1MAAAAJ
+Ulrike Lechner,Bundeswehr University Munich,https://www.unibw.de/wirtschaftsinformatik,OzCAdaMAAAAJ
 Ulrike Meyer,RWTH Aachen,https://itsec.rwth-aachen.de/people/prof.-dr.-ulrike-meyer,y9RHiq0AAAAJ
 Ulrike Sattler,University of Manchester,http://www.cs.man.ac.uk/~sattler,NOSCHOLARPAGE
 Ulrike Stege,University of Victoria,http://webhome.cs.uvic.ca/~stege/Ulrike_Steges_Homepage/Welcome.html,1Zp5jw8AAAAJ
@@ -14617,6 +14634,7 @@ Uwe Aßmann,TU Dresden,http://www1.inf.tu-dresden.de/~ua1,KiiBpMgAAAAJ
 Uwe Baumgarten,TU Munich,http://www.os.in.tum.de/personen/baumgarten,NOSCHOLARPAGE
 Uwe D. Hanebeck,Karlsruhe Institute of Technology (KIT),https://isas.iar.kit.edu/de/Mitarbeiter_Hanebeck.php,q-f3ITAAAAAJ
 Uwe Glässer,Simon Fraser University,http://www.cs.sfu.ca/~glaesser,NOSCHOLARPAGE
+Uwe M. Borghoff,Bundeswehr University Munich,https://www.unibw.de/inf2/personen/professoren/borghoff,Xn-P8FwAAAAJ
 Uwe Naumann,RWTH Aachen,https://www.stce.rwth-aachen.de/people/uwe-naumann,vRVzEDMAAAAJ
 Uwe Nestmann,TU Berlin,https://www.mtv.tu-berlin.de/nestmann,8zjcWf0AAAAJ
 Uwe Petersohn,TU Dresden,https://www.inf.tu-dresden.de/content/institutes/ki/awv/Personen/petersohn.de.html,NOSCHOLARPAGE
@@ -14683,6 +14701,7 @@ Varun Dutt,IIT Mandi,https://faculty.iitmandi.ac.in/~varun,jly9u8AAAAAJ
 Varun Kanade,University of Oxford,http://www.cs.ox.ac.uk/people/varun.kanade,NOSCHOLARPAGE
 Vasant G. Honavar,Pennsylvania State University,https://www.eecs.psu.edu/departments/directory-detail-g.aspx?q=vuh11/vuh14,pD_y458AAAAJ
 Vasco Amaral, Universidade NOVA de Lisboa , https://sites.google.com/site/vascoamaral, p6lbgbAAAAAJ
+Vasco Brattka,Bundeswehr University Munich,http://theory.cca-net.de/vasco.php,BlPeOrIAAAAJ
 Vasco M. Manquinho,Universidade de Lisboa,http://sat.inesc-id.pt/~vmm,vG7Gj6QAAAAJ
 Vashek Matyas,Masaryk University,https://www.muni.cz/en/people/344,x6uv-rkAAAAJ
 Vashek Matyás,Masaryk University,https://www.muni.cz/en/people/344,x6uv-rkAAAAJ
@@ -15246,12 +15265,14 @@ Wolfgang Emmerich,University College London,http://www0.cs.ucl.ac.uk/staff/w.emm
 Wolfgang Gatterbauer,Northeastern University,https://www.ccis.northeastern.edu/people/wolfgang-gatterbauer,9mIBxkMAAAAJ
 Wolfgang Heidrich,KAUST,http://vccimaging.org/People/heidriw,IQSbom0AAAAJ
 Wolfgang Hesse,LMU Munich,https://www.sosy-lab.org/people/hesse,NOSCHOLARPAGE
+Wolfgang Hommel,Bundeswehr University Munich,https://www.unibw.de/inf2/personen/professoren/hommel,LCsesngAAAAJ
 Wolfgang Karl,Karlsruhe Institute of Technology (KIT),http://capp.itec.kit.edu/~karl/?lang=d,NOSCHOLARPAGE
 Wolfgang Klas,University of Vienna,https://cs.univie.ac.at/wolfgang.klas,NOSCHOLARPAGE
 Wolfgang Lehner,TU Dresden,https://wwwdb.inf.tu-dresden.de/team/head/wolfgang-lehner,YYzvyMQAAAAJ
 Wolfgang Maass 0001,Graz University of Technology,https://igi-web.tugraz.at/people/maass,2WpvdH0AAAAJ
 Wolfgang Pree,University of Salzburg,http://www.softwareresearch.net/home,NOSCHOLARPAGE
 Wolfgang Prinz,RWTH Aachen,http://dbis.rwth-aachen.de/cms/staff/prinz,QWWLOGQAAAAJ
+Wolfgang Reinhardt 0002,Bundeswehr University Munich,https://websrv.rz.unibw-muenchen.de/inf4/professuren/geoinformatik/index_html,Xar_GqcAAAAJ
 Wolfgang Slany,Graz University of Technology,http://www.ist.tugraz.at/wolfgang_slany.html,yCR2h98AAAAJ
 Wolfgang Thomas,RWTH Aachen,https://www.lii.rwth-aachen.de/en/mitarbeiter/13-mitarbeiter/professoren/7-wolfgang-thomas.html,NOSCHOLARPAGE
 Wolfgang W. Bein,University of Nevada Las Vegas, http://web.cs.unlv.edu/bein,oUwEYt4AAAAJ


### PR DESCRIPTION
Added all full-time faculty in the department of computer science at Bundeswehr University Munich (official English name of Universität der Bundeswehr München).