### PR TITLE
Added 55 authors from Universidade de Lisboa with relevant work that …

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -9560,7 +9560,7 @@ Meiyappan Nagappan,University of Waterloo,https://cs.uwaterloo.ca/~m2nagapp,QKpk
 Mel Slater,University College London,http://www0.cs.ucl.ac.uk/staff/m.slater/Mel_Slaters_Home_Page/Home.html,5gGSgcUAAAAJ
 Melanie Baljko,York University,http://www.cse.yorku.ca/~mb,VdrPPMsAAAAJ
 Melanie E. Moses,University of New Mexico,https://www.cs.unm.edu/~melaniem,WFZ4azsAAAAJ
-Melanie Ganz-Benjaminsen,https://di.ku.dk/english/staff/vip/?pure=en/persons/341919,5AXE0skAAAAJ
+Melanie Ganz-Benjaminsen,https://di.ku.dk/english/staff/vip/?pure=en/persons/341919,5AXE0skAAAAJ,
 Melanie Herschel,University of Stuttgart,https://www.ipvs.uni-stuttgart.de/abteilungen/de/abteilung/mitarbeiter/Melanie.Herschel,K5VPw-IAAAAJ
 Melanie Mitchell,Portland State University,http://web.cecs.pdx.edu/~mm,k4gbv2AAAAAJ
 Melanie Volkamer,TU Darmstadt,https://www.secuso.informatik.tu-darmstadt.de/de/secuso-home/team/melanie-volkamer,ve0UJIEAAAAJ
@@ -9733,7 +9733,7 @@ Michael Kazhdan,Johns Hopkins University,http://www.cs.jhu.edu/~misha,soUq_eQAAA
 Michael Kearns,University of Pennsylvania,http://www.cis.upenn.edu/~mkearns,8iQk0DIAAAAJ
 Michael Kifer,Stony Brook University,http://www3.cs.stonybrook.edu/~kifer,HIOYWhYAAAAJ
 Michael King,Florida Institute of Technology,https://www.fit.edu/faculty-profiles/5/michael-king,NOSCHOLARPAGE
-Michael Kirkedal Thomsen,https://di.ku.dk/english/staff/vip/?pure=en/persons/196082,3VsQv0sAAAAJ
+Michael Kirkedal Thomsen,https://di.ku.dk/english/staff/vip/?pure=en/persons/196082,3VsQv0sAAAAJ,
 Michael Kirley,University of Melbourne,http://people.eng.unimelb.edu.au/mkirley,te9wVHwAAAAJ
 Michael Koch 0001,Bundeswehr University Munich,http://www.unibw.de/michael.koch,knY18cEAAAAJ
 Michael Kwok-Po Ng,Hong Kong Baptist University,http://www.math.hkbu.edu.hk/~mng,BBpjLiIAAAAJ
@@ -16231,3 +16231,79 @@ Zygmunt J. Haas,University of Texas at Dallas,http://www.utdallas.edu/~zjh130030
 Öznur Özkasap,Koç University,http://home.ku.edu.tr/~oozkasap,v2WiJeIAAAAJ
 Øystein Nytrø,NTNU,https://www.ntnu.edu/employees/nytroe,-Zavs80AAAAJ
 Ümit V. Çatalyürek,Georgia Institute of Technology,https://www.cc.gatech.edu/~umit,OLDMURQAAAAJ
+Alexandre Miguel Pinto,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/amdpinto,CnhikhoAAAAJ
+Alysson Bessani,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/anbessani,-mFXT_oAAAAJ
+Alysson Neves Bessani,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/anbessani,-mFXT_oAAAAJ
+Ana Paula Cláudio,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/apclaudio,q8mWLdoAAAAJ
+Antonio Casimiro,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/accosta,wKMmqlUAAAAJ
+António Horta Branco,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/ambranco,JeBor2UAAAAJ
+António Branco,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/ambranco,JeBor2UAAAAJ
+Carlos Duarte,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/caduarte,I7hcyJgAAAAJ
+Carlos M. Duarte,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/caduarte,I7hcyJgAAAAJ
+Carlos Teixeira,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/cjteixeira,gnbk7PgAAAAJ
+Fernando M. V. Ramos,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/fvramos,NhC7jcQAAAAJ
+Fernando Manuel Valente Ramos,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/fvramos,NhC7jcQAAAAJ
+Francisco Martins,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/fcmartins,lUc2k74AAAAJ
+Francisco M. Couto,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/fjcouto,9_78rfMAAAAJ
+Hugo Miranda,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/hamiranda,hywVBUIAAAAJ
+Hugo M. Miranda,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/hamiranda,hywVBUIAAAAJ
+Ibéria Medeiros,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/ivmedeiros,bRMCeKYAAAAJ
+Iberia Medeiros,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/ivmedeiros,bRMCeKYAAAAJ
+José Rufino,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/jmrufino,phen2ukAAAAJ
+Joao Marques-Silva,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/jpmsilva,1b9hppwAAAAJ
+João Marques-Silva,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/jpmsilva,1b9hppwAAAAJ
+João P. Marques Silva,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/jpmsilva,1b9hppwAAAAJ
+João Ricardo Silva,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/jrsilva,FLVyMLcAAAAJ
+Luís Carriço,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/lmcarrico,MLg1ZJMAAAAJ
+Luís Miguel Parreira Correia,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/lmcorreia,2IbMjzgAAAAJ
+Marco Giunti,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/mgiunti,xdrpRlcAAAAJ
+Antónia Lopes,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/malopes,BQluvIMAAAAJ
+Maria Beatriz Carmo,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/mbcarmo,3-kUQBoAAAAJ
+Graça Gaspar,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/mdgaspar,Y7mExc8AAAAJ
+Dulce Domingos,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/mddomingos,oW97QngAAAAJ
+Isabel Nunes,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/minunes,CLnZIEQAAAAJ
+Teresa Chambel,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/mtchambel,Gvmh4NQAAAAJ
+Mario Calha,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/mcalha,GSDogzwAAAAJ
+Paulo Urbano,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/pjurbano,r8zV1FsAAAAJ
+Pedro M. Ferreira,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/pmferreira,_-nQkzsAAAAJ
+Sara Silva,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/sgsilva,g15oqi0AAAAJ
+Thibault Langlois,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/tnlanglois,1MHDJwkAAAAJ
+Vasco Thudichum Vasconcelos,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/vmvasconcelos,dsRKl04AAAAJ
+Vasco T. Vasconcelos,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/vmvasconcelos,dsRKl04AAAAJ
+Alexandre Bernardino,Universidade de Lisboa,http://users.isr.ist.utl.pt/~alex/pmwiki/index.php,auFmh9MAAAAJ
+Ana Almeida Matos,Universidade de Lisboa,http://web.ist.utl.pt/~ist24690/,D6nVmPQAAAAJ
+Ana Gualdina Almeida Matos,Universidade de Lisboa,http://web.ist.utl.pt/~ist24690/,D6nVmPQAAAAJ
+André Vasconcelos,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist10876/doutoramentos,mSzH4DQAAAAJ
+Artur Caetano,Universidade de Lisboa,http://w3.dgeec.mec.pt/rebides/2011/rebid_m2.asp?CodR=110&CodP=0807,HXYfCUIAAAAJ
+Carlos Caleiro,Universidade de Lisboa,http://sqig.math.ist.utl.pt/ccal,YnVAMh4AAAAJ
+Diogo R. Ferreira,Universidade de Lisboa,http://web.tecnico.ulisboa.pt/diogo.ferreira/,CSEqKy8AAAAJ
+J. G. Cederquist,Universidade de Lisboa,http://web.ist.utl.pt/~ist24691/,ImQ41W0AAAAJ
+Jan Cederquist,Universidade de Lisboa,http://web.ist.utl.pt/~ist24691/,ImQ41W0AAAAJ
+Jorge S. Marques,Universidade de Lisboa,http://users.isr.ist.utl.pt/~jsm/,8Vwg-7sAAAAJ
+José Carlos Alves Pereira Monteiro,Universidade de Lisboa,http://algos.inesc-id.pt/~jcm,tkeh3OAAAAAJ
+José Monteiro,Universidade de Lisboa,http://algos.inesc-id.pt/~jcm,tkeh3OAAAAAJ
+José C. Monteiro,Universidade de Lisboa,http://algos.inesc-id.pt/~jcm,tkeh3OAAAAAJ
+José Santos-Victor,Universidade de Lisboa,http://users.isr.ist.utl.pt/~jasv/,ZMuNAXQAAAAJ
+João Paulo Costeira,Universidade de Lisboa,http://welcome.isr.tecnico.ulisboa.pt/author/joaopaulosalgadoarriscado/,Xi33QRIAAAAJ
+João Rasga,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist14184,teFGWr4AAAAJ
+Manuel Lopes,Universidade de Lisboa,http://web.tecnico.ulisboa.pt/manuel.lopes/,8tO0CikAAAAJ
+Miguel L. Pardal,Universidade de Lisboa,http://web.tecnico.ulisboa.pt/miguel.pardal/,hAqbWoQAAAAJ
+Miguel M. Silva,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist13948,8Lmbw5kAAAAJ
+Miguel Mira da Silva,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist13948,8Lmbw5kAAAAJ
+Miguel Leitão Bignolas Mira da Silva,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist13948,8Lmbw5kAAAAJ
+Mário A. T. Figueiredo,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist12403,S-pd0NwAAAAJ
+Nuno Horta,Universidade de Lisboa,http://www.it.pt/person_detail_p.asp?id=426,IVjOUCcAAAAJ
+Nuno Cavaco Gomes Horta,Universidade de Lisboa,http://www.it.pt/person_detail_p.asp?id=426,IVjOUCcAAAAJ
+Nuno C. G. Horta,Universidade de Lisboa,http://www.it.pt/person_detail_p.asp?id=426,IVjOUCcAAAAJ
+Paulo Mateus,Universidade de Lisboa,http://sqig.math.ist.utl.pt/paulo.mateus,8KiAAz0AAAAJ
+Pedro Manuel Moreira Vaz Antunes de Sousa,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist12951,LksdyM8AAAAJ
+Pedro Sousa,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist12951,LksdyM8AAAAJ
+Pedro Manuel Antunes Sousa,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist12951,LksdyM8AAAAJ
+Pedro Adão,Universidade de Lisboa,https://www.it.pt/Members/Index/1909,9wisdigAAAAJ
+Pedro Urbano Lima,Universidade de Lisboa,http://users.isr.ist.utl.pt/~pal/,NUiEEYkAAAAJ
+Pedro U. Lima,Universidade de Lisboa,http://users.isr.ist.utl.pt/~pal/,NUiEEYkAAAAJ
+Rodrigo M. M. Ventura,Universidade de Lisboa,http://users.isr.ist.utl.pt/~yoda/homepage/,sftSuj8AAAAJ
+Rodrigo Ventura,Universidade de Lisboa,http://users.isr.ist.utl.pt/~yoda/homepage/,sftSuj8AAAAJ
+Sérgio Guerreiro,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist62654,n-27wAQAAAAJ
+Sergio Miguel Fernandes,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist14264,VR4qbCIAAAAJ
+Susana Vinga,Universidade de Lisboa,http://web.ist.utl.pt/susanavinga/,tqCfgygAAAAJ

--- a/dblp-aliases.csv
+++ b/dblp-aliases.csv
@@ -2196,3 +2196,79 @@ Oscar Cánovas Reverte,Óscar Cánovas Reverte
 Óscar Cánovas,Óscar Cánovas Reverte
 Oznur Tastan,Öznur Tastan
 Flora D. Salim,Flora Dilys Salim
+Alexandre Miguel Pinto,Alexandre Miguel Pinto
+Alysson Bessani,Alysson Bessani
+Alysson Neves Bessani,Alysson Neves Bessani
+Ana Paula Cláudio,Ana Paula Cláudio
+Antonio Casimiro,Antonio Casimiro
+António Horta Branco,António Horta Branco
+António Branco,António Branco
+Carlos Duarte,Carlos Duarte
+Carlos M. Duarte,Carlos M. Duarte
+Carlos Teixeira,Carlos Teixeira
+Fernando M. V. Ramos,Fernando M. V. Ramos
+Fernando Manuel Valente Ramos,Fernando Manuel Valente Ramos
+Francisco Martins,Francisco Martins
+Francisco M. Couto,Francisco M. Couto
+Hugo Miranda,Hugo Miranda
+Hugo M. Miranda,Hugo M. Miranda
+Ibéria Medeiros,Ibéria Medeiros
+Iberia Medeiros,Iberia Medeiros
+José Rufino,José Rufino
+Joao Marques-Silva,Joao Marques-Silva
+João Marques-Silva,João Marques-Silva
+João P. Marques Silva,João P. Marques Silva
+João Ricardo Silva,João Ricardo Silva
+Luís Carriço,Luís Carriço
+Luís Miguel Parreira Correia,Luís Miguel Parreira Correia
+Marco Giunti,Marco Giunti
+Antónia Lopes,Antónia Lopes
+Maria Beatriz Carmo,Maria Beatriz Carmo
+Graça Gaspar,Graça Gaspar
+Dulce Domingos,Dulce Domingos
+Isabel Nunes,Isabel Nunes
+Teresa Chambel,Teresa Chambel
+Mario Calha,Mario Calha
+Paulo Urbano,Paulo Urbano
+Pedro M. Ferreira,Pedro M. Ferreira
+Sara Silva,Sara Silva
+Thibault Langlois,Thibault Langlois
+Vasco Thudichum Vasconcelos,Vasco Thudichum Vasconcelos
+Vasco T. Vasconcelos,Vasco T. Vasconcelos
+Alexandre Bernardino,Alexandre Bernardino
+Ana Almeida Matos,Ana Almeida Matos
+Ana Gualdina Almeida Matos,Ana Gualdina Almeida Matos
+André Vasconcelos,André Vasconcelos
+Artur Caetano,Artur Caetano
+Carlos Caleiro,Carlos Caleiro
+Diogo R. Ferreira,Diogo R. Ferreira
+J. G. Cederquist,J. G. Cederquist
+Jan Cederquist,Jan Cederquist
+Jorge S. Marques,Jorge S. Marques
+José Carlos Alves Pereira Monteiro,José Carlos Alves Pereira Monteiro
+José Monteiro,José Monteiro
+José C. Monteiro,José C. Monteiro
+José Santos-Victor,José Santos-Victor
+João Paulo Costeira,João Paulo Costeira
+João Rasga,João Rasga
+Manuel Lopes,Manuel Lopes
+Miguel L. Pardal,Miguel L. Pardal
+Miguel M. Silva,Miguel M. Silva
+Miguel Mira da Silva,Miguel Mira da Silva
+Miguel Leitão Bignolas Mira da Silva,Miguel Leitão Bignolas Mira da Silva
+Mário A. T. Figueiredo,Mário A. T. Figueiredo
+Nuno Horta,Nuno Horta
+Nuno Cavaco Gomes Horta,Nuno Cavaco Gomes Horta
+Nuno C. G. Horta,Nuno C. G. Horta
+Paulo Mateus,Paulo Mateus
+Pedro Manuel Moreira Vaz Antunes de Sousa,Pedro Manuel Moreira Vaz Antunes de Sousa
+Pedro Sousa,Pedro Sousa
+Pedro Manuel Antunes Sousa,Pedro Manuel Antunes Sousa
+Pedro Adão,Pedro Adão
+Pedro Urbano Lima,Pedro Urbano Lima
+Pedro U. Lima,Pedro U. Lima
+Rodrigo M. M. Ventura,Rodrigo M. M. Ventura
+Rodrigo Ventura,Rodrigo Ventura
+Sérgio Guerreiro,Sérgio Guerreiro
+Sergio Miguel Fernandes,Sergio Miguel Fernandes
+Susana Vinga,Susana Vinga


### PR DESCRIPTION
…were missing to csrankings.csv and corresponding aliases to dblp-aliases.csv

# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [ ] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [ ] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [ ] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

