### PR TITLE
Added DBLP translation support for names with i-acute characters

### DIFF
--- a/csrankings.ts
+++ b/csrankings.ts
@@ -465,7 +465,8 @@ class CSRankings {
 		name = name.replace(/Á/g, "=Aacute=");
 		name = name.replace(/á/g, "=aacute=");
 		name = name.replace(/è/g, "=egrave=");
-		name = name.replace(/é/g, "=eacute=");
+		name = name.replace(/é/g, "=eacute=");		
+		name = name.replace(/í/g, "=iacute=");
 		name = name.replace(/ï/g, "=iuml=");
 		name = name.replace(/ó/g, "=oacute=");
 		name = name.replace(/ç/g, "=ccedil=");


### PR DESCRIPTION
This is a small bug fix for the author name to DBLP page translation function. DBLP translates i-acute characters to "=iacute=" but csrankings didn't support this translation.