### PR TITLE
Add missing professors to Tokyo Tech

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -5599,6 +5599,7 @@ Heung-Kyu Lee,KAIST,http://hklee.kaist.ac.kr,f7uaLWEAAAAJ
 Hezy Yeshurun,Tel Aviv University,https://english.tau.ac.il/profile/hezy,NOSCHOLARPAGE
 Hichem Frigui,University of Louisville,http://louisville.edu/speed/people/faculty/friguiHichem,kj8gkFAAAAAJ
 Hideaki Ishii,Tokyo Institute of Technology,http://www.sc.dis.titech.ac.jp/ishii,q2n6QFAAAAAJ
+Hidehiko Masuhara,Tokyo Institute of Technology,http://prg.is.titech.ac.jp/people/masuhara/,tq4dtkUAAAAJ
 Hideki Koike,Tokyo Institute of Technology,https://www.vogue.cs.titech.ac.jp,Ih8cJXQAAAAJ
 Hideki Nakayama,University of Tokyo,http://www.nlab.ci.i.u-tokyo.ac.jp/~nakayama/index_en.html,AJUldKwAAAAJ
 Hidetoshi Shimodaira,Kyoto University,http://stat.sys.i.kyoto-u.ac.jp,LvoIaIsAAAAJ
@@ -7801,6 +7802,7 @@ Kazuo Yano,Tokyo Institute of Technology,https://www.facebook.com/yano.labo,tqMG
 Kazuyoshi Takagi,Kyoto University,http://kyouindb.iimc.kyoto-u.ac.jp/e/hU7zC,NOSCHOLARPAGE
 Kazuyoshi Yoshii,Kyoto University,http://sap.ist.i.kyoto-u.ac.jp/members/yoshii,QaNTClUAAAAJ
 Kazuyuki Aihara,University of Tokyo,https://www.iis.u-tokyo.ac.jp/en/research/staff/kazuyuki-aihara,NOSCHOLARPAGE
+Kazuyuki Shudo,Tokyo Institute of Technology,http://www.shudo.net,RJyUXU0AAAAJ
 Kazuyuki Yagasaki,Kyoto University,http://yang.amp.i.kyoto-u.ac.jp/~yagasaki/index_e.html,NOSCHOLARPAGE
 Ke Chen 0005,Zhejiang University,http://mypage.zju.edu.cn/kechenpage,NOSCHOLARPAGE
 Ke Deng,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/d/deng-dr-ke,MuWCgskAAAAJ
@@ -7818,6 +7820,7 @@ Keh-Hsun Chen,UNC - Charlotte,https://webpages.uncc.edu/chen,NOSCHOLARPAGE
 Kei Okada,University of Tokyo,http://www.jsk.t.u-tokyo.ac.jp/~k-okada/index-e.html,D0I9x20AAAAJ
 Keijo Heljanko,Aalto University,https://users.ics.aalto.fi/kepa,TOSfazMAAAAJ
 Keishi Tajima,Kyoto University,http://www.dl.soc.i.kyoto-u.ac.jp/~tajima/index.html,NOSCHOLARPAGE
+Keisuke Tanaka,Tokyo Institute of Technology,www.is.titech.ac.jp/~keisuke/,sNHvEUwAAAAJ
 Keith Andrews,Graz University of Technology,https://keithandrews.com/keith,NOSCHOLARPAGE
 Keith Brian Gallagher,Florida Institute of Technology,https://cs.fit.edu/~kgallagher,iDCDbB4AAAAJ
 Keith Clark,Imperial College London,http://www.doc.ic.ac.uk/~klc,fjZMW1oAAAAJ
@@ -7853,6 +7856,7 @@ Ken Mitchell,University of Missouri - Kansas City,https://sce.umkc.edu/about/dir
 Ken Perlin,New York University,https://mrl.nyu.edu/~perlin,TGRPKRIAAAAJ
 Ken S. Stevens,University of Utah,http://www.ece.utah.edu/~kstevens,WeRUynMAAAAJ
 Ken Umeno,Kyoto University,http://chaosken.amp.i.kyoto-u.ac.jp/index_eng.html,LH8eRMMAAAAJ
+Ken Wakita,Tokyo Institute of Technology,https://kwakita.blog,lh5DnywAAAAJ
 Ken Wing-Kin Sung,National University of Singapore,https://www.comp.nus.edu.sg/~ksung,KaCbE9MAAAAJ
 Ken Wong 0001,University of Alberta,https://webapps.cs.ualberta.ca/profile,I__Yju4AAAAJ
 Kendall E. Nygard,North Dakota State University,http://www.cs.ndsu.nodak.edu/~nygard,NOSCHOLARPAGE
@@ -8811,6 +8815,7 @@ Majid Sarrafzadeh,University of California - Los Angeles,http://www.cs.ucla.edu/
 Majid Zamani,University of Colorado Boulder,https://sites.google.com/site/zamani1362/home,-XDU9ZMAAAAJ
 Makoto Nakayama,DePaul University,https://www.cdm.depaul.edu/about/Pages/People/FacultyInfo.aspx?fid=107,NOSCHOLARPAGE
 Makoto Yamada,Kyoto University,https://riken-yamada.github.io,1cKNu1gAAAAJ
+Makoto Yamashita,Tokyo Institute of Technology,http://www.opt.c.titech.ac.jp/yamashita/,NOSCHOLARPAGE
 Maksim Serbyn,IST Austria,https://ist.ac.at/research/physical_sciences,NOSCHOLARPAGE
 Malcolm D. Atkinson,University of Edinburgh,http://www.research.ed.ac.uk/portal/en/persons/malcolm-atkinson(8e51eafb-dd78-468b-8970-ec2349e92305).html,NOSCHOLARPAGE
 Malcolm Heywood,Dalhousie University,https://www.dal.ca/faculty/computerscience/faculty-staff/malcolm-heywood.html,_d-AGjUAAAAJ
@@ -10052,6 +10057,7 @@ Mitesh M. Khapra,IIT Madras,http://www.cse.iitm.ac.in/~miteshk,DV8z8DYAAAAJ
 Mitsunori Ogihara,University of Miami,http://www.cs.miami.edu/~ogihara,vdMVIH4AAAAJ
 Mitsunori Ogiwara,University of Miami,http://www.cs.miami.edu/~ogihara,vdMVIH4AAAAJ
 Mitsuru Shibayama,Kyoto University,http://yang.amp.i.kyoto-u.ac.jp/~shibayama/top_e.html,NOSCHOLARPAGE
+Mituhiro Fukuda,Tokyo Institute of Technology,http://mf.c.titech.ac.jp/mituhiro/,NOSCHOLARPAGE
 Mladen A. Vouk,North Carolina State University,http://renoir.csc.ncsu.edu/Faculty/Vouk,NOSCHOLARPAGE
 Mo Chen,Simon Fraser University,https://www.sfu.ca/computing/people/faculty/mochen1111.html,4372x88AAAAJ
 Mo Li,Nanyang Technological University,http://www.ntu.edu.sg/home/limo,U77AEBsAAAAJ
@@ -10327,6 +10333,7 @@ Naomi Feldman,University of Maryland - College Park,http://legacydirs.umiacs.umd
 Naomi H. Feldman,University of Maryland - College Park,http://legacydirs.umiacs.umd.edu/~nhf/index.html,FvRFQZ8AAAAJ
 Naomi Nishimura,University of Waterloo,https://cs.uwaterloo.ca/~nishi,SO3M2JwAAAAJ
 Naoshi Nishimura,Kyoto University,http://www.cs.kyoto-u.ac.jp/en/profile/naoshi-nishimura,NOSCHOLARPAGE
+Naoto Miyoshi,Tokyo Institute of Technology,http://www.is.c.titech.ac.jp/~is0000_miyoshi/,NOSCHOLARPAGE
 Naphtali David Rishe,Florida International University,http://cake.fiu.edu/Rishe,bA1-qT0AAAAJ
 Naphtali Rishe,Florida International University,http://cake.fiu.edu/Rishe,bA1-qT0AAAAJ
 Narain Gehani,NJIT,http://cs.njit.edu/~gehani,NOSCHOLARPAGE
@@ -10669,6 +10676,7 @@ Norman Ramsey,Tufts University,http://www.cs.tufts.edu/~nr,7QTGa98AAAAJ
 Norman S. Matloff,University of California - Davis,http://faculty.engineering.ucdavis.edu/matloff,NOSCHOLARPAGE
 Norman W. Paton,University of Manchester,http://www.cs.man.ac.uk/~norm,X-9OH6AAAAAJ
 Novi Quadrianto,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/335583,I-rLzGcAAAAJ
+Nukada Akira,Tokyo Institute of Technology,https://nrid.nii.ac.jp/nrid/1000040545688/,vjE9JnYAAAAJ
 Nuno Bandeira,University of California - San Diego,https://cseweb.ucsd.edu/~nbandeir,dufShEsAAAAJ
 Nuno Correia 0001, Universidade NOVA de Lisboa , http://www-ctp.di.fct.unl.pt/~nmc, w7cia2AAAAAJ
 Nuno Filipe Valentim Roma,Universidade de Lisboa,http://sips.inesc-id.pt/~nfvr,iDxEJwIAAAAJ
@@ -10782,6 +10790,7 @@ Orna Grumberg,Technion,http://www.cs.technion.ac.il/~orna,ZPed8YYAAAAJ
 Orna Kupferman,Hebrew University of Jerusalem,http://www.cs.huji.ac.il/~ornak,5o111aIAAAAJ
 Osama Halabi,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/osama_halabi.php,jYUTRTcAAAAJ
 Osama Shata,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/osama.php,SgSSzKIAAAAJ
+Osamu Watanabe 0001,Tokyo Institute of Technology,http://tcs.c.titech.ac.jp,d7xpGDUAAAAJ
 Oscar Avila,Universidad de los Andes,http://profesores.virtual.uniandes.edu.co/oj.avila,sBulnrkAAAAJ
 Oscar Cánovas Reverte,University of Murcia,http://webs.um.es/ocanovas/miwiki/doku.php,iAPkCb8AAAAJ
 Oscar González,Universidad de los Andes,https://sistemasacademico.uniandes.edu.co/~o-gonza1,RPqeGp0AAAAJ
@@ -12567,8 +12576,10 @@ Ryan Williams,Massachusetts Institute of Technology,http://web.stanford.edu/~rrw
 Ryan Williams 0001,Massachusetts Institute of Technology,http://web.stanford.edu/~rrwill,Wp38QQYAAAAJ
 Rym Wenkstern,University of Texas at Dallas,http://www.utdallas.edu/~rmili,NOSCHOLARPAGE
 Rym Zalila-Wenkstern,University of Texas at Dallas,http://www.utdallas.edu/~rmili,NOSCHOLARPAGE
+Ryo Kashima,Tokyo Institute of Technology,http://www.is.c.titech.ac.jp/~is0000_kashima/lab/index-e.html,NOSCHOLARPAGE
 Ryohei Kanzaki,University of Tokyo,http://www.rcast.u-tokyo.ac.jp/research/people/staff-kanzaki_ryohei_en.html,91sdymMAAAAJ
 Ryszard Janicki,McMaster University,http://www.cas.mcmaster.ca/~janicki,NOSCHOLARPAGE
+Ryuhei Mori,Tokyo Institute of Technology,http://q.c.titech.ac.jp/profile.html,7q_zIE0AAAAJ
 Ryuichi Shigemoto,IST Austria,https://ist.ac.at/research/research-groups/shigemoto-group,NOSCHOLARPAGE
 Ryuma Niiyama,University of Tokyo,http://www.isi.imi.i.u-tokyo.ac.jp/en/member.html,NOSCHOLARPAGE
 Rémi Emonet,Université Jean Monnet,http://home.heeere.com,TOqZIGgAAAAJ
@@ -12857,6 +12868,7 @@ Satish Narayanasamy,University of Michigan,http://web.eecs.umich.edu/~nsatish,MZ
 Satish Rao,University of California - Berkeley,http://www.cs.berkeley.edu/~satishr,x_cgL6gAAAAJ
 Satoru Iwata 0001,University of Tokyo,http://www.opt.mist.i.u-tokyo.ac.jp/~iwata,6FWSv1EAAAAJ
 Satoru Miyano,University of Tokyo,http://bonsai.hgc.jp/people/miyano/profile.html,NOSCHOLARPAGE
+Satoshi Matsuoka,Tokyo Institute of Technology,http://matsu-www.is.titech.ac.jp/~matsu/index.html.en,UcWOl8YAAAAJ
 Satoshi Tsujimoto,Kyoto University,http://www-is.amp.i.kyoto-u.ac.jp/lab/en/tujimoto,NOSCHOLARPAGE
 Satyadev Nandakumar,IIT Kanpur,http://www.cse.iitk.ac.in/users/satyadev,lMAxggwAAAAJ
 Satyajayant Misra,New Mexico State University,http://www.cs.nmsu.edu/~misra,KJPGePAAAAAJ
@@ -13850,6 +13862,7 @@ Suman Kumar Maji,IIT Patna,https://iitp.ac.in/index.php/departments/engineering/
 Sumanta N. Pattanaik,University of Central Florida,http://www.cs.ucf.edu/~sumant,NOSCHOLARPAGE
 Sumeet Dua,Louisiana Tech University,http://dmrl.latech.edu,NOSCHOLARPAGE
 Sumi Helal,University of Florida,http://www.cise.ufl.edu/~helal,NOSCHOLARPAGE
+Sumio Watanabe,Tokyo Institute of Technology,http://watanabe-www.math.dis.titech.ac.jp/users/swatanab/,_KUAdxcAAAAJ
 Sumit Ganguly,IIT Kanpur,http://www.cse.iitk.ac.in/users/sganguly,NOSCHOLARPAGE
 Sumit Kumar Jha 0001,University of Central Florida,http://sumitkumarjha.com/www/jha,3kJbs98AAAAJ
 Sumita Mishra,Rochester Institute of Technology,http://csec.rit.edu/~smishra,WdVZoP4AAAAJ
@@ -14045,6 +14058,7 @@ Tajana Simunic,University of California - San Diego,http://cseweb.ucsd.edu/~tros
 Tajana Simunic Rosing,University of California - San Diego,http://cseweb.ucsd.edu/~trosing,CeieiIgAAAAJ
 Tak-Kei Lam,Chinese University of Hong Kong,http://www.cse.cuhk.edu.hk/v7/en/people/lec.html,NOSCHOLARPAGE
 Takaaki Ohnishi,University of Tokyo,http://www.canon-igs.org/en/fellows/takaaki_ohnishi.html,NOSCHOLARPAGE
+Takafumi Kanamori,Tokyo Institute of Technology,https://sites.google.com/site/tokyotechkanamoritakafumilab/english,NOSCHOLARPAGE
 Takanori Kigawa,Tokyo Institute of Technology,http://kigawa-lab.riken.jp/titech,jSi1DZ0AAAAJ
 Takashi Ishida,Tokyo Institute of Technology,http://www.cb.cs.titech.ac.jp/en,kudXipEAAAAJ
 Takashi Kobayashi,Tokyo Institute of Technology,http://www.sa.cs.titech.ac.jp/en,QTY3pv0AAAAJ
@@ -14475,6 +14489,7 @@ Tommy Kaplan,Hebrew University of Jerusalem,http://www.cs.huji.ac.il/~tommy,Zqqw
 Tommy Thorne,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Thomas_Thorne.html,o0MPrIwAAAAJ
 Tomofumi Yuki,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/tomofumi.yuki,SV9UUhYAAAAJ
 Tomohiro Tanikawa,University of Tokyo,http://www.cyber.t.u-tokyo.ac.jp,NOSCHOLARPAGE
+Tomomi Matsui,Tokyo Institute of Technology,http://tomomi.my.coocan.jp/welcomeE.html,6lYy6-QAAAAJ
 Tomoyuki Takahata,University of Tokyo,http://www.leopard.t.u-tokyo.ac.jp/~takahata,NOSCHOLARPAGE
 Tomás Brázdil,Masaryk University,https://www.muni.cz/en/people/4074,4Mp6OSYAAAAJ
 Tomás García Ferrari,University of Waikato,http://www.cms.waikato.ac.nz/people/tomasgf,U5v_QA0AAAAJ
@@ -14518,9 +14533,11 @@ Torsten Möller,University of Vienna,https://cs.univie.ac.at/torsten.moeller,3cG
 Torsten Suel,New York University,http://engineering.nyu.edu/~suel,eQUn8ugAAAAJ
 Torsten W. Kuhlen,RWTH Aachen,http://www.rwth-aachen.de/cms/root/Die-RWTH/Jobs-Ausbildung/Berufungen-an-der-RWTH-Aachen/Neuberufene/~kgfh/Univ-Prof-Torsten-Wolfgang-Kuhlen/lidx/1,O9ywg_UAAAAJ
 Torsten Wolfgang Kuhlen,RWTH Aachen,http://www.rwth-aachen.de/cms/root/Die-RWTH/Jobs-Ausbildung/Berufungen-an-der-RWTH-Aachen/Neuberufene/~kgfh/Univ-Prof-Torsten-Wolfgang-Kuhlen/lidx/1,O9ywg_UAAAAJ
+Toshiaki Murofushi,Tokyo Institute of Technology,http://www.fz.dis.titech.ac.jp/~murofusi/,NOSCHOLARPAGE
 Toru Ishida,Kyoto University,http://www.ai.soc.i.kyoto-u.ac.jp/~ishida,x11Wp_sAAAAJ
 Toshihiko Yamasaki,University of Tokyo,https://www.hal.t.u-tokyo.ac.jp/~yamasaki/index-e.html,rE9iY5MAAAAJ
 Toshio Aoyagi,Kyoto University,http://wwwfs.acs.i.kyoto-u.ac.jp/~aoyagi/DATA/TOP.html,NOSCHOLARPAGE
+Toshio Endo,Tokyo Institute of Technology,http://www.el.gsic.titech.ac.jp/~endo/index.html.en,xP3NeMEAAAAJ
 Toshiya Hachisuka,University of Tokyo,http://www.ci.i.u-tokyo.ac.jp/~hachisuka,SPK8lekAAAAJ
 Toshiyuki Nakata,University of Tokyo,http://www.ms.u-tokyo.ac.jp/~toshi,wXZ9Ym4AAAAJ
 Toshiyuki Tanaka,Kyoto University,http://www-adsys.sys.i.kyoto-u.ac.jp/tt/Tanaka-e.html,J_bqd7EAAAAJ
@@ -14983,6 +15000,7 @@ Wai-Kei Mak,National Tsing Hua University,http://www.cs.nthu.edu.tw/~wkmak,NOSCH
 Wai-Tat Fu,Univ. of Illinois at Urbana-Champaign,http://web.engr.illinois.edu/~wfu,W_KpAMcAAAAJ
 Wail Gueaieb,University of Ottawa,http://www.site.uottawa.ca/~wgueaieb,qN4Y3NEAAAAJ
 Wajdi Al Jedaibi,King Abdulaziz University,http://waljedaibi.kau.edu.sa/Default.aspx?Site_ID=0005903&lng=EN,NOSCHOLARPAGE
+Wakaha Ogata,Tokyo Institute of Technology,http://www.security.mot.titech.ac.jp/users/wakaha/,NOSCHOLARPAGE
 Waldemar Celes Filho,PUC-RIO,www.inf.puc-rio.br/~celes,i0ECFCEAAAAJ
 Walid A. Najjar,University of California - Riverside,http://www.cs.ucr.edu/~najjar,H0Y2wgUAAAAJ
 Walid G. Aref,Purdue University,https://www.cs.purdue.edu/people/aref,vX45evgAAAAJ
@@ -15680,6 +15698,7 @@ Yashar Ganjali,University of Toronto,http://www.cs.toronto.edu/~yganjali,9btkXOg
 Yashvardhan Sharma,BITS Pilani,http://www.bits-pilani.ac.in/pilani/yash/profile,9qP1-sMAAAAJ
 Yashwant K. Malaiya,Colorado State University,http://www.cs.colostate.edu/~malaiya,y2fSlecAAAAJ
 Yasir Mehmood,LUMS,https://lums.edu.pk/lums_employee/4841,_Ur63fwAAAAJ
+Yasuhiko Minamide,Tokyo Institute of Technology,http://sv.c.titech.ac.jp/minamide/index.en.html,NOSCHOLARPAGE
 Yasuo Kuniyoshi,University of Tokyo,http://www.isi.imi.i.u-tokyo.ac.jp/en,hOjZ1ZcAAAAJ
 Yasuo Okabe,Kyoto University,https://www.net.ist.i.kyoto-u.ac.jp/ja,Y4AUoowAAAAJ
 Yasutaka Furukawa,Simon Fraser University,http://www.cse.wustl.edu/~furukawa,wCxzFrMAAAAJ
@@ -15865,6 +15884,7 @@ Yoshimasa Nakamura,Kyoto University,http://www-is.amp.i.kyoto-u.ac.jp/ynaka/inde
 Yoshimasa Tsuruoka,University of Tokyo,http://www.logos.ic.i.u-tokyo.ac.jp/~tsuruoka,J2CkFngAAAAJ
 Yoshitaka Ushiku,University of Tokyo,http://www.mi.t.u-tokyo.ac.jp/ushiku,kxUld9MAAAAJ
 Yoshito Ohta,Kyoto University,http://www.bode.amp.i.kyoto-u.ac.jp/member/yoshito_ohta/research-en.html,NOSCHOLARPAGE
+Yoshiyuki Kabashima,Tokyo Institute of Technology,http://www.sp.dis.titech.ac.jp/~kaba/index_e.html,NLBZuoEAAAAJ
 Yoshua Bengio,University of Montreal,http://www.iro.umontreal.ca/~bengioy,kukA0LcAAAAJ
 Yossi Azar,Tel Aviv University,http://www.cs.tau.ac.il/~azar,ShzSUnwAAAAJ
 Yossi Gil,Technion,http://www.cs.technion.ac.il/~yogi,NOSCHOLARPAGE


### PR DESCRIPTION
Add missing professors from the Department of Mathematical and Computing Science, Tokyo Institute of Technology. FYI: https://educ.titech.ac.jp/is/eng/faculty/research_lab/