### PR TITLE
Add Alan Kuhnle and fix Zhi Wang's Google scholar page

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -309,6 +309,7 @@ Alan Hayes,University of Bath,http://www.bath.ac.uk/comp-sci/contacts/academics/
 Alan J. Hu,University of British Columbia,http://www.cs.ubc.ca/~ajh,6-JE5-cAAAAJ
 Alan K. Mackworth,University of British Columbia,http://www.cs.ubc.ca/~mack,6Jf5GeYAAAAJ
 Alan Kaminsky,Rochester Institute of Technology,https://www.cs.rit.edu/~ark,NOSCHOLARPAGE
+Alan Kuhnle,Florida State University,http://www.alankuhnle.com/,-zrlrKgAAAAJ
 Alan L. Cox,Rice University,https://www.cs.rice.edu/~alc,z28ApZkAAAAJ
 Alan L. Davis,University of Utah,http://www.cs.utah.edu/~ald,yY-df4UAAAAJ
 Alan L. Yuille,Johns Hopkins University,http://www.cs.jhu.edu/~ayuille,FJ-huxgAAAAJ
@@ -16174,7 +16175,7 @@ Zhentao Li,Ecole Normale Superieure,http://www.di.ens.fr/~zhentao,NOSCHOLARPAGE
 Zhenying He,Fudan University,http://homepage.fudan.edu.cn/zhenying,NOSCHOLARPAGE
 Zhi Jin,Peking University,http://www.sei.pku.edu.cn/people/zhijin,ZC7SObAAAAAJ
 Zhi Tang,Peking University,http://www.icst.pku.edu.cn/intro/tz/tangzhi.html,NOSCHOLARPAGE
-Zhi Wang 0004,Florida State University,http://www.cs.fsu.edu/~zwang,9YaLgEkAAAAJ
+Zhi Wang 0004,Florida State University,http://www.cs.fsu.edu/~zwang,Y9SwH_0AAAAJ
 Zhi Wei,NJIT,https://web.njit.edu/~zhiwei,1s4N3SIAAAAJ
 Zhi-Hong Deng,Peking University,http://www.cis.pku.edu.cn/faculty/system/dengzhihong/dengzhihong.htm,tRoAxlsAAAAJ
 Zhi-Hua Zhou,Nanjing University,https://cs.nju.edu.cn/zhouzh,rSVIHasAAAAJ


### PR DESCRIPTION
Add Dr. Alan Kuhnle to FSU. He is our most recent tenure-track hire. 
Also fix Dr. Zhi Wang's Google scholar pape. 

Thank you!
