### PR TITLE
Fixed a researcher's entry by using DBLP name

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -10327,7 +10327,7 @@ Mubbasir Kapadia,Rutgers University,http://www.cs.rutgers.edu/~mk1353,xhkzmycAAA
 Muffy Calder,University of Glasgow,http://www.dcs.gla.ac.uk/~muffy,HvAfVsAAAAAJ
 Muffy Thomas,University of Glasgow,http://www.dcs.gla.ac.uk/~muffy,HvAfVsAAAAAJ
 Muhammad Ali Babar,University of Adelaide,http://www.adelaide.edu.au/directory/ali.babar,BjzKrCsAAAAJ
-Muhammad Fareed Zafar,LUMS,https://lums.edu.pk/lums_employee/422,NOSCHOLARPAGE
+Muhammad Fareed Zaffar,LUMS,https://lums.edu.pk/lums_employee/422,NOSCHOLARPAGE
 Muhammad Hamad Alizai,LUMS,http://web.lums.edu.pk/~alizai,L4lhO6AAAAAJ
 Muhammad Naveed 0001,University of Southern California,https://www.cs.usc.edu/people/faculty/tenured-tenure-track-faculty/naveed-muhammad,nBUl6TEAAAAJ
 Muhammad Rizwan Asghar,University of Auckland,https://www.cs.auckland.ac.nz/~asghar,Oe5b51kAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -4434,6 +4434,7 @@ Fanxin Kong,University of Victoria,https://sites.google.com/site/fanxink,XeDepww
 Faramarz F. Samavati,University of Calgary,http://www.cpsc.ucalgary.ca/~samavati,NOSCHOLARPAGE
 Faramarz Samavati,University of Calgary,http://www.cpsc.ucalgary.ca/~samavati,NOSCHOLARPAGE
 Faraz Hasan,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=572350,sL4S7W0AAAAJ
+Fareed Zaffar,LUMS,https://lums.edu.pk/lums_employee/422,NOSCHOLARPAGE
 Farhad Ahani Kamangar,University of Texas at Arlington,http://ranger.uta.edu/~kamangar,NOSCHOLARPAGE
 Farhad Kamangar,University of Texas at Arlington,http://ranger.uta.edu/~kamangar,NOSCHOLARPAGE
 Farhad Pourkamali Anaraki,University of Massachusetts Lowell,http://www.cs.uml.edu/~farhad,NB2B59cAAAAJ
@@ -10327,7 +10328,6 @@ Mubbasir Kapadia,Rutgers University,http://www.cs.rutgers.edu/~mk1353,xhkzmycAAA
 Muffy Calder,University of Glasgow,http://www.dcs.gla.ac.uk/~muffy,HvAfVsAAAAAJ
 Muffy Thomas,University of Glasgow,http://www.dcs.gla.ac.uk/~muffy,HvAfVsAAAAAJ
 Muhammad Ali Babar,University of Adelaide,http://www.adelaide.edu.au/directory/ali.babar,BjzKrCsAAAAJ
-Muhammad Fareed Zaffar,LUMS,https://lums.edu.pk/lums_employee/422,NOSCHOLARPAGE
 Muhammad Hamad Alizai,LUMS,http://web.lums.edu.pk/~alizai,L4lhO6AAAAAJ
 Muhammad Naveed 0001,University of Southern California,https://www.cs.usc.edu/people/faculty/tenured-tenure-track-faculty/naveed-muhammad,nBUl6TEAAAAJ
 Muhammad Rizwan Asghar,University of Auckland,https://www.cs.auckland.ac.nz/~asghar,Oe5b51kAAAAJ

--- a/dblp-aliases.csv
+++ b/dblp-aliases.csv
@@ -660,6 +660,7 @@ F. R. K. Chung,Fan Chung Graham
 Fan Chung,Fan Chung Graham
 Fan R. K. Chung,Fan Chung Graham
 Faramarz Samavati,Faramarz F. Samavati
+Muhammad Fareed Zaffar,Fareed Zaffar
 Farhad Ahani Kamangar,Farhad Kamangar
 Farookh Hussain,Farookh Khadeer Hussain
 Farzad Farnoud Hassanzadeh,Farzad Farnoud


### PR DESCRIPTION
Corrected spelling of 'Fareed Zaffar' (should not have been 'Fareed Zafar'). Modified csrankings.csv to reflect the DBLP. Added alias ('Muhammad Fareed Zaffar') to dblp-aliases.csv.