### PR TITLE
Webpages and Googlescholar link fixes

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -129,7 +129,7 @@ Adam A. Porter,University of Maryland - College Park,https://www.cs.umd.edu/user
 Adam Bates,Univ. of Illinois at Urbana-Champaign,http://adambates.org,1dVglBkAAAAJ
 Adam Belay,Massachusetts Institute of Technology,https://engineering.mit.edu/faculty-research/year-2017,AKQec5wAAAAJ
 Adam Chlipala,Massachusetts Institute of Technology,http://adam.chlipala.net,Imh0w3AAAAAJ
-Adam Czajka,University of Notre Dame,https://engineering.nd.edu/profiles/aczajka,OObpEkAAAAJ
+Adam Czajka,University of Notre Dame,https://engineering.nd.edu/profiles/aczajka,_OObpEkAAAAJ
 Adam D. Smith,Boston University,http://www.cse.psu.edu/~ads22,fkGi-JMAAAAJ
 Adam Doupé,Arizona State University,http://adamdoupe.com,hsJqhNAAAAAJ
 Adam Finkelstein,Princeton University,https://www.cs.princeton.edu/~af,a959F6AAAAAJ
@@ -192,7 +192,7 @@ Adriana Schulz,University of Washington,https://homes.cs.washington.edu/~adriana
 Adriano Alonso Veloso,UFMG,http://homepages.dcc.ufmg.br/~adrianov,j2BEVSoAAAAJ
 Adriano C. M. Pereira,UFMG,http://homepages.dcc.ufmg.br/~adrianoc,MT9oSSwAAAAJ
 Adriano César Machado Pereira,UFMG,http://homepages.dcc.ufmg.br/~adrianoc,MT9oSSwAAAAJ
-Adriano Velasque Werhli,FURG Federal University of Rio Grande,http://www.werhli.c3.furg.br,xBlg2sAAAAJ
+Adriano Velasque Werhli,FURG Federal University of Rio Grande,http://www.werhli.c3.furg.br,NOSCHOLARPAGE
 Adriano Veloso,UFMG,http://homepages.dcc.ufmg.br/~adrianov,j2BEVSoAAAAJ
 Adrien Basso-Blandin,Ecole Normale Superieure de Lyon,http://www.ens-lyon.fr/recherche/laboratoire-de-l-informatique-du-parallelisme-umr-5668-83273.kjsp,zVizzZIAAAAJ
 Adrienne Decker,Rochester Institute of Technology,https://www.rit.edu/gccis/igm/adrienne-decker,JjLxdewAAAAJ
@@ -1320,7 +1320,7 @@ Armando Solar-Lezama,Massachusetts Institute of Technology,https://people.csail.
 Armin Haller,Australian National University,https://cs.anu.edu.au/people/armin-haller,BehUprAAAAAJ
 Armin R. Mikler,University of North Texas,http://www.cse.unt.edu/~mikler/A.R.Mikler,41ckZZsAAAAJ
 Arnab Bhattacharyya 0001,National University of Singapore,https://www.comp.nus.edu.sg/~arnab,eECXWqUAAAAJ
-Arnab Nandi 0001,Ohio State University,http://arnab.org,OhiNDfkAAAAJa
+Arnab Nandi 0001,Ohio State University,http://arnab.org,OhiNDfkAAAAJ
 Arnab Sarkar,IIT Guwahati,https://www.iitg.ernet.in/arnabsarkar,aElWxu8AAAAJ
 Arnaldo Vieira Moura,UNICAMP,http://santana.ic.unicamp.br,NOSCHOLARPAGE
 Arnaldo de Albuquerque Araújo,UFMG,http://homepages.dcc.ufmg.br/~arnaldo,AitxvQIAAAAJ
@@ -2611,8 +2611,8 @@ Christof Lutteroth,University of Bath,https://www.cs.auckland.ac.nz/~lutteroth,u
 Christof Monz,University of Amsterdam,https://staff.science.uva.nl/c.monz,0r3PWLQAAAAJ
 Christof Paar,Ruhr-University Bochum,http://emsec.rub.de/chair/home,w81afLAAAAAJ
 Christof Seiler,Maastricht University,http://christofseiler.github.io,fxMt84EAAAAJ
-Christoffer Heckman,University of Colorado Boulder,http://www.ristoffer.ch,YOtPcIAAAAJ
-Christoffer R. Heckman,University of Colorado Boulder,http://www.ristoffer.ch,YOtPcIAAAAJ
+Christoffer Heckman,University of Colorado Boulder,http://www.ristoffer.ch,-YOtPcIAAAAJ
+Christoffer R. Heckman,University of Colorado Boulder,http://www.ristoffer.ch,-YOtPcIAAAAJ
 Christoforos E. Kozyrakis,Stanford University,http://csl.stanford.edu/~christos,G2EJz5kAAAAJ
 Christoforos Moutafis,University of Manchester,http://www.cs.manchester.ac.uk/about-us/staff/profile/?ea=christoforos.moutafis,adiGYU8AAAAJ
 Christoph Borst,University of Louisiana - Lafayette,https://cmix.louisiana.edu/news-events/news/20170103/dr-christoph-borst-named-state-winner-lacue%E2%80%99s-2016-post-secondary-educator,AJJ0vS8AAAAJ
@@ -3574,7 +3574,7 @@ Desh Ranjan,Old Dominion University,http://odu.edu/directory/people/d/dranjan,NO
 Desheng Zhang,Rutgers University,https://www.cs.rutgers.edu/~dz220,cyEM2BoAAAAJ
 Deshun Yang,Peking University,http://www.icst.pku.edu.cn/audioLab/researchgroup.htm,NOSCHOLARPAGE
 Desmond Elliott,University of Copenhagen,https://elliottd.github.io,OjYpMi4AAAAJ
-Despina Michael,Cyprus University of Technology,https://www.cut.ac.cy/faculties/aac/mga/staff/elected-staff/despina.michael/?languageId=1,mPuIqtAAAAA
+Despina Michael,Cyprus University of Technology,https://www.cut.ac.cy/faculties/aac/mga/staff/elected-staff/despina.michael/?languageId=1,mPuIqtAAAAAJ
 Detlef Plump,University of York,https://www-users.cs.york.ac.uk/~det,nh6AHbIAAAAJ
 Deuk Heo,Washington State University,https://school.eecs.wsu.edu/people/faculty/deuk-heo,NOSCHOLARPAGE
 Deva Ramanan,Carnegie Mellon University,http://www.cs.cmu.edu/~deva,9B8PoXUAAAAJ
@@ -3944,7 +3944,7 @@ Edson Cáceres,UFMS,https://www.facom.ufms.br/~edson,NOSCHOLARPAGE
 Edson Norberto Cáceres,UFMS,https://www.facom.ufms.br/~edson,NOSCHOLARPAGE
 Edson Prestes,UFRGS,http://www.inf.ufrgs.br/~prestes,NOSCHOLARPAGE
 Edson Prestes e Silva Jr.,UFRGS,http://www.inf.ufrgs.br/~prestes,NOSCHOLARPAGE
-Edson Takashi Matsubara,UFMS,https://www.facom.ufms.br/~edsontm,IkaSwy0boIC
+Edson Takashi Matsubara,UFMS,https://www.facom.ufms.br/~edsontm,-IkaSwy0boIC
 Edson dos Santos Moreira,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/edson,QisD2NoAAAAJ
 Eduard Ayguadé,Polytechnic University of Catalonia,http://people.ac.upc.edu/eduard,lEho8pkAAAAJ
 Eduard Ayguadé Parra,Polytechnic University of Catalonia,http://people.ac.upc.edu/eduard,lEho8pkAAAAJ
@@ -6022,7 +6022,7 @@ In So Kweon,KAIST,http://rcv.kaist.ac.kr/v2/bbs/member_detail.php?mb_id=%20iskwe
 In-So Kweon,KAIST,http://rcv.kaist.ac.kr/v2/bbs/member_detail.php?mb_id=%20iskweon,XA8EOlEAAAAJ
 In-Young Ko,KAIST,http://bigbear.kaist.ac.kr/~iko,qf6c5k4AAAAJ
 Ina Schaefer,TU Braunschweig,https://www.tu-braunschweig.de/isf/team/schaefer,odzaci8AAAAJ
-Ina Schieferdecker,TU Berlin,https://www.eecs.tu-berlin.de/menue/einrichtungen/professuren/professorinnen/schieferdecker,WDSZfEAAAAJ
+Ina Schieferdecker,TU Berlin,https://www.eecs.tu-berlin.de/menue/einrichtungen/professuren/professorinnen/schieferdecker,-WDSZfEAAAAJ
 Ina Schäfer,TU Braunschweig,https://www.tu-braunschweig.de/isf/team/schaefer,odzaci8AAAAJ
 Inah Omoronyia,University of Glasgow,http://www.dcs.gla.ac.uk/~inah,BWgdh1wAAAAJ
 Inald Lagendijk,TU Delft,http://mmc.tudelft.nl/users/inald-lagendijk,NOSCHOLARPAGE
@@ -6268,7 +6268,7 @@ Jaelson Brelaz de Castro,UFPE,www.cin.ufpe.br/~jbc,Um1B6_4AAAAJ
 Jaelson Castro,UFPE,www.cin.ufpe.br/~jbc,Um1B6_4AAAAJ
 Jaelson Freire Brelaz de Castro,UFPE,www.cin.ufpe.br/~jbc,Um1B6_4AAAAJ
 Jaesik Choi,UNIST,http://sail.unist.ac.kr,RqMLVzUAAAAJ
-Jaewoo Kang,Korea University,http://dmis.korea.ac.kr/people,iiIxp8cAAAA
+Jaewoo Kang,Korea University,http://dmis.korea.ac.kr/people,iiIxp8cAAAAJ
 Jafar Habibi,Sharif University of Technology,http://sharif.ir/~jhabibi,fKvyreEAAAAJ
 Jagannathan Sarangapani,Missouri University of Technology,http://web.mst.edu/~sarangap,RTewL_wAAAAJ
 Jagarlapudi Saketha Nath,IIT Hyderabad,http://www.iith.ac.in/~saketha,k70LrvsAAAAJ
@@ -6303,7 +6303,7 @@ James A. Jones,University of California - Irvine,http://jamesajones.com,3lB8Y8kA
 James A. Landay,Stanford University,https://profiles.stanford.edu/james-landay,oQsObk0AAAAJ
 James A. Reggia,University of Maryland - College Park,https://www.cs.umd.edu/~reggia,NOSCHOLARPAGE
 James A. Storer,Brandeis University,http://www.cs.brandeis.edu/~storer,v3vdZycAAAAJ
-James A. Thom,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/t/thom-associate-professor-james,7ZXutEAAAAJ
+James A. Thom,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/t/thom-associate-professor-james,-7ZXutEAAAAJ
 James Alexander Hendler,Rensselaer Polytechnic Institute,http://www.cs.rpi.edu/~hendler,JNPbTdIAAAAJ
 James Alfred Walker,University of York,https://www.cs.york.ac.uk/people/?group=Research%20Fellows%20and%20Research%20Associates&username=jawalker,Yl5OycsAAAAJ
 James Allan,University of Massachusetts Amherst,https://ciir.cs.umass.edu/~allan,NOSCHOLARPAGE
@@ -6711,7 +6711,7 @@ Jernej Barbic,University of Southern California,http://www-bcf.usc.edu/~jbarbic,
 Jeroen Boydens,KU Leuven,https://distrinet.cs.kuleuven.be/people/jeroen,ljI2jYsAAAAJ
 Jeroen J. A. Keiren,TU Delft,https://www.jeroenkeiren.nl/teaching/in4387,_nrYKCoAAAAJ
 Jeroen Keiren,TU Delft,https://www.jeroenkeiren.nl/teaching/in4387,_nrYKCoAAAAJ
-Jeroen van de Graaf,UFMG,http://homepages.dcc.ufmg.br/~jvdg,w8olWwAAAAJ
+Jeroen van de Graaf,UFMG,http://homepages.dcc.ufmg.br/~jvdg,-w8olWwAAAAJ
 Jerome Harri,EURECOM,http://www.eurecom.fr/~haerri,QSAclH8AAAAJ
 Jerome Knopp,University of Missouri - Kansas City,https://sce.umkc.edu/about/directory/name/jerome-knopp-ph-d,NOSCHOLARPAGE
 Jerry Alan Fails,Boise State University,http://cs.boisestate.edu/~jfails,eO71_M8AAAAJ
@@ -7898,7 +7898,7 @@ Katsumi Inoue,Tokyo Institute of Technology,http://research.nii.ac.jp/il/index18
 Katy Börner,Indiana University,http://info.ils.indiana.edu/~katy,YirSp_cAAAAJ
 Katy Howland,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/172510,XUfk6ekAAAAJ
 Kaushal K. Shukla,IIT (BHU) Varanasi,http://www.old.iitbhu.ac.in/cse/index.php/people/faculty/30_pubs.html,2kCEA2kAAAAJ
-Kaveh Razavi,VU Amsterdam,https://www.vusec.net/people/kaveh-razavi,bWBN3cwAAAJ
+Kaveh Razavi,VU Amsterdam,https://www.vusec.net/people/kaveh-razavi,bWBN3cwAAAAJ
 Kavi Arya,IIT Bombay,https://www.cse.iitb.ac.in/~kavi,Qz7H0U0AAAAJ
 Kavita Bala,Cornell University,http://www.cs.cornell.edu/~kb,Rh16nsIAAAAJ
 Kavita Vemuri,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/kvemuri,NOSCHOLARPAGE
@@ -8145,7 +8145,7 @@ Koiti Hasida,University of Tokyo,http://www.i.u-tokyo.ac.jp/edu/course/ice/membe
 Kok-Ming Leung,New York University,http://engineering.nyu.edu/people/kok-ming-leung,NOSCHOLARPAGE
 Kolin Paul,IIT Delhi,http://www.cse.iitd.ernet.in/~kolin,6TWEO3IAAAAJ
 Konrad Iwanicki,University of Warsaw,http://www.mimuw.edu.pl/~iwanicki,ALTjvpMAAAAJ
-Konrad Rieck,TU Braunschweig,https://www.tu-braunschweig.de/sec/team/rieck,MrYBOTEAAAA
+Konrad Rieck,TU Braunschweig,https://www.tu-braunschweig.de/sec/team/rieck,MrYBOTEAAAAJ
 Konstantin Korovin,University of Manchester,http://www.cs.manchester.ac.uk/about-us/staff/profile/?ea=Konstantin.Korovin,NCNsDlYAAAAJ
 Konstantin Makarychev,Northwestern University,http://www.mccormick.northwestern.edu/research-faculty/directory/profiles/makarychev-konstantin.html,NOSCHOLARPAGE
 Konstantinos Daniilidis,University of Pennsylvania,http://www.cis.upenn.edu/~kostas,dGs2BcIAAAAJ
@@ -8171,8 +8171,8 @@ Kousha Etessami,University of Edinburgh,http://homepages.inf.ed.ac.uk/kousha,_rU
 Koushik Sen,University of California - Berkeley,http://www.eecs.berkeley.edu/Faculty/Homepages/ksen.html,Vn3L_ioAAAAJ
 Kris Bubendorfer,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/KrisBubendorfer,PufVt-8AAAAJ
 Kris De Brabanter,Iowa State University,http://kbrabant.public.iastate.edu,NOSCHOLARPAGE
-Kris Hauser,Duke University,http://people.duke.edu/~kh269,sGaL8sAAAAJ
-Kris K. Hauser,Duke University,http://people.duke.edu/~kh269,sGaL8sAAAAJ
+Kris Hauser,Duke University,http://people.duke.edu/~kh269,-sGaL8sAAAAJ
+Kris K. Hauser,Duke University,http://people.duke.edu/~kh269,-sGaL8sAAAAJ
 Kris Pister,University of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/pister.html,NOSCHOLARPAGE
 Krishna K. Venkatasubramanian,Worcester Polytechnic Institute,http://hibou.cs.wpi.edu/~kven/wordpress,PFlrXooAAAAJ
 Krishna Kant,Temple University,http://www.kkant.net,sME_06YAAAAJ
@@ -8194,7 +8194,7 @@ Kristen Walcott-Justice,Univ. of Colorado Colorado Springs,http://cs.uccs.edu/~k
 Kristian G. Olesen,Aalborg University,http://people.cs.aau.dk/~kgo/cv.html,qrPdfAcAAAAJ
 Kristian J. Hammond,Northwestern University,http://www.mccormick.northwestern.edu/research-faculty/directory/profiles/hammond-kristian.html,c324JbkAAAAJ
 Kristian Kersting,TU Darmstadt,http://www.ml.informatik.tu-darmstadt.de,QY-earAAAAAJ
-Kristian M. Müller,Bielefeld University,https://ekvv.uni-bielefeld.de/pers_publ/publ/PersonDetail.jsp?personId=37324073&lang=en,AZ7oPkcAAAA
+Kristian M. Müller,Bielefeld University,https://ekvv.uni-bielefeld.de/pers_publ/publ/PersonDetail.jsp?personId=37324073&lang=en,AZ7oPkcAAAAJ
 Kristian Torp,Aalborg University,http://people.cs.aau.dk/~torp,EusRZN0AAAAJ
 Kristin J. Dana,Rutgers University,https://www.cs.rutgers.edu/people/faculty/affiliated-faculty,FLmgLo0AAAAJ
 Kristof Van Laerhoven,University of Freiburg,https://es.informatik.uni-freiburg.de/team/kristof-van-laerhoven,iPI39lEAAAAJ
@@ -11622,7 +11622,7 @@ Pradeep K. Atrey,University at Albany - SUNY,http://www.cs.albany.edu/~patrey,2s
 Pradeep K. Khosla,University of California - San Diego,http://chancellor.ucsd.edu/chancellor-khosla,HtgKHRIAAAAJ
 Pradeep K. Murukannaiah,Rochester Institute of Technology,http://www.se.rit.edu/~pkm,zezL27wAAAAJ
 Pradeep Ravikumar,Carnegie Mellon University,http://www.cs.cmu.edu/~pradeepr,Q4DTPw4AAAAJ
-Pradeep Sen,University of California - Santa Barbara,https://www.ece.ucsb.edu/~psen,H57VkAAAAJ
+Pradeep Sen,University of California - Santa Barbara,https://www.ece.ucsb.edu/~psen,9_H57VkAAAAJ
 Pradeep Varakantham,Singapore Management University,https://www.smu.edu.sg/faculty/profile/9641/Pradeep-Reddy-VARAKANTHAM,BAdQpFkAAAAJ
 Pradeesha Ashok,IIIT Bangalore,http://www.iiitb.ac.in/faculty_page.php?name=PradeeshaAshok,kYEa1aIAAAAJ
 Pradip K. Das,IIT Guwahati,http://www.iitg.ernet.in/pkdas,zNNnCEUAAAAJ
@@ -12809,7 +12809,7 @@ Sabine Glesner,TU Berlin,https://www.sese.tu-berlin.de/menue/ueber_uns/team/sabi
 Sabine Süsstrunk,EPFL,http://ivrl.epfl.ch/people/susstrunk,EX3OYP4AAAAJ
 Sabrina Marczak,PUC-RS,http://www.inf.pucrs.br/sabrina.marczak/SabrinaMarczak/Welcome.html,tjnEfX4AAAAJ
 Sabrina Senatore,University of Salerno,http://docenti.unisa.it/005133/home,dkBV8b8AAAAJ
-Sabrina de Azevedo Silveira,Universidade Federal de Viçosa,http://homepages.dcc.ufmg.br,~sabrinas/
+Sabrina de Azevedo Silveira,Universidade Federal de Viçosa,http://homepages.dcc.ufmg.br%2C~sabrinas/,NOSCHOLARPAGE
 Sachin Chaudhari,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/sachin.chaudhari,vowwEQgAAAAJ
 Sachin Katti,Stanford University,http://stanford.edu/~skatti,cc4Qi_IAAAAJ
 Sachin Rajsekhar Katti,Stanford University,http://stanford.edu/~skatti,cc4Qi_IAAAAJ
@@ -14988,7 +14988,7 @@ Venkatesan Guruswami,Carnegie Mellon University,http://www.cs.cmu.edu/~venkatg,E
 Venkatesh Choppella,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/choppell,fGj4T74AAAAJ
 Venkatesh Prasad Ranganath,Kansas State University,http://people.cis.ksu.edu/~rvprasad,efsT3ykAAAAJ
 Venkatesh Raman 0001,IMSc,http://www.imsc.res.in/~vraman,NOSCHOLARPAGE
-Venkatesh Saligrama,Boston University,https://www.bu.edu/eng/profile/venkatesh-saligrama,S4z3uzMAAAAJE
+Venkatesh Saligrama,Boston University,https://www.bu.edu/eng/profile/venkatesh-saligrama,S4z3uzMAAAAJ
 Venkatesh Srinivasan 0001,University of Victoria,http://www.cs.uvic.ca/~venkat,xn6BVdoAAAAJ
 Venkatesh-Prasad Ranganath,Kansas State University,http://people.cis.ksu.edu/~rvprasad,efsT3ykAAAAJ
 Venu Govindaraju,University at Buffalo,https://cubs.buffalo.edu/about-the-director,ruIgbscAAAAJ
@@ -15466,7 +15466,7 @@ William L. Kocay,University of Manitoba,http://www.combinatorialmath.ca/billkoca
 William L. Scherlis,Carnegie Mellon University,http://www.cs.cmu.edu/~wls,F6LzqwMAAAAJ
 William L. Whittaker,Carnegie Mellon University,http://www.ri.cmu.edu/person.html?person_id=339,ouKJUyEAAAAJ
 William M. Farmer,McMaster University,http://imps.mcmaster.ca/wmfarmer,zNX4etkAAAAJ
-William Mansky,University of Illinois at Chicago,https://www.cs.uic.edu/~mansky,BGmHzcAAAAJ
+William Mansky,University of Illinois at Chicago,https://www.cs.uic.edu/~mansky,-BGmHzcAAAAJ
 William Moloney,University of Massachusetts Lowell,https://www.uml.edu/Sciences/computer-science/faculty/moloney-william.aspx,gHYMJZ0AAAAJ
 William N. Sumner,Simon Fraser University,http://http://www.cs.sfu.ca/~wsumner,NOSCHOLARPAGE
 William R. Cook,University of Texas at Austin,http://www.cs.utexas.edu/~wcook,tMWwWEAAAAAJ
@@ -16406,7 +16406,7 @@ Zhong Shao,Yale University,http://www.cs.yale.edu/~shao,9OukeycAAAAJ
 Zhong Zhou,Beihang University,http://scse.buaa.edu.cn/info/1078/2679.htm,sWbTqxEAAAAJ
 Zhongfei (Mark) Zhang,Binghamton University,http://www.cs.binghamton.edu/~zhongfei,RM7y-rcAAAAJ
 Zhongfei Zhang,Binghamton University,http://www.cs.binghamton.edu/~zhongfei,RM7y-rcAAAAJ
-Zhongyu Wei,Fudan University,http://www.sdspeople.fudan.edu.cn/zywei,AjLDxxgAAAAJ&
+Zhongyu Wei,Fudan University,http://www.sdspeople.fudan.edu.cn/zywei,AjLDxxgAAAAJ
 Zhongzhi Zhang,Fudan University,http://homepage.fudan.edu.cn/zhangzz,DrcEuSkAAAAJ
 Zhou Yu,University of California - Davis,https://faculty.engineering.ucdavis.edu/yu,jee2Dy0AAAAJ
 Zhou Zhao,Zhejiang University,http://mypage.zju.edu.cn/zhaozhou,IIoFY90AAAAJ


### PR DESCRIPTION
- Fixing one link that had a comma in it. All links should be encoded to conver commas to %2C

- Fixing ~19 wrong google scholar links. It seems that your algorithm ignores chars [-_] if it was the first letter.

- I gave a previous comment that you could remove the AAAAJ from the userID to enhance performance. Please ignore it because it is not correct. Some google scholar IDs do not end with AAAAJ such as [-IkaSwy0boIC].
