### PR TITLE
Added Brandenburg University of Technology's CS department

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -10,6 +10,7 @@ BITS Pilani,asia
 Bar-Ilan University,europe
 Beihang University,asia
 Ben-Gurion University of the Negev,europe
+Brandenburg University of Technology,europe
 Bundeswehr University Munich,europe
 CMI,asia
 CWI,europe

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -979,6 +979,7 @@ Andri Ioannou,Cyprus University of Technology,http://www.cut.ac.cy/faculties/aac
 Andri Ioannou-Nicolaou,Cyprus University of Technology,http://www.cut.ac.cy/faculties/aac/mga/staff/elected-staff/andri.i.ioannou,RT7cgC8AAAAJ
 Andrian Marcus,University of Texas at Dallas,http://www.utdallas.edu/~amarcus,ZZiaPdYAAAAJ
 Andries van Dam,Brown University,http://cs.brown.edu/~avd,NOSCHOLARPAGE
+Andriy Panchenko,Brandenburg University of Technology,https://www.b-tu.de/en/it-security,NOSCHOLARPAGE
 Andriy V. Miranskyy,Ryerson University,www.scs.ryerson.ca/~avm,NOSCHOLARPAGE
 Andruid Kerne,Texas A&M University,https://engineering.tamu.edu/cse/people/akerne,TD6dCG0AAAAJ
 Andrzej Filinski,University of Copenhagen,http://www.diku.dk/~andrzej,Yh6akOEAAAAJ
@@ -2800,6 +2801,7 @@ Claudio Gutiérrez 0001,Universidad de Chile,https://www.dcc.uchile.cl/cgutierr,
 Claudio Luis de Amorim,UFRJ,http://www.cos.ufrj.br/index.php/pt-BR/pessoas/details/18/1007-amorim,YQNnYZQAAAAJ
 Claudio Orlandi,Aarhus University,http://www.cs.au.dk/~orlandi,EVDZd5oAAAAJ
 Claus Brabrand,IT University of Copenhagen,http://itu.dk/people/brabrand,oxk_o-UAAAAJ
+Claus Lewerentz,Brandenburg University of Technology,https://www.b-tu.de/fg-software-systemtechnik/team/professor,fANb-HAAAAAJ
 Clay Shields,Georgetown University,http://people.cs.georgetown.edu/~clay,flCzpwcAAAAJ
 Clayton H. Lewis,University of Colorado Boulder,https://www.colorado.edu/faculty/lewis-clayton,eIYoeT4AAAAJ
 Cleber Zanchettin,UFPE,http://www.cin.ufpe.br/~cz,Xs-elnEAAAAJ
@@ -3850,6 +3852,7 @@ Douglas S. Reeves,North Carolina State University,http://reeves.csc.ncsu.edu,UUA
 Douglas Stebila,University of Waterloo,https://www.douglas.stebila.ca,b1DDIcYAAAAJ
 Douglas Thain,University of Notre Dame,http://www3.nd.edu/~dthain,53RlhUcAAAAJ
 Douglas Troeger,CUNY,https://www.ccny.cuny.edu/profiles/douglas-troeger,NOSCHOLARPAGE
+Douglas W. Cunningham,https://www.b-tu.de/fg-graphische-systeme/team/professor,Lo4fRbwAAAAJ
 Douglas W. Jones,University of Iowa,https://www.cs.uiowa.edu/~jones,gX8LBfgAAAAJ
 Douglas W. Oard,University of Maryland - College Park,http://terpconnect.umd.edu/~oard,3ctKkysAAAAJ
 Douglas Wikström,KTH Royal Institute of Technology,http://www.csc.kth.se/~dog,NOSCHOLARPAGE
@@ -4978,6 +4981,7 @@ Gerardo Canfora,University of Sannio,http://www.gerardocanfora.net,3wkA_aYAAAAJ
 Gerardo Pelosi,Politecnico di Milano,http://home.deib.polimi.it/pelosi,Rlp-N_gAAAAJ
 Gerasimos Spanakis,Maastricht University,https://dke.maastrichtuniversity.nl/jerry.spanakis,LiUXYVgAAAAJ
 Gerd Hirzinger,TU Munich,http://www6.in.tum.de/Main/Hirzinge,NOSCHOLARPAGE
+Gerd Wagner,Brandenburg University of Technology,https://www.b-tu.de/fg-internet-technologie/team/professor,zna3SeQAAAAJ
 Gerda Janssens,KU Leuven,https://people.cs.kuleuven.be/~gerda.janssens,JTZxGp0AAAAJ
 Gerhard Hirzinger,TU Munich,http://www6.in.tum.de/Main/Hirzinge,NOSCHOLARPAGE
 Gerhard Holzapfel,Graz University of Technology,https://www.biomech.tugraz.at/people/gerhard_holzapfel,TCfOWgUAAAAJ
@@ -6035,6 +6039,7 @@ Indranil Sengupta 0001,IIT Kharagpur,http://www.facweb.iitkgp.ernet.in/~isg,1IIL
 Ing-Ray Chen,Virginia Tech,http://people.cs.vt.edu/~irchen,UdangLEAAAAJ
 Ingemar J. Cox,University College London,http://mediafutures.cs.ucl.ac.uk/people/IngemarCox,b88nUpYAAAAJ
 Ingemar Johansson Cox,University College London,http://mediafutures.cs.ucl.ac.uk/people/IngemarCox,b88nUpYAAAAJ
+Ingo Schmitt,Brandenburg University of Technology,https://www.b-tu.de/fg-dbis/team/professor,NOSCHOLARPAGE
 Ingolf H. Krüger,University of California - San Diego,http://jacobsschool.ucsd.edu/faculty/faculty_bios/index.sfe?fmp_recid=199,NOSCHOLARPAGE
 Ingolf Krueger,University of California - San Diego,http://jacobsschool.ucsd.edu/faculty/faculty_bios/index.sfe?fmp_recid=199,NOSCHOLARPAGE
 Ingolf Krüger,University of California - San Diego,http://jacobsschool.ucsd.edu/faculty/faculty_bios/index.sfe?fmp_recid=199,NOSCHOLARPAGE
@@ -7673,6 +7678,7 @@ Jörg Henkel,Karlsruhe Institute of Technology (KIT),http://ces.itec.kit.edu/21_
 Jörg Kienzle,McGill University,http://www.cs.mcgill.ca/~joerg/Home/Jorgs_Home.html,INUL3eEAAAAJ
 Jörg Liebeherr,University of Toronto,http://www.comm.utoronto.ca/~jorg,8WrYVG8AAAAJ
 Jörg Müller,Aarhus University,http://pure.au.dk/portal/en/persons/id(3e718f2c-7cc4-4cc5-8f05-87e65963d7c1).html,qU5PVzAAAAAJ
+Jörg Nolte,Brandenburg University of Technology,https://www.b-tu.de/en/distributed-systems-operating-systems-group/team/professor,NOSCHOLARPAGE
 Jörg Ott,TU Munich,https://www.netlab.tkk.fi/~jo,h16ode4AAAAJ
 Jörg Peters,University of Florida,http://www.cise.ufl.edu/~jorg,MoMic_4AAAAJ
 Jörg Sander 0001,University of Alberta,https://webdocs.cs.ualberta.ca/~joerg,QzFTFLEAAAAJ
@@ -8125,6 +8131,7 @@ Klaus Diller,University of Koblenz-Landau,https://www.uni-koblenz-landau.de/de/k
 Klaus Hildebrandt,TU Delft,https://graphics.tudelft.nl/klaus-hildebrandt,qYZBq5cAAAAJ
 Klaus Kabitzsch,TU Dresden,https://tu-dresden.de/cdd/leitung_und_beteiligte/mitglieder/bereich-mathematik/Kabitzsch,NOSCHOLARPAGE
 Klaus Marius Hansen,University of Copenhagen,http://www.diku.dk/~klausmh,6yJ09KwAAAAJ
+Klaus Meer,Brandenburg University of Technology,https://www.b-tu.de/fg-theoretische-informatik/team/lehrstuhlinhaber,NOSCHOLARPAGE
 Klaus Meißner,TU Dresden,https://mmt.inf.tu-dresden.de/Team/mitarbeiter.xhtml?id=66,NOSCHOLARPAGE
 Klaus Mueller,Stony Brook University,http://www3.cs.stonybrook.edu/~mueller,uya_Zb4AAAAJ
 Klaus Obermayer,TU Berlin,https://www.ni.tu-berlin.de/menue/mitarbeiter/leiter_der_forschungsgruppe/obermayer_klaus/parameter/de,pGKzaMMAAAAJ
@@ -9828,6 +9835,7 @@ Michael Hatzopoulos,University of Athens,http://cgi.di.uoa.gr/~mike,NOSCHOLARPAG
 Michael Henry Albert,University of Otago,http://www.cs.otago.ac.nz/staff/michael.html,oZL1wnUAAAAJ
 Michael Herrmann,University of Edinburgh,http://www.research.ed.ac.uk/portal/en/persons/michael-herrmann(cf1b7c31-3a87-4812-bf0a-05cf49b0120e).html,MJiOEy0AAAAJ
 Michael Hicks 0001,University of Maryland - College Park,http://www.cs.umd.edu/~mwh,I9Vzs-4AAAAJ
+Michael Hübner,Brandenburg University of Technology,https://www.b-tu.de/en/fg-technische-informatik/team/professor,0U6y9RoAAAAJ
 Michael Homer,Victoria University of Wellington,https://ecs.victoria.ac.nz/Main/MichaelHomer,ss2RKjoAAAAJ
 Michael Horsch,University of Saskatchewan,http://artsandscience.usask.ca/profile/MHorsch,NOSCHOLARPAGE
 Michael Huth,Imperial College London,http://www.doc.ic.ac.uk/~mrh,ZBlUaIAAAAAJ
@@ -10290,6 +10298,7 @@ Monica Divitini,NTNU,https://www.ntnu.edu/employees/divitini,w9p5LZoAAAAJ
 Monica N. Nicolescu,University of Nevada,https://www.cse.unr.edu/~monica,CjRSS8MAAAAJ
 Monica S. Lam,Stanford University,https://suif.stanford.edu/~lam,fVaS7a8AAAAJ
 Monica Sebillo,University of Salerno,http://www.unisa.it/docenti/monicamariasebillo/index,NOSCHOLARPAGE
+Monika Heiner,Brandenburg University of Technology,https://www-dssz.informatik.tu-cottbus.de/DSSZ/Main/MonikaHeiner,UseozQIAAAAJ
 Monika Henzinger,University of Vienna,https://cs.univie.ac.at/monika.henzinger,NXbggxYAAAAJ
 Monika Rauch,University of Vienna,https://cs.univie.ac.at/monika.henzinger,NXbggxYAAAAJ
 Monika Rauch Henzinger,University of Vienna,https://cs.univie.ac.at/monika.henzinger,NXbggxYAAAAJ
@@ -10894,6 +10903,7 @@ Oliver Cossairt,Northwestern University,http://compphotolab.northwestern.edu,Qxx
 Oliver Deussen,University of Konstanz,https://www.cgmi.uni-konstanz.de/en/persons/prof-dr-oliver-deussen,y3j0c80AAAAJ
 Oliver Diessel,UNSW,http://www.cse.unsw.edu.au/~odiessel,mVtckacAAAAJ
 Oliver Eulenstein,Iowa State University,http://www.cs.iastate.edu/~oeulenst,HWF6UxgAAAAJ
+Oliver Hohlfeld,Brandenburg University of Technology,http://www.ohohlfeld.com,2dy3cC4AAAAJ
 Oliver Kennedy,University at Buffalo,http://www.cse.buffalo.edu/people/?u=okennedy,9Q9tiCsAAAAJ
 Oliver Matias van Kaick,Carleton University,http://people.scs.carleton.ca/~olivervankaick,IfvyBBUAAAAJ
 Oliver Ray,University of Bristol,https://www.cs.bris.ac.uk/~oray,3vwgzlUAAAAJ
@@ -11411,6 +11421,7 @@ Peter King,University of Manitoba,http://www.cs.umanitoba.ca/~prking,jENQurUAAAA
 Peter Kreider,Australian National University,https://cecs.anu.edu.au/people/peter-kreider,q_YvaJMAAAAJ
 Peter Krogstrup,IST Austria,https://ist.ac.at/research/research-groups/krogstrup-group,_tAV9MMAAAAJ
 Peter L. Bartlett,University of California - Berkeley,http://www.stat.berkeley.edu/~bartlett,UPVvV6kAAAAJ
+Peter Langendörfer,Brandenburg University of Technology,https://www.b-tu.de/fg-sicherheit-in-pervasiven-systemen/team/professor,giUyxgYAAAAJ
 Peter Lutz,Rochester Institute of Technology,http://www.ist.rit.edu/~phl,Z2E0SisAAAAJ
 Peter M. Andreae,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/PeterAndreae,NOSCHOLARPAGE
 Peter M. Chen,University of Michigan,http://web.eecs.umich.edu/~pmchen,dVZNQqUAAAAJ
@@ -11471,6 +11482,7 @@ Petr Holub,Masaryk University,https://www.muni.cz/en/people/3248,NOSCHOLARPAGE
 Petr Matula,Masaryk University,https://www.muni.cz/en/people/3019,_J1EjksAAAAJ
 Petr Sojka,Masaryk University,https://www.muni.cz/en/people/2378,9piza88AAAAJ
 Petra Berenbrink,Simon Fraser University,http://www.cs.sfu.ca/~petra,NOSCHOLARPAGE
+Petra Hofstedt,Brandenburg University of Technology,https://www.b-tu.de/fg-programmiersprachen-compilerbau/team/professorin/petra-hofstedt,NOSCHOLARPAGE
 Petra Schubert,University of Koblenz-Landau,https://www.uni-koblenz-landau.de/de/koblenz/fb4/iwvi/agschubert/team/petra-schubert/petra-schubert,RvlHMVUAAAAJ
 Petri Vuorimaa,Aalto University,https://people.aalto.fi/petri_vuorimaa,Bcg93pAAAAAJ
 Petros Drineas,Purdue University,http://www.drineas.org,Yw2PquQAAAAJ
@@ -12542,6 +12554,7 @@ Rolando Estrada,Georgia State University,https://grid.cs.gsu.edu/~restrada1,choj
 Rolf Backofen,University of Freiburg,http://www.bioinf.uni-freiburg.de/~backofen,ZCTrqQkAAAAJ
 Rolf Hennicker,LMU Munich,https://www.sosy-lab.org/people/hennicker,NOSCHOLARPAGE
 Rolf Krause,Università della Svizzera italiana,http://search.usi.ch/people/385ec98e41e4068a2f61ba6cdbf33c9d/Krause-Rolf,NOSCHOLARPAGE
+Rolf Kraemer,Brandenburg University of Technology,https://www.b-tu.de/fg-systeme/team/professor,-rT-Qp0AAAAJ
 Rolf Niedermeier,TU Berlin,https://www.akt.tu-berlin.de/index.php?id=110570,NC3NEUkAAAAJ
 Roman Bader,Australian National University,https://cecs.anu.edu.au/people/roman-bader,Al0Z-YEAAAAJ
 Roman Belavkin,Middlesex University,http://www.eis.mdx.ac.uk/staffpages/rvb,EYJhJ1oAAAAJ


### PR DESCRIPTION
Added the CS department at Brandenburg University of Technology: https://www.b-tu.de/institut-informatik/institut/fachgebiete