### PR TITLE
Google Scholar Links Update

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -9,7 +9,7 @@ A. D. Fekete,University of Sydney,https://sydney.edu.au/engineering/it/~fekete,H
 A. E. Eiben,VU Amsterdam,http://www.cs.vu.nl/~gusz,NMuDAe0AAAAJ
 A. Ercument Cicek,Bilkent University,http://ciceklab.cs.bilkent.edu.tr/ercumentcicek,n25sJzkAAAAJ
 A. J. Field,Imperial College London,http://wp.doc.ic.ac.uk/ajf,rn3Lg2wAAAAJ
-A. J. Jansen,CWI,http://homepages.cwi.nl/~jack,qHiBTg0AAAAJ
+A. J. Jansen,CWI,http://homepages.cwi.nl/~jack,NOSCHOLARPAGE
 A. J. Kfoury,Boston University,http://www.cs.bu.edu/~kfoury,VpdYemsAAAAJ
 A. Jefferson Offutt,George Mason University,http://cs.gmu.edu/~offutt,NOSCHOLARPAGE
 A. John Power,University of Bath,http://www.bath.ac.uk/comp-sci/contacts/academics/john_power,mCvZPDn8heUC
@@ -198,7 +198,7 @@ Adrien Basso-Blandin,Ecole Normale Superieure de Lyon,http://www.ens-lyon.fr/rec
 Adrienne Decker,Rochester Institute of Technology,https://www.rit.edu/gccis/igm/adrienne-decker,JjLxdewAAAAJ
 Aduri Pavan,Iowa State University,http://www.cs.iastate.edu/people/pavan-aduri,4QIV0FUAAAAJ
 Adwait Jog,College of William and Mary,http://adwaitjog.github.io,9RgqL8gAAAAJ
-Adwait Nadkarni,College of William and Mary,http://www.wm.edu/as/computerscience/faculty/jog_a.php,5JwbQc0AAAAJ
+Adwait Nadkarni,College of William and Mary,http://www.wm.edu/as/computerscience/faculty/jog_a.php,Al2MvLoAAAAJ
 Afra Alishahi,Tilburg University,https://ilk.uvt.nl/~aalishah,IuAwLqUAAAAJ
 Afzel Noore,West Virginia University,https://www.statler.wvu.edu/faculty-staff/adjunct-faculty/afzel-noore,rEopbiMAAAAJ
 Agata Ciabattoni,TU Wien,https://www.logic.at/staff/agata,pAyqI0wAAAAJ
@@ -361,7 +361,7 @@ Alberto Egon Schaeffer Filho,UFRGS,http://inf.ufrgs.br/~alberto,y6oOiqYAAAAJ
 Alberto H. F. Laender,UFMG,http://homepages.dcc.ufmg.br/~laender,HJhu4csAAAAJ
 Alberto L. Sangiovanni-Vincentelli,University of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/sangiovanni-vicentelli.html,AhgjQ2QAAAAJ
 Alberto Manuel Rodrigues da Silva,Universidade de Lisboa,http://isg.inesc-id.pt/alb,NjZqNwEAAAAJ
-Alberto Maria Segre,University of Iowa,https://www.cs.uiowa.edu/people/alberto-maria-segre,IXnzCb8AAAAJ
+Alberto Maria Segre,University of Iowa,https://www.cs.uiowa.edu/people/alberto-maria-segre,NOSCHOLARPAGE
 Alberto Negro,University of Salerno,http://www.unisa.it/docenti/albertonegro/en/index,NOSCHOLARPAGE
 Alberto Postiglione,University of Salerno,http://www.unisa.it/docenti/postiglionea/index,EW1w6DkAAAAJ
 Alberto Quattrini Li,Dartmouth College,https://web.cs.dartmouth.edu/people/alberto-quattrini-li,06ldpDMAAAAJ
@@ -387,7 +387,7 @@ Aleksandar Nanevski,IMDEA Software Institute,http://software.imdea.org/~aleks,JG
 Aleksandar Nikolov,University of Toronto,http://www.cs.toronto.edu/~anikolov,glV_LWsAAAAJ
 Aleksander Madry,Massachusetts Institute of Technology,https://people.csail.mit.edu/madry,SupjsEUAAAAJ
 Aleksandra Korolova,University of Southern California,http://informatics.usc.edu/people/aleksandra-korolova.htm,oK_XUmsAAAAJ
-Aleksy Schubert,University of Warsaw,http://www.mimuw.edu.pl/~alx,0vbRwBQAAAAJ
+Aleksy Schubert,University of Warsaw,http://www.mimuw.edu.pl/~alx,NOSCHOLARPAGE
 Ales Horák,Masaryk University,https://www.muni.cz/en/people/1648,lBJuYA8AAAAJ
 Alessandra Cavarra,University of Oxford,http://www.cs.ox.ac.uk/people/alessandra.cavarra,NOSCHOLARPAGE
 Alessandra Gorla,IMDEA Software Institute,http://software.imdea.org/~alessandra.gorla,6uUwTrwAAAAJ
@@ -469,7 +469,7 @@ Alexander Gerhard Schwing,Univ. of Illinois at Urbana-Champaign,http://www.alexa
 Alexander Herzog,Clemson University,http://www.alexherzog.net,jrfFYAIAAAAJ
 Alexander Huth,University of Texas at Austin,http://www.cs.utexas.edu/~huth,JNXWWkIAAAAJ
 Alexander J. Hartemink,Duke University,https://users.cs.duke.edu/~amink,HLRZ3oAAAAAJ
-Alexander Jung,Aalto University,https://users.aalto.fi/~junga1,mHjdZdwAAAAJ
+Alexander Jung,Aalto University,https://users.aalto.fi/~junga1,NOSCHOLARPAGE
 Alexander Kain,OHSU,http://www.ohsu.edu/xd/education/schools/school-of-medicine/departments/basic-science-departments/csee/csee-people/kain.cfm,gK85itIAAAAJ
 Alexander Kemper,TU Munich,https://www-db.in.tum.de/~kemper,dliZB7MAAAAJ
 Alexander Kotov,Wayne State University,http://www.cs.wayne.edu/kotov,83gsCFsAAAAJ
@@ -489,7 +489,7 @@ Alexander Pretschner,TU Munich,https://www22.in.tum.de/en/mitarbeiter/pretschner
 Alexander Pudmenzky,University of Queensland,http://researchers.uq.edu.au/researcher/804,NOSCHOLARPAGE
 Alexander Raake,TU Berlin,https://www.aipa.tu-berlin.de/menue/team/alexander_raake,MoOhyrQAAAAJ
 Alexander Rabinovich,Tel Aviv University,http://www.cs.tau.ac.il/~rabinoa,NOSCHOLARPAGE
-Alexander Rakhlin,University of Pennsylvania,http://www-stat.wharton.upenn.edu/~rakhlin,fds2VpgAAAAJ
+Alexander Rakhlin,University of Pennsylvania,http://www-stat.wharton.upenn.edu/~rakhlin,NOSCHOLARPAGE
 Alexander Rasin,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=1041,FGs9EMwAAAAJ
 Alexander Reinefeld,Humboldt University of Berlin,http://www.zib.de/institute/parallel-and-distributed-computing,NOSCHOLARPAGE
 Alexander Russell,University of Connecticut,http://www.engr.uconn.edu/~acr,EsJmgf4AAAAJ
@@ -648,7 +648,7 @@ Allison Bishop Lewko,Columbia University,http://www.cs.columbia.edu/~allison,NOS
 Alneu de Andrade Lopes,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/alneu,3ejEglwAAAAJ
 Alois C. Knoll,TU Munich,http://www6.in.tum.de/Main/Knoll,NOSCHOLARPAGE
 Alois Knoll,TU Munich,http://www6.in.tum.de/Main/Knoll,NOSCHOLARPAGE
-Alok N. Choudhary,Northwestern University,http://www.eecs.northwestern.edu/~choudhar,q0nuNrEAAAAJ
+Alok N. Choudhary,Northwestern University,http://www.eecs.northwestern.edu/~choudhar,NOSCHOLARPAGE
 Alon Efrat,University of Arizona,http://www.cs.arizona.edu/people/alon,QH90248AAAAJ
 Alon Keinan,Cornell University,http://keinanlab.cb.bscb.cornell.edu,rS0EX5EAAAAJ
 Alon Nilli,Tel Aviv University,http://www.tau.ac.il/~nogaa,vOYl40wAAAAJ
@@ -678,7 +678,7 @@ Amal J. Ahmed,Northeastern University,http://www.ccs.neu.edu/home/amal,Y1C007wAA
 Amali Weerasinghe,University of Adelaide,http://www.adelaide.edu.au/directory/amali.weerasinghe,cW9YyJAAAAAJ
 Aman Parnami,IIIT Delhi,https://www.iiitd.ac.in/aman,PI30hN8AAAAJ
 Amanda Lazar,University of Maryland - College Park,https://ischool.umd.edu/faculty-staff/amanda-lazar,WrnEVwQAAAAJ
-Amanda Lee Hughes,Utah State University,http://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=1433&context=researchweek,Sjbz8ngAAAAJ
+Amanda Lee Hughes,Utah State University,http://digitalcommons.usu.edu/cgi/viewcontent.cgi?article=1433&context=researchweek,NOSCHOLARPAGE
 Amanda Prorok,University of Cambridge,https://www.proroklab.org,o7xMDgEAAAAJ
 Amarda Shehu,George Mason University,https://cs.gmu.edu/~ashehu,HkB_Gz0AAAAJ
 Amarjeet Singh 0001,IIIT Delhi,https://www.iiitd.ac.in/amarjeet,cZhWKd0AAAAJ
@@ -699,7 +699,7 @@ Amiangshu Bosu,Wayne State University,http://amiangshu.com,kIrGUa8AAAAJ
 Amihai Motro,George Mason University,http://cs.gmu.edu/~ami,YPhI-YsAAAAJ
 Amihood Amir,Bar-Ilan University,http://u.cs.biu.ac.il/~amir,otHomQ8AAAAJ
 Amin Alipour,University of Houston,http://alipourm.github.io,hwlkAZYAAAAJ
-Amin Karbasi,Yale University,http://seas.yale.edu/faculty-research/faculty-directory/amin-karbasi,VusVB38AAAAJ
+Amin Karbasi,Yale University,http://seas.yale.edu/faculty-research/faculty-directory/amin-karbasi,hC4JfeMAAAAJ
 Amin M. Abbosh,University of Queensland,http://researchers.uq.edu.au/researcher/1576,B3nuBzwAAAAJ
 Amin Shokrollahi,EPFL,https://people.epfl.ch/amin.shokrollahi,ho_asq8AAAAJ
 Amin Y. Noaman,King Abdulaziz University,http://anoaman.kau.edu.sa/CVEn.aspx?Site_ID=0002639&Lng=EN,btssDVcAAAAJ
@@ -716,7 +716,7 @@ Amir Rahmati,Stony Brook University,https://amir.rahmati.com,_Y_YRLAAAAAJ
 Amir Sadovnik,University of Tennessee,http://uvu.eecs.utk.edu,NOSCHOLARPAGE
 Amir Salman Avestimehr,Cornell University,http://www-bcf.usc.edu/~avestime/Home.html,Qhe5ua0AAAAJ
 Amir Shpilka,Tel Aviv University,http://www.cs.tau.ac.il/~shpilka,NOSCHOLARPAGE
-Amir-Hossein Jahangir,Sharif University of Technology,http://sina.sharif.ac.ir/~jahangir,1R13EcIAAAAJ
+Amir-Hossein Jahangir,Sharif University of Technology,http://sina.sharif.ac.ir/~jahangir,NOSCHOLARPAGE
 Amiram Yehudai,Tel Aviv University,http://www.cs.tau.ac.il/~amiramy,NOSCHOLARPAGE
 Amirreza Masoumzadeh,University at Albany - SUNY,https://www.albany.edu/ceas/amirreza-masoumzadeh.php,Ld-xtdcAAAAJ
 Amit A. Levy,Princeton University,https://www.amitlevy.com,r6-jCnUAAAAJ
@@ -728,7 +728,7 @@ Amit Daniely,Hebrew University of Jerusalem,http://amitdaniely.com,jUtYwE0AAAAJ
 Amit Dua,BITS Pilani,http://www.bits-pilani.ac.in/pilani/amitdua/profile,NOSCHOLARPAGE
 Amit Dvir,Ariel University,http://www.ariel.ac.il/sites/amitd,S6wdYwIAAAAJ
 Amit H. Bermano,Tel Aviv University,http://en-exact-sciences.tau.ac.il/profile/amberman,EPO5_f4AAAAJ
-Amit Jain,Boise State University,http://cs.boisestate.edu/~amit,Pk-vgwEAAAAJ
+Amit Jain,Boise State University,http://cs.boisestate.edu/~amit,NOSCHOLARPAGE
 Amit K. Roy-Chowdhury,University of California - Riverside,http://www.ee.ucr.edu/~amitrc,hfgwx0oAAAAJ
 Amit Kumar 0001,IIT Delhi,http://www.cse.iitd.ernet.in/~amitk,btq_vjcAAAAJ
 Amit Levy,Princeton University,https://www.amitlevy.com,r6-jCnUAAAAJ
@@ -777,8 +777,8 @@ Amy Ulinski Banic,University of Wyoming,http://www.uwyo.edu/cosc/cosc-directory/
 Amy Voida,University of Colorado Boulder,http://amy.voida.com,J2FI8YoAAAAJ
 Amy W. Apon,Clemson University,https://people.cs.clemson.edu/~aapon,jN87wQ4AAAAJ
 Amélie Marian,Rutgers University,https://www.cs.rutgers.edu/~amelie,hcqjUUQAAAAJ
-An-I Andy Wang,Florida State University,http://www.cs.fsu.edu/~awang,QK-cRZ0AAAAJ
-An-I Wang,Florida State University,http://www.cs.fsu.edu/~awang,QK-cRZ0AAAAJ
+An-I Andy Wang,Florida State University,http://www.cs.fsu.edu/~awang,NOSCHOLARPAGE
+An-I Wang,Florida State University,http://www.cs.fsu.edu/~awang,NOSCHOLARPAGE
 AnHai Doan,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~anhai,Qa_TAw4AAAAJ
 Ana Almeida Matos,Universidade de Lisboa,http://web.ist.utl.pt/~ist24690,D6nVmPQAAAAJ
 Ana Busic,Ecole Normale Superieure,http://www.di.ens.fr/~busic,627OFsIAAAAJ
@@ -931,10 +931,10 @@ Andrew H. Sung,University of Southern Mississippi,https://www.usm.edu/computing/
 Andrew Hamilton-Wright,University of Guelph,https://www.uoguelph.ca/computing/people/andrew-hamilton-wright,nWoiQrQAAAAJ
 Andrew Hopper,University of Cambridge,https://www.cl.cam.ac.uk/~ah12,WBr_GXUAAAAJ
 Andrew J. Davison,Imperial College London,https://www.doc.ic.ac.uk/~ajd,SNQFnBEAAAAJ
-Andrew J. Ko,University of Washington,http://faculty.washington.edu/ajko,otmdDLoAAAAJ
+Andrew J. Ko,University of Washington,http://faculty.washington.edu/ajko,hCTbv4MAAAAJ
 Andrew J. McAllister,University of New Brunswick,http://www.cs.unb.ca/~andrewm,d1yVDNgAAAAJ
 Andrew J. Wellings,University of York,https://www-users.cs.york.ac.uk/~andy,yPa4QrkAAAAJ
-Andrew Jensen Ko,University of Washington,http://faculty.washington.edu/ajko,otmdDLoAAAAJ
+Andrew Jensen Ko,University of Washington,http://faculty.washington.edu/ajko,hCTbv4MAAAAJ
 Andrew Klapper,University of Kentucky,https://www.cs.uky.edu/people/faculty/aklapper,nn3Fx0cAAAAJ
 Andrew Lo,Massachusetts Institute of Technology,http://alo.mit.edu,4M-iGXMAAAAJ
 Andrew Lukefahr,Indiana University,http://homes.sice.indiana.edu/lukefahr,tZ4fdX0AAAAJ
@@ -965,7 +965,7 @@ Andrew S. Tanenbaum,VU Amsterdam,http://www.cs.vu.nl/~ast,TvjaNqkAAAAJ
 Andrew Simpson,University of Oxford,http://www.cs.ox.ac.uk/andrew.simpson,rrydyHwAAAAJ
 Andrew Sohn,NJIT,http://cs.njit.edu/people/sohn.php,NOSCHOLARPAGE
 Andrew T. Campbell,Dartmouth College,http://www.cs.dartmouth.edu/~campbell,rthco5oAAAAJ
-Andrew T. Duchowski,Clemson University,http://andrewd.ces.clemson.edu,J_oQ4-oAAAAJ
+Andrew T. Duchowski,Clemson University,http://andrewd.ces.clemson.edu,xYK0xy4AAAAJ
 Andrew Taylor,UNSW,http://www.cse.unsw.edu.au/~andrewt,bODP_fkAAAAJ
 Andrew Tolmach,Portland State University,http://web.cecs.pdx.edu/~black,NOSCHOLARPAGE
 Andrew Trotman,University of Otago,http://www.cs.otago.ac.nz/homepages/andrew,YiiS_hUAAAAJ
@@ -1021,7 +1021,7 @@ Andy Gill,University of Kansas,http://www.ittc.ku.edu/csdl/fpg/people/andygill,y
 Andy Hopper,University of Cambridge,https://www.cl.cam.ac.uk/~ah12,WBr_GXUAAAAJ
 Andy J. Wellings,University of York,https://www-users.cs.york.ac.uk/~andy,yPa4QrkAAAAJ
 Andy King,University of Kent,https://www.cs.kent.ac.uk/people/staff/amk,LuzPQ1UAAAAJ
-Andy Ko,University of Washington,http://faculty.washington.edu/ajko,otmdDLoAAAAJ
+Andy Ko,University of Washington,http://faculty.washington.edu/ajko,hCTbv4MAAAAJ
 Andy Mirzaian,York University,http://www.eecs.yorku.ca/~andy,NOSCHOLARPAGE
 Andy Nealen,New York University,http://engineering.nyu.edu/people/andy-nealen,YjpanIYAAAAJ
 Andy Pavlo,Carnegie Mellon University,http://www.cs.cmu.edu/~pavlo,u1UDm4wAAAAJ
@@ -1051,7 +1051,7 @@ Ani Nenkova,University of Pennsylvania,http://www.cis.upenn.edu/~nenkova,vXQdb5k
 Aniello Cimitile,University of Sannio,https://www.ding.unisannio.it/persone/docenti/cimitile,NOSCHOLARPAGE
 Aniket Kate,Purdue University,https://www.cs.purdue.edu/homes/akate,dmhWxJgAAAAJ
 Aniket Kittur,Carnegie Mellon University,https://www.hcii.cmu.edu/people/aniket-kittur,2vZ5zRQAAAAJ
-Aniket Mahanti,University of Auckland,https://www.cs.auckland.ac.nz/~amahanti,n-Ch9JQAAAAJ
+Aniket Mahanti,University of Auckland,https://www.cs.auckland.ac.nz/~amahanti,NOSCHOLARPAGE
 Anil Damle,Cornell University,https://www.cs.cornell.edu/~damle,VqOc5C8AAAAJ
 Anil K. Jain,Michigan State University,https://www.cse.msu.edu/~jain,g-_ZXGsAAAAJ
 Anil K. Jain 0001,Michigan State University,https://www.cse.msu.edu/~jain,g-_ZXGsAAAAJ
@@ -1161,7 +1161,7 @@ Anthony Faiola,University of Illinois at Chicago,https://ahs.uic.edu/biomedical-
 Anthony Finkelstein,University College London,http://www0.cs.ucl.ac.uk/staff/A.Finkelstein,n8xuCVkAAAAJ
 Anthony Gitter,University of Wisconsin - Madison,https://www.biostat.wisc.edu/~gitter,j0_fn9oAAAAJ
 Anthony Hoi Tin Tang,University of Calgary,http://hcitang.org,RG1EQowAAAAJ
-Anthony Hunter,University College London,http://www0.cs.ucl.ac.uk/staff/a.hunter,N7ETYzcAAAAJ
+Anthony Hunter,University College London,http://www0.cs.ucl.ac.uk/staff/a.hunter,fcxriTYAAAAJ
 Anthony Ian Wirth,University of Melbourne,http://people.eng.unimelb.edu.au/awirth,qVuN4MIAAAAJ
 Anthony J. Bonner,University of Toronto,http://www.cs.toronto.edu/~bonner,NOSCHOLARPAGE
 Anthony J. Field,Imperial College London,http://wp.doc.ic.ac.uk/ajf,rn3Lg2wAAAAJ
@@ -1286,7 +1286,7 @@ Arden Ruttan,Kent State University,https://www.kent.edu/cs/profile/arden-ruttan,
 Areej Malibari,King Abdulaziz University,http://aamalibari1.kau.edu.sa/CVEn.aspx?Site_ID=0004507&Lng=EN,NOSCHOLARPAGE
 Arend Hintze,Michigan State University,http://hintzelab.msu.edu,9OItN4cAAAAJ
 Ari Juels,Cornell University,http://tech.cornell.edu/people/ari-juels,uf0D-uoAAAAJ
-Ari Rappoport,Hebrew University of Jerusalem,http://www.cs.huji.ac.il/~arir,dNDnP3QAAAAJ
+Ari Rappoport,Hebrew University of Jerusalem,http://www.cs.huji.ac.il/~arir,qhQPnpMAAAAJ
 Ariadne Maria Brito Rizzoni Carvalho,UNICAMP,http://www.ic.unicamp.br/~ariadne,NOSCHOLARPAGE
 Arie E. Kaufman,Stony Brook University,http://www3.cs.stonybrook.edu/~ari,fDdcWBEAAAAJ
 Arie Gurfinkel,University of Waterloo,https://uwaterloo.ca/electrical-computer-engineering/people-profiles/arie-gurfinkel,WHTB3_MAAAAJ
@@ -1342,7 +1342,7 @@ Arpita Patra,IISc Bangalore,http://www.csa.iisc.ac.in/~arpita,RG6kKh8AAAAJ
 Arrvindh Shriraman,Simon Fraser University,http://www.cs.sfu.ca/~ashriram,ZuBFPTcAAAAJ
 Arslan Munir,University of Nevada,http://www.cs.ksu.edu/people/faculty/munir,-P9waaQAAAAJ
 Arthorn Luangsodsai,Chulalongkorn University,http://pioneer.netserv.chula.ac.th/~larthorn,NOSCHOLARPAGE
-Arti Ramesh,Binghamton University,https://www.binghamton.edu/cs/people/aramesh.html,XjWqmtMAAAAJ
+Arti Ramesh,Binghamton University,https://www.binghamton.edu/cs/people/aramesh.html,7_8fTv8AAAAJ
 Artur Caetano,Universidade de Lisboa,http://w3.dgeec.mec.pt/rebides/2011/rebid_m2.asp?CodR=110&CodP=0807,HXYfCUIAAAAJ
 Artur Jez,University of Wroclaw,http://www.ii.uni.wroc.pl/~aje,z4tT55IAAAAJ
 Arturo Azcorra,IMDEA Networks Institute,https://www.networks.imdea.org/people/dr-arturo-azcorra,pui4ym6mQiwC
@@ -1417,7 +1417,7 @@ Assaf J. Kfoury,Boston University,http://www.cs.bu.edu/~kfoury,VpdYemsAAAAJ
 Assaf Schuster,Technion,http://assaf.net.technion.ac.il,KfwgjswAAAAJ
 Assefaw Hadish Gebremedhin,Washington State University,http://www.eecs.wsu.edu/~assefaw,NOSCHOLARPAGE
 Asterios Katsifodimos,TU Delft,http://asterios.katsifodimos.com,1KdkcSoAAAAJ
-Asuman E. Ozdaglar,Massachusetts Institute of Technology,https://asu.mit.edu,nWnBSOsAAAAJ
+Asuman E. Ozdaglar,Massachusetts Institute of Technology,https://asu.mit.edu,NOSCHOLARPAGE
 Atanas Rountev,Ohio State University,http://web.cse.ohio-state.edu/~rountev,Y9Jw4lcAAAAJ
 Athanasios Mouchtaris,University of Crete,https://www.csd.uoc.gr/~mouchtar,CMNg4XUAAAAJ
 Athanassia Alonistioti,University of Athens,http://scan.di.uoa.gr/dr-spyridon-panagiotakis,jIQo9VwAAAAJ
@@ -1502,7 +1502,7 @@ B. Berk Ustundag,Istanbul Technical University,http://akademi.itu.edu.tr/bustund
 B. David Saunders,University of Delaware,https://www.eecis.udel.edu/~saunders,U-0PM_cAAAAJ
 B. G. Kim,University of Massachusetts Lowell,http://www.cs.uml.edu/~kim,ujXxdMIAAAAJ
 B. John Oommen,Carleton University,http://www.scs.carleton.ca/~oommen,E5TiDR4AAAAJ
-B. Prabhakaran,University of Texas at Dallas,http://www.utdallas.edu/~praba,BENEK78AAAAJ
+B. Prabhakaran,University of Texas at Dallas,http://www.utdallas.edu/~praba,NOSCHOLARPAGE
 B. R. Badrinath,Rutgers University,http://www.cs.rutgers.edu/~badri,ZuCDNqwAAAAJ
 B. S. Manjunath,University of California - Santa Barbara,https://vision.ece.ucsb.edu/people/bs-manjunath,wRYM4qgAAAAJ
 B. Srivathsan,CMI,http://www.cmi.ac.in/~sri,2SMNivQAAAAJ
@@ -1525,7 +1525,7 @@ Balajee Vamanan,University of Illinois at Chicago,https://www.cs.uic.edu/~balaje
 Balaji Parthasarathy,IIIT Bangalore,http://citapp.iiitb.ac.in/staff-members/balaji-parthasarathy,cbrHE1YAAAAJ
 Balaji Prabhakar,Stanford University,http://web.stanford.edu/~balaji,NOSCHOLARPAGE
 Balaji Raghavachari,University of Texas at Dallas,https://www.utdallas.edu/~rbk,NOSCHOLARPAGE
-Balakrishnan Prabhakaran,University of Texas at Dallas,http://www.utdallas.edu/~praba,BENEK78AAAAJ
+Balakrishnan Prabhakaran,University of Texas at Dallas,http://www.utdallas.edu/~praba,NOSCHOLARPAGE
 Balaraman Ravindran,IIT Madras,http://www.cse.iitm.ac.in/~ravi,nGUcGrYAAAAJ
 Balasubramaniam Srinivasan,Monash University,http://monash.edu/research/explore/en/persons/balasubramaniam-srinivasan(6a75b48c-6276-4090-90c9-0d784c16c78d).html,NOSCHOLARPAGE
 Balasubramanian Raman,IIT Roorkee,http://www.iitr.ac.in/departments/CSE/pages/Home+Departments_and_Centres+Mathematics+People+Faculty+Balasubramanian_R_.html,QU2O6JMAAAAJ
@@ -1731,7 +1731,7 @@ Bernhard Reus,University of Sussex,http://www.sussex.ac.uk/informatics/people/pe
 Bernhard Rumpe,RWTH Aachen,http://www.se-rwth.de/~rumpe,nED1C7QAAAAJ
 Bernhard Scholz,University of Sydney,http://web.it.usyd.edu.au/~scholz,0z6_oNEAAAAJ
 Bernhard Schölkopf,Max Planck Institute,https://is.mpg.de/~bs,DZ-fHPgAAAAJ
-Bernhard Thomaszewski,University of Montreal,http://www-labs.iro.umontreal.ca/~bernhard,Qtzmow0AAAAJ
+Bernhard Thomaszewski,University of Montreal,http://www-labs.iro.umontreal.ca/~bernhard,NOSCHOLARPAGE
 Bernt Schiele,Max Planck Institute,https://www.mpi-inf.mpg.de/departments/computer-vision-and-multimodal-computing/people/bernt-schiele,z76PBfYAAAAJ
 Berrin A. Yanikoglu,Sabancı University,http://people.sabanciuniv.edu/berrin,CyWTeecAAAAJ
 Bert Arnrich,Hasso Plattner Institute,https://hpi.de/en/the-hpi/people/professors/prof-dr-bert-arnrich.html,GGtsB6kAAAAJ
@@ -1744,7 +1744,7 @@ Berthold Klaus Paul Horn,Massachusetts Institute of Technology,http://people.csa
 Bertram Ludäscher,Univ. of Illinois at Urbana-Champaign,https://ischool.illinois.edu/people/faculty/ludaesch,nYx9xasAAAAJ
 Bertrand Cambou,Northern Arizona University,https://nau.edu/siccs/faculty/bertrand-cambou,NOSCHOLARPAGE
 Beryl Plimmer,University of Auckland,https://www.cs.auckland.ac.nz/people/b-plimmer,16CrO58AAAAJ
-Berç Rustem,Imperial College London,http://www.doc.ic.ac.uk/~br,AeKQNY0AAAAJ
+Berç Rustem,Imperial College London,http://www.doc.ic.ac.uk/~br,NOSCHOLARPAGE
 Beth A. Plale,Indiana University,http://www.cs.indiana.edu/~plale,CyGvFJkAAAAJ
 Beth Plale,Indiana University,http://www.cs.indiana.edu/~plale,CyGvFJkAAAAJ
 Betsy DiSalvo,Georgia Institute of Technology,http://betsydisalvo.com,NOSCHOLARPAGE
@@ -1781,7 +1781,7 @@ Bihuan Chen 0001,Fudan University,https://chenbihuan.github.io,Cz-4wl0AAAAJ
 Biing-Feng Wang,National Tsing Hua University,http://clark.cs.nthu.edu.tw/advisor.php,NOSCHOLARPAGE
 Bijan Parsia,University of Manchester,http://www.cs.man.ac.uk/~bparsia,UBcjZigAAAAJ
 Bijaya Karki,Louisiana State University - Baton Rouge,https://www.lsu.edu/science/geology/people/faculty/karki.php,PVKPY-IAAAAJ
-Bikramjit Banerjee,University of Southern Mississippi,https://www.usm.edu/computing/faculty/bikramjit-banerjee,WHs9gMMAAAAJ
+Bikramjit Banerjee,University of Southern Mississippi,https://www.usm.edu/computing/faculty/bikramjit-banerjee,NOSCHOLARPAGE
 Bilal Khan,CUNY,https://www.gc.cuny.edu/Page-Elements/Academics-Research-Centers-Initiatives/Doctoral-Programs/Computer-Science/Faculty-Bios/Bilal-Khan,uOBB1tEAAAAJ
 Bilge Mutlu,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~bilge,VGr54BoAAAAJ
 Bill Aiello,University of British Columbia,https://www.cs.ubc.ca/people/bill-aiello,7gbCeoEAAAAJ
@@ -2059,7 +2059,7 @@ Bryan Minor,Washington State University,https://school.eecs.wsu.edu/people/facul
 Bryan Ng,Victoria University of Wellington,https://ecs.victoria.ac.nz/Main/BryanNg,OypvS8QAAAAJ
 Bryan Pardo,Northwestern University,http://www.cs.northwestern.edu/~pardo,vxEKYqsAAAAJ
 Bryan Parno,Carnegie Mellon University,https://www.cylab.cmu.edu/education/faculty/parno.html,kTTBpJkAAAAJ
-Bryan S. Morse,Brigham Young University,http://morse.cs.byu.edu,yOyREHoAAAAJ
+Bryan S. Morse,Brigham Young University,http://morse.cs.byu.edu,NOSCHOLARPAGE
 Bryant W. York,Portland State University,http://web.cecs.pdx.edu/~york,NOSCHOLARPAGE
 Brygg Ullmer,Louisiana State University - Baton Rouge,https://www.lsu.edu/eng/cse/people/faculty/ullmer.php,JxG7a6sAAAAJ
 Bu-Sung Lee,Nanyang Technological University,http://research.ntu.edu.sg/expertise/academicprofile/Pages/StaffProfile.aspx?ST_EMAILID=ebslee,TyytTfQAAAAJ
@@ -2082,7 +2082,7 @@ Byrav Ramamurthy,University of Nebraska,http://cse.unl.edu/~byrav,Moj2TLMAAAAJ
 Byron Boots,Georgia Institute of Technology,http://www.cc.gatech.edu/~bboots3,kXB8FBoAAAAJ
 Byron C. Wallace,Northeastern University,http://www.byronwallace.com,KTzRHmwAAAAJ
 Byron Choi,Hong Kong Baptist University,http://www.comp.hkbu.edu.hk/~bchoi,S6L1eOMAAAAJ
-Byron J. Williams,Mississippi State University,http://www.fsnhp.msstate.edu/docs/staff/Byron%20%20Williams%20CV%20July%202012%20.pdf,t4bGLWUAAAAJ
+Byron J. Williams,Mississippi State University,http://www.fsnhp.msstate.edu/docs/staff/Byron%20%20Williams%20CV%20July%202012%20.pdf,NOSCHOLARPAGE
 Byung Guk Kim,University of Massachusetts Lowell,https://www.uml.edu/Sciences/computer-science/faculty/kim-byung-guk.aspx,FkDwvF0AAAAJ
 Byung Ro Moon,Seoul National University,http://soar.snu.ac.kr/members,N_9XjY4AAAAJ
 Byung Seub Lee,University of Vermont,http://www.uvm.edu/~cems/?Page=employee/profile.php&SM=employee/_employeemenu.html&EmID=195,NOSCHOLARPAGE
@@ -2128,7 +2128,7 @@ Calvin Lin,University of Texas at Austin,http://www.cs.utexas.edu/~lin,VDMARucAA
 Calvin Newport,Georgetown University,http://people.cs.georgetown.edu/~cnewport,EhodjeAAAAAJ
 Cam Nguyen,Texas A&M at Qatar,https://engineering.tamu.edu/electrical/profiles/cnguyen.html,hIL52f8AAAAJ
 Cameron Browne,Maastricht University,http://cambolbro.com,e6dyku8AAAAJ
-Camillo J. Taylor,University of Pennsylvania,http://www.cis.upenn.edu/~cjtaylor,vMDCJHcAAAAJ
+Camillo J. Taylor,University of Pennsylvania,http://www.cis.upenn.edu/~cjtaylor,NOSCHOLARPAGE
 Campbell Wilson,Monash University,http://monash.edu/research/explore/en/persons/campbell-wilson(3e5445ab-5a7f-43c9-bb99-6fde0a2d0962).html,NOSCHOLARPAGE
 Can Alkan,Bilkent University,http://www.cs.bilkent.edu.tr/~calkan,wo5_FngAAAAJ
 Can C. Özturan,Boğaziçi University,https://www.cmpe.boun.edu.tr/~ozturan,--uJKY0AAAAJ
@@ -2137,7 +2137,7 @@ Can Özturan,Boğaziçi University,https://www.cmpe.boun.edu.tr/~ozturan,--uJKY0
 Candace L. Sidner,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/cls.html,j8ULfMsAAAAJ
 Candido Cabo,CUNY,https://www.gc.cuny.edu/Page-Elements/Academics-Research-Centers-Initiatives/Doctoral-Programs/Computer-Science/Faculty-Bios/Candido-Cabo,pvFqstUAAAAJ
 Candy L. Sidner,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/cls.html,j8ULfMsAAAAJ
-Cang Ye,Virginia Commonwealth University,https://egr.vcu.edu/directory/cangye,3kvDgyMAAAAJ
+Cang Ye,Virginia Commonwealth University,https://egr.vcu.edu/directory/cangye,NOSCHOLARPAGE
 Cara K. MacNish,University of Western Australia,http://www.web.uwa.edu.au/people/cara.macnish,NOSCHOLARPAGE
 Cara MacNish,University of Western Australia,http://www.web.uwa.edu.au/people/cara.macnish,NOSCHOLARPAGE
 Carey L. Williamson,University of Calgary,http://www.cpsc.ucalgary.ca/~carey,NOSCHOLARPAGE
@@ -2235,7 +2235,7 @@ Caroline Jay,University of Manchester,https://www.research.manchester.ac.uk/port
 Caroline M. Eastman,University of South Carolina,https://cse.sc.edu/~eastman,NOSCHOLARPAGE
 Caroline Uhler,Massachusetts Institute of Technology,https://www.carolineuhler.com,dIJFcaoAAAAJ
 Carolyn Penstein Rosé,Carnegie Mellon University,http://www.cs.cmu.edu/~cprose,BMydCgcAAAAJ
-Carolyn R. Watters,Dalhousie University,https://www.dal.ca/about-dal/leadership-and-vision/leadership-team/carolyn-watters.html,ACAErxoAAAAJ
+Carolyn R. Watters,Dalhousie University,https://www.dal.ca/about-dal/leadership-and-vision/leadership-team/carolyn-watters.html,P02fwREAAAAJ
 Carrick Detweiler,University of Nebraska,http://cse.unl.edu/~carrick,E4kvshMAAAAJ
 Carroll C. Morgan,UNSW,http://www.cse.unsw.edu.au/~carrollm,YqrcydIAAAAJ
 Carroll Morgan,UNSW,http://www.cse.unsw.edu.au/~carrollm,YqrcydIAAAAJ
@@ -2494,7 +2494,7 @@ Cho-Jui Hsieh,University of California - Los Angeles,http://web.cs.ucla.edu/~cho
 Chog Barugkin,Australian National University,https://cecs.anu.edu.au/people/chog-barugkin,NOSCHOLARPAGE
 Chong-Jun Wang,Nanjing University,https://hpi.de/en/research/research-school/international-branches/nanjing-university.html,NOSCHOLARPAGE
 Chong-kwon Kim,Seoul National University,http://popeye.snu.ac.kr,KRykCKkAAAAJ
-Chongjie Zhang,Tsinghua University,http://iiis.tsinghua.edu.cn/~zhang,LjxqXycAAAAJ
+Chongjie Zhang,Tsinghua University,http://iiis.tsinghua.edu.cn/~zhang,NOSCHOLARPAGE
 Chongjun Wang,Nanjing University,https://hpi.de/en/research/research-school/international-branches/nanjing-university.html,NOSCHOLARPAGE
 Choonhwa Lee,Hanyang University,http://dcc.hanyang.ac.kr/members.htm,NOSCHOLARPAGE
 Chris Bailey,University of York,https://www-users.cs.york.ac.uk/~chrisb,QQ_dWtcAAAAJ
@@ -2962,10 +2962,10 @@ Da Yan,University of Alabama - Birmingham,http://yanda.cis.uab.edu,NOSCHOLARPAGE
 Daan Huybrechs,KU Leuven,https://people.cs.kuleuven.be/~daan.huybrechs,bT4V4uYAAAAJ
 Dabbala Rajagopal Reddy,Carnegie Mellon University,http://www.rr.cs.cmu.edu,6n7rzokAAAAJ
 Dacheng Tao,University of Sydney,https://sydney.edu.au/engineering/people/dacheng.tao.php,RwlJNLcAAAAJ
-Dae Hyun Kim,Washington State University,https://school.eecs.wsu.edu/people/faculty/dae-hyun-kim,nG4hcN4AAAAJ
+Dae Hyun Kim,Washington State University,https://school.eecs.wsu.edu/people/faculty/dae-hyun-kim,3xLjsIsAAAAJ
 Dae Young Kim,KAIST,http://www.resl.kaist.ac.kr,encxuNcAAAAJ
 Dae-Kyoo Kim,Oakland University,https://oakland.edu/secs/directory/kim,IR_UyOgAAAAJ
-Daehyun Kim,Washington State University,https://school.eecs.wsu.edu/people/faculty/dae-hyun-kim,nG4hcN4AAAAJ
+Daehyun Kim,Washington State University,https://school.eecs.wsu.edu/people/faculty/dae-hyun-kim,3xLjsIsAAAAJ
 Dafna Shahaf,Hebrew University of Jerusalem,http://www.cs.huji.ac.il/~dshahaf,AgyW_90AAAAJ
 Dag Svanaes,NTNU,https://www.ntnu.edu/employees/dag.svanes,rrAsOFsAAAAJ
 Dag Svanæs,NTNU,https://www.ntnu.edu/employees/dag.svanes,rrAsOFsAAAAJ
@@ -3022,7 +3022,7 @@ Dan Olteanu,University of Oxford,http://www.cs.ox.ac.uk/dan.olteanu,4eeIj2gAAAAJ
 Dan Ophir,Ariel University,http://ariel.academia.edu/DanOphir,NOSCHOLARPAGE
 Dan Page,University of Bristol,http://www.cs.bris.ac.uk/~page,z55uDZcAAAAJ
 Dan Pei,Tsinghua University,https://netman.cs.tsinghua.edu.cn/~peidan,i_zA1VsAAAAJ
-Dan Roth,University of Pennsylvania,http://l2r.cs.uiuc.edu,WHOHV3AAAAAJ
+Dan Roth,University of Pennsylvania,http://l2r.cs.uiuc.edu,E-bpPWgAAAAJ
 Dan Rubenstein,Columbia University,http://www.cs.columbia.edu/~danr,FM3vRPgAAAAJ
 Dan S. Wallach,Rice University,https://www.cs.rice.edu/~dwallach,oM25EQkAAAAJ
 Dan Simovici,University of Massachusetts Boston,http://www.cs.umb.edu/~dsim,Pun4WO8AAAAJ
@@ -3087,12 +3087,12 @@ Daniel Fabbri,Vanderbilt University,https://www.vumc.org/dbmi/person/daniel-fabb
 Daniel Fernandes Macedo,UFMG,http://homepages.dcc.ufmg.br/~damacedo,_01uvzwAAAAJ
 Daniel Fischer 0001,University at Buffalo,https://www.cse.buffalo.edu/people/?u=df33,6BL4WukAAAAJ
 Daniel G. Aliaga,Purdue University,https://www.cs.purdue.edu/homes/aliaga,Bj5YOnYAAAAJ
-Daniel G. Brown 0001,University of Waterloo,https://cs.uwaterloo.ca/~browndg,cD37cXcAAAAJ
+Daniel G. Brown 0001,University of Waterloo,https://cs.uwaterloo.ca/~browndg,NOSCHOLARPAGE
 Daniel Genkin,University of Michigan,http://web.eecs.umich.edu/~genkin,BqkyhDEAAAAJ
 Daniel Gildea,University of Rochester,https://www.cs.rochester.edu/u/gildea,NOSCHOLARPAGE
 Daniel Gillis,University of Guelph,https://www.uoguelph.ca/computing/people/daniel-gillis,mcKPf6gAAAAJ
 Daniel Gonçalves 0002,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist13898,_D1cFMkAAAAJ
-Daniel Gregory Brown,University of Waterloo,https://cs.uwaterloo.ca/~browndg,cD37cXcAAAAJ
+Daniel Gregory Brown,University of Waterloo,https://cs.uwaterloo.ca/~browndg,NOSCHOLARPAGE
 Daniel Grosu,Wayne State University,http://www.cs.wayne.edu/~dgrosu,LhsomaUAAAAJ
 Daniel Gruss,Graz University of Technology,https://gruss.cc,JmCg4uQAAAAJ
 Daniel Gusfield,University of California - Davis,http://www.cs.ucdavis.edu/~gusfield,VoAHydgAAAAJ
@@ -3190,7 +3190,7 @@ Danielle Albers,University of Colorado Boulder,http://www.colorado.edu/cmci/peop
 Danielle Albers Szafir,University of Colorado Boulder,http://www.colorado.edu/cmci/people/information-science/danielle-albers-szafir,CGb88B0AAAAJ
 Danielle Azar,Lebanese American University,http://sas.lau.edu.lb/csm/people/danielle-azar.php,lcd1FHgAAAAJ
 Danilo Ardagna,Politecnico di Milano,http://home.deib.polimi.it/ardagna,2S6m-oYAAAAJ
-Daning Hu,University of Zurich,http://www.ifi.uzh.ch/bi/people/hu,d_RBF58AAAAJ
+Daning Hu,University of Zurich,http://www.ifi.uzh.ch/bi/people/hu,NOSCHOLARPAGE
 Danny C. Cheng,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742667028&command=GETPROFILE,J1ri4YIAAAAJ
 Danny Chen,University of Notre Dame,http://www3.nd.edu/~dchen,tRerdSIAAAAJ
 Danny Cheng,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742667028&command=GETPROFILE,J1ri4YIAAAAJ
@@ -3307,7 +3307,7 @@ David Finkel,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facult
 David G. Andersen,Carnegie Mellon University,https://www.cs.cmu.edu/~dga,wUArfPgAAAAJ
 David G. Green,Monash University,http://monash.edu/research/explore/en/persons/david-green(b9dbf939-a5b9-4cf4-b4b0-9b7c30356f08).html,dbfeR3YAAAAJ
 David G. Mitchell,Simon Fraser University,https://www.cs.sfu.ca/~mitchell,sSf5Fb4AAAAJ
-David Garlan,Carnegie Mellon University,https://www.cs.cmu.edu/~garlan,p6HgUFEAAAAJ
+David Garlan,Carnegie Mellon University,https://www.cs.cmu.edu/~garlan,NOSCHOLARPAGE
 David Gavaghan,University of Oxford,http://www.cs.ox.ac.uk/david.gavaghan,riGX3YsAAAAJ
 David Gelernter,Yale University,http://cpsc.yale.edu/people/david-gelernter,NOSCHOLARPAGE
 David Gesbert,EURECOM,http://www.eurecom.fr/cm/gesbert,WJPjaDgAAAAJ
@@ -3436,7 +3436,7 @@ David W. Jacobs,University of Maryland - College Park,https://www.cs.umd.edu/~dj
 David W. Juedes,Ohio University,http://oucsace.cs.ohiou.edu/~juedes,eTFiw7wAAAAJ
 David W. Petr,University of Kansas,http://www.ittc.ku.edu/~dwp,K4xD9GAAAAAJ
 David Walker,Princeton University,http://www.cs.princeton.edu/~dpw,W-IMms4AAAAJ
-David Welch,University of Auckland,https://www.cs.auckland.ac.nz/~davidw,W3-SgVAAAAAJ
+David Welch,University of Auckland,https://www.cs.auckland.ac.nz/~davidw,NOSCHOLARPAGE
 David Wentzlaff,Princeton University,https://www.princeton.edu/~wentzlaf,82FA9YIAAAAJ
 David Windridge,Middlesex University,http://www.cs.mdx.ac.uk/people/david-windridge,p0K-zIsAAAAJ
 David Wingate,Brigham Young University,https://cs.byu.edu/faculty/dw87,W9uPOIQAAAAJ
@@ -3453,13 +3453,13 @@ Davide Martinenghi,Politecnico di Milano,http://home.deib.polimi.it/martinen,E0Q
 Davide Mottin,Aarhus University,https://mott.in,evZ9Q9EAAAAJ
 Davide Scaramuzza,University of Zurich,http://rpg.ifi.uzh.ch,SC9wV2kAAAAJ
 Davood Rafiei,University of Alberta,https://webdocs.cs.ualberta.ca/~drafiei,lNxSDIwAAAAJ
-Davor Svetinovic,Masdar Institute,https://www.masdar.ac.ae/aboutus/management/faculty-directory/item/5669-davor-svetinovic,5jy7MH0AAAAJ
+Davor Svetinovic,Masdar Institute,https://www.masdar.ac.ae/aboutus/management/faculty-directory/item/5669-davor-svetinovic,NOSCHOLARPAGE
 Dawei Jiang,Zhejiang University,http://mypage.zju.edu.cn/jiangdw,NOSCHOLARPAGE
 Dawei Li,University of Vermont,http://www.uvm.edu/genomics/index.html,HNZDQxYAAAAJ
 Dawn MacIsaac,University of New Brunswick,https://www.cs.unb.ca/people/dmac,bJi2F0MAAAAJ
 Dawn Song,University of California - Berkeley,http://www.cs.berkeley.edu/~dawnsong,84WzBlYAAAAJ
 Dawn T. MacIsaac,University of New Brunswick,https://www.cs.unb.ca/people/dmac,bJi2F0MAAAAJ
-Dawn Wilkins,University of Mississippi,http://flagshipconstellations.olemiss.edu/leaders/dawn-wilkins,wIzASCoAAAAJ
+Dawn Wilkins,University of Mississippi,http://flagshipconstellations.olemiss.edu/leaders/dawn-wilkins,vNspG44AAAAJ
 Dawn Xiaodong Song,University of California - Berkeley,http://www.cs.berkeley.edu/~dawnsong,84WzBlYAAAAJ
 Dawson R. Engler,Stanford University,http://web.stanford.edu/~engler,Bz-b2a0AAAAJ
 Dawu Gu,Shanghai Jiao Tong University,http://english.seiee.sjtu.edu.cn/english/detail/841_663.htm,NOSCHOLARPAGE
@@ -3482,7 +3482,7 @@ Debasis Samanta,IIT Kharagpur,http://www.nid.iitkgp.ernet.in/dsamanta,RctLVqcAAA
 Debbie Leung,University of Waterloo,http://www.math.uwaterloo.ca/~wcleung,U8igvVgAAAAJ
 Debbie W. Leung,University of Waterloo,http://www.math.uwaterloo.ca/~wcleung,U8igvVgAAAAJ
 Debdeep Mukhopadhyay,IIT Kharagpur,cse.iitkgp.ac.in/~debdeep,2ELnl9IAAAAJ
-Debi Prosad Dogra,IIT Bhubaneswar,http://www.iitbbs.ac.in/profile.php/dpdogra,e7AbmE8AAAAJ
+Debi Prosad Dogra,IIT Bhubaneswar,http://www.iitbbs.ac.in/profile.php/dpdogra,nPCSmCMAAAAJ
 Debin Gao,Singapore Management University,http://flyer.sis.smu.edu.sg,ufQVl6UAAAAJ
 Debin Zhao,Harbin Institute of Technology,http://homepage.hit.edu.cn/zhaodebin,QXyj0hkAAAAJ
 Debmalya Panigrahi,Duke University,https://users.cs.duke.edu/~debmalya,syv4e-EAAAAJ
@@ -3523,7 +3523,7 @@ Demetrios Achlioptas,University of California - Santa Cruz,https://www.soe.ucsc.
 Deming Chen,Univ. of Illinois at Urbana-Champaign,https://www.ece.illinois.edu/directory/profile/dchen,A_A_LrsAAAAJ
 Demosthenis Teneketzis,University of Michigan,http://web.eecs.umich.edu/~teneket,NOSCHOLARPAGE
 Deng Cai,Zhejiang University,http://www.cad.zju.edu.cn/home/dengcai,vzxDyJoAAAAJ
-Deng Pan,Florida International University,http://www.cs.fiu.edu/~pand,o0lXy-UAAAAJ
+Deng Pan,Florida International University,http://www.cs.fiu.edu/~pand,NOSCHOLARPAGE
 Denilson Barbosa,University of Alberta,https://www.ualberta.ca/~denilson,usr3H7gAAAAJ
 Denis Deratani Mauá,USP,http://www.ime.usp.br/~ddm,NOSCHOLARPAGE
 Denis F. Wolf,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/denis,ncy_2xUAAAAJ
@@ -3648,7 +3648,7 @@ Dilvan de Abreu Moreira,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/dilvan,y15S
 Dima Alhadidi,University of New Brunswick,http://www.cs.unb.ca/people/dalhadid,AkMtNxcAAAAJ
 Dima Damen,University of Bristol,https://www.cs.bris.ac.uk/~damen,OxL9Wn8AAAAJ
 Dimitar Kazakov,University of York,https://www-users.cs.york.ac.uk/~kazakov,CLI_4LYAAAAJ
-Dimitri Theodoratos,NJIT,https://web.njit.edu/~dth,FxSyhSgAAAAJ
+Dimitri Theodoratos,NJIT,https://web.njit.edu/~dth,NOSCHOLARPAGE
 Dimitri Van De Ville,EPFL,https://miplab.epfl.ch,kFz4LNMAAAAJ
 Dimitrios Damopoulos,Stevens Institute of Technology,https://web.stevens.edu/facultyprofile/?id=2162,PQ8eoRMAAAAJ
 Dimitrios Gunopulos,University of Athens,http://kddlab.di.uoa.gr/dg.html,PHJokEQAAAAJ
@@ -3758,8 +3758,8 @@ Don Sheehy,University of Connecticut,http://donsheehy.net,A5D1DF4AAAAJ
 Don Towsley,University of Massachusetts Amherst,https://www.cics.umass.edu/faculty/directory/towsley_donald,KIFPVWoAAAAJ
 Donald A. Adjeroh,West Virginia University,https://www.statler.wvu.edu/faculty-staff/faculty/donald-a-adjeroh,NOSCHOLARPAGE
 Donald Bailey,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=282130,kbZTGusAAAAJ
-Donald C. Wunsch,Missouri University of Technology,http://people.mst.edu/faculty/dwunsch/index.html,nML1gAwAAAAJ
-Donald C. Wunsch II,Missouri University of Technology,http://people.mst.edu/faculty/dwunsch/index.html,nML1gAwAAAAJ
+Donald C. Wunsch,Missouri University of Technology,http://people.mst.edu/faculty/dwunsch/index.html,NOSCHOLARPAGE
+Donald C. Wunsch II,Missouri University of Technology,http://people.mst.edu/faculty/dwunsch/index.html,NOSCHOLARPAGE
 Donald E. Porter,University of North Carolina,http://www3.cs.stonybrook.edu/~porter,jVOPqi0AAAAJ
 Donald F. Towsley,University of Massachusetts Amherst,https://www.cics.umass.edu/faculty/directory/towsley_donald,KIFPVWoAAAAJ
 Donald G. Bailey,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=282130,kbZTGusAAAAJ
@@ -3827,7 +3827,7 @@ Doron Peled,Bar-Ilan University,http://u.cs.biu.ac.il/~doronp,XF61SSwAAAAJ
 Dorothea Blostein,Queen’s University,http://www.cs.queensu.ca/home/blostein,hb8j8qAAAAAJ
 Dorothea Wagner,Karlsruhe Institute of Technology (KIT),http://i11www.iti.uni-karlsruhe.de/members/dorothea_wagner/index,iqm5N9IAAAAJ
 Dorsa Sadigh,Stanford University,https://dorsa.fyi,MEeYxLMAAAAJ
-Doug A. Bowman,Virginia Tech,https://research.cs.vt.edu/3di/user/123,Zc7YEbgAAAAJ
+Doug A. Bowman,Virginia Tech,https://research.cs.vt.edu/3di/user/123,KXCqonwAAAAJ
 Doug Downey,Northwestern University,http://www.cs.northwestern.edu/~ddowney,NpvcLukAAAAJ
 Doug L. James,Stanford University,https://profiles.stanford.edu/doug-james,r70ags0AAAAJ
 Douglas B. Armstrong,University of Edinburgh,http://www.ed.ac.uk/integrative-physiology/staff-profiles/associate-members/j-douglas-armstrong,NOSCHOLARPAGE
@@ -3924,8 +3924,8 @@ Edgar Gabriel,University of Houston,http://www2.cs.uh.edu/~gabriel,_82EhT4AAAAJ
 Edison Pignaton de Freitas,UFRGS,http://inf.ufrgs.br/~epfreitas,d6vo3uwAAAAJ
 Edith Elkind,University of Oxford,https://www.cs.ox.ac.uk/people/edith.elkind,MsGRzsoAAAAJ
 Edith Hemaspaandra,Rochester Institute of Technology,https://www.cs.rit.edu/~eh,Z9W_SPAAAAAJ
-Edith L. M. Law,University of Waterloo,http://edithlaw.ca,dfKl1qQAAAAJ
-Edith Law,University of Waterloo,http://edithlaw.ca,dfKl1qQAAAAJ
+Edith L. M. Law,University of Waterloo,http://edithlaw.ca,NOSCHOLARPAGE
+Edith Law,University of Waterloo,http://edithlaw.ca,NOSCHOLARPAGE
 Edith Spaan,Rochester Institute of Technology,https://www.cs.rit.edu/~eh,Z9W_SPAAAAAJ
 Edmond Chow,Georgia Institute of Technology,http://www.edmondchow.com,NOSCHOLARPAGE
 Edmund H. Durfee,University of Michigan,http://ai.eecs.umich.edu/people/durfee,NOSCHOLARPAGE
@@ -3969,7 +3969,7 @@ Eduardo Torres-Jara,Worcester Polytechnic Institute,http://www.wpi.edu/academics
 Eduardo Velloso,University of Melbourne,http://www.eduardovelloso.com,yHHlOiQAAAAJ
 Eduardo del Castillo-Sánchez,EPFL,https://people.epfl.ch/eduardo.sanchez,NOSCHOLARPAGE
 Eduardo do Valle Simões,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/simoes,acJCV0AAAAAJ
-Edward A. Fox,Virginia Tech,https://fox.cs.vt.edu/foxinfo.html,uDwy_JgAAAAJ
+Edward A. Fox,Virginia Tech,https://fox.cs.vt.edu/foxinfo.html,KcbSBrUAAAAJ
 Edward A. Lee,University of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/lee.html,IJgXsgwAAAAJ
 Edward Currie,Middlesex University,http://www.cs.mdx.ac.uk/people/ed-currie,NOSCHOLARPAGE
 Edward D. Lazowska,University of Washington,http://www.cs.washington.edu/people/faculty/lazowska,NhY4TT4AAAAJ
@@ -3992,7 +3992,7 @@ Edwin V. Bonilla,UNSW,http://ebonilla.github.io,uDLRZQMAAAAJ
 Ee-Chien Chang,National University of Singapore,https://www.comp.nus.edu.sg/~changec,qZavFBcAAAAJ
 Ee-Peng Lim,Singapore Management University,https://sis.smu.edu.sg/faculty/profile/9626,r0wOAikAAAAJ
 Eelco Visser,TU Delft,http://eelcovisser.org,1OA7zicAAAAJ
-Eelke Folmer,University of Nevada,https://www.unr.edu/cse/people/folmer,1QermAgAAAAJ
+Eelke Folmer,University of Nevada,https://www.unr.edu/cse/people/folmer,NOSCHOLARPAGE
 Eerke A. Boiten,University of Kent,https://www.cs.kent.ac.uk/~eab2,eUtcV10AAAAJ
 Eero Hyvönen,Aalto University,https://seco.cs.aalto.fi/u/eahyvone,FqbJBcsAAAAJ
 Eero Vainikko,University of Tartu,http://kodu.ut.ee/~eero,Ym_SSO8AAAAJ
@@ -4010,7 +4010,7 @@ Eike Kiltz,Ruhr-University Bochum,http://kiltz.net,8d8jP60AAAAJ
 Eileen Kraemer,Clemson University,https://people.cs.clemson.edu/~etkraem,_5tjpG0AAAAJ
 Eilish O'Rourke,UNSW,https://www.engineering.unsw.edu.au/computer-science-engineering/staff/eilish-orourke,NOSCHOLARPAGE
 Eisa Zarepour,UNSW,https://research.unsw.edu.au/people/dr-eisa-zarepour,MgSbGaYAAAAJ
-Eitan Grinspun,Columbia University,http://www.cs.columbia.edu/~eitan,0_vvBZkAAAAJ
+Eitan Grinspun,Columbia University,http://www.cs.columbia.edu/~eitan,-HyEryoAAAAJ
 Eitan Yaakobi,Technion,http://www.cs.technion.ac.il/people/yaakobi,Viv2E9AAAAAJ
 Ekaterina Lebedeva,Australian National University,https://cecs.anu.edu.au/people/ekaterina-lebedeva,3Ey9ZWIAAAAJ
 Ekaterina Shutova,University of Amsterdam,https://www.illc.uva.nl/People/show_person.php?Person_id=Shutova+E.,jqOFBGoAAAAJ
@@ -4067,7 +4067,7 @@ Elisabetta Di Nitto,Politecnico di Milano,http://home.deib.polimi.it/dinitto,2xV
 Elise de Doncker,Western Michigan University,https://wmich.edu/cs/directory/doncker,NOSCHOLARPAGE
 Elisha Sacks,Purdue University,https://www.cs.purdue.edu/people/eps,NOSCHOLARPAGE
 Elissa Weeden,Rochester Institute of Technology,https://www.rit.edu/gccis/elissa-weeden,NOSCHOLARPAGE
-Elizabeth Bradley,University of Colorado Boulder,https://www.cs.colorado.edu/~lizb,5HLGWrIAAAAJ
+Elizabeth Bradley,University of Colorado Boulder,https://www.cs.colorado.edu/~lizb,s4duj0sAAAAJ
 Elizabeth D. Mynatt,Georgia Institute of Technology,http://ipat.gatech.edu/people/beth-mynatt,NOSCHOLARPAGE
 Elizabeth L. White,George Mason University,https://cs.gmu.edu/~white,p1OyJIAAAAAJ
 Elizabeth Lawley,Rochester Institute of Technology,http://lawley.rit.edu,aJi1r9wAAAAJ
@@ -4199,7 +4199,7 @@ Eric K. Ringger,Brigham Young University,https://faculty.cs.byu.edu/~ringger,Xkk
 Eric Keller,University of Colorado Boulder,https://eric-keller.github.io,ngLX-kwAAAAJ
 Eric Koskinen,Stevens Institute of Technology,http://www.erickoskinen.com,XUhd_LwAAAAJ
 Eric Larson,Southern Methodist University,https://www.smu.edu/Lyle/Departments/CSE/People/Faculty/LarsonEric,vThE9GIAAAAJ
-Eric Lo,Chinese University of Hong Kong,https://appsrv.cse.cuhk.edu.hk/~ericlo,saGnAtQAAAAJ
+Eric Lo,Chinese University of Hong Kong,https://appsrv.cse.cuhk.edu.hk/~ericlo,NOSCHOLARPAGE
 Eric Martin 0002,UNSW,https://www.engineering.unsw.edu.au/computer-science-engineering/staff/eric-martin,dgTxZiUAAAAJ
 Eric McCreath,Australian National University,https://cs.anu.edu.au/people/eric-mccreath,zbAjO4EAAAAJ
 Eric Mercer,Brigham Young University,https://cs.byu.edu/faculty/egm,FbUhdYYAAAAJ
@@ -4216,7 +4216,7 @@ Eric Po Xing,Carnegie Mellon University,http://www.cs.cmu.edu/~epxing,5pKTRxEAAA
 Eric Postma,Tilburg University,https://www.tilburguniversity.edu/webwijs/show/e.o.postma.htm,EpsyWjIAAAAJ
 Eric Price,University of Texas at Austin,http://www.cs.utexas.edu/~ecprice,UiKzYNMAAAAJ
 Eric Roberts,Stanford University,http://cs.stanford.edu/people/eroberts,BgLKWLUAAAAJ
-Eric Rozier,Iowa State University,http://www.cs.iastate.edu/people/eric-rozier,IUkqD5YAAAAJ
+Eric Rozier,Iowa State University,http://www.cs.iastate.edu/people/eric-rozier,NOSCHOLARPAGE
 Eric Rozner,University of Colorado Boulder,http://www.ericrozner.com,z0KD3z4AAAAJ
 Eric Ruppert,York University,http://www.cs.yorku.ca/~ruppert,ficDn98AAAAJ
 Eric S. K. Yu,University of Toronto,http://www.cs.toronto.edu/~eric,c36OREEAAAAJ
@@ -4228,7 +4228,7 @@ Eric Van Wyk,University of Minnesota,http://www-users.cs.umn.edu/~evw,fMI1OlIAAA
 Eric Vigoda,Georgia Institute of Technology,http://www.cc.gatech.edu/home/vigoda,NOSCHOLARPAGE
 Eric W. Frew,University of Colorado Boulder,https://www.colorado.edu/faculty/frew,Tvmf6RAAAAAJ
 Eric Walkingshaw,Oregon State University,http://web.engr.oregonstate.edu/~walkiner,0kPwMDwAAAAJ
-Eric William Davis Rozier,Iowa State University,http://www.cs.iastate.edu/people/eric-rozier,IUkqD5YAAAAJ
+Eric William Davis Rozier,Iowa State University,http://www.cs.iastate.edu/people/eric-rozier,NOSCHOLARPAGE
 Eric Wustrow,University of Colorado Boulder,https://ericw.us/trow,becbtxgAAAAJ
 Erich Grädel,RWTH Aachen,https://logic.rwth-aachen.de/~graedel,4TbxnY0AAAAJ
 Erich P. Ippen,Massachusetts Institute of Technology,http://web.mit.edu/physics/people/faculty/ippen_erich.html,5RfBYzcAAAAJ
@@ -4495,7 +4495,7 @@ Femke van Raamsdonk,VU Amsterdam,http://www.cs.vu.nl/~femke,i9-twtYAAAAJ
 Feng Gu,CUNY,http://www.cs.csi.cuny.edu/~gu,6JuoIAUAAAAJ
 Feng Lin 0004,Zhejiang University,https://person.zju.edu.cn/person/flin,gyBxQOAAAAAJ
 Feng Liu 0005,University of Queensland,http://researchers.uq.edu.au/researcher/951,NOSCHOLARPAGE
-Feng Liu 0015,Portland State University,http://web.cecs.pdx.edu/~fliu,uiqXutMAAAAJ
+Feng Liu 0015,Portland State University,http://web.cecs.pdx.edu/~fliu,NOSCHOLARPAGE
 Feng Lu 0005,Beihang University,http://shi.buaa.edu.cn/lufeng,NOSCHOLARPAGE
 Feng Luo,Clemson University,https://people.cs.clemson.edu/~luofeng,joROlFwAAAAJ
 Feng Qian 0001,University of Minnesota,https://www-users.cs.umn.edu/~fengqian,NOSCHOLARPAGE
@@ -4973,7 +4973,7 @@ Gerard J. Kim,Korea University,https://dxp.korea.ac.kr/index.php?mid=page_QEGJ80
 Gerard Jounghyun Kim,Korea University,https://dxp.korea.ac.kr/index.php?mid=page_QEGJ80,7UCco8IAAAAJ
 Gerard R. Richter,Rutgers University,http://www.cs.rutgers.edu/~richter,NOSCHOLARPAGE
 Gerard de Melo,Rutgers University,http://gerard.demelo.org,WCQXaGkAAAAJ
-Gerardo Aragon-Camarasa,University of Glasgow,http://www.dcs.gla.ac.uk/~gerardo,mbSbOegAAAAJ
+Gerardo Aragon-Camarasa,University of Glasgow,http://www.dcs.gla.ac.uk/~gerardo,NOSCHOLARPAGE
 Gerardo Canfora,University of Sannio,http://www.gerardocanfora.net,3wkA_aYAAAAJ
 Gerardo Pelosi,Politecnico di Milano,http://home.deib.polimi.it/pelosi,Rlp-N_gAAAAJ
 Gerasimos Spanakis,Maastricht University,https://dke.maastrichtuniversity.nl/jerry.spanakis,LiUXYVgAAAAJ
@@ -5032,7 +5032,7 @@ Gianluca Memoli,University of Sussex,http://www.sussex.ac.uk/informatics/people/
 Gianluca Palermo,Politecnico di Milano,http://home.deib.polimi.it/gpalermo,A5GSaaoAAAAJ
 Gianluca Stringhini,Boston University,https://seclab.bu.edu/people/gianluca,fM-s2vQAAAAJ
 Gianluigi Ferrari,University of Pisa,http://www.di.unipi.it/~giangi,F2bbBksAAAAJ
-Gianna Del Corso,University of Pisa,http://www.di.unipi.it/~delcorso,AGDMVeIAAAAJ
+Gianna Del Corso,University of Pisa,http://www.di.unipi.it/~delcorso,NOSCHOLARPAGE
 Giannis F. Marias,AUEB,http://www.scirp.org/journal/DetailedInforOfEditorialBoard.aspx?personID=953,EO_hUg4AAAAJ
 Gianpolo Cugola,Politecnico di Milano,http://home.deib.polimi.it/cugola,bLmEkPsAAAAJ
 Gideon Gouws,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/GideonGouws,NOSCHOLARPAGE
@@ -5070,7 +5070,7 @@ Giovanna Rosone,University of Pisa,http://pages.di.unipi.it/rosone,gx_HzA0AAAAJ
 Giovanni Agosta,Politecnico di Milano,http://home.deib.polimi.it/agosta,eLxnBysAAAAJ
 Giovanni Comarela,Universidade Federal de Viçosa,http://www.dpi.ufv.br/~gcom,onfmt40AAAAJ
 Giovanni Da San Martino,Qatar Computing Research Institute,http://www.qcri.org/our-people/bio?pid=201&amp;par=acc&amp;name=GiovanniDa_San Martino,URABLy0AAAAJ
-Giovanni De Micheli,EPFL,http://si2.epfl.ch/~demichel,7SUnVDsAAAAJ
+Giovanni De Micheli,EPFL,http://si2.epfl.ch/~demichel,1Z0AeMkAAAAJ
 Giovanni Moretti,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=455100,NOSCHOLARPAGE
 Giovanni Quattrone,Middlesex University,https://www.mdx.ac.uk/about-us/our-people/staff-directory/profile/quattrone-giovanni,cN4fbBsAAAAJ
 Giovanni Russello,University of Auckland,https://www.cs.auckland.ac.nz/~russello,sXvrlqgAAAAJ
@@ -5136,18 +5136,18 @@ Gorjan Alagic,University of Maryland - College Park,http://www.alagic.org,NOSCHO
 Gorkem Serbes,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/gorkem?lang=en,96vDpfcAAAAJ
 Gouhei Tanaka,University of Tokyo,http://www.sat.t.u-tokyo.ac.jp/~gouhei,NOSCHOLARPAGE
 Gourab Sen Gupta,Massey University,http://seat.massey.ac.nz/g.sengupta,NOSCHOLARPAGE
-Gourinath Banda,IIT Indore,http://cse.iiti.ac.in/faculty.html,k5nOs00AAAAJ
+Gourinath Banda,IIT Indore,http://cse.iiti.ac.in/faculty.html,NQCSkqQAAAAJ
 Govindarajulu Regeti,IIIT Hyderabad,https://iiit.ac.in/people/faculty/gregeti,TvcR9REAAAAJ
 Gowtham Atluri,University of Cincinnati,http://homepages.uc.edu/~atlurigm,tpfik0wAAAAJ
 Gozde B. Unal,Istanbul Technical University,http://akademi.itu.edu.tr/en/unalgo,soanB6MAAAAJ
 Grace Hui Yang,Georgetown University,http://infosense.cs.georgetown.edu/grace,nafo_HAAAAAJ
 Grace Ngai,The Hong Kong Polytechnic University,http://www4.comp.polyu.edu.hk/~csgngai,XDmI44EAAAAJ
-Grace Rumantir,Monash University,http://monash.edu/research/explore/en/persons/grace-rumantir(94545a4b-f62b-4a71-96ab-d0b27cb904bd).html,rOMD8K4AAAAJ
-Grace W. Rumantir,Monash University,http://monash.edu/research/explore/en/persons/grace-rumantir(94545a4b-f62b-4a71-96ab-d0b27cb904bd).html,rOMD8K4AAAAJ
+Grace Rumantir,Monash University,http://monash.edu/research/explore/en/persons/grace-rumantir(94545a4b-f62b-4a71-96ab-d0b27cb904bd).html,NOSCHOLARPAGE
+Grace W. Rumantir,Monash University,http://monash.edu/research/explore/en/persons/grace-rumantir(94545a4b-f62b-4a71-96ab-d0b27cb904bd).html,NOSCHOLARPAGE
 Grace Wahba,University of Wisconsin - Madison,http://www.stat.wisc.edu/~wahba,2lPABNoAAAAJ
 Graeme G. Shanks,University of Melbourne,http://people.eng.unimelb.edu.au/gshanks,or0dr-4AAAAJ
 Graeme Hirst,University of Toronto,http://www.cs.toronto.edu/~gh,VGdVdjwAAAAJ
-Graeme Smith,University of Queensland,http://staff.itee.uq.edu.au/smith,HYas6BgAAAAJ
+Graeme Smith,University of Queensland,http://staff.itee.uq.edu.au/smith,qHiBTg0AAAAJ
 Graham E. Farr,Monash University,http://www.csse.monash.edu.au/~gfarr,NOSCHOLARPAGE
 Graham Farr,Monash University,http://www.csse.monash.edu.au/~gfarr,NOSCHOLARPAGE
 Graham Knight,University College London,http://www.cs.ucl.ac.uk/staff/graham_knight,HdunwTkAAAAJ
@@ -5364,7 +5364,7 @@ Haining Fan,Tsinghua University,http://www.tsinghua.edu.cn/publish/soften/3131/2
 Haipeng Cai,Washington State University,https://school.eecs.wsu.edu/people/faculty/haipeng-cai,Ru4B_wkAAAAJ
 Haipeng Luo,University of Southern California,http://www-bcf.usc.edu/~haipengl,ct2hw4UAAAAJ
 Hairong Qi,University of Tennessee,http://www.eecs.utk.edu/people/faculty/hqi,GqnNG-kAAAAJ
-Haitao Wang,Utah State University,https://cs.usu.edu/people/haitaowang,1PyJ5VwAAAAJ
+Haitao Wang,Utah State University,https://cs.usu.edu/people/haitaowang,NOSCHOLARPAGE
 Haitao Zheng,University of Chicago,http://www.cs.ucsb.edu/~htzheng,XrIr0nYAAAAJ
 Haitham Abu-Rub,Texas A&M at Qatar,http://energy.tamu.edu/faculty-experts/haitham-abu-rub,gggnQKsAAAAJ
 Haitham Akkary,American University of Beirut,https://www.aub.edu.lb/fea/publicprofile/Pages/profile.aspx?MemberId=ha95,IOoBNcsAAAAJ
@@ -5654,7 +5654,7 @@ Heon-Chang Yu,Korea University,http://ds.korea.ac.kr/index.php/professor,dwvceYU
 HeonChang Yu,Korea University,http://ds.korea.ac.kr/index.php/professor,dwvceYUAAAAJ
 Heping Shen,Australian National University,https://cecs.anu.edu.au/people/heping-shen,NOSCHOLARPAGE
 Herbert Bos,VU Amsterdam,http://www.cs.vu.nl/~herbertb,KHMut54AAAAJ
-Herbert Edelsbrunner,IST Austria,https://ist.ac.at/research/research-groups/edelsbrunner-group,w0PeAfAAAAAJ
+Herbert Edelsbrunner,IST Austria,https://ist.ac.at/research/research-groups/edelsbrunner-group,rBHZ-LkAAAAJ
 Herbert Wiklicky,Imperial College London,http://www.doc.ic.ac.uk/~herbert,6Uh6z5AAAAAJ
 Heri Ramampiaro,NTNU,http://www.idi.ntnu.no/~heri,3H_HYnIAAAAJ
 Herman J. Haverkort,TU Eindhoven,http://www.win.tue.nl/~hermanh,j6fj3YMAAAAJ
@@ -5777,7 +5777,7 @@ Hovhannes Harutyunyan,Concordia University,http://www.concordia.ca/faculty/hovha
 Howard Blair,Syracuse University,https://experts.syr.edu/en/persons/howard-a-blair/network-organisations,NOSCHOLARPAGE
 Howard Bowman,University of Kent,https://www.cs.kent.ac.uk/people/staff/hb5,pcKQix4AAAAJ
 Howard C. Elman,University of Maryland - College Park,https://www.cs.umd.edu/users/elman,7zf7xGkAAAAJ
-Howard Straubing,Boston College,http://www.cs.bc.edu/~straubin,VdkpR4kAAAAJ
+Howard Straubing,Boston College,http://www.cs.bc.edu/~straubin,TulXsLEAAAAJ
 Howie Choset,Carnegie Mellon University,http://www.cs.cmu.edu/~./choset,4fvo61oAAAAJ
 Hridesh Rajan,Iowa State University,http://www.cs.iastate.edu/~hridesh,aiFvpucAAAAJ
 Hrishikesh B. Acharya,Rochester Institute of Technology,https://www.rit.edu/gccis/computingsecurity/people/hrishikesh-acharya,NOSCHOLARPAGE
@@ -5798,7 +5798,7 @@ Hua Xu,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/
 Huaishu Peng,University of Maryland - College Park,http://www.huaishu.me,nimapDwAAAAJ
 Huajie Zhang,University of New Brunswick,http://www.cs.unb.ca/~hzhang,AFn_Ki0AAAAJ
 Huajun Chen,Zhejiang University,http://mypage.zju.edu.cn/huajun,NOSCHOLARPAGE
-Huamin Qu,HKUST,http://huamin.org,J7a5zGEAAAAJ
+Huamin Qu,HKUST,http://huamin.org,IqaSkHcAAAAJ
 Huamin Wang,Ohio State University,http://web.cse.ohio-state.edu/~whmin,jbKlGgQAAAAJ
 Huaming Zhang,University of Alabama - Huntsville,https://www.uah.edu/science/departments/computer-science/faculty-staff/huaming-zhang,NOSCHOLARPAGE
 Huan Liu,Arizona State University,http://www.public.asu.edu/~huanliu,Dzf46C8AAAAJ
@@ -5825,7 +5825,7 @@ Hui Gary Zhang,University College London,http://mig.cs.ucl.ac.uk/index.php?n=Peo
 Hui Guo,UNSW,https://research.unsw.edu.au/people/dr-hui-guo,F-0Gu0kAAAAJ
 Hui Huang 0004,Shenzhen University,http://vcc.szu.edu.cn/~huihuang,wjzkl3YAAAAJ
 Hui Jiang 0001,York University,https://wiki.eecs.yorku.ca/user/hj,DZyVTk8AAAAJ
-Hui Lin 0005,University of Nevada,https://www.cse.unr.edu/~hui,kPh6yWIAAAAJ
+Hui Lin 0005,University of Nevada,https://www.cse.unr.edu/~hui,NOSCHOLARPAGE
 Hui Lu 0001,Binghamton University,http://www.cs.binghamton.edu/~huilu,nJLcewkAAAAJ
 Hui Ma 0001,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/HuiMa,o4ssNv4AAAAJ
 Hui Qian,Zhejiang University,http://mypage.zju.edu.cn/qianhui,NOSCHOLARPAGE
@@ -6031,7 +6031,7 @@ Indrajit Ray,Colorado State University,http://www.cs.colostate.edu/~indrajit,blF
 Indrakshi Ray,Colorado State University,http://www.cs.colostate.edu/~iray,7G5G9mkAAAAJ
 Indranil Gupta,Univ. of Illinois at Urbana-Champaign,http://indy.cs.illinois.edu,Waaj7a8AAAAJ
 Indranil Saha,IIT Kanpur,http://cse.iitk.ac.in/users/isaha,2-juveEAAAAJ
-Indranil Sengupta 0001,IIT Kharagpur,http://www.facweb.iitkgp.ernet.in/~isg,1IIL5HUAAAAJ
+Indranil Sengupta 0001,IIT Kharagpur,http://www.facweb.iitkgp.ernet.in/~isg,Nf46wucAAAAJ
 Ing-Ray Chen,Virginia Tech,http://people.cs.vt.edu/~irchen,UdangLEAAAAJ
 Ingemar J. Cox,University College London,http://mediafutures.cs.ucl.ac.uk/people/IngemarCox,b88nUpYAAAAJ
 Ingemar Johansson Cox,University College London,http://mediafutures.cs.ucl.ac.uk/people/IngemarCox,b88nUpYAAAAJ
@@ -6047,7 +6047,7 @@ Inkyoung Hur,Nova Southeastern University,https://cec.nova.edu/faculty/Hur-Inkyo
 Inna Pivkina,New Mexico State University,http://www.cs.nmsu.edu/~ipivkina,NOSCHOLARPAGE
 Insik Shin,KAIST,http://cps.kaist.ac.kr/~ishin,FE04Zl8AAAAJ
 Inso Kweon,KAIST,http://rcv.kaist.ac.kr/v2/bbs/member_detail.php?mb_id=%20iskweon,XA8EOlEAAAAJ
-Insup Lee,University of Pennsylvania,http://www.cis.upenn.edu/~lee,kBGGEjUAAAAJ
+Insup Lee,University of Pennsylvania,http://www.cis.upenn.edu/~lee,qPlUgrgAAAAJ
 Inwhee Joe,Hanyang University,http://wm.hanyang.ac.kr/xe/professor,NOSCHOLARPAGE
 Inês Lynce,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist14029,uvgyhBMAAAAJ
 Ioan Raicu,Illinois Institute of Technology,https://science.iit.edu/people/faculty/ioan-raicu,jE73HYAAAAAJ
@@ -6103,7 +6103,7 @@ Isabel F. Cruz,University of Illinois at Chicago,https://www.cs.uic.edu/Cruz,kdv
 Isabel Harb Manssour,PUC-RS,http://www.inf.pucrs.br/~manssour,Fgas70kAAAAJ
 Isabel Maria Cacho Teixeira,Universidade de Lisboa,https://ciencias.ulisboa.pt/en/perfil/sacmadeira,GuI5uHoAAAAJ
 Isabel Méndez-Díaz,University of Buenos Aires,https://www.dc.uba.ar/rrhh/profesores/mendezdiaz,NOSCHOLARPAGE
-Isabel Nunes,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/minunes,CLnZIEQAAAAJ
+Isabel Nunes,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/minunes,NOSCHOLARPAGE
 Isabel Rosseti,UFF,http://www2.ic.uff.br/~rosseti,PEyGjwsAAAAJ
 Isabel Trancoso,Universidade de Lisboa,https://www.l2f.inesc-id.pt/wiki/index.php/Isabel_Trancoso,Auzu_DcAAAAJ
 Isabelle Augenstein,University of Copenhagen,http://isabelleaugenstein.github.io,DjJp0dcAAAAJ
@@ -6196,7 +6196,7 @@ J. Montgomery,Georgetown University,http://explore.georgetown.edu/people/jm985,X
 J. Nathan Foster,Cornell University,http://www.cs.cornell.edu/~jnfoster,AH5j40kAAAAJ
 J. Nelson Rushton,Texas Tech University,http://www.depts.ttu.edu/cs/department/seminars.php,NOSCHOLARPAGE
 J. P. Misra,BITS Pilani,http://www.bits-pilani.ac.in/pilani/computerscience/Faculty,7HBV4QwAAAAJ
-J. Paul Siebert,University of Glasgow,http://www.dcs.gla.ac.uk/~psiebert,DoEOa80AAAAJ
+J. Paul Siebert,University of Glasgow,http://www.dcs.gla.ac.uk/~psiebert,p_QXUIcAAAAJ
 J. Robin B. Cockett,University of Calgary,http://www.cpsc.ucalgary.ca/~robin,NOSCHOLARPAGE
 J. Ross Beveridge,Colorado State University,http://www.cs.colostate.edu/~ross,pAI5S50AAAAJ
 J. S. Marron,University of North Carolina,http://cs.unc.edu/people/steve-marron,Ft9MrIoAAAAJ
@@ -6220,7 +6220,7 @@ Jack C. Wileden,University of Massachusetts Amherst,http://www.cics.umass.edu/~j
 Jack Dongarra,University of Tennessee,http://www.netlib.org/utk/people/JackDongarra,X4SbSTAAAAAJ
 Jack H. Lutz,Iowa State University,http://www.cs.iastate.edu/~lutz,mxv3BeAAAAAJ
 Jack J. Dongarra,University of Tennessee,http://www.netlib.org/utk/people/JackDongarra,X4SbSTAAAAAJ
-Jack Jansen,CWI,http://homepages.cwi.nl/~jack,qHiBTg0AAAAJ
+Jack Jansen,CWI,http://homepages.cwi.nl/~jack,NOSCHOLARPAGE
 Jack Mostow,Carnegie Mellon University,http://www.cs.cmu.edu/~mostow,P0Mv6pIAAAAJ
 Jack Poulson,Georgia Institute of Technology,http://ideas.gatech.edu/hg/item/185201,NOSCHOLARPAGE
 Jack Sampson,Pennsylvania State University,http://www.cse.psu.edu/~jms1257,fSQCT0YAAAAJ
@@ -6269,7 +6269,7 @@ Jaelson Castro,UFPE,www.cin.ufpe.br/~jbc,Um1B6_4AAAAJ
 Jaelson Freire Brelaz de Castro,UFPE,www.cin.ufpe.br/~jbc,Um1B6_4AAAAJ
 Jaesik Choi,UNIST,http://sail.unist.ac.kr,RqMLVzUAAAAJ
 Jaewoo Kang,Korea University,http://dmis.korea.ac.kr/people,iiIxp8cAAAAJ
-Jafar Habibi,Sharif University of Technology,http://sharif.ir/~jhabibi,fKvyreEAAAAJ
+Jafar Habibi,Sharif University of Technology,http://sharif.ir/~jhabibi,SCmyROQAAAAJ
 Jagannathan Sarangapani,Missouri University of Technology,http://web.mst.edu/~sarangap,RTewL_wAAAAJ
 Jagarlapudi Saketha Nath,IIT Hyderabad,http://www.iith.ac.in/~saketha,k70LrvsAAAAJ
 Jagath C. Rajapakse,Nanyang Technological University,http://www.ntu.edu.sg/home/asjagath,9WPWHiEAAAAJ
@@ -6281,9 +6281,9 @@ Jaijeet S. Roychowdhury,University of California - Berkeley,https://www2.eecs.be
 Jaikumar Radhakrishnan,Tata Institute of Fundamental Research,http://www.tcs.tifr.res.in/~jaikumar,R-Iyl4gAAAAJ
 Jaime Delgado,Polytechnic University of Catalonia,http://ieeexplore.ieee.org/document/6214725/?section=abstract,RSDAEdAAAAAJ
 Jaime Delgado Merce,Polytechnic University of Catalonia,http://ieeexplore.ieee.org/document/6214725/?section=abstract,RSDAEdAAAAAJ
-Jaime G. Carbonell,Carnegie Mellon University,https://www.cs.cmu.edu/~jgc,uSfaEgUAAAAJ
+Jaime G. Carbonell,Carnegie Mellon University,https://www.cs.cmu.edu/~jgc,wlqqttEAAAAJ
 Jaime Ruiz,University of Florida,https://www.jaimeruiz.com,K1O-ZPIAAAAJ
-Jaime Simao Sichman,USP,https://www2.pcs.usp.br/pcsv6/index.php/131-docentes/223-jaime,rlSHIHIAAAAJ
+Jaime Simao Sichman,USP,https://www2.pcs.usp.br/pcsv6/index.php/131-docentes/223-jaime,AB5eMwwAAAAJ
 Jaime Viegas,Masdar Institute,https://www.masdar.ac.ae/aboutus/management/faculty-directory/item/5686-jaime-viegas,R97KDQ0AAAAJ
 Jainendra K. Navlakha,Florida International University,https://www.cis.fiu.edu/faculty-staff/navlakha-jainendra-k,NOSCHOLARPAGE
 Jakob Eriksson,University of Illinois at Chicago,https://www.cs.uic.edu/Jakob,kLUW0psAAAAJ
@@ -6326,7 +6326,7 @@ James Cheney,University of Edinburgh,http://homepages.inf.ed.ac.uk/jcheney,G-1f1
 James Cheng,Chinese University of Hong Kong,http://www.cse.cuhk.edu.hk/~jcheng,M--dS1EAAAAJ
 James Clause,University of Delaware,https://www.eecis.udel.edu/~clause,CappitoAAAAJ
 James Cremer,University of Iowa,https://www.cs.uiowa.edu/~cremer,At2chacAAAAJ
-James Cussens,University of York,https://www-users.cs.york.ac.uk/~jc,OEFkOR0AAAAJ
+James Cussens,University of York,https://www-users.cs.york.ac.uk/~jc,xsWMG_UAAAAJ
 James D. Foley,Georgia Institute of Technology,http://www.cc.gatech.edu/fac/Jim.Foley/foley.html,GmcChLIAAAAJ
 James D. Herbsleb,Carnegie Mellon University,http://herbsleb.org,NOSCHOLARPAGE
 James D. Hollan,University of California - San Diego,http://hci.ucsd.edu/hollan,LOFYnLkAAAAJ
@@ -6340,7 +6340,7 @@ James E. Young,University of Manitoba,http://home.cs.umanitoba.ca/~young,NOSCHOL
 James Elder,York University,http://elderlab.yorku.ca/~elder,wSBFrb8AAAAJ
 James Everett Young,University of Manitoba,http://home.cs.umanitoba.ca/~young,NOSCHOLARPAGE
 James F. Allen,University of Rochester,http://www.cs.rochester.edu/~james,FxPzh9kAAAAJ
-James F. Kurose,University of Massachusetts Amherst,http://www-net.cs.umass.edu/personnel/kurose.html,ogj8ppAAAAAJ
+James F. Kurose,University of Massachusetts Amherst,http://www-net.cs.umass.edu/personnel/kurose.html,NOSCHOLARPAGE
 James F. O'Brien,University of California - Berkeley,http://obrien.berkeley.edu,UWZA0v4AAAAJ
 James Fastook,University of Maine,https://umaine.edu/scis/faculty-and-staff/james-fastook,ea1-wPUAAAAJ
 James Fleming,Dalhousie University,https://www.dal.ca/faculty/computerscience/faculty-staff/james-fleming.html,BU9Rmm8AAAAJ
@@ -6451,7 +6451,7 @@ Jan Otop,University of Wroclaw,http://popl16.sigplan.org/profile/janotop,EueQHIg
 Jan P. H. van Santen,OHSU,http://cslu.ohsu.edu/~vansanten,NOSCHOLARPAGE
 Jan P. de Ruiter,Tufts University,http://www.uni-bielefeld.de/lili/personen/jruiter,NOSCHOLARPAGE
 Jan Paredis,Maastricht University,https://www.maastrichtuniversity.nl/j.paredis,hJqMjHYAAAAJ
-Jan Paul Siebert,University of Glasgow,http://www.dcs.gla.ac.uk/~psiebert,DoEOa80AAAAJ
+Jan Paul Siebert,University of Glasgow,http://www.dcs.gla.ac.uk/~psiebert,p_QXUIcAAAAJ
 Jan Peter de Ruiter,Tufts University,http://www.uni-bielefeld.de/lili/personen/jruiter,NOSCHOLARPAGE
 Jan Peters 0001,TU Darmstadt,http://www.kyb.mpg.de/~jrpeters,gXj_GRwAAAAJ
 Jan Prins,University of North Carolina,http://www.cs.unc.edu/~prins,VFMbBPgAAAAJ
@@ -6464,7 +6464,7 @@ Jan Strejcek,Masaryk University,https://www.muni.cz/en/people/3366,2Bdz-iAAAAAJ
 Jan Treur,VU Amsterdam,http://www.cs.vu.nl/~treur,2NzjnkYAAAAJ
 Jan Vitek,Northeastern University,http://janvitek.org,Ws0GjboAAAAJ
 Jan van Eijck,CWI,http://homepages.cwi.nl/~jve,ptYHch4AAAAJ
-Jan-Michael Frahm,University of North Carolina,http://frahm.web.unc.edu,3YOe4NMAAAAJ
+Jan-Michael Frahm,University of North Carolina,http://frahm.web.unc.edu,nzz6PQMAAAAJ
 Jan-Willem van de Meent,Northeastern University,http://www.robots.ox.ac.uk/~jwvdm,CX9Lu38AAAAJ
 Jana Kosecka,George Mason University,https://cs.gmu.edu/~kosecka,sQ6l4sMAAAAJ
 Jana Kosecká,George Mason University,https://cs.gmu.edu/~kosecka,sQ6l4sMAAAAJ
@@ -6537,7 +6537,7 @@ Jatindra Kumar Deka,IIT Guwahati,https://www.iitg.ernet.in/jatin,yCTfZRwAAAAJ
 Javad Sadri,Concordia University,https://users.encs.concordia.ca/~j_sadri,DYai0j0AAAAJ
 Javed A. Aslam,Northeastern University,http://www.ccs.neu.edu/home/jaa,M9OmxR8AAAAJ
 Javed Khan,Kent State University,http://www.cs.kent.edu/~javed,NOSCHOLARPAGE
-Javier Cuenca,University of Murcia,http://ditec.um.es/%7Ejaviercm/index_english.html,VfJyirIAAAAJ
+Javier Cuenca,University of Murcia,http://ditec.um.es/%7Ejaviercm/index_english.html,NOSCHOLARPAGE
 Javier Cámara,University of York,http://www.javicamara.com,iMMncw8AAAAJ
 Javier Cámara Moreno,University of York,http://www.javicamara.com,iMMncw8AAAAJ
 Javier Esparza,TU Munich,https://www7.in.tum.de/people/detail/index.php?id=people.detail&arg=33,c9qgPSYAAAAJ
@@ -6572,7 +6572,7 @@ Jean Goubault-Larrecq,Ecole Normale Superieure de Cachan,http://www.lsv.ens-cach
 Jean Gourd,Louisiana Tech University,https://www.latech.edu/faculty-staff/single-entry/name/jean-gourd,NOSCHOLARPAGE
 Jean H. Gallier,University of Pennsylvania,http://www.cis.upenn.edu/~jean,kYK4tvsAAAAJ
 Jean Honorio,Purdue University,https://www.cs.purdue.edu/homes/jhonorio,8OW3TMMAAAAJ
-Jean Mayo,Michigan Technological University,https://www.mtu.edu/cs/department/faculty-staff/faculty/mayo,MjIy_X0AAAAJ
+Jean Mayo,Michigan Technological University,https://www.mtu.edu/cs/department/faculty-staff/faculty/mayo,NOSCHOLARPAGE
 Jean Meunier,University of Montreal,http://www.iro.umontreal.ca/~meunier,El03_L8AAAAJ
 Jean Ponce,Ecole Normale Superieure,http://www.di.ens.fr/~ponce,vC2vywcAAAAJ
 Jean Vuillemin,Ecole Normale Superieure,http://www.di.ens.fr/~jv,tPVtuMwAAAAJ
@@ -6603,7 +6603,7 @@ Jefersson Alex dos Santos,UFMG,http://homepages.dcc.ufmg.br/~jefersson,wXQnnTUAA
 Jeff Clune,University of Wyoming,http://www.uwyo.edu/profiles/extras/playing-with-robots.html,5TZ7f5wAAAAJ
 Jeff Dalton 0001,University of Glasgow,https://www.gla.ac.uk/schools/computing/staff/jeffdalton,mgwLi-EAAAAJ
 Jeff Edmonds,York University,http://www.cs.yorku.ca/~jeff,AjD7zfgAAAAJ
-Jeff Erickson 0001,Univ. of Illinois at Urbana-Champaign,http://jeffe.cs.illinois.edu,uS9jHPkAAAAJ
+Jeff Erickson 0001,Univ. of Illinois at Urbana-Champaign,http://jeffe.cs.illinois.edu,NOSCHOLARPAGE
 Jeff Gray,The University of Alabama,http://gray.cs.ua.edu,83an8lYAAAAJ
 Jeff Heflin,Lehigh University,http://www.cse.lehigh.edu/~heflin,NOSCHOLARPAGE
 Jeff Huang 0001,Texas A&M University,https://parasol.tamu.edu/~jeff,UmrxW60AAAAJ
@@ -6742,7 +6742,7 @@ Jessica Hammer,Carnegie Mellon University,https://www.hcii.cmu.edu/people/jessic
 Jessica Hullman,Northwestern University,http://faculty.washington.edu/jhullman,OLa9EKsAAAAJ
 Jessica K. Hodgins,Carnegie Mellon University,http://www.cs.cmu.edu/~jkh,NOSCHOLARPAGE
 Jessica Lin 0001,George Mason University,http://cs.gmu.edu/~jessica,tRHOWkcAAAAJ
-Jesualdo Tomás Fernández-Breis,University of Murcia,http://webs.um.es/jfernand/miwiki/doku.php,KaEwPLIAAAAJ
+Jesualdo Tomás Fernández-Breis,University of Murcia,http://webs.um.es/jfernand/miwiki/doku.php,NOSCHOLARPAGE
 Jesus García Molina,University of Murcia,http://dis.um.es/~jmolina,GU8Kf8UAAAAJ
 Jesus Ángel Velázquez-Iturbide,Universidad Rey Juan Carlos,http:/www.lite.etsii.urjc.es/angel.velazquez,JfWXVVgAAAAJ
 Jesús Labarta,Polytechnic University of Catalonia,https://www.bsc.es/labarta-mancho-jesus,6vj6TdsAAAAJ
@@ -6785,7 +6785,7 @@ Jian-Hua Chen,Louisiana State University - Baton Rouge,https://www.lsu.edu/eng/c
 Jian-Xin Wu,Nanjing University,https://cs.nju.edu.cn/wujx,NOSCHOLARPAGE
 Jian-Yun Nie,University of Montreal,http://rali.iro.umontreal.ca/nie/jian-yun-nie-en,W7uYg0UAAAAJ
 Jian-bin Hu,Peking University,http://eecs.pku.edu.cn/EN/People/Faculty/Detail/?ID=6086,NOSCHOLARPAGE
-Jianbin Qin,UNSW,http://www.cse.unsw.edu.au/~jqin,sYRSNY8AAAAJ
+Jianbin Qin,UNSW,http://www.cse.unsw.edu.au/~jqin,2ZmhZpgAAAAJ
 Jianbo Shi,University of Pennsylvania,https://www.cis.upenn.edu/~jshi,Sm14jYIAAAAJ
 Jianer Chen,Texas A&M University,http://faculty.cs.tamu.edu/chen,0zVOVQ0AAAAJ
 Jianfei Cai,Nanyang Technological University,http://www.ntu.edu.sg/home/asjfcai,N6czCoUAAAAJ
@@ -6885,7 +6885,7 @@ Jim Griffioen,University of Kentucky,http://protocols.netlab.uky.edu/~griff,NOSC
 Jim Hendler,Rensselaer Polytechnic Institute,http://www.cs.rpi.edu/~hendler,JNPbTdIAAAAJ
 Jim Hollan,University of California - San Diego,http://hci.ucsd.edu/hollan,LOFYnLkAAAAJ
 Jim Ji,Texas A&M at Qatar,https://www.qatar.tamu.edu/programs/ecen/faculty-and-staff/duplicate-of-dr.-luc-vechot,i_OEg60AAAAJ
-Jim Kurose,University of Massachusetts Amherst,http://www-net.cs.umass.edu/personnel/kurose.html,ogj8ppAAAAAJ
+Jim Kurose,University of Massachusetts Amherst,http://www-net.cs.umass.edu/personnel/kurose.html,NOSCHOLARPAGE
 Jim Laird,University of Bath,http://www.bath.ac.uk/comp-sci/contacts/academics/james_laird,_Gi9Hl4AAAAJ
 Jim Leone,Rochester Institute of Technology,http://www.ist.rit.edu/~leone,ivIz4JYAAAAJ
 Jim Martin,Clemson University,https://people.cs.clemson.edu/~jmarty,66VE-3MAAAAJ
@@ -6924,7 +6924,7 @@ Jing He,Old Dominion University,http://www.cs.odu.edu/~jhe,r4WtU2oAAAAJ
 Jing Hua,Wayne State University,http://www.cs.wayne.edu/~jinghua,E0PGasMAAAAJ
 Jing Jiang 0001,Singapore Management University,http://www.mysmu.edu/faculty/jingjiang,hVTK2YwAAAAJ
 Jing Jiang 0002,University of Technology Sydney,https://www.uts.edu.au/staff/jing.jiang,XFtCe08AAAAJ
-Jing Kong,Massachusetts Institute of Technology,http://www.rle.mit.edu/nmeg,WNOWLXAAAAAJ
+Jing Kong,Massachusetts Institute of Technology,http://www.rle.mit.edu/nmeg,w0iKa2kAAAAJ
 Jing Li 0002,Case Western Reserve University,https://cwru.pure.elsevier.com/en/publications/drug-target-predictions-based-on-heterogeneous-graph-inference-2,X6P8JOIAAAAJ
 Jing Li 0025,NJIT,https://web.njit.edu/~jingli,eFjZ6jAAAAAJ
 Jing Sun 0002,University of Auckland,https://www.cs.auckland.ac.nz/~jingsun,GUXAGAYAAAAJ
@@ -7064,7 +7064,7 @@ John A. Carroll,University of Sussex,http://www.sussex.ac.uk/informatics/people/
 John A. Goldsmith,University of Chicago,https://linguistics.uchicago.edu/faculty/goldsmith,OGbi6t0AAAAJ
 John A. Halderman,University of Michigan,https://jhalderm.com,h6yXnyEAAAAJ
 John A. Kapenga,Western Michigan University,https://wmich.edu/cs/directory/kapenga,NOSCHOLARPAGE
-John A. McDermid,University of York,https://www-users.cs.york.ac.uk/~jam,REscLkoAAAAJ
+John A. McDermid,University of York,https://www-users.cs.york.ac.uk/~jam,NOSCHOLARPAGE
 John A. Miller,University of Georgia,http://cobweb.cs.uga.edu/~jam,zTBeQq0AAAAJ
 John A. Richards,Australian National University,https://cecs.anu.edu.au/people/john-richards,UxmHb8sAAAAJ
 John A. Stankovic,University of Virginia,https://engineering.virginia.edu/faculty/john-stankovic,4VJre9IAAAAJ
@@ -7193,9 +7193,9 @@ John Williamson,University of Glasgow,http://www.dcs.gla.ac.uk/~jhw,fcvb8f8AAAAJ
 John Yiannis Cotronis,University of Athens,http://www.di.uoa.gr/eng/staff/1022,9IbOFmMAAAAJ
 John Zahorjan,University of Washington,https://homes.cs.washington.edu/~zahorjan,NOSCHOLARPAGE
 John Zimmerman,Carnegie Mellon University,https://www.cs.cmu.edu/~johnz,A-4JUL4AAAAJ
-Johnny S. Wong,Iowa State University,http://www.cs.iastate.edu/people/johnny-wong,w3UeCAoAAAAJ
-Johnny Wong,Iowa State University,http://www.cs.iastate.edu/people/johnny-wong,w3UeCAoAAAAJ
-Johnson Thomas,Oklahoma State University,http://www.cs.okstate.edu/~jpt,pyIZFggAAAAJ
+Johnny S. Wong,Iowa State University,http://www.cs.iastate.edu/people/johnny-wong,57pKMKwAAAAJ
+Johnny Wong,Iowa State University,http://www.cs.iastate.edu/people/johnny-wong,57pKMKwAAAAJ
+Johnson Thomas,Oklahoma State University,http://www.cs.okstate.edu/~jpt,eKLr0EgAAAAJ
 Joke Blom,CWI,http://homepages.cwi.nl/~gollum,Za0-ttMAAAAJ
 Joke G. Blom,CWI,http://homepages.cwi.nl/~gollum,Za0-ttMAAAAJ
 Jon A. Solworth,University of Illinois at Chicago,http://parsys.eecs.uic.edu/~solworth,NOSCHOLARPAGE
@@ -7243,7 +7243,7 @@ Jonathan Turner,Washington University in St. Louis,http://www.arl.wustl.edu/~jst
 Jonathan Ullman,Northeastern University,http://www.ccis.northeastern.edu/people/jonathan-ullman,WfS41RAAAAAJ
 Jonathan Ventura,Univ. of Colorado Colorado Springs,http://jventura.net,k0E68OgAAAAJ
 Jonathan W. Pillow,Princeton University,http://pillowlab.princeton.edu,NOSCHOLARPAGE
-Jonathan Walpole,Portland State University,http://web.cecs.pdx.edu/~walpole,-pS6P-oAAAAJ
+Jonathan Walpole,Portland State University,http://web.cecs.pdx.edu/~walpole,NOSCHOLARPAGE
 Jonathan Whittle,Monash University,https://research.monash.edu/en/persons/jon-whittle,igMJAZwAAAAJ
 Jonathan Zittrain,Harvard University,http://hls.harvard.edu/faculty/directory/10992/Zittrain,aWZ0YN4AAAAJ
 Jong Cheol Park,KAIST,http://nlp.kaist.ac.kr,u1XiOgvCXnQC
@@ -7423,7 +7423,7 @@ José Viterbo Filho,UFF,http://www.ic.uff.br/index.php/en-GB/people/317-faculty-
 Jouko Lampinen,Aalto University,https://people.aalto.fi/new/jouko.lampinen,Hk0Q8TkAAAAJ
 Joxan Jaffar,National University of Singapore,https://www.comp.nus.edu.sg/~joxan,TElUKBYAAAAJ
 Joy Arulraj,Georgia Institute of Technology,https://www.cc.gatech.edu/~jarulraj,rp8dOfAAAAAJ
-Joyce C. Ho,Emory University,http://joyceho.github.io,e-aNh24AAAAJ
+Joyce C. Ho,Emory University,http://joyceho.github.io,DrUBb5sAAAAJ
 Joyce Y. Chai,Michigan State University,http://www.cse.msu.edu/~jchai,NOSCHOLARPAGE
 Joyce Yue Chai,Michigan State University,http://www.cse.msu.edu/~jchai,NOSCHOLARPAGE
 Joydeep Biswas,University of Massachusetts Amherst,https://www.cics.umass.edu/person/biswas-joydeep,f28F1YUAAAAJ
@@ -7546,7 +7546,7 @@ Julie A. McCann,Imperial College London,http://wp.doc.ic.ac.uk/aese/person/julie
 Julie A. Shah,Massachusetts Institute of Technology,http://people.csail.mit.edu/julie_a_shah,NOSCHOLARPAGE
 Julie Ann McCann,Imperial College London,http://wp.doc.ic.ac.uk/aese/person/julie-a-mccann,S6wyzdwAAAAJ
 Julie Dorsey,Yale University,http://graphics.cs.yale.edu/julie,IYXVU-QAAAAJ
-Julie Fisher,Monash University,http://www.sims.monash.edu.au/staff/jfisher,hLCaPfAAAAAJ
+Julie Fisher,Monash University,http://www.sims.monash.edu.au/staff/jfisher,NOSCHOLARPAGE
 Julie Rico,University of Glasgow,http://juliericowilliamson.com,qUtAKFQAAAAJ
 Julie Rico Williamson,University of Glasgow,http://juliericowilliamson.com,qUtAKFQAAAAJ
 Julie Weeds,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/116624,goWjVPQAAAAJ
@@ -7579,7 +7579,7 @@ Jun Kong,North Dakota State University,http://www.cs.ndsu.nodak.edu/~jkong,NOSCH
 Jun Li 0001,University of Oregon,http://ix.cs.uoregon.edu/~lijun,J8NUZDMAAAAJ
 Jun Luo,Nanyang Technological University,http://www.ntu.edu.sg/home/junluo,Ng_zmUUAAAAJ
 Jun Miyazaki,Tokyo Institute of Technology,http://www.lsc.cs.titech.ac.jp/en,NOSCHOLARPAGE
-Jun Sun 0001,SUTD,http://www.icst.pku.edu.cn/vip/people-sunjE.html,1YOovW8AAAAJ
+Jun Sun 0001,SUTD,http://www.icst.pku.edu.cn/vip/people-sunjE.html,NOSCHOLARPAGE
 Jun Sun 0012,Peking University,http://www.icst.pku.edu.cn/vip/people-sunjE.html,NOSCHOLARPAGE
 Jun Wang 0001,University of Central Florida,http://www.cass.eecs.ucf.edu/?page_id=1249,wYNgwnMAAAAJ
 Jun Wang 0012,University College London,http://www.cs.ucl.ac.uk/people/J.Wang.html,wIE1tY4AAAAJ
@@ -7615,7 +7615,7 @@ Junghoo Cho,University of California - Los Angeles,http://www.cs.ucla.edu/~cho,D
 Junhui Deng,Tsinghua University,https://dsa.cs.tsinghua.edu.cn,NOSCHOLARPAGE
 Junichi Suzuki,University of Massachusetts Boston,https://www.umb.edu/academics/csm/faculty_staff/jun_suzuki,4oVjDuoAAAAJ
 Junier B. Oliva, University of North Carolina,https://sites.google.com/cs.unc.edu/joliva/home,CqH_t6MAAAAJ
-Junior Barrera,USP,http://www.ime.usp.br/~jb,NbfbLAwAAAAJ
+Junior Barrera,USP,http://www.ime.usp.br/~jb,FSrFOAMAAAAJ
 Junliang Xing,Chinese Academy of Sciences,https://sites.google.com/site/junliangxing,jSwNd3MAAAAJ
 Junlin Lu,Peking University,http://eecs.pku.edu.cn/EN/People/Faculty/Detail/?ID=5937,NOSCHOLARPAGE
 Junlin Zhou,Uninversity of Electronic Science and Technology of China,http://en.uestc.edu.cn/index.php?m=content&c=index&a=show&catid=79&id=4779,pOmjyCEAAAAJ
@@ -7634,8 +7634,8 @@ Jure Leskovec,Stanford University,https://cs.stanford.edu/people/jure,Q_kKkIUAAA
 Jurgen J. Vinju,CWI,http://homepages.cwi.nl/~jurgenv,NOSCHOLARPAGE
 Jurriaan Rot,Ecole Normale Superieure de Lyon,http://www.summerschool.sei.ecnu.edu.cn,o5kqbqIAAAAJ
 Juseop Lee,Korea University,https://sites.google.com/site/juseoplee,NOSCHOLARPAGE
-Jussara M. Almeida,UFMG,http://homepages.dcc.ufmg.br/~jussara,pkf_HjEAAAAJ
-Jussara Marques de Almeida,UFMG,http://homepages.dcc.ufmg.br/~jussara,pkf_HjEAAAAJ
+Jussara M. Almeida,UFMG,http://homepages.dcc.ufmg.br/~jussara,vr8aFwUAAAAJ
+Jussara Marques de Almeida,UFMG,http://homepages.dcc.ufmg.br/~jussara,vr8aFwUAAAAJ
 Justin Bradley,University of Nebraska,http://justinbradley.unl.edu,JOvtrn8AAAAJ
 Justin Cappos,New York University,http://engineering.nyu.edu/people/justin-cappos,COE6KUgAAAAJ
 Justin Domke,University of Massachusetts Amherst,https://www.cics.umass.edu/faculty/directory/domke-justin,NOSCHOLARPAGE
@@ -7702,7 +7702,7 @@ K. Kalorkoti,University of Edinburgh,http://www.research.ed.ac.uk/portal/en/pers
 K. Lakshmanan,IIT (BHU) Varanasi,http://www.iitbhu.ac.in/cse/index.php/people/faculty.html,K2Q4ZxkAAAAJ
 K. M. George,Oklahoma State University,https://www.cs.okstate.edu/~kmg,NOSCHOLARPAGE
 K. Madhava Krishna,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/mkrishna,QDuPGHwAAAAJ
-K. Narayan Kumar,CMI,http://www.cmi.ac.in/~kumar,iREqKFwAAAAJ
+K. Narayan Kumar,CMI,http://www.cmi.ac.in/~kumar,tCMqMNIAAAAJ
 K. S. Rajan,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/rajan,00_zU7QAAAAJ
 K. Selçuk Candan,Arizona State University,http://aria.asu.edu/candan,keO-0s0AAAAJ
 K. Sreenivas Rao,IIT Kharagpur,http://sit.iitkgp.ernet.in/~ksrao,TATEL2EAAAAJ
@@ -8022,7 +8022,7 @@ Kentaro Shimizu,University of Tokyo,http://www.bi.a.u-tokyo.ac.jp/~shimizu/index
 Keon Jang,Max Planck Institute,http://www.mpi-sws.org/~keonjang,L-nHQIkAAAAJ
 Keren Censor,Technion,http://ckeren.net.technion.ac.il,HdOuwlQAAAAJ
 Keren Censor-Hillel,Technion,http://ckeren.net.technion.ac.il,HdOuwlQAAAAJ
-Kerri Morgan,Monash University,http://monash.edu/research/explore/en/persons/kerri-morgan(62727ef9-6bfc-4a09-9d9c-b91b69d8b6bb).html,5WOihGQAAAAJ
+Kerri Morgan,Monash University,http://monash.edu/research/explore/en/persons/kerri-morgan(62727ef9-6bfc-4a09-9d9c-b91b69d8b6bb).html,NOSCHOLARPAGE
 Kerstin Bach,NTNU,https://www.ntnu.edu/employees/kerstin.bach,DJzQ1J8AAAAJ
 Kerstin Eder,University of Bristol,http://www.bris.ac.uk/engineering/people/kerstin-i-eder/index.html,SyDaZIoAAAAJ
 Keshav Pingali,University of Texas at Austin,http://www.cs.utexas.edu/~pingali,02UU6wgAAAAJ
@@ -8064,10 +8064,10 @@ Khair Eddin Sabri,University of Jordan,http://eacademic.ju.edu.jo/k.sabri,JBbuUt
 Khaled B. Shaban,Qatar University,http://qufaculty.qu.edu.qa/khaled-shaban,jO_M2XoAAAAJ
 Khaled Bashir Shaban,Qatar University,http://qufaculty.qu.edu.qa/khaled-shaban,jO_M2XoAAAAJ
 Khaled Harfoush,North Carolina State University,http://www4.ncsu.edu/~kaharfou,NOSCHOLARPAGE
-Khaled Khan,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/khaled_khan.php,SpQmNnoAAAAJ
+Khaled Khan,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/khaled_khan.php,apJhxSwAAAAJ
 Khaled M. Elbassioni,Masdar Institute,https://www.masdar.ac.ae/aboutus/management/faculty-directory/item/5982-khaled-elbassioni,yOXQRzMAAAAJ
-Khaled M. Khan,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/khaled_khan.php,SpQmNnoAAAAJ
-Khaled Md. Khan,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/khaled_khan.php,SpQmNnoAAAAJ
+Khaled M. Khan,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/khaled_khan.php,apJhxSwAAAAJ
+Khaled Md. Khan,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/khaled_khan.php,apJhxSwAAAAJ
 Khaled Rasheed,University of Georgia,http://cobweb.cs.uga.edu/~khaled,h_GqAPAAAAAJ
 Khaled Shaban,Qatar University,http://qufaculty.qu.edu.qa/khaled-shaban,jO_M2XoAAAAJ
 Khalid A. Qaraqe,Texas A&M at Qatar,http://people.qatar.tamu.edu/khalid.qaraqe/kqperso,bY3oBEAAAAAJ
@@ -8300,7 +8300,7 @@ L. Ridgway Scott,University of Chicago,http://people.cs.uchicago.edu/~ridg,gBefo
 L. Sunil Chandran,IISc Bangalore,http://www.csa.iisc.ac.in/~sunil,020isz4AAAAJ
 Laci Babai,University of Chicago,http://people.cs.uchicago.edu/~laci,NOSCHOLARPAGE
 Ladislau Bölöni,University of Central Florida,http://www.cs.ucf.edu/~lboloni,NOSCHOLARPAGE
-Ladislav Kavan,University of Utah,https://www.cs.utah.edu/~ladislav,6YTlV5oAAAAJ
+Ladislav Kavan,University of Utah,https://www.cs.utah.edu/~ladislav,NOSCHOLARPAGE
 Lai-Wan Chan,Chinese University of Hong Kong,http://www.cse.cuhk.edu.hk/~lwchan,9z_5eo8AAAAJ
 Laila Nassef,King Abdulaziz University,http://www.kau.edu.sa/Contacts.aspx?Site_ID=611&Lng=EN&Cont=17753,NOSCHOLARPAGE
 Laiwan Chan,Chinese University of Hong Kong,http://www.cse.cuhk.edu.hk/~lwchan,9z_5eo8AAAAJ
@@ -8504,7 +8504,7 @@ Leonid Kontorovich,Ben-Gurion University of the Negev,https://www.cs.bgu.ac.il/~
 Leonid Libkin,University of Edinburgh,http://homepages.inf.ed.ac.uk/libkin,4q-MIB0AAAAJ
 Leonid Reyzin,Boston University,https://www.cs.bu.edu/~reyzin,1KRXBIwAAAAJ
 Leonid Sazanov,IST Austria,https://ist.ac.at/research/research-groups/sazanov-group,njTNIzUAAAAJ
-Leonid Sigal,University of British Columbia,https://www.cs.ubc.ca/~lsigal,Ywx45aQAAAAJ
+Leonid Sigal,University of British Columbia,https://www.cs.ubc.ca/~lsigal,NOSCHOLARPAGE
 Leonidas Fegaras,University of Texas at Arlington,http://lambda.uta.edu,NOSCHOLARPAGE
 Leonidas J. Guibas,Stanford University,http://geometry.stanford.edu/member/guibas,5JlEyTAAAAAJ
 Leopoldo E. Bertossi,Carleton University,http://www.scs.carleton.ca/~bertossi,TeBUgNcAAAAJ
@@ -8595,7 +8595,7 @@ Lin Zhong 0001,Rice University,http://www.ruf.rice.edu/~lzhong,HeHFFW8AAAAJ
 Lin-shan Lee,National Taiwan University,http://speech.ee.ntu.edu.tw/previous_version/lslNew.htm,NOSCHOLARPAGE
 LinLin Shen,Shenzhen University,http://csse.szu.edu.cn/en/people31dd.html?25226,AZ_y9HgAAAAJ
 Lina Yao,UNSW,http://www.linayao.com,EU3snBgAAAAJ
-Linda G. Shapiro,University of Washington,http://cs.washington.edu/homes/shapiro,6pGeV2wAAAAJ
+Linda G. Shapiro,University of Washington,http://cs.washington.edu/homes/shapiro,nBwaXUsAAAAJ
 Linda Jean Camp,Indiana University,http://ljean.com,wJPGa2IAAAAJ
 Linda Ott,Michigan Technological University,https://www.mtu.edu/cs/department/faculty-staff/faculty/ott,HnxM2zkAAAAJ
 Linda Pagli,University of Pisa,http://www.di.unipi.it/~pagli,NOSCHOLARPAGE
@@ -8708,7 +8708,7 @@ Louay M. J. Bazzi,American University of Beirut,https://www.aub.edu.lb/fea/publi
 Louis D'Alotto,CUNY,https://www.york.cuny.edu/portal_college/ldaotto,OtxLPl4AAAAJ
 Louis D. Nel,Carleton University,http://www.scs.carleton.ca/~ldnel,NOSCHOLARPAGE
 Louis I. Steinberg,Rutgers University,https://www.cs.rutgers.edu/~lou,NOSCHOLARPAGE
-Louis Petingi,CUNY,http://www.cs.csi.cuny.edu/~petingi,LCBI27EAAAAJ
+Louis Petingi,CUNY,http://www.cs.csi.cuny.edu/~petingi,NOSCHOLARPAGE
 Louis Salvail,University of Montreal,http://www.iro.umontreal.ca/~salvail,NOSCHOLARPAGE
 Louis-Philippe Morency,Carnegie Mellon University,https://www.cs.cmu.edu/~morency,APgaFK0AAAAJ
 Lourdes Agapito,University College London,http://www0.cs.ucl.ac.uk/people/L.Agapito.html,IRMX4-4AAAAJ
@@ -8785,7 +8785,7 @@ Luiz Fernando Bittencourt,UNICAMP,http://www.ic.unicamp.br/~bit,ohMT6gcAAAAJ
 Luiz Filipe M. Vieira,UFMG,http://homepages.dcc.ufmg.br/~lfvieira,KGysOTEAAAAJ
 Luiz Filipe Menezes Vieira,UFMG,http://homepages.dcc.ufmg.br/~lfvieira,KGysOTEAAAAJ
 Luiz Gustavo Almeida Martins,UFU,http://www.facom.ufu.br/~gustavo,2p2GbVYAAAAJ
-Luiz Gustavo Fernandes,PUC-RS,http://www.inf.pucrs.br/~gustavo,ZkUd394AAAAJ
+Luiz Gustavo Fernandes,PUC-RS,http://www.inf.pucrs.br/~gustavo,NOSCHOLARPAGE
 Luiz S. Ochi,UFF,http://www2.ic.uff.br/~satoru,w3KB2MoAAAAJ
 Luiz Satoru Ochi,UFF,http://www2.ic.uff.br/~satoru,w3KB2MoAAAAJ
 Luiza Antonie,University of Guelph,http://www.uoguelph.ca/~lantonie,NOSCHOLARPAGE
@@ -8800,7 +8800,7 @@ Luke J. Lee,University of California - Berkeley,http://biopoets.berkeley.edu,xAD
 Luke N. Olson,Univ. of Illinois at Urbana-Champaign,http://lukeo.cs.illinois.edu,o43oc6AAAAAJ
 Luke Olson,Univ. of Illinois at Urbana-Champaign,http://lukeo.cs.illinois.edu,o43oc6AAAAAJ
 Luke Ong,University of Oxford,https://www.cs.ox.ac.uk/luke.ong,NOSCHOLARPAGE
-Lunjin Lu,Oakland University,http://www.secs.oakland.edu/~l2lu,HkY25zMAAAAJ
+Lunjin Lu,Oakland University,http://www.secs.oakland.edu/~l2lu,3a1NXCwAAAAJ
 Luoyi Fu,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/~fu-ly/index.html,xHs9mCUAAAAJ
 Luqi,Naval Postgraduate School,http://faculty.nps.edu/luqi,OJBm5MYAAAAJ
 Lutz Maicher,Friedrich Schiller University Jena,http://tt.uni-jena.de,8k5_f7cAAAAJ
@@ -8875,9 +8875,9 @@ Macario O. Cordel II,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs
 Maciej Piróg,University of Wroclaw,https://www.cs.ox.ac.uk/people/maciej.pirog,xxwcLlAAAAAJ
 Madalina Fiterau,University of Massachusetts Amherst,http://www.cs.cmu.edu/~mfiterau,NTHsaUQAAAAJ
 Madeleine Udell,Cornell University,https://people.orie.cornell.edu/mru8,tZ9pEDMAAAAJ
-Madhav Marathe,University of Virginia,https://engineering.virginia.edu/faculty/madhav-marathe,cLjMQqsAAAAJ
+Madhav Marathe,University of Virginia,https://engineering.virginia.edu/faculty/madhav-marathe,diIore8AAAAJ
 Madhav Rao,IIIT Bangalore,http://www.iiitb.ac.in/faculty_page.php?name=MadhavRao,B7Eg5RsAAAAJ
-Madhav V. Marathe,University of Virginia,https://engineering.virginia.edu/faculty/madhav-marathe,cLjMQqsAAAAJ
+Madhav V. Marathe,University of Virginia,https://engineering.virginia.edu/faculty/madhav-marathe,diIore8AAAAJ
 Madhavan Mukund,CMI,http://www.cmi.ac.in/~madhavan,NOSCHOLARPAGE
 Madhu Lata Goyal,University of Technology Sydney,https://www.uts.edu.au/staff/madhu.goyal-2,sDCO31YAAAAJ
 Madhu Mutyam,IIT Madras,http://www.cse.iitm.ac.in/~madhu,HS4VEdYAAAAJ
@@ -8920,7 +8920,7 @@ Mahmoud R. El-Sakka,Western University,http://www.csd.uwo.ca/~elsakka,NOSCHOLARP
 Mahmoud Rasras,Masdar Institute,https://www.masdar.ac.ae/aboutus/management/faculty-directory/item/5980-mahmoud-s-rasras,O4yH6_cAAAAJ
 Mahmut T. Kandemir,Pennsylvania State University,http://www.cse.psu.edu/~mtk2,j67v24EAAAAJ
 Mahmut Taylan Kandemir,Pennsylvania State University,http://www.cse.psu.edu/~mtk2,j67v24EAAAAJ
-Mahsa Mirzargar,University of Miami,https://ccs.miami.edu/team_member/mahsa-mirzargar-phd,nm7Oe6sAAAAJ
+Mahsa Mirzargar,University of Miami,https://ccs.miami.edu/team_member/mahsa-mirzargar-phd,NOSCHOLARPAGE
 Mahshid Mojtabavi Naeini,Texas Tech University,https://www.depts.ttu.edu/provost/facultybios/2014/m-rahnamay-naeini.php,NOSCHOLARPAGE
 Mai Fadel,King Abdulaziz University,http://mfadel.kau.edu.sa/Default.aspx?Site_ID=0011432&Lng=EN,NOSCHOLARPAGE
 Mai Zheng,New Mexico State University,http://www.cs.nmsu.edu/~mzheng,mFcB0JMAAAAJ
@@ -8959,7 +8959,7 @@ Manar S. Ali,King Abdulaziz University,http://mali.kau.edu.sa/CVEn.aspx?Site_ID=
 Manas Khatua,IIT Jodhpur,http://manaskhatua.github.io,TQshktIAAAAJ
 Maneesh Agrawala,Stanford University,http://graphics.stanford.edu/~maneesh,YPzKczYAAAAJ
 Manel Guerrero Zapata,Polytechnic University of Catalonia,http://personals.ac.upc.edu/guerrero/my_cv.html,eFe60BoAAAAJ
-Manel Medina,Polytechnic University of Catalonia,http://personals.ac.upc.edu/medina,pPqLc2MAAAAJ
+Manel Medina,Polytechnic University of Catalonia,http://personals.ac.upc.edu/medina,suxty1YAAAAJ
 Manfred Hauswirth,TU Berlin,https://www.ods.tu-berlin.de/menue/chair_for_open_distributed_systems/about_us/professor,WwjTJ3YAAAAJ
 Manfred Huber,University of Texas at Arlington,http://ranger.uta.edu/~huber,2lIq2nMAAAAJ
 Manfred Jaeger,Aalborg University,http://people.cs.aau.dk/~jaeger,1E085gUAAAAJ
@@ -8974,7 +8974,7 @@ Manindra Agrawal,IIT Kanpur,http://www.cse.iitk.ac.in/users/manindra,UBXqggoAAAA
 Manish Gupta 0001,IIIT Bangalore,http://www.iiitb.ac.in/faculty_page.php?name=ManishGupta,dt_xftUAAAAJ
 Manish Narwaria,DAIICT,http://www.daiict.ac.in/daiict/people/faculty.html,RVc_D94AAAAJ
 Manish Parashar,Rutgers University,http://parashar.rutgers.edu,SCM35lMAAAAJ
-Manish Shrivastava 0001,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/m.shrivastava,DKC3xNYAAAAJ
+Manish Shrivastava 0001,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/m.shrivastava,-UglwrwAAAAJ
 Manish Singh 0001,Rutgers University,https://www.cs.rutgers.edu/people/faculty/affiliated-faculty,9XRvM88AAAAJ
 Manja Marz,Friedrich Schiller University Jena,http://www.rna.uni-jena.de,NOSCHOLARPAGE
 Manjunath V. Joshi,DAIICT,http://www.daiict.ac.in/daiict/people/faculty.html,iDqnnKkAAAAJ
@@ -8983,7 +8983,7 @@ Manmohan Krishna Chandraker,University of California - San Diego,http://cseweb.u
 Manohar Kaul,IIT Hyderabad,http://www.iith.ac.in/~mkaul,jNroyK4AAAAJ
 Manoj Gupta,IIT Gandhinagar,http://www.iitgn.ac.in/faculty/comp/manoj.htm,PGzgTLoAAAAJ
 Manoj M. Prabhakaran,IIT Bombay,http://mmp.cs.illinois.edu,FANRIhwAAAAJ
-Manoj Misra,IIT Roorkee,http://www.iitr.ac.in/departments/CSE/pages/People+Faculty+manojfec.html,EwxWd40AAAAJ
+Manoj Misra,IIT Roorkee,http://www.iitr.ac.in/departments/CSE/pages/People+Faculty+manojfec.html,-3K29xAAAAAJ
 Manoj Prabhakaran,IIT Bombay,http://mmp.cs.illinois.edu,FANRIhwAAAAJ
 Manolis Katevenis,University of Crete,http://users.ics.forth.gr/~kateveni,E2-GshsAAAAJ
 Manolis Kellis,Massachusetts Institute of Technology,http://mit.edu/manoli,lsYXBx8AAAAJ
@@ -9014,7 +9014,7 @@ Manuel Lopes,Universidade de Lisboa,http://web.tecnico.ulisboa.pt/manuel.lopes,8
 Manuel M. Oliveira,UFRGS,http://inf.ufrgs.br/~oliveira,f2UrnmAAAAAJ
 Manuel M. Silva,Universidade de Lisboa,http://ce3c.ciencias.ulisboa.pt/member/joatildeo-manuel-medeiros-da-silva,NOSCHOLARPAGE
 Manuel Medeiros Silva,Universidade de Lisboa,http://ce3c.ciencias.ulisboa.pt/member/joatildeo-manuel-medeiros-da-silva,NOSCHOLARPAGE
-Manuel Medina,Polytechnic University of Catalonia,http://personals.ac.upc.edu/medina,pPqLc2MAAAAJ
+Manuel Medina,Polytechnic University of Catalonia,http://personals.ac.upc.edu/medina,suxty1YAAAAJ
 Manuel Menezes de Oliveira Neto,UFRGS,http://inf.ufrgs.br/~oliveira,f2UrnmAAAAAJ
 Manuel Roveri,Politecnico di Milano,http://home.deib.polimi.it/roveri,j2NbakMAAAAJ
 Manuel V. Hermenegildo,IMDEA Software Institute,http://software.imdea.org/people/manuel.hermenegildo,VXQGJD0AAAAJ
@@ -9116,7 +9116,7 @@ Marco Servetto,Victoria University of Wellington,https://ecs.victoria.ac.nz/Main
 Marco Tagliasacchi,Politecnico di Milano,http://home.deib.polimi.it/tagliasa,zwH1rZQAAAAJ
 Marco Tulio Valente,UFMG,http://homepages.dcc.ufmg.br/~mtov,0vFkqMIAAAAJ
 Marco Tulio de Oliveira Valente,UFMG,http://homepages.dcc.ufmg.br/~mtov,0vFkqMIAAAAJ
-Marco Valtorta,University of South Carolina,http://www.cse.sc.edu/~mgv,IXWSOxcAAAAJ
+Marco Valtorta,University of South Carolina,http://www.cse.sc.edu/~mgv,l53UPjoAAAAJ
 Marco Wiering,University of Groningen,http://www.ai.rug.nl/~mwiering,880vFIgAAAAJ
 Marco Zuniga,TU Delft,http://www.st.ewi.tudelft.nl/~marco,xWdb5R8AAAAJ
 Marcos André Gonçalves,UFMG,http://homepages.dcc.ufmg.br/~mgoncalv,IStCGaoAAAAJ
@@ -9178,8 +9178,8 @@ Maria Garcia de la Banda,Monash University,http://www.csse.monash.edu.au/~mbanda
 Maria Grazia Fugini,Politecnico di Milano,http://fugini.faculty.polimi.it/?lang=en,xiSJFg4AAAAJ
 Maria Grazia Scutellà,University of Pisa,http://www.di.unipi.it/~scut,PcGjfV8AAAAJ
 Maria Hybinette,University of Georgia,http://cobweb.cs.uga.edu/~maria,d6gfNpIAAAAJ
-Maria Indrawan,Monash University,http://monash.edu/research/explore/en/persons/maria-indrawansantiago(f6075934-9dab-4cc5-82ef-d26d20d5b294).html,xzE1AkgAAAAJ
-Maria Indrawan-Santiago,Monash University,http://monash.edu/research/explore/en/persons/maria-indrawansantiago(f6075934-9dab-4cc5-82ef-d26d20d5b294).html,xzE1AkgAAAAJ
+Maria Indrawan,Monash University,http://monash.edu/research/explore/en/persons/maria-indrawansantiago(f6075934-9dab-4cc5-82ef-d26d20d5b294).html,NOSCHOLARPAGE
+Maria Indrawan-Santiago,Monash University,http://monash.edu/research/explore/en/persons/maria-indrawansantiago(f6075934-9dab-4cc5-82ef-d26d20d5b294).html,NOSCHOLARPAGE
 Maria J. García de la Banda,Monash University,http://www.csse.monash.edu.au/~mbanda,mkm8ZlQAAAAJ
 Maria K. Wolters,University of Edinburgh,http://www.research.ed.ac.uk/portal/en/persons/maria-wolters(2b06b072-20c7-48d5-90cd-ec9c59205b49).html,NOSCHOLARPAGE
 Maria Kihl,Lund University,http://www.eit.lth.se/staff/maria.kihl,a8CP0V8AAAAJ
@@ -9244,7 +9244,7 @@ Mario R. F. Benevides,UFRJ,http://www.cos.ufrj.br/~mario,O3lJvk4AAAAJ
 Mario Schaarschmidt,University of Koblenz-Landau,https://www.uni-koblenz-landau.de/de/koblenz/fb4/ifm/agschaarschmidt/team/schaarschmidt/mario-schaarschmidt,LmkFPYkAAAAJ
 Mario Szegedy,Rutgers University,http://www.cs.rutgers.edu/~szegedy,NOSCHOLARPAGE
 Mario Vento,University of Salerno,http://mivia.unisa.it/people/vento,3PwXGpgAAAAJ
-Mariofanna Milanova,University of Arkansas - Little Rock,http://ualr.academia.edu/MariofannaMilanova,oJr0BfEAAAAJ
+Mariofanna Milanova,University of Arkansas - Little Rock,http://ualr.academia.edu/MariofannaMilanova,n4Uu1lIAAAAJ
 Marios C. Papaefthymiou,University of Michigan,http://web.eecs.umich.edu/~marios,NOSCHOLARPAGE
 Maristella Matera,Politecnico di Milano,http://home.deib.polimi.it/matera,NScXYC0AAAAJ
 Marius Portmann,University of Queensland,http://staff.itee.uq.edu.au/marius,hiYVpa0AAAAJ
@@ -9288,7 +9288,7 @@ Mark Gahegan,University of Auckland,https://www.cs.auckland.ac.nz/people/mark-ga
 Mark Giesbrecht,University of Waterloo,https://uwaterloo.ca/~mwg,NOSCHOLARPAGE
 Mark Grechanik,University of Illinois at Chicago,https://www.cs.uic.edu/~drmark,Gn5kfF8AAAAJ
 Mark Guzdial,University of Michigan,http://www.cc.gatech.edu/home/guzdial,iQV2L2IAAAAJ
-Mark H. Chignell,University of Toronto,https://www.mie.utoronto.ca/mie/faculty/chignell,etEk4e0AAAAJ
+Mark H. Chignell,University of Toronto,https://www.mie.utoronto.ca/mie/faculty/chignell,6C1lQzwAAAAJ
 Mark H. M. Winands,Maastricht University,https://dke.maastrichtuniversity.nl/m.winands,5S6bWAwAAAAJ
 Mark Handley,University College London,http://www0.cs.ucl.ac.uk/staff/M.Handley,XRyUF6gAAAAJ
 Mark Hasegawa-Johnson,Univ. of Illinois at Urbana-Champaign,http://www.ifp.illinois.edu/~hasegawa,18O0OAwAAAAJ
@@ -9353,7 +9353,7 @@ Markus Püschel,ETH Zurich,https://www.inf.ethz.ch/personal/markusp,az9ZryAAAAAJ
 Markus Schneider,University of Florida,http://www.cise.ufl.edu/~mschneid,lOhijLUAAAAJ
 Markus Siegle,Bundeswehr University Munich,https://www.unibw.de/technische-informatik/mitarbeiter/professoren/siegle/entwurf-von-rechen-und-kommunikationssystemen,Sdh-toEAAAAJ
 Markus Steinberger,Graz University of Technology,https://www.markussteinberger.net,meRwdycAAAAJ
-Markus Wagner 0007,University of Adelaide,https://cs.adelaide.edu.au/~markus,DVbOu8MAAAAJ
+Markus Wagner 0007,University of Adelaide,https://cs.adelaide.edu.au/~markus,NOSCHOLARPAGE
 Marleen de Bruijne,University of Copenhagen,http://image.diku.dk/marleen,7kTk3LUAAAAJ
 Marlon Dumas,University of Tartu,http://math.ut.ee/~dumas,9lIttRkAAAAJ
 Marnel Peradilla,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32665800576&command=GETPROFILE,Cc5_76kAAAAJ
@@ -9512,7 +9512,7 @@ Massimo Pappalardo,University of Pisa,http://pages.di.unipi.it/mpappalardo,NOSCH
 Massimo Poesio,Queen Mary University of London,http://gameai.eecs.qmul.ac.uk/team_member/massimo-poesio,89aa1X0AAAAJ
 Massimo Tornatore,Politecnico di Milano,http://home.deib.polimi.it/tornatore,50-RA6kAAAAJ
 Massimo Torquati,University of Pisa,http://calvados.di.unipi.it/dokuwiki/doku.php/torquatinamespace:about,TCpEfU8AAAAJ
-Matan Gavish,Hebrew University of Jerusalem,http://ratio.huji.ac.il/node/779,j0nK_CsAAAAJ
+Matan Gavish,Hebrew University of Jerusalem,http://ratio.huji.ac.il/node/779,NOSCHOLARPAGE
 Matei A. Zaharia,Stanford University,https://people.csail.mit.edu/matei,I1EvjZsAAAAJ
 Matei Ripeanu,University of British Columbia,http://www.ece.ubc.ca/~matei,eeMpO3wAAAAJ
 Matei Zaharia,Stanford University,https://people.csail.mit.edu/matei,I1EvjZsAAAAJ
@@ -9567,7 +9567,7 @@ Matthew Hicks,Virginia Tech,http://www.impedimenttoprogress.com,_rJCgzIAAAAJ
 Matthew J. Luckie,University of Waikato,http://www.cms.waikato.ac.nz/people/mluckie,y_BSpQYAAAAJ
 Matthew J. Patitz,University of Arkansas,http://self-assembly.net/mpatitz,fv8RSFgAAAAJ
 Matthew J. Thazhuthaveetil,IISc Bangalore,http://www.csa.iisc.ac.in/~mjt,NOSCHOLARPAGE
-Matthew Johnson,CUNY,http://www.matthewpjohnson.org,k-0MEIMAAAAJ
+Matthew Johnson,CUNY,http://www.matthewpjohnson.org,55gsOuoAAAAJ
 Matthew Johnston,Oregon State University,http://eecs.oregonstate.edu/people/johnston-matthew,AN-PNI4AAAAJ
 Matthew K. Farrens,University of California - Davis,http://faculty.engineering.ucdavis.edu/farrens,ExEEjcQAAAAJ
 Matthew K. Franklin,University of California - Davis,http://www.cs.ucdavis.edu/~franklin,D6ptFeMAAAAJ
@@ -9657,7 +9657,7 @@ Mayank Vatsa,IIIT Delhi,https://www.iiitd.edu.in/~mayank,NOSCHOLARPAGE
 Mayur Naik,University of Pennsylvania,http://www.cis.upenn.edu/~mhnaik,fmsV6nEAAAAJ
 Maziar Goudarzi,Sharif University of Technology,http://sharif.edu/~goudarzi,qAJqk9IAAAAJ
 Md. Endadul Hoque,Florida International University,https://users.cs.fiu.edu/~ehoque,dSLXaKUAAAAJ
-Md. Khaled Khan,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/khaled_khan.php,SpQmNnoAAAAJ
+Md. Khaled Khan,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/khaled_khan.php,apJhxSwAAAAJ
 Md. Tamjidul Hoque,University of New Orleans,http://new.uno.edu/profile/faculty/tamjidul_hoque,8tQmDZQAAAAJ
 Mea Wang,University of Calgary,http://networks.cpsc.ucalgary.ca/mea,CgdJUiMAAAAJ
 Medha Atre,IIT Kanpur,http://www.cse.iitk.ac.in/users/atrem,N_manZoAAAAJ
@@ -9731,7 +9731,7 @@ Mi Zhang 0001,Fudan University,http://homepage.fudan.edu.cn/zhangmi,NOSCHOLARPAG
 Mian M. Awais,LUMS,https://lums.edu.pk/lums_employee/516,wkxlfFAAAAAJ
 Mian Muhammad Awais,LUMS,https://lums.edu.pk/lums_employee/516,wkxlfFAAAAAJ
 Miao Jin,University of Louisiana - Lafayette,http://www.ucs.louisiana.edu/~mxj9809,rhZtTHsAAAAJ
-Miao Qiao,Massey University,https://www.massey.ac.nz/massey/learning/colleges/college-of-sciences/staff-list.cfm?stref=689350,Guff-1wAAAAJ
+Miao Qiao,Massey University,https://www.massey.ac.nz/massey/learning/colleges/college-of-sciences/staff-list.cfm?stref=689350,NOSCHOLARPAGE
 Miaomiao Zhang,Washington University in St. Louis,http://www.cse.lehigh.edu/~miaomiao,EGBMBTwAAAAJ
 Miaoqing Huang,University of Arkansas,http://www.csce.uark.edu/~mqhuang,NOSCHOLARPAGE
 Micah Beck,University of Tennessee,http://web.eecs.utk.edu/~mbeck,oAMW4OEAAAAJ
@@ -9782,7 +9782,7 @@ Michael D. Bond,Ohio State University,http://web.cse.ohio-state.edu/~mikebond,zo
 Michael D. Ekstrand,Boise State University,https://coen.boisestate.edu/faculty-staff/michaelekstrand,YicUduAAAAAJ
 Michael D. Ernst,University of Washington,https://homes.cs.washington.edu/~mernst,oQ6AeyEAAAAJ
 Michael D. Jones,Brigham Young University,https://cs.byu.edu/faculty/jones,OLUt0kgAAAAJ
-Michael D. Smith,Harvard University,http://www.fas.harvard.edu/pages/dean-michael-smith,rzPlMfQAAAAJ
+Michael D. Smith,Harvard University,http://www.fas.harvard.edu/pages/dean-michael-smith,NOSCHOLARPAGE
 Michael D. Vose,University of Tennessee,http://www.eecs.utk.edu/people/faculty/mvose1,NOSCHOLARPAGE
 Michael Dennis,Australian National University,https://cecs.anu.edu.au/people/mike-dennis,4-7T68EAAAAJ
 Michael Dinitz,Johns Hopkins University,http://www.cs.jhu.edu/~mdinitz,Q2yN84AAAAAJ
@@ -9881,7 +9881,7 @@ Michael Kwok-Po Ng,Hong Kong Baptist University,http://www.math.hkbu.edu.hk/~mng
 Michael Kölling,University of Kent,https://www.cs.kent.ac.uk/people/staff/mik,NOSCHOLARPAGE
 Michael L. Best,Georgia Institute of Technology,http://mikeb.inta.gatech.edu,gLLhIb8AAAAJ
 Michael L. Fredman,Rutgers University,https://www.cs.rutgers.edu/faculty/michael-fredman,NOSCHOLARPAGE
-Michael L. Littman,Brown University,http://cs.brown.edu/~mlittman,Jj00ksMAAAAJ
+Michael L. Littman,Brown University,http://cs.brown.edu/~mlittman,iRMZ2hoAAAAJ
 Michael L. Nelson,Old Dominion University,http://www.cs.odu.edu/~mln,oWQaPnwAAAAJ
 Michael L. Overton,New York University,https://cs.nyu.edu/overton,q6LXYtUAAAAJ
 Michael L. Scott,University of Rochester,https://www.cs.rochester.edu/~scott,PzaBy-UAAAAJ
@@ -9908,8 +9908,8 @@ Michael N. Huhns,University of South Carolina,http://www.cse.sc.edu/~huhns,hvtmB
 Michael Nebeling,University of Michigan,http://www.michael-nebeling.de,W2XLsXoAAAAJ
 Michael Neff,University of California - Davis,http://www.cs.ucdavis.edu/~neff,9ENU67IAAAAJ
 Michael O'Neal,Louisiana Tech University,https://www.latech.edu/faculty-staff/single-entry/name/michael-oneal,NOSCHOLARPAGE
-Michael O. Rabin,Harvard University,https://www.seas.harvard.edu/directory/rabin,EFZyUcEAAAAJ
-Michael Oser Rabin,Harvard University,https://www.seas.harvard.edu/directory/rabin,EFZyUcEAAAAJ
+Michael O. Rabin,Harvard University,https://www.seas.harvard.edu/directory/rabin,_UUtVF4AAAAJ
+Michael Oser Rabin,Harvard University,https://www.seas.harvard.edu/directory/rabin,_UUtVF4AAAAJ
 Michael P. Fourman,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Michael_Fourman.html,psO0rckAAAAJ
 Michael P. Friedlander,University of British Columbia,http://www.cs.ubc.ca/~mpf,mOgIIH4AAAAJ
 Michael P. Wellman,University of Michigan,http://www.eecs.umich.edu/ai/people/wellman,UruIct4AAAAJ
@@ -9997,7 +9997,7 @@ Michel Steuwer,University of Glasgow,http://www.dcs.gla.ac.uk/~msteu,XdXJRZEAAAA
 Michel Westenberg,TU Eindhoven,http://www.win.tue.nl/~mwestenb,5eK84bMAAAAJ
 Michela Taufer,University of Delaware,https://gcl.cis.udel.edu/personal/taufer,3DWI0HcAAAAJ
 Michelangelo Grigni,Emory University,http://www.mathcs.emory.edu/~mic,61uuS7YAAAAJ
-Michele Benzi,Emory University,http://www.mathcs.emory.edu/~benzi,SiPqtAEAAAAJ
+Michele Benzi,Emory University,http://www.mathcs.emory.edu/~benzi,NOSCHOLARPAGE
 Michele C. Weigle,Old Dominion University,http://www.cs.odu.edu/~mweigle,MOLPTqcAAAAJ
 Michele Ceccarelli,University of Sannio,https://www.unisannio.it/it/users/michele-ceccarelli,OIQsgqoAAAAJ
 Michele Lanza,Università della Svizzera italiana,http://search.usi.ch/persone/8b4717057b3c2d30a3b28425aa4e29d5/Lanza-Michele,hKMBth8AAAAJ
@@ -10036,7 +10036,7 @@ Mihaela Cardei,Florida Atlantic University,http://www.cse.fau.edu/~mihaela,TJ_Yu
 Mihaela van der Schaar,University of California - Los Angeles,http://medianetlab.ee.ucla.edu/NewWebsite,DZ3S--MAAAAJ
 Mihaela van der Schaar-Mitrea,University of California - Los Angeles,http://medianetlab.ee.ucla.edu/NewWebsite,DZ3S--MAAAAJ
 Mihai Pop,University of Maryland - College Park,http://www.cbcb.umd.edu/~mpop,4glkLD0AAAAJ
-Mihai Sanduleanu,Masdar Institute,https://www.masdar.ac.ae/aboutus/management/faculty-directory/item/5662-mihai-sanduleanu,sKP9fu0AAAAJ
+Mihai Sanduleanu,Masdar Institute,https://www.masdar.ac.ae/aboutus/management/faculty-directory/item/5662-mihai-sanduleanu,paPk6boAAAAJ
 Mihai Surdeanu,University of Arizona,http://surdeanu.info/mihai,a3133-8AAAAJ
 Mihalis Yannakakis,Columbia University,http://www.cs.columbia.edu/~mihalis,_pPy-pAAAAAJ
 Mihir Bellare,University of California - San Diego,https://cseweb.ucsd.edu/~mihir,2pW1g5IAAAAJ
@@ -10103,7 +10103,7 @@ Min Chi,North Carolina State University,https://www.csc.ncsu.edu/people/mchi,gJm
 Min Chih Lin,University of Buenos Aires,http://www.ic.fcen.uba.ar/~mlin/homepage.html,NOSCHOLARPAGE
 Min H. Kim 0001,KAIST,http://vclab.kaist.ac.kr/minhkim,pMT5lrwAAAAJ
 Min Long,Boise State University,http://flash.uchicago.edu/~long,Ex_raoQAAAAJ
-Min Shin,UNC - Charlotte,https://viscenter.uncc.edu/min-shin,T50sdQ8AAAAJ
+Min Shin,UNC - Charlotte,https://viscenter.uncc.edu/min-shin,NOSCHOLARPAGE
 Min Song,Michigan Technological University,https://www.mtu.edu/cs/department/faculty-staff/adjunct-research/song,NOSCHOLARPAGE
 Min Suk Kang,National University of Singapore,http://comp.nus.edu.sg/~kangms,R6KDuS8AAAAJ
 Min Tang 0001,Zhejiang University,http://give.zju.edu.cn/memberHomepage/TangMin.html,E1RM9OUAAAAJ
@@ -10364,7 +10364,7 @@ Murray Cole,University of Edinburgh,http://homepages.inf.ed.ac.uk/mic,NOSCHOLARP
 Murray Shanahan,Imperial College London,https://www.doc.ic.ac.uk/~mpsha,00bnGpAAAAAJ
 Murtaza Taj,LUMS,https://lums.edu.pk/lums_employee/2860,Gk3G9N0AAAAJ
 Murtuza Jadliwala,University of Texas at San Antonio,http://www.cs.utsa.edu/~jadliwala,FWPlkI0AAAAJ
-Musard Balliu,KTH Royal Institute of Technology,http://www.csc.kth.se/~musard,aTUgj08AAAAJ
+Musard Balliu,KTH Royal Institute of Technology,http://www.csc.kth.se/~musard,NOSCHOLARPAGE
 Mustafa Bilgic 0001,Illinois Institute of Technology,https://science.iit.edu/people/faculty/mustafa-bilgic,bOM9qN8AAAAJ
 Mustafa Cenk Gursoy,Syracuse University,http://eng-cs.syr.edu/directory,qBxl76YAAAAJ
 Mustafa E. Kamasak,Istanbul Technical University,http://web.itu.edu.tr/kamasak,U5UhNHEAAAAJ
@@ -10494,7 +10494,7 @@ Naresh Jotwani,DAIICT,http://ieee.daiict.ac.in/erte/naresh-jotwani.html,NOSCHOLA
 Naresh Manwani,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/naresh.manwani,qz4eDmgAAAAJ
 Narges Mahyar,University of Massachusetts Amherst,http://nmahyar.ucsd.edu,AEh2T1IAAAAJ
 Narseo Vallina-Rodriguez,IMDEA Networks Institute,http://people.networks.imdea.org/~narseo_vallina,yOlNzfcAAAAJ
-Narsingh Deo,University of Central Florida,http://www.cs.ucf.edu/~deo,A_I5MiAAAAAJ
+Narsingh Deo,University of Central Florida,http://www.cs.ucf.edu/~deo,NOSCHOLARPAGE
 Narumi Takuji,University of Tokyo,http://www.u-tokyo.ac.jp/en/people/?id=3953484460,yXOFssEAAAAJ
 Nashat Mansour,Lebanese American University,http://www.lau.edu.lb/about/governance-policies/executive-officers/nashat-mansour.php,F0bsq18AAAAJ
 Nasir D. Memon,New York University,http://isis.poly.edu/memon,Pz0YttAAAAAJ
@@ -10561,7 +10561,7 @@ Neelam Soundarajan,Ohio State University,https://cse.osu.edu/people/soundarajan.
 Neeldhara Misra,IIT Gandhinagar,http://www.iitgn.ac.in/faculty/comp/neeldhara.htm,XFgieDYAAAAJ
 Neeraj Goel,IIT Ropar,http://www.iitrpr.ac.in/cse/neerajgoel,6AERbuMAAAAJ
 Neeraj Mittal,University of Texas at Dallas,https://www.utdallas.edu/~neerajm,V9MH9v8AAAAJ
-Neeraj Suri,TU Darmstadt,https://www.deeds.informatik.tu-darmstadt.de/suri,YAia0U8AAAAJ
+Neeraj Suri,TU Darmstadt,https://www.deeds.informatik.tu-darmstadt.de/suri,NOSCHOLARPAGE
 Neil A. Dodgson,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/NeilDodgson,kfYJVXEAAAAJ
 Neil A. Ernst,University of Victoria,http://neilernst.net,byBabzAAAAAJ
 Neil Anthony Dodgson,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/NeilDodgson,kfYJVXEAAAAJ
@@ -10679,8 +10679,8 @@ Nicolas Navet,University of Luxembourg,http://nicolas.navet.eu,dhYgyRUAAAAJ
 Nicolas T. Courtois,University College London,http://www0.cs.ucl.ac.uk/staff/n.courtois,sTwMEA8AAAAJ
 Nicolas Trotignon,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/nicolas.trotignon/indexFr.html,NOSCHOLARPAGE
 Nicolas Wu,University of Bristol,http://www.bris.ac.uk/engineering/people/nicolas-wu/index.html,nlNpvqYAAAAJ
-Nicole Beckage,University of Kansas,http://www.eecs.ku.edu/people/faculty,4uNXEYkAAAAJ
-Nicole McFarlane,University of Tennessee,http://www.eecs.utk.edu/people/faculty/mcf,gC6GzlEAAAAJ
+Nicole Beckage,University of Kansas,http://www.eecs.ku.edu/people/faculty,ctZpxrsAAAAJ
+Nicole McFarlane,University of Tennessee,http://www.eecs.utk.edu/people/faculty/mcf,NOSCHOLARPAGE
 Nicole Schweikardt,Humboldt University of Berlin,http://www2.informatik.hu-berlin.de/logik,Ghy_9r8AAAAJ
 Nicoleta Roman,Ohio State University,https://cse.osu.edu/people/roman.45,ZXS-VpgAAAAJ
 Nicoletta Di Blas,Politecnico di Milano,http://home.deib.polimi.it/diblas,Qa9fmQsAAAAJ
@@ -10759,7 +10759,7 @@ Ning Gu,Fudan University,http://www.cs.fudan.edu.cn/?page_id=2089,NOSCHOLARPAGE
 Ning Xie 0002,Florida International University,http://www.cs.fiu.edu/~nxie,H9x5YXkAAAAJ
 Ning Xie 0003,UESTC,http://cfm.uestc.edu.cn/~xiening,sTKVj4IAAAAJ
 Ning Zhang 0017,Washington University in St. Louis,https://n1ngz.github.io,gwB_pJcAAAAJ
-Ninghui Li,Purdue University,https://www.cs.purdue.edu/homes/ninghui,Qc_4yiYAAAAJ
+Ninghui Li,Purdue University,https://www.cs.purdue.edu/homes/ninghui,XpHwrPsAAAAJ
 Nipun Batra 0001,IIT Gandhinagar,https://www.iitgn.ac.in/faculty/comp/nipun.htm,rFGzHlIAAAAJ
 Nir Ailon,Technion,http://nailon.net.technion.ac.il,NOSCHOLARPAGE
 Nir Bitansky,Tel Aviv University,https://simons.berkeley.edu/people/nir-bitansky,XBk56N0AAAAJ
@@ -10805,7 +10805,7 @@ Noga Alon,Tel Aviv University,http://www.tau.ac.il/~nogaa,vOYl40wAAAAJ
 Nohpill Park,Oklahoma State University,http://www.cs.okstate.edu/%7Enpark,NOSCHOLARPAGE
 Nojun Kwak,Seoul National University,http://mipal.snu.ac.kr/index.php/Nojun_Kwak,h_8-1M0AAAAJ
 Nolen Scaife,University of Colorado Boulder,https://nolen.io,r9uneEYAAAAJ
-Noman Mohammed,University of Manitoba,http://www.cs.umanitoba.ca/~noman,8xIFX4wAAAAJ
+Noman Mohammed,University of Manitoba,http://www.cs.umanitoba.ca/~noman,1FFsjaAAAAAJ
 Noor Al-Máadeed,Qatar University,http://www.qu.edu.qa/offices/research/CAM/about/staff.php,NOSCHOLARPAGE
 Noora Fetais,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/noora.php,NOSCHOLARPAGE
 Nora Ayanian,University of Southern California,http://www-bcf.usc.edu/~ayanian,ke2MEF0AAAAJ
@@ -10816,10 +10816,10 @@ Noriko Tomuro,DePaul University,http://condor.depaul.edu/~ntomuro,NOSCHOLARPAGE
 Norma G. Sutcliffe,DePaul University,http://condor.depaul.edu/mnakayam/Nakayama%20IandM%202005.pdf,NOSCHOLARPAGE
 Norma Saiph Savage,West Virginia University,https://www.statler.wvu.edu/faculty-staff/faculty/saiph-savage,GHGHYZAAAAAJ
 Norman C. Hutchinson,University of British Columbia,https://www.cs.ubc.ca/people/norm-hutchinson,NOSCHOLARPAGE
-Norman E. Fenton,Queen Mary University of London,https://www.eecs.qmul.ac.uk/~norman,c_cQr4EAAAAJ
-Norman Fenton,Queen Mary University of London,https://www.eecs.qmul.ac.uk/~norman,c_cQr4EAAAAJ
+Norman E. Fenton,Queen Mary University of London,https://www.eecs.qmul.ac.uk/~norman,0APV5ScAAAAJ
+Norman Fenton,Queen Mary University of London,https://www.eecs.qmul.ac.uk/~norman,0APV5ScAAAAJ
 Norman I. Badler,University of Pennsylvania,https://www.cis.upenn.edu/~badler,e8e5qGcAAAAJ
-Norman M. Sadeh,Carnegie Mellon University,http://www.normsadeh.org,If_k6LgAAAAJ
+Norman M. Sadeh,Carnegie Mellon University,http://www.normsadeh.org,NOSCHOLARPAGE
 Norman Makoto Su,Indiana University,https://www.soic.indiana.edu/faculty-research/directory/profile.html?profile_id=306,eqs6v1wAAAAJ
 Norman Ramsey,Tufts University,http://www.cs.tufts.edu/~nr,7QTGa98AAAAJ
 Norman S. Matloff,University of California - Davis,http://faculty.engineering.ucdavis.edu/matloff,NOSCHOLARPAGE
@@ -10904,7 +10904,7 @@ Oliver van Kaick,Carleton University,http://people.scs.carleton.ca/~olivervankai
 Olivier Alata,Université Jean Monnet,http://perso.univ-st-etienne.fr/ao29170h,ClqgTp8AAAAJ
 Olivier Danvy,Aarhus University,http://cs.au.dk/~danvy,OZJGoVoAAAAJ
 Olivier Glück,Ecole Normale Superieure de Lyon,http://perso.univ-lyon1.fr/olivier.gluck,NOSCHOLARPAGE
-Olivier Laurent,Ecole Normale Superieure de Lyon,https://perso.ens-lyon.fr/olivier.laurent,UXrN6aUAAAAJ
+Olivier Laurent,Ecole Normale Superieure de Lyon,https://perso.ens-lyon.fr/olivier.laurent,NOSCHOLARPAGE
 Olivier Markowitch,Université libre de Bruxelles,https://qualsec.ulb.ac.be/people/olivier-markowitch,wfBB0CAAAAAJ
 Olivier Tremblay-Savard,University of Manitoba,http://www.cs.umanitoba.ca/~tremblao,UAzcju4AAAAJ
 Olof B. Widlund,New York University,https://www.cs.nyu.edu/widlund,NOSCHOLARPAGE
@@ -11010,7 +11010,7 @@ Pablo de Cristóforis,University of Buenos Aires,https://www.dc.uba.ar/rrhh/prof
 Padhraic Smyth,University of California - Irvine,http://www.ics.uci.edu/~smyth,OsoQ-dcAAAAJ
 Padma Daryanani,Middlesex University,http://www.cs.mdx.ac.uk/people/padma-daryanani,NOSCHOLARPAGE
 Padma Raghavan,Vanderbilt University,http://www.cse.psu.edu/~pxr3,JDctypMAAAAJ
-Padmanabhan Rajan,IIT Mandi,https://faculty.iitmandi.ac.in/~padman,3sZ-nzAAAAAJ
+Padmanabhan Rajan,IIT Mandi,https://faculty.iitmandi.ac.in/~padman,g2W04wkAAAAJ
 Padmini Srinivasan,University of Iowa,https://cs.uiowa.edu/people/padmini-srinivasan,NOSCHOLARPAGE
 Padraic Edgington,University of Connecticut,http://www.cse.uconn.edu/people/faculty,eivODg0AAAAJ
 Pai H. Chou,National Tsing Hua University,http://epl.tw/people/phchou,r7I9N5cAAAAJ
@@ -11156,7 +11156,7 @@ Patrick Prosser,University of Glasgow,http://www.dcs.gla.ac.uk/~pat,94vlGrgAAAAJ
 Patrick Th. Eugster,Università della Svizzera italiana,https://www.inf.usi.ch/faculty/eugstp,NOSCHOLARPAGE
 Patrick Thiran,EPFL,https://people.epfl.ch/patrick.thiran,7Ek7pqgAAAAJ
 Patrick Traynor,University of Florida,https://www.cise.ufl.edu/~traynor,oCFvA2UAAAAJ
-Patrick Troy,University of Illinois at Chicago,https://www.cs.uic.edu/Troy,G7wW4HoAAAAJ
+Patrick Troy,University of Illinois at Chicago,https://www.cs.uic.edu/Troy,dtyWvtUAAAAJ
 Patrick W. Dymond,York University,http://eecs.lassonde.yorku.ca/faculty/patrick-w-dymond,i1ZltlsAAAAJ
 Patrick Yin Chiang,Oregon State University,http://eecs.oregonstate.edu/people/chiang-patrick,4nYbZ0YAAAAJ
 Patrick van der Smagt,TU Munich,https://brml.org/people/smagt,5ybzvbsAAAAJ
@@ -11220,7 +11220,7 @@ Paul Ralph,University of Auckland,https://unidirectory.auckland.ac.nz/people/pro
 Paul Rosen,University of South Florida,http://www.cspaul.com/wordpress,6iv6AEcAAAAJ
 Paul S. Rosenbloom,University of Southern California,http://cs.usc.edu/~rosenblo,SeW3bhwAAAAJ
 Paul Schweizer,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Paul_Schweizer.html,M0uLiP0AAAAJ
-Paul Siebert,University of Glasgow,http://www.dcs.gla.ac.uk/~psiebert,DoEOa80AAAAJ
+Paul Siebert,University of Glasgow,http://www.dcs.gla.ac.uk/~psiebert,p_QXUIcAAAAJ
 Paul T. Groth,VU Amsterdam,https://www.nbic.nl/about-nbic/nbic-faculty/pages1/4/details/groth-paul-t-dr,0tHSHCIAAAAJ
 Paul T. Tymann,Rochester Institute of Technology,https://www.cs.rit.edu/~ptt,NOSCHOLARPAGE
 Paul Tarau,University of North Texas,http://www.cse.unt.edu/~tarau,JUMRc-oAAAAJ
@@ -11256,7 +11256,7 @@ Paulo Mateus,Universidade de Lisboa,http://sqig.math.ist.utl.pt/paulo.mateus,8Ki
 Paulo Roberto Oliveira,UFRJ,http://www.cos.ufrj.br/index.php/pt-BR/pessoas/details/18/1045-poliveir,55Or75UAAAAJ
 Paulo Rogério Pereira,Universidade de Lisboa,http://mariel.inesc-id.pt/people/prbp.html,sdOt-CcAAAAJ
 Paulo Roma Cavalcanti,UFRJ,http://orion.lcg.ufrj.br/roma,HhJul8QAAAAJ
-Paulo S. G. de Mattos Neto,UFPE,http://www.cin.ufpe.br/~psgmn,4jmNb3gAAAAJ
+Paulo S. G. de Mattos Neto,UFPE,http://www.cin.ufpe.br/~psgmn,mXg6UKgAAAAJ
 Paulo S. L. Souza,USP-ICMC,http://icmc.usp.br/pessoas?id=3258655,epwMhL4AAAAJ
 Paulo Sergio Lopes de Souza,USP-ICMC,http://icmc.usp.br/pessoas?id=3258655,epwMhL4AAAAJ
 Paulo Urbano,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/pjurbano,r8zV1FsAAAAJ
@@ -11359,7 +11359,7 @@ Peter Bodorik,Dalhousie University,https://www.cs.dal.ca/~bodorik,NOSCHOLARPAGE
 Peter Brass,CUNY,http://www-cs.ccny.cuny.edu/~peter,ZTGVnVkAAAAJ
 Peter Braß,CUNY,http://www-cs.ccny.cuny.edu/~peter,ZTGVnVkAAAAJ
 Peter Buneman,University of Edinburgh,http://homepages.inf.ed.ac.uk/opb,d9bq04sAAAAJ
-Peter C. J. Graham,University of Manitoba,http://www.cs.umanitoba.ca/~pgraham,5suVxUYAAAAJ
+Peter C. J. Graham,University of Manitoba,http://www.cs.umanitoba.ca/~pgraham,pjWtdVsAAAAJ
 Peter C. Rigby,Concordia University,http://users.encs.concordia.ca/~pcr,lGVxz58AAAAJ
 Peter C.-H. Cheng,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/100650,KsqCJVQAAAAJ
 Peter Christen,Australian National University,https://cs.anu.edu.au/people/peter-christen,oz-2CXsAAAAJ
@@ -11375,7 +11375,7 @@ Peter F. Linington,University of Kent,https://www.cs.kent.ac.uk/people/staff/pfl
 Peter Fejer,University of Massachusetts Boston,http://www.cs.umb.edu/~fejer,NOSCHOLARPAGE
 Peter G. Harrison,Imperial College London,http://www.imperial.ac.uk/people/p.harrison,f6GUPSUAAAAJ
 Peter G. Jeavons,University of Oxford,http://www.cs.ox.ac.uk/peter.jeavons,xEE8Q8EAAAAJ
-Peter Graham,University of Manitoba,http://www.cs.umanitoba.ca/~pgraham,5suVxUYAAAAJ
+Peter Graham,University of Manitoba,http://www.cs.umanitoba.ca/~pgraham,pjWtdVsAAAAJ
 Peter Grunwald,CWI,http://homepages.cwi.nl/~pdg,wItp6h8AAAAJ
 Peter Grünwald,CWI,http://homepages.cwi.nl/~pdg,wItp6h8AAAAJ
 Peter H. Welch,University of Kent,https://www.cs.kent.ac.uk/~phw,hd1j2w0AAAAJ
@@ -11408,7 +11408,7 @@ Peter Kenny,University of Kent,https://www.cs.kent.ac.uk/people/staff/pgk,AcVmd4
 Peter King,University of Manitoba,http://www.cs.umanitoba.ca/~prking,jENQurUAAAAJ
 Peter Kreider,Australian National University,https://cecs.anu.edu.au/people/peter-kreider,q_YvaJMAAAAJ
 Peter Krogstrup,IST Austria,https://ist.ac.at/research/research-groups/krogstrup-group,_tAV9MMAAAAJ
-Peter L. Bartlett,University of California - Berkeley,http://www.stat.berkeley.edu/~bartlett,UPVvV6kAAAAJ
+Peter L. Bartlett,University of California - Berkeley,http://www.stat.berkeley.edu/~bartlett,yQNhFGUAAAAJ
 Peter Lutz,Rochester Institute of Technology,http://www.ist.rit.edu/~phl,Z2E0SisAAAAJ
 Peter M. Andreae,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/PeterAndreae,NOSCHOLARPAGE
 Peter M. Chen,University of Michigan,http://web.eecs.umich.edu/~pmchen,dVZNQqUAAAAJ
@@ -11447,7 +11447,7 @@ Peter Schröder,California Institute of Technology,http://www.cs.caltech.edu/~ps
 Peter Sestoft,IT University of Copenhagen,http://www.itu.dk/people/sestoft,qz1BCu8AAAAJ
 Peter Sewell,University of Cambridge,https://www.cl.cam.ac.uk/~pes20,NOSCHOLARPAGE
 Peter Sheridan Dodds,University of Vermont,http://www.uvm.edu/pdodds,xK3kOxQAAAAJ
-Peter Slater,University of Alabama - Huntsville,https://www.uah.edu/science/departments/math/faculty-staff/peter-slater,c2Zg-x8AAAAJ
+Peter Slater,University of Alabama - Huntsville,https://www.uah.edu/science/departments/math/faculty-staff/peter-slater,NOSCHOLARPAGE
 Peter Steenkiste,Carnegie Mellon University,http://www.cs.cmu.edu/~prs,DK7TEvkAAAAJ
 Peter Stone,University of Texas at Austin,https://www.cs.utexas.edu/~pstone,qnwjcfAAAAAJ
 Peter Strazdins,Australian National University,http://users.cecs.anu.edu.au/~peter,14xw7S4AAAAJ
@@ -11602,7 +11602,7 @@ Piyush Srivastava,Tata Institute of Fundamental Research,http://www.tifr.res.in/
 Po-Ling Loh,University of Wisconsin - Madison,http://homepages.cae.wisc.edu/~loh,NOSCHOLARPAGE
 Pokhar Mal Jat,DAIICT,http://www.daiict.ac.in/daiict/people/faculty.html,NOSCHOLARPAGE
 Polepalli Krishna Reddy,IIIT Hyderabad,http://faculty.iiit.ac.in/~pkreddy,XIgl8kUAAAAJ
-Polina Golland,Massachusetts Institute of Technology,https://www.csail.mit.edu/person/polina-golland,eeyDrJ8AAAAJ
+Polina Golland,Massachusetts Institute of Technology,https://www.csail.mit.edu/person/polina-golland,NOSCHOLARPAGE
 Polyvios Pratikakis,University of Crete,https://www.csd.uoc.gr/~polyvios,ACXEa94AAAAJ
 Pong C. Yuen,Hong Kong Baptist University,http://www.comp.hkbu.edu.hk/~pcyuen,CwhIcHkAAAAJ
 Pong Chi Yuen,Hong Kong Baptist University,http://www.comp.hkbu.edu.hk/~pcyuen,CwhIcHkAAAAJ
@@ -11633,7 +11633,7 @@ Prakash Ishwar,Boston University,https://www.bu.edu/eng/profile/prakash-ishwar,R
 Prakash Panangaden,McGill University,http://www.cs.mcgill.ca/~prakash,IROzEKQAAAAJ
 Pralay Mitra,IIT Kharagpur,http://cse.iitkgp.ac.in/~pralay,LPzuRBUAAAAJ
 Pramod Bhatotia,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Pramod_Bhatotia.html,_nr10fgAAAAJ
-Pramod K. Varshney,Syracuse University,http://www.ecs.syr.edu/research/SensorFusionLab/People/varshney,PLvsUUcAAAAJ
+Pramod K. Varshney,Syracuse University,http://www.ecs.syr.edu/research/SensorFusionLab/People/varshney,-SJSv8oAAAAJ
 Pranab Sen,Tata Institute of Fundamental Research,http://www.tcs.tifr.res.in/~pgdsen,Ka5re30AAAAJ
 Pranjal Awasthi,Rutgers University,http://www.cs.rutgers.edu/~pa336,MDfW21AAAAAJ
 Prasad Calyam,University of Missouri,https://engineering.missouri.edu/faculty/prasad-calyam,Plnnv18AAAAJ
@@ -11665,7 +11665,7 @@ Prem Kumar Kalra,IIT Delhi,http://www.cse.iitd.ernet.in/~pkalra,NOSCHOLARPAGE
 Premkumar T. Devanbu,University of California - Davis,http://www.cs.ucdavis.edu/~devanbu,NOSCHOLARPAGE
 Preslav Ivanov Nakov,Qatar Computing Research Institute,http://www.qcri.org/our-people/bio?pid=35&amp;par=acc&amp;name=PreslavNakov,DfXsKZ4AAAAJ
 Preslav Nakov,Qatar Computing Research Institute,http://www.qcri.org/our-people/bio?pid=35&amp;par=acc&amp;name=PreslavNakov,DfXsKZ4AAAAJ
-Prithviraj Dasgupta,University of Nebraska - Omaha,https://www.unomaha.edu/college-of-information-science-and-technology/about/faculty-staff/prithviraj-dasgupta.php,DOlGwQIAAAAJ
+Prithviraj Dasgupta,University of Nebraska - Omaha,https://www.unomaha.edu/college-of-information-science-and-technology/about/faculty-staff/prithviraj-dasgupta.php,fxni7uYAAAAJ
 Priya Narasimhan,Carnegie Mellon University,http://www.cs.cmu.edu/~priya,qyPWUBcAAAAJ
 Priyanka Srivastava,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/priyanka,xjiw6DYAAAAJ
 Prosenjit Bose,Carleton University,http://jitbose.ca,1jR53ZQAAAAJ
@@ -11698,7 +11698,7 @@ Qian-Ping Gu,Simon Fraser University,https://www.cs.sfu.ca/~qgu,NOSCHOLARPAGE
 Qiang Fu,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/QiangFu,6GgAPRsAAAAJ
 Qiang Liu 0001,University of Texas at Austin,https://www.cs.utexas.edu/~lqiang,XEx1fZkAAAAJ
 Qiang Ma 0001,Kyoto University,https://www.db.soc.i.kyoto-u.ac.jp/~qiang/index-e.html,h4AD-WQAAAAJ
-Qiang Tang 0005,NJIT,https://web.njit.edu/~qiang,i6oKWhEAAAAJ
+Qiang Tang 0005,NJIT,https://web.njit.edu/~qiang,NOSCHOLARPAGE
 Qiang Xu 0001,Chinese University of Hong Kong,http://www.cse.cuhk.edu.hk/~qxu,eSiKPqUAAAAJ
 Qiang Yang 0001,HKUST,http://www.cs.ust.hk/~qyang,6vQP4KIAAAAJ
 Qiang Zeng 0001,University of South Carolina,https://cse.sc.edu/~zeng1,NOSCHOLARPAGE
@@ -11748,8 +11748,8 @@ Quan Z. Sheng,University of Adelaide,https://cs.adelaide.edu.au/~qsheng,lwy2C5YA
 Quanquan Gu,University of California - Los Angeles,http://web.cs.ucla.edu/~qgu,GU9HgNAAAAAJ
 Quentin F. Stout,University of Michigan,http://web.eecs.umich.edu/~qstout,ypOvMY0AAAAJ
 Quin Yang 0008,University of North Texas,http://www.cse.unt.edu/~qingyang,FIMxNL0AAAAJ
-Quinn O. Snell,Brigham Young University,https://faculty.cs.byu.edu/~snell,EaEutcUAAAAJ
-Quinn Snell,Brigham Young University,https://faculty.cs.byu.edu/~snell,EaEutcUAAAAJ
+Quinn O. Snell,Brigham Young University,https://faculty.cs.byu.edu/~snell,MqW-au4AAAAJ
+Quinn Snell,Brigham Young University,https://faculty.cs.byu.edu/~snell,MqW-au4AAAAJ
 Quintin I. Cutts,University of Glasgow,http://www.dcs.gla.ac.uk/~quintin,I9U41jQAAAAJ
 Qun Li,College of William and Mary,http://www.cs.wm.edu/~liqun,CtGBKt4AAAAJ
 Qutaibah M. Malluhi,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/qutaibah.php,uxzUkuUAAAAJ
@@ -11763,7 +11763,7 @@ R. James Cunningham,Imperial College London,http://www.doc.ic.ac.uk/~rjc,Y_Gh7b8
 R. Jayakumar,Concordia University,http://www.concordia.ca/faculty/rajagopalan-jayakumar.html,uyA1jcQAAAAJ
 R. K. Bagga,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/rbagga,NOSCHOLARPAGE
 R. Lyndon While,University of Western Australia,http://uwa.edu.au/people/lyndon.while,NOSCHOLARPAGE
-R. Michael Young,University of Utah,https://www.csc.ncsu.edu/people/rmyoung,HLz6zx4AAAAJ
+R. Michael Young,University of Utah,https://www.csc.ncsu.edu/people/rmyoung,-lZ-w10AAAAJ
 R. Mukundan,University of Canterbury,http://www.cosc.canterbury.ac.nz/mukundan,Bk5BJ80AAAAJ
 R. Paul Wiegand,University of Central Florida,http://www.tesseract.org/paul,f6cjEJcAAAAJ
 R. Rodrey Howell,Kansas State University,http://people.cs.ksu.edu/~rhowell,NOSCHOLARPAGE
@@ -11829,7 +11829,7 @@ Rafal A. Angryk,Georgia State University,https://grid.cs.gsu.edu/~rangryk,Phw2Rf
 Rafal K. Mantiuk,University of Cambridge,https://www.cl.cam.ac.uk/~rkm38,pJEb8x4AAAAJ
 Rafal Mantiuk,University of Cambridge,https://www.cl.cam.ac.uk/~rkm38,pJEb8x4AAAAJ
 Raffaella Mirandola,Politecnico di Milano,http://home.deib.polimi.it/mirandol,_NqFoiYAAAAJ
-Ragesh Jaiswal,IIT Delhi,http://www.cse.iitd.ernet.in/~rjaiswal,hrbj92oAAAAJ
+Ragesh Jaiswal,IIT Delhi,http://www.cse.iitd.ernet.in/~rjaiswal,I5CBvwIAAAAJ
 Raghav Sampangi,Dalhousie University,https://www.dal.ca/academics/programs/graduate/computer-science/graduate-life/current-students/raghav-sampangi.html,x_Cy69EAAAAJ
 Raghavan Komondoor,IISc Bangalore,http://www.csa.iisc.ac.in/~raghavan,fZq9W2cAAAAJ
 Raghu Machiraju,Ohio State University,http://web.cse.ohio-state.edu/~raghu,HHialjcAAAAJ
@@ -11913,7 +11913,7 @@ Rakesh B. Bobba,Oregon State University,http://eecs.oregonstate.edu/people/bobba
 Rakesh Bobba,Oregon State University,http://eecs.oregonstate.edu/people/bobba-rakesh,_0x5unAAAAAJ
 Rakesh Kumar 0002,Univ. of Illinois at Urbana-Champaign,https://www.ece.illinois.edu/directory/profile/rakeshk,HN8BPrEAAAAJ
 Rakesh V. Vohra,University of Pennsylvania,https://economics.sas.upenn.edu/faculty/rakesh-vohra,JnWSU4oAAAAJ
-Rakesh Verma,University of Houston,http://www2.cs.uh.edu/~rmverma,va3JOtYAAAAJ
+Rakesh Verma,University of Houston,http://www2.cs.uh.edu/~rmverma,NOSCHOLARPAGE
 Rakesh Vohra,University of Pennsylvania,https://economics.sas.upenn.edu/faculty/rakesh-vohra,JnWSU4oAAAAJ
 Rakeshbabu Bobba,Oregon State University,http://eecs.oregonstate.edu/people/bobba-rakesh,_0x5unAAAAAJ
 Ralf H. Reussner,Karlsruhe Institute of Technology (KIT),http://sdq.ipd.kit.edu/people/ralf_reussner,wsPDe4IAAAAJ
@@ -12152,7 +12152,7 @@ Reza Curtmola,NJIT,https://web.njit.edu/~crix,mS1VzxkAAAAJ
 Reza Derakhshani,University of Missouri - Kansas City,https://info.umkc.edu/scenews/tag/reza-derakhshani,NOSCHOLARPAGE
 Reza Haffari,Monash University,http://users.monash.edu.au/~gholamrh,Perjx5EAAAAJ
 Reza Rejaie,University of Oregon,http://ix.cs.uoregon.edu/~reza,dgRIYXIAAAAJ
-Reza Samavi,McMaster University,http://www.cas.mcmaster.ca/samavi,wbObcaQAAAAJ
+Reza Samavi,McMaster University,http://www.cas.mcmaster.ca/samavi,b-IpalkAAAAJ
 Reza Shokri,National University of Singapore,https://www.comp.nus.edu.sg/~reza,udlZXXcAAAAJ
 Reza Zafarani,Syracuse University,http://ecs.syr.edu/faculty/reza,NOSCHOLARPAGE
 Rezaul Alam Chowdhury,Stony Brook University,http://www3.cs.stonybrook.edu/~rezaul,NOSCHOLARPAGE
@@ -12216,23 +12216,23 @@ Richard D. Green,University of Canterbury,http://www.cosc.canterbury.ac.nz/richa
 Richard E. Jones,University of Kent,https://www.cs.kent.ac.uk/~rej,WL9WBgoAAAAJ
 Richard E. Korf,University of California - Los Angeles,http://www.cs.ucla.edu/~korf,LsuWoRoAAAAJ
 Richard E. Ladner,University of Washington,http://www.cs.washington.edu/people/faculty/ladner,hgOSI1EAAAAJ
-Richard E. Newman,University of Florida,http://www.cise.ufl.edu/~nemo,7im4NjEAAAAJ
-Richard E. Newman-Wolfe,University of Florida,http://www.cise.ufl.edu/~nemo,7im4NjEAAAAJ
+Richard E. Newman,University of Florida,http://www.cise.ufl.edu/~nemo,NOSCHOLARPAGE
+Richard E. Newman-Wolfe,University of Florida,http://www.cise.ufl.edu/~nemo,NOSCHOLARPAGE
 Richard F. Paige,University of York,https://www-users.cs.york.ac.uk/~paige,HzFjuyUAAAAJ
 Richard F. Riesenfeld,University of Utah,https://www.cs.utah.edu/~rfr,NOSCHOLARPAGE
 Richard Fujimoto,Georgia Institute of Technology,http://www.cc.gatech.edu/~fujimoto,q1bkP7AAAAAJ
 Richard Furuta,Texas A&M University,http://www.csdl.tamu.edu/~furuta,vygtLDcAAAAJ
 Richard G. Baraniuk,Rice University,http://richb.rice.edu,N-BBA20AAAAJ
 Richard H. Lathrop,University of California - Irvine,http://www.ics.uci.edu/~rickl,D9UDlHYAAAAJ
-Richard Han,University of Colorado Boulder,http://www.cs.colorado.edu/~rhan,mah-B4IAAAAJ
+Richard Han,University of Colorado Boulder,http://www.cs.colorado.edu/~rhan,v1h6k2oAAAAJ
 Richard Haverkamp,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=627430,UanjyZMAAAAJ
 Richard Hughey,University of California - Santa Cruz,https://www.soe.ucsc.edu/people/rph,D8iiWtEAAAAJ
 Richard I. Hartley,Australian National University,http://axiom.anu.edu.au/~hartley,cHia5p0AAAAJ
 Richard J. Anderson,University of Washington,http://www.cs.washington.edu/people/faculty/anderson,uLsDDUMAAAAJ
 Richard J. Enbody,Michigan State University,http://www.cse.msu.edu/~enbody,QR4VpsIAAAAJ
-Richard J. Lipton,Georgia Institute of Technology,http://www.cc.gatech.edu/people/richard-lipton,f8B4yewAAAAJ
+Richard J. Lipton,Georgia Institute of Technology,http://www.cc.gatech.edu/people/richard-lipton,Jrr6ricAAAAJ
 Richard J. Trefler,University of Waterloo,https://cs.uwaterloo.ca/~trefler,NOSCHOLARPAGE
-Richard Jay Lipton,Georgia Institute of Technology,http://www.cc.gatech.edu/people/richard-lipton,f8B4yewAAAAJ
+Richard Jay Lipton,Georgia Institute of Technology,http://www.cc.gatech.edu/people/richard-lipton,Jrr6ricAAAAJ
 Richard M. Fujimoto,Georgia Institute of Technology,http://www.cc.gatech.edu/~fujimoto,q1bkP7AAAAAJ
 Richard M. Karp,University of California - Berkeley,https://www.eecs.berkeley.edu/Faculty/Homepages/karp.html,NOSCHOLARPAGE
 Richard M. Stern,Carnegie Mellon University,http://www.cs.cmu.edu/~rms,ffUu1PcAAAAJ
@@ -12249,7 +12249,7 @@ Richard Peng,Georgia Institute of Technology,http://www.cc.gatech.edu/~rpeng,NOS
 Richard Rasala,Northeastern University,http://www.ccs.neu.edu/home/rasala,NOSCHOLARPAGE
 Richard Ryan Williams,Massachusetts Institute of Technology,http://web.stanford.edu/~rrwill,Wp38QQYAAAAJ
 Richard S. Bird,University of Oxford,http://www.cs.ox.ac.uk/richard.bird,1vrc8EUAAAAJ
-Richard S. Sutton,University of Alberta,https://webdocs.cs.ualberta.ca/~sutton,hNTyptAAAAAJ
+Richard S. Sutton,University of Alberta,https://webdocs.cs.ualberta.ca/~sutton,NOSCHOLARPAGE
 Richard S. Zemel,University of Toronto,http://www.cs.toronto.edu/~zemel,iBeDoRAAAAAJ
 Richard Shillcock,University of Edinburgh,http://www.ppls.ed.ac.uk/people/richard-shillcock,oqirbaYAAAAJ
 Richard Souvenir,Temple University,https://cis.temple.edu/~souvenir,1sMNiJIAAAAJ
@@ -12277,7 +12277,7 @@ Rijurekha Sen,IIT Delhi,http://www.cse.iitd.ernet.in/~rijurekha/,yTPVlzgAAAAJ
 Rik Sarkar,University of Edinburgh,http://homepages.inf.ed.ac.uk/rsarkar,rmMWizEAAAAJ
 Rikky Muller,University of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/rikky.html,4bgii4oAAAAJ
 Riko Jacob,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/riko-jacob(e6f70fb0-caf1-4736-b583-b0777bc1390f).html,Bt7TAOYAAAAJ
-Rina Dechter,University of California - Irvine,http://www.ics.uci.edu/~dechter,Uph176YAAAAJ
+Rina Dechter,University of California - Irvine,http://www.ics.uci.edu/~dechter,NOSCHOLARPAGE
 Rineke Verbrugge,University of Groningen,http://www.ai.rug.nl/~rineke,p6lcxiMAAAAJ
 Rini van Solingen,TU Delft,http://www.se.ewi.tudelft.nl,9LxiPOUAAAAJ
 Rinku Dewri,University of Denver,http://www.cs.du.edu/~rdewri,gJ7XMyoAAAAJ
@@ -12298,7 +12298,7 @@ Rizos Sakellariou,University of Manchester,http://www.cs.man.ac.uk/~rizos,5LPRRM
 Rob A. Rutenbar,University of Pittsburgh,http://chancellor.pitt.edu/people/rob-rutenbar,avq8-1QAAAAJ
 Rob Alexander,University of York,https://www-users.cs.york.ac.uk/~rda,DFdBpC0AAAAJ
 Rob Kremer,University of Calgary,http://kremer.cpsc.ucalgary.ca,KTHrGlQAAAAJ
-Rob Meredith,Monash University,http://monash.edu/research/explore/en/persons/robert-meredith(d68a8248-25e6-42e7-a8df-a4cba6db333a).html,agSLx_kAAAAJ
+Rob Meredith,Monash University,http://monash.edu/research/explore/en/persons/robert-meredith(d68a8248-25e6-42e7-a8df-a4cba6db333a).html,NOSCHOLARPAGE
 Rob Miller 0001,Massachusetts Institute of Technology,http://www.mit.edu/~rcm,1MK2_tMAAAAJ
 Rob Smith,University College London,http://www0.cs.ucl.ac.uk/people/Rob.Smith.html,NOSCHOLARPAGE
 Rob V. van Nieuwpoort,VU Amsterdam,http://www.cs.vu.nl/~rob,z7-NbJ0AAAAJ
@@ -12457,7 +12457,7 @@ Roberto Palmieri,Lehigh University,http://www.cse.lehigh.edu/~palmieri,NOSCHOLAR
 Roberto Perdisci,University of Georgia,http://roberto.perdisci.com,M_soLLcAAAAJ
 Roberto Solis-Oba,Western University,http://www.csd.uwo.ca/faculty/solis,NOSCHOLARPAGE
 Roberto Souto Maior de Barros,UFPE,http://www.cin.ufpe.br/~roberto,OnmLz-AAAAAJ
-Roberto Tagliaferri,University of Salerno,http://www.unisa.it/docenti/robertotagliaferri/en/index,lwgZxjIAAAAJ
+Roberto Tagliaferri,University of Salerno,http://www.unisa.it/docenti/robertotagliaferri/en/index,WdQ9HBAAAAAJ
 Roberto Tamassia,Brown University,http://cs.brown.edu/~rt,eEYPTKUAAAAJ
 Robi Malik,University of Waikato,http://www.cs.waikato.ac.nz/~robi,ZPixU7kAAAAJ
 Robin Burke,DePaul University,http://josquin.cti.depaul.edu/%7Erburke,wRwI6d0AAAAJ
@@ -12584,7 +12584,7 @@ Ronald Freund,TU Berlin,https://www.eecs.tu-berlin.de/menue/einrichtungen/profes
 Ronald G. Dreslinski,University of Michigan,https://web.eecs.umich.edu/~rdreslin,4O-rMYEAAAAJ
 Ronald Garcia,University of British Columbia,http://www.cs.ubc.ca/~rxg,QqnkA2IAAAAJ
 Ronald J. Brachman,Cornell University,http://brachman.org,NOSCHOLARPAGE
-Ronald J. Gould,Emory University,http://www.mathcs.emory.edu/~rg,CckhtnYAAAAJ
+Ronald J. Gould,Emory University,http://www.mathcs.emory.edu/~rg,NOSCHOLARPAGE
 Ronald L. Chrisley,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/476,9Cy00wEAAAAJ
 Ronald L. Graham,University of California - San Diego,https://cseweb.ucsd.edu/~rgraham,qrPaF3QAAAAJ
 Ronald L. Rivest,Massachusetts Institute of Technology,http://people.csail.mit.edu/rivest,6qE0tdAAAAAJ
@@ -12593,7 +12593,7 @@ Ronald M. Baecker,University of Toronto,http://ron.taglab.ca,NOSCHOLARPAGE
 Ronald N. Goldman,Rice University,https://www.cs.rice.edu/~rng,6Vv8ZGAAAAAJ
 Ronald Parr,Duke University,https://users.cs.duke.edu/~parr,b-GJ3QIAAAAJ
 Ronald Rosenfeld,Carnegie Mellon University,http://www.cs.cmu.edu/~roni,vrbjXlMAAAAJ
-Ronald S. Fearing,University of California - Berkeley,https://robotics.eecs.berkeley.edu/~ronf,mx9gMZ4AAAAJ
+Ronald S. Fearing,University of California - Berkeley,https://robotics.eecs.berkeley.edu/~ronf,uA0kNBUAAAAJ
 Ronald Vullo,Rochester Institute of Technology,http://ist.rit.edu/~rpv,NOSCHOLARPAGE
 Ronald de Wolf,CWI,http://homepages.cwi.nl/~rdewolf,0tUCIPwAAAAJ
 Ronaldo A. Ferreira,UFMS,https://www.facom.ufms.br/~raf,WlY9jd8AAAAJ
@@ -12823,7 +12823,7 @@ Saeid Belkasim,Georgia State University,https://grid.cs.gsu.edu/belkasim,NOSCHOL
 Saeid Mehrkanoon,University of Queensland,http://researchers.uq.edu.au/researcher/14135,NOSCHOLARPAGE
 Saeid Nooshabadi,Michigan Technological University,https://www.mtu.edu/data-science/people-groups/faculty/nooshabadi,NOSCHOLARPAGE
 Saewoong Bahk,Seoul National University,http://netlab.snu.ac.kr/~sbahk,QQ8diWkAAAAJ
-Safwan Wshah,University of Vermont,https://www.uvm.edu/cems/cs/profiles/safwan-wshah,7fk521IAAAAJ
+Safwan Wshah,University of Vermont,https://www.uvm.edu/cems/cs/profiles/safwan-wshah,Q7NskmwAAAAJ
 Sageev Oore,Dalhousie University,https://www.dal.ca/faculty/computerscience/faculty-staff/sageev-oore.html,cI0dYX4AAAAJ
 Sahand N. Negahban,Yale University,http://www.stat.yale.edu/~snn7,3p-KQUwAAAAJ
 Sahand Negahban,Yale University,http://www.stat.yale.edu/~snn7,3p-KQUwAAAAJ
@@ -12849,7 +12849,7 @@ Sakire Arslan Ay,Washington State University,https://school.eecs.wsu.edu/people/
 Salamah Salamah,University of Texas - El Paso,http://www.cs.utep.edu/isalamah,NOSCHOLARPAGE
 Saleh Al-Sharaeh,University of Jordan,http://eacademic.ju.edu.jo/ssharaeh,7zZ86FsAAAAJ
 Salil Kanhere,UNSW,http://www.cse.unsw.edu.au/~salilk,sgqmaPMAAAAJ
-Salil P. Vadhan,Harvard University,http://www.eecs.harvard.edu/~salil,37frPb8AAAAJ
+Salil P. Vadhan,Harvard University,http://www.eecs.harvard.edu/~salil,dqVjyRQAAAAJ
 Salil S. Kanhere,UNSW,http://www.cse.unsw.edu.au/~salilk,sgqmaPMAAAAJ
 Salles Viana Gomes Magalhães,Universidade Federal de Viçosa,http://www2.dpi.ufv.br/?page_id=548,9xmUqzUAAAAJ
 Sally Fincher,University of Kent,https://www.cs.kent.ac.uk/people/staff/saf,CwnKRzMAAAAJ
@@ -12857,7 +12857,7 @@ Sally Jo Cunningham,University of Waikato,http://www.cms.waikato.ac.nz/people/sa
 Salman Avestimehr,Cornell University,http://www-bcf.usc.edu/~avestime/Home.html,Qhe5ua0AAAAJ
 Salman Durrani,Australian National University,http://users.cecs.anu.edu.au/Salman.Durrani,_stHeQMAAAAJ
 Salsabeel F. M. AlFalah,University of Jordan,http://ieeexplore.ieee.org/document/6918271,AIQFoMkAAAAJ
-Salvatore J. Stolfo,Columbia University,http://www.cs.columbia.edu/~sal,DknsgF8AAAAJ
+Salvatore J. Stolfo,Columbia University,http://www.cs.columbia.edu/~sal,iLXSMP8AAAAJ
 Salvatore La Torre,University of Salerno,http://www.di.unisa.it/professori/latorre,aWRR6EAAAAAJ
 Salvatore Rampone,University of Sannio,https://www.unisannio.it/it/users/salvatore-rampone,SONRi2UAAAAJ
 Salvatore Romeo,Qatar Computing Research Institute,http://www.qcri.org/our-people/bio?pid=242&amp;par=acc&amp;name=SalvatoreRomeo,rE8OSHwAAAAJ
@@ -12890,7 +12890,7 @@ Samir Khuller,Northwestern University,https://www.cs.umd.edu/people/samirk,6vXTt
 Samir R. Das,Stony Brook University,http://www3.cs.stonybrook.edu/~samir,NOSCHOLARPAGE
 Samir Ranjan Das,Stony Brook University,http://www3.cs.stonybrook.edu/~samir,NOSCHOLARPAGE
 Samira Manabi Khan,University of Virginia,http://www.cs.virginia.edu/~smk9u,NOSCHOLARPAGE
-Samira Shaikh,UNC - Charlotte,https://analyticsfrontiers.uncc.edu/speakers/samira-shaikh,IM-64IoAAAAJ
+Samira Shaikh,UNC - Charlotte,https://analyticsfrontiers.uncc.edu/speakers/samira-shaikh,x39kyaYAAAAJ
 Samit Bhattacharya,IIT Guwahati,http://www.iitg.ernet.in/samit,oXu5o6gAAAAJ
 Samory Kpotufe,Princeton University,http://www.princeton.edu/~samory,NOSCHOLARPAGE
 Sampalli Srinivas,Dalhousie University,https://web.cs.dal.ca/~srini,NOSCHOLARPAGE
@@ -13035,7 +13035,7 @@ Sasa Radomirovic,University of Dundee,https://www.computing.dundee.ac.uk/about/s
 Sascha Fahl,Ruhr-University Bochum,https://saschafahl.de,uiB3WGEAAAAJ
 Sascha Ossowski,Universidad Rey Juan Carlos,http://www.ia.urjc.es/~sossowski,UYvMqW8AAAAJ
 Sasha Boldyreva,Georgia Institute of Technology,http://www.cc.gatech.edu/~aboldyre,8mHLyRoAAAAJ
-Sasha Rakhlin,University of Pennsylvania,http://www-stat.wharton.upenn.edu/~rakhlin,fds2VpgAAAAJ
+Sasha Rakhlin,University of Pennsylvania,http://www-stat.wharton.upenn.edu/~rakhlin,NOSCHOLARPAGE
 Saswata Shannigrahi,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/saswata.sh,PbbIftYAAAAJ
 Sathiamoorthy Manoharan,University of Auckland,https://unidirectory.auckland.ac.nz/profile/s-manoharan,NOSCHOLARPAGE
 Sathish Gopalakrishnan,University of British Columbia,https://www.ece.ubc.ca/faculty/sathish-gopalakrishnan,NOSCHOLARPAGE
@@ -13398,14 +13398,14 @@ Shiqiang Yang,Tsinghua University,http://media.cs.tsinghua.edu.cn/en/yangsq,NOSC
 Shira L. Broschat,Washington State University,https://school.eecs.wsu.edu/people/faculty/shira-broschat,NOSCHOLARPAGE
 Shiri Azenkot,Cornell University,https://tech.cornell.edu/people/shiri-azenkot,jNQlAkoAAAAJ
 Shiri Chechik,Tel Aviv University,https://www.cs.tau.ac.il/~schechik,ILDtD7oAAAAJ
-Shirin Nilizadeh,University of Texas at Arlington,http://crystal.uta.edu/~shirin,PxFbFJgAAAAJ
+Shirin Nilizadeh,University of Texas at Arlington,http://crystal.uta.edu/~shirin,UaSo4BoAAAAJ
 Shirish K. Shevade,IISc Bangalore,http://www.csa.iisc.ac.in/~shirish,HOIpJSwAAAAJ
 Shirley B. Chu,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742689439&command=GETPROFILE,y_VBFTMAAAAJ
 Shishir K. Shah,University of Houston,http://www.uh.edu/nsm/computer-science/people/faculty,gJ3JGSsAAAAJ
 Shiu-Kai Chin,Syracuse University,https://news.syr.edu/faculty-experts/shiu-kai-chin,NOSCHOLARPAGE
 Shiva Azadegan,Towson University,http://cis1.towson.edu/~cisweb/dev/?staff=azadegan-shiva,NOSCHOLARPAGE
 Shivakant Mishra,University of Colorado Boulder,https://www.cs.colorado.edu/~mishras,0RMteS0AAAAJ
-Shivani Agarwal 0001,University of Pennsylvania,http://www.shivani-agarwal.net,z7lkXXkAAAAJ
+Shivani Agarwal 0001,University of Pennsylvania,http://www.shivani-agarwal.net,rBHZ-LkAAAAJ
 Shivaram Kalyanakrishnan,IIT Bombay,https://www.cse.iitb.ac.in/~shivaram,YZkeEqAAAAAJ
 Shivaram Venkataraman,University of Wisconsin - Madison,http://shivaram.org,5LLV29oAAAAJ
 Shivashankar B. Nair,IIT Guwahati,https://www.iitg.ernet.in/sbnair,wfeT0bYAAAAJ
@@ -13420,10 +13420,10 @@ Shmuel Peleg,Hebrew University of Jerusalem,http://www.cs.huji.ac.il/~peleg,CshJ
 Shmuel Rotenstreich,George Washington University,https://www2.seas.gwu.edu/~shmuel/WORK/Contact.html,NOSCHOLARPAGE
 Shmuel Safra,Tel Aviv University,http://www.tau.ac.il/~safra,NOSCHOLARPAGE
 Shmuel Sagiv,Tel Aviv University,http://www.cs.tau.ac.il/~msagiv,j4UuW80AAAAJ
-Shmuel T. Klein,Bar-Ilan University,http://u.cs.biu.ac.il/~tomi,4GBCCpgAAAAJ
-Shmuel Tomi Klein,Bar-Ilan University,http://u.cs.biu.ac.il/~tomi,4GBCCpgAAAAJ
+Shmuel T. Klein,Bar-Ilan University,http://u.cs.biu.ac.il/~tomi,rBHZ-LkAAAAJ
+Shmuel Tomi Klein,Bar-Ilan University,http://u.cs.biu.ac.il/~tomi,rBHZ-LkAAAAJ
 Shmuel Zaks,Technion,http://www.cs.technion.ac.il/~zaks,rWc3QtgAAAAJ
-Shobha Vasudevan,Univ. of Illinois at Urbana-Champaign,http://faculty.ece.illinois.edu/shobhav,_bdmmpAAAAAJ
+Shobha Vasudevan,Univ. of Illinois at Urbana-Champaign,http://faculty.ece.illinois.edu/shobhav,NOSCHOLARPAGE
 Shohei Nobuhara,Kyoto University,https://shohei.nobuhara.org/index.en.html,keXiLQ0AAAAJ
 Shohreh Kasaei,Sharif University of Technology,http://sharif.ir/~skasaei,mvx4PvgAAAAJ
 Shoji Takeuchi,University of Tokyo,http://www.iis.u-tokyo.ac.jp/~takeuchi,DqVCX9AAAAAJ
@@ -13450,7 +13450,7 @@ Shuangjiu Xiao,Shanghai Jiao Tong University,http://dalab.se.sjtu.edu.cn/www/hom
 Shuangshuang Jin,Clemson University,https://sjinwsu.wixsite.com/jin6,bYSZ-egAAAAJ
 Shubham Jain,Old Dominion University,http://www.cs.odu.edu/~jain,P9Z011YAAAAJ
 Shubhangi Saraf,Rutgers University,https://www.math.rutgers.edu/~ss1984,NiRqwkcAAAAJ
-Shucheng Yu,University of Arkansas - Little Rock,https://ualr.edu/faculty-7wazt/yu,jYW_WCwAAAAJ
+Shucheng Yu,University of Arkansas - Little Rock,https://ualr.edu/faculty-7wazt/yu,NOSCHOLARPAGE
 Shuchi Chawla 0001,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~shuchi,Znp3UkEAAAAJ
 Shueng-Han Gary Chan,HKUST,https://home.cse.ust.hk/~gchan,uiCSOycAAAAJ
 Shuhui Wang,Chinese Academy of Sciences,http://vipl.ict.ac.cn/view_people.php?url=&id=62,h-JxBSYAAAAJ
@@ -13672,7 +13672,7 @@ Spiros E. Papadimitriou,Rutgers University,https://www.cs.rutgers.edu/people/fac
 Spiros Mancoridis,Drexel University,http://drexel.edu/cci/contact/Faculty/Mancoridis-Spiros,bKGwUrQAAAAJ
 Spiros Papadimitriou,Rutgers University,https://www.cs.rutgers.edu/people/faculty/affiliated-faculty,WUrGGDgAAAAJ
 Spyros Blanas,Ohio State University,http://web.cse.ohio-state.edu/~sblanas,4_1z8yEAAAAJ
-Spyros Voulgaris,VU Amsterdam,http://www.cs.vu.nl/~spyros,M_tdQJAAAAAJ
+Spyros Voulgaris,VU Amsterdam,http://www.cs.vu.nl/~spyros,GG9rRS8AAAAJ
 Srdjan Capkun,ETH Zurich,http://www.syssec.ethz.ch/people/capkun,VtkPBNsAAAAJ
 Sreepathi Pai,University of Rochester,http://cs.rochester.edu/~spai4,0j47sRUAAAAJ
 Sri Hastuti Kurniawan,University of California - Santa Cruz,https://users.soe.ucsc.edu/~srikur,NOSCHOLARPAGE
@@ -13711,9 +13711,9 @@ Sriram Subramanian,University of Sussex,http://www.sussex.ac.uk/informatics/peop
 Sriram V. Pemmaraju,University of Iowa,https://www.cs.uiowa.edu/~sriram,s_yIH3gAAAAJ
 Srivas Chennu,University of Kent,https://www.cs.kent.ac.uk/people/staff/sc785,8BIf5MEAAAAJ
 Stacey D. Scott,University of Guelph,https://www.uoguelph.ca/computing/people/stacey-scott,fB_xzi8AAAAJ
-Stacy C. Marsella,Northeastern University,http://www.ccis.northeastern.edu/people/stacy-c-marsella,LkoaA0gAAAAJ
+Stacy C. Marsella,Northeastern University,http://www.ccis.northeastern.edu/people/stacy-c-marsella,NOSCHOLARPAGE
 Stacy M. Branham,University of California - Irvine,https://stacybranham.com,AmJ8iWcAAAAJ
-Stacy Marsella,Northeastern University,http://www.ccis.northeastern.edu/people/stacy-c-marsella,LkoaA0gAAAAJ
+Stacy Marsella,Northeastern University,http://www.ccis.northeastern.edu/people/stacy-c-marsella,NOSCHOLARPAGE
 Stacy Patterson,Rensselaer Polytechnic Institute,http://www.cs.rpi.edu/~pattes3,7b_ipvgAAAAJ
 Stan Ahalt,University of North Carolina,http://cs.unc.edu/people/stan-ahalt,NOSCHOLARPAGE
 Stan Klasa,Concordia University,https://www.concordia.ca/encs/computer-science-software-engineering/faculty.html.html?fpid=stan-klasa,NOSCHOLARPAGE
@@ -13805,7 +13805,7 @@ Steffen Hölldobler,TU Dresden,http://www.computational-logic.org/~sh,NOSCHOLARP
 Steffen Rothkugel,University of Luxembourg,http://wwwen.uni.lu/research/fstc/communicative_systems_laboratory_com_sys/members/steffen_rothkugel,NOSCHOLARPAGE
 Steffen Staab,University of Koblenz-Landau,https://west.uni-koblenz.de/de/about-us/team/prof-dr-steffen-staab,QvpcUn8AAAAJ
 Steffen van Bakel,Imperial College London,http://www.doc.ic.ac.uk/~svb,wSUVpA0AAAAJ
-Stelian Coros,ETH Zurich,http://crl.ethz.ch/coros.html,DFQNrvUAAAAJ
+Stelian Coros,ETH Zurich,http://crl.ethz.ch/coros.html,sX31JjwAAAAJ
 Stenio F. L. Fernandes,UFPE,www.steniofernandes.com,4UjuNLkAAAAJ
 Stenio Fernandes,UFPE,www.steniofernandes.com,4UjuNLkAAAAJ
 Stephan Chalup,Newcastle University,https://www.newcastle.edu.au/profile/stephan-chalup,61q7GXYAAAAJ
@@ -13840,7 +13840,7 @@ Stephen G. Kobourov,University of Arizona,http://www.cs.arizona.edu/~kobourov,P2
 Stephen G. Pulman,University of Oxford,https://www.cs.ox.ac.uk/people/stephen.pulman,dzxbFGgAAAAJ
 Stephen G. Ware,University of New Orleans,http://www.uno.edu/news/2015/uno-digital-media-lab-grant.aspx,mkFBt8oAAAAJ
 Stephen Gilmore,University of Edinburgh,http://homepages.inf.ed.ac.uk/stg,S7iYkO8AAAAJ
-Stephen Gould,Australian National University,http://users.cecs.anu.edu.au/~sgould,kALUT54AAAAJ
+Stephen Gould,Australian National University,http://users.cecs.anu.edu.au/~sgould,i7VQcR8AAAAJ
 Stephen H. Edwards,Virginia Tech,http://webcore.cs.vt.edu/user/edwards,5pV6DQ4AAAAJ
 Stephen H. Muggleton,Imperial College London,http://wp.doc.ic.ac.uk/shm,WxJXT2MAAAAJ
 Stephen Huang,University of Houston,http://www2.cs.uh.edu/shuang,hPY6T7gAAAAJ
@@ -13856,14 +13856,14 @@ Stephen M. Pizer,University of North Carolina,http://www.cs.unc.edu/~smp,8UCWq-U
 Stephen M. Thebaut,University of Florida,https://www.cise.ufl.edu/people/faculty/smt,NOSCHOLARPAGE
 Stephen M. Watt,University of Waterloo,https://uwaterloo.ca/math/about/people/smwatt,O4bB0QkAAAAJ
 Stephen Mann,University of Waterloo,http://www.cgl.uwaterloo.ca/smann,r8jslMgAAAAJ
-Stephen Marsland,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=895830,XfFhVhAAAAAJ
+Stephen Marsland,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=895830,B9jo4m0AAAAJ
 Stephen McCamant,University of Minnesota,http://www-users.cs.umn.edu/~mccamant,NOSCHOLARPAGE
 Stephen Muggleton,Imperial College London,http://wp.doc.ic.ac.uk/shm,WxJXT2MAAAAJ
 Stephen Oney,University of Michigan,http://from.so,o75yGRIAAAAJ
 Stephen Pettifer,University of Manchester,https://www.research.manchester.ac.uk/portal/en/researchers/stephen-pettifer(2be3e283-7ad3-4926-85ea-501491a382d2).html,yUwh2bEAAAAJ
 Stephen Pulman,University of Oxford,https://www.cs.ox.ac.uk/people/stephen.pulman,dzxbFGgAAAAJ
 Stephen R. Marschner,Cornell University,http://www.cs.cornell.edu/~srm,llo3F3QAAAAJ
-Stephen R. Marsland,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=895830,XfFhVhAAAAAJ
+Stephen R. Marsland,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=895830,B9jo4m0AAAAJ
 Stephen Ramsey,Oregon State University,http://eecs.oregonstate.edu/people/ramsey-stephen,286qVQYAAAAJ
 Stephen Renals,University of Edinburgh,http://homepages.inf.ed.ac.uk/srenals,sAfu3yIAAAAJ
 Stephen Robert Pettifer,University of Manchester,https://www.research.manchester.ac.uk/portal/en/researchers/stephen-pettifer(2be3e283-7ad3-4926-85ea-501491a382d2).html,yUwh2bEAAAAJ
@@ -13975,19 +13975,19 @@ Su Yang,Fudan University,http://homepage.fudan.edu.cn/suyang,NOSCHOLARPAGE
 Su-In Lee,University of Washington,http://suinlee.cs.washington.edu,3ifikJ0AAAAJ
 Su-Lin Lee,Imperial College London,http://www.imperial.ac.uk/people/su-lin.lee,JzfbzH0AAAAJ
 Subash Shankar,CUNY,http://www.cs.hunter.cuny.edu/~sshankar,NOSCHOLARPAGE
-Subashish Datta,IIT Mandi,https://www.facebook.com/subashish.datta,dyRc_BIAAAAJ
+Subashish Datta,IIT Mandi,https://www.facebook.com/subashish.datta,yWnFZ6kAAAAJ
 Subbarao Kambhampati,Arizona State University,http://rakaposhi.eas.asu.edu,yl3L07sAAAAJ
 Subbayyan Venkatesan,University of Texas at Dallas,https://www.utdallas.edu/~venky,l80_pjYAAAAJ
 Subhajit Roy,IIT Kanpur,http://www.cse.iitk.ac.in/users/subhajit,FIiF03AAAAAJ
 Subhajit Sen,IIIT Bangalore,http://www.iiitb.ac.in/faculty_page.php?name=SubajitSen,uPa54XcAAAAJ
 Subhankar Mishra,IIT Roorkee,http://faculty.iitr.ac.in/~smishrafcs,FICz_ukAAAAJ
-Subhanshu Gupta,Washington State University,https://sites.google.com/site/researcheecswsusubhanshu/home,GNhTWHoAAAAJ
+Subhanshu Gupta,Washington State University,https://sites.google.com/site/researcheecswsusubhanshu/home,NOSCHOLARPAGE
 Subhas C. Mukhopadhyay,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=265530,fsu2yL8AAAAJ
 Subhas Chandra Mukhopadhyay,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=265530,fsu2yL8AAAAJ
 Subhas Mukhopadhyay,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=265530,fsu2yL8AAAAJ
 Subhash Khot,New York University,http://www.cs.nyu.edu/~khot,NOSCHOLARPAGE
 Subhash Suri,University of California - Santa Barbara,https://www.cs.ucsb.edu/~suri,VgrH9A8AAAAJ
-Subhashis Banerjee,IIT Delhi,http://www.cse.iitd.ernet.in/~suban,UU9KftAAAAAJ
+Subhashis Banerjee,IIT Delhi,http://www.cse.iitd.ernet.in/~suban,NOSCHOLARPAGE
 Subhasish Mazumdar,New Mexico Tech,https://nmt.edu/academics/compsci/faculty/smazumdar.php,NOSCHOLARPAGE
 Subhasish Mitra,Stanford University,https://web.stanford.edu/~subh,ZZrSuh8AAAAJ
 Subhransu Maji,University of Massachusetts Amherst,http://people.cs.umass.edu/~smaji,l7Qx0zAAAAAJ
@@ -14046,7 +14046,7 @@ Sukomal Pal,IIT (BHU) Varanasi,http://www.iitbhu.ac.in/cse/index.php/people/facu
 Sukumar Ghosh,University of Iowa,https://www.cs.uiowa.edu/~ghosh,LCVf0lcAAAAJ
 Sukumar Nandi,IIT Guwahati,https://www.iitg.ernet.in/sukumar,ChtruacAAAAJ
 Sukyoung Ryu,KAIST,http://plrg.kaist.ac.kr/ryu,c98U5D0AAAAJ
-Sulamita Klein,UFRJ,http://www.cos.ufrj.br/index.php/pt-BR/pessoas/details/18/1054-sula,r4ZrGiIAAAAJ
+Sulamita Klein,UFRJ,http://www.cos.ufrj.br/index.php/pt-BR/pessoas/details/18/1054-sula,QfH2BxYAAAAJ
 Sule Gündüz,Istanbul Technical University,http://web.itu.edu.tr/sgunduz,E5OlkJMAAAAJ
 Sule Gündüz Ögüdücü,Istanbul Technical University,http://web.itu.edu.tr/sgunduz,E5OlkJMAAAAJ
 Suleman Shahid,LUMS,https://lums.edu.pk/lums_employee/4407,NOSCHOLARPAGE
@@ -14080,7 +14080,7 @@ Sung-Gi Min,Korea University,http://hcl.korea.ac.kr/index.php/people,NOSCHOLARPA
 Sung-Hee Lee,KAIST,http://motionlab.kaist.ac.kr/?page_id=41,AVII4wsAAAAJ
 Sung-Hyon Myaeng,KAIST,http://ir.kaist.ac.kr/member/professor,NOSCHOLARPAGE
 Sung-Ju Lee,KAIST,https://cs.kaist.ac.kr/people/view?idx=508&kind=faculty&menu=167,d_DQh8IAAAAJ
-Sungahn Ko,UNIST,http://ivader.unist.ac.kr,xkJvgb0AAAAJ
+Sungahn Ko,UNIST,http://ivader.unist.ac.kr,gKnZiVcAAAAJ
 Sungdeok Cha,Korea University,http://dependable.korea.ac.kr/professor,NOSCHOLARPAGE
 Sunghee Choi,KAIST,http://gclab.kaist.ac.kr/sunghee.html,JX6jaiUAAAAJ
 Sungho Jo,KAIST,http://isnl.kaist.ac.kr,NOSCHOLARPAGE
@@ -14305,7 +14305,7 @@ Tanmoy Chakraborty 0002,IIIT Delhi,https://www.iiitd.ac.in/tanmoy,ciFgnaoAAAAJ
 Tanu Malik,DePaul University,http://www.cdm.depaul.edu/Faculty-and-Staff/Pages/faculty-info.aspx?fid=1328,ZvYwdsUAAAAJ
 Tanushree Mitra,Virginia Tech,http://people.cs.vt.edu/tmitra,pgKClXQAAAAJ
 Tanya Plotkin,Bar-Ilan University,http://cs.biu.ac.il/en/node/648,NOSCHOLARPAGE
-Tanya Y. Berger-Wolf,University of Illinois at Chicago,http://compbio.cs.uic.edu/~tanya,Hq28JM0AAAAJ
+Tanya Y. Berger-Wolf,University of Illinois at Chicago,http://compbio.cs.uic.edu/~tanya,fDQUHyIAAAAJ
 Tanzeem Choudhury,Cornell University,http://www.cs.cornell.edu/~tanzeem,NOSCHOLARPAGE
 Tao Gu,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/g/gu-associate-professor-tao,YfeWvwYAAAAJ
 Tao Jiang 0001,University of California - Riverside,http://www.cs.ucr.edu/~jiang,XUhsCZwAAAAJ
@@ -14322,7 +14322,7 @@ Tapio Lokki,Aalto University,https://users.aalto.fi/~ktlokki,vz4vC1cAAAAJ
 Tapio Takala,Aalto University,https://people.aalto.fi/new/tapio.takala,NOSCHOLARPAGE
 Tarek Elfouly,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/tarek.php,fItzV6EAAAAJ
 Tarek F. Abdelzaher,Univ. of Illinois at Urbana-Champaign,http://web.engr.illinois.edu/~zaher,cA28Zs0AAAAJ
-Tarek S. Abdelrahman,University of Toronto,http://www.eecg.toronto.edu/~tsa,Tp5qZjsAAAAJ
+Tarek S. Abdelrahman,University of Toronto,http://www.eecg.toronto.edu/~tsa,NOSCHOLARPAGE
 Tariq Andersen,University of Copenhagen,http://www.di.ku.dk/english/staff/?pure=en/persons/353044,FMtPAZ0AAAAJ
 Tariq O. Andersen,University of Copenhagen,http://www.di.ku.dk/english/staff/?pure=en/persons/353044,FMtPAZ0AAAAJ
 Tasos Kyrillidis,Rice University,http://akyrillidis.github.io,TEGzkZMAAAAJ
@@ -14425,7 +14425,7 @@ Thomas A. Goldstein,University of Maryland - College Park,https://www.cs.umd.edu
 Thomas A. Henzinger,IST Austria,http://pub.ist.ac.at/~tah,jpgplxUAAAAJ
 Thomas A. Horan,Claremont Graduate University,https://www.redlands.edu/study/schools-and-centers/business/staff/thomas-horan,2aFmaaAAAAAJ
 Thomas A. Runkler,TU Munich,https://www7.in.tum.de/~runkler,9ulZrB8AAAAJ
-Thomas Abeel,TU Delft,http://bioinformatics.tudelft.nl,eCS5_oAAAAAJ
+Thomas Abeel,TU Delft,http://bioinformatics.tudelft.nl,SLuGeK4AAAAJ
 Thomas Begin,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/thomas.begin,YJS1hw0AAAAJ
 Thomas Berlage,RWTH Aachen,http://dbis.rwth-aachen.de/cms/staff/berlage,NOSCHOLARPAGE
 Thomas Brox,University of Freiburg,https://lmb.informatik.uni-freiburg.de/people/brox/index.en.html,0VAe-TQAAAAJ
@@ -14719,7 +14719,7 @@ Tony R. Martinez,Brigham Young University,http://axon.cs.byu.edu/~martinez,R1JyT
 Tony Smith,University of Waikato,http://www.cms.waikato.ac.nz/people/tcs,mSp4V_4AAAAJ
 Tony Tan,National Taiwan University,https://www.csie.ntu.edu.tw/~tonytan,NOSCHOLARPAGE
 Tony Wauters,KU Leuven,https://people.cs.kuleuven.be/~tony.wauters,moTbWMUAAAAJ
-Tony White,Carleton University,https://carleton.ca/scs/people/tony-white,EkUL_2kAAAAJ
+Tony White,Carleton University,https://carleton.ca/scs/people/tony-white,GG_Ewu0AAAAJ
 Tony Wirth,University of Melbourne,http://people.eng.unimelb.edu.au/awirth,qVuN4MIAAAAJ
 Tor M. Aamodt,University of British Columbia,https://www.ece.ubc.ca/~aamodt,zCsB5XsAAAAJ
 Torben Amtoft,Kansas State University,http://cis.ksu.edu/~tamtoft,NOSCHOLARPAGE
@@ -14983,7 +14983,7 @@ Venkat Chandrasekaran,California Institute of Technology,http://users.cms.caltec
 Venkat N. Venkatakrishnan,University of Illinois at Chicago,https://www.cs.uic.edu/~venkat,6enh82kAAAAJ
 Venkata Yaramasu,Northern Arizona University,https://nau.edu/siccs/faculty/venkata-yaramasu,9WeLp14AAAAJ
 Venkatachalam Anantharam,University of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/anantharam.html,NOSCHOLARPAGE
-Venkataramana Badarla,IIT Jodhpur,http://home.iitj.ac.in/~ramana,r8QoCG4AAAAJ
+Venkataramana Badarla,IIT Jodhpur,http://home.iitj.ac.in/~ramana,NOSCHOLARPAGE
 Venkatesan Guruswami,Carnegie Mellon University,http://www.cs.cmu.edu/~venkatg,Es6jE1kAAAAJ
 Venkatesh Choppella,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/choppell,fGj4T74AAAAJ
 Venkatesh Prasad Ranganath,Kansas State University,http://people.cis.ksu.edu/~rvprasad,efsT3ykAAAAJ
@@ -15035,7 +15035,7 @@ Vida Dujmovic,University of Ottawa,http://cglab.ca/~vida,NOSCHOLARPAGE
 Viera K. Proulx,Northeastern University,http://www.ccs.neu.edu/home/vkp,NOSCHOLARPAGE
 Viet Tung Hoang,Florida State University,http://www.cs.fsu.edu/~tvhoang,ggcCMuIAAAAJ
 Viggo Kann,KTH Royal Institute of Technology,http://www.csc.kth.se/~viggo,4Fexy5ml2cMC
-Vijay Chidambaram,University of Texas at Austin,http://www.cs.utexas.edu/~vijay,KlpusxAAAAAJ
+Vijay Chidambaram,University of Texas at Austin,http://www.cs.utexas.edu/~vijay,sbbRtWwAAAAJ
 Vijay Ganesh,University of Waterloo,https://ece.uwaterloo.ca/~vganesh,YP23eR0AAAAJ
 Vijay Kumar 0001,University of Pennsylvania,http://www.kumarrobotics.org,h6h5FdoAAAAJ
 Vijay Kumar 0002,University of Missouri - Kansas City,http://k.web.umkc.edu/kumarv/index.html,NOSCHOLARPAGE
@@ -15098,8 +15098,8 @@ Vineeth N. Balasubramanian,IIT Hyderabad,http://www.iith.ac.in/~vineethnb,7soDcb
 Vineeth Nallure Balasubramanian,IIT Hyderabad,http://www.iith.ac.in/~vineethnb,7soDcboAAAAJ
 Vinhthuy Phan,University of Memphis,https://www.memphis.edu/cs/people/faculty_pages/vinhthuy-phan.php,ZeYNKGcAAAAJ
 Vinhthuy T. Phan,University of Memphis,https://www.memphis.edu/cs/people/faculty_pages/vinhthuy-phan.php,ZeYNKGcAAAAJ
-Vinicius C. Garcia,UFPE,http://viniciusgarcia.me,qPQabK4AAAAJ
-Vinicius Cardoso Garcia,UFPE,http://viniciusgarcia.me,qPQabK4AAAAJ
+Vinicius C. Garcia,UFPE,http://viniciusgarcia.me,3xG-lZoAAAAJ
+Vinicius Cardoso Garcia,UFPE,http://viniciusgarcia.me,3xG-lZoAAAAJ
 Vinicius Menezes de Oliveira,FURG Federal University of Rio Grande,http://vinicius.c3.furg.br,NQfy0ioAAAAJ
 Vinnie Monaco,Naval Postgraduate School,http://www.vmonaco.com,iG64YJUAAAAJ
 Vinod Achutavarrier Prasad,Nanyang Technological University,http://www.ntu.edu.sg/home/asvinod,NOSCHOLARPAGE
@@ -15109,7 +15109,7 @@ Vinod M. Prabhakaran,Tata Institute of Fundamental Research,http://www.tcs.tifr.
 Vinod Vaikuntanathan,Massachusetts Institute of Technology,http://www.mit.edu/~vinodv,a8jIPIkAAAAJ
 Vinodchandran Variyam,University of Nebraska,http://cse.unl.edu/~vinod,NOSCHOLARPAGE
 Vinícius Fernandes dos Santos,UFMG,http://homepages.dcc.ufmg.br/~viniciussantos,KNe4ZD0AAAAJ
-Viola Schiaffonati,Politecnico di Milano,http://home.deib.polimi.it/schiaffo,oAljVVUAAAAJ
+Viola Schiaffonati,Politecnico di Milano,http://home.deib.polimi.it/schiaffo,DZ7YDPEAAAAJ
 Violet R. Syrotiuk,Arizona State University,http://www.public.asu.edu/~syrotiuk,NOSCHOLARPAGE
 Viorela Ila,Australian National University,https://cecs.anu.edu.au/people/viorela-ila,HeaQbWsAAAAJ
 Viorica Sofronie,University of Koblenz-Landau,https://www.uni-koblenz-landau.de/en/campus-koblenz/fb4/ics/RGVSS/team/viorica-sofronie-stokkermans,aFGMdHQAAAAJ
@@ -15128,8 +15128,8 @@ Virginia Torczon,College of William and Mary,http://www.wm.edu/as/computerscienc
 Virginia Vassilevska,Massachusetts Institute of Technology,http://theory.stanford.edu/~virgi,Wph6P_IAAAAJ
 Virginia Vassilevska Williams,Massachusetts Institute of Technology,http://theory.stanford.edu/~virgi,Wph6P_IAAAAJ
 Virginie Fresse,Université Jean Monnet,https://laboratoirehubertcurien.univ-st-etienne.fr/en/the-lab/staff.html,NOSCHOLARPAGE
-Virgílio A. F. Almeida,UFMG,http://homepages.dcc.ufmg.br/~virgilio,sPKpIPwAAAAJ
-Virgílio Augusto Fernandes Almeida,UFMG,http://homepages.dcc.ufmg.br/~virgilio,sPKpIPwAAAAJ
+Virgílio A. F. Almeida,UFMG,http://homepages.dcc.ufmg.br/~virgilio,Wbi6RfAAAAAJ
+Virgílio Augusto Fernandes Almeida,UFMG,http://homepages.dcc.ufmg.br/~virgilio,Wbi6RfAAAAAJ
 Virpi Roto,Aalto University,http://www.allaboutux.org/virpiroto,KntdFBMAAAAJ
 Vishal Garg,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/vishal,vyH26MIAAAAJ
 Vishal Misra,Columbia University,http://www.cs.columbia.edu/~misra,9hPnkXsAAAAJ
@@ -15211,7 +15211,7 @@ Wai-Tat Fu,Univ. of Illinois at Urbana-Champaign,http://web.engr.illinois.edu/~w
 Wail Gueaieb,University of Ottawa,http://www.site.uottawa.ca/~wgueaieb,qN4Y3NEAAAAJ
 Wajdi Al Jedaibi,King Abdulaziz University,http://waljedaibi.kau.edu.sa/Default.aspx?Site_ID=0005903&lng=EN,NOSCHOLARPAGE
 Wakaha Ogata,Tokyo Institute of Technology,http://www.security.mot.titech.ac.jp/users/wakaha,NOSCHOLARPAGE
-Waldemar Celes Filho,PUC-RIO,www.inf.puc-rio.br/~celes,i0ECFCEAAAAJ
+Waldemar Celes Filho,PUC-RIO,www.inf.puc-rio.br/~celes,41BmgdUAAAAJ
 Walid A. Najjar,University of California - Riverside,http://www.cs.ucr.edu/~najjar,H0Y2wgUAAAAJ
 Walid G. Aref,Purdue University,https://www.cs.purdue.edu/people/aref,vX45evgAAAAJ
 Walid Magdy,University of Edinburgh,http://homepages.inf.ed.ac.uk/wmagdy,ACQD8jMAAAAJ
@@ -15221,7 +15221,7 @@ Walter A. Burkhard,University of California - San Diego,http://jacobsschool.ucsd
 Walter Alexander Pretschner,TU Munich,https://www22.in.tum.de/en/mitarbeiter/pretschner,pBIEpNcAAAAJ
 Walter Binder,Università della Svizzera italiana,http://www.inf.usi.ch/faculty/binder,g0nBOnMAAAAJ
 Walter D. Potter,University of Georgia,http://cobweb.cs.uga.edu/~potter,GDkG3T4AAAAJ
-Walter F. Mascarenhas,USP,http://www.ime.usp.br/~walter,AifN5CUAAAAJ
+Walter F. Mascarenhas,USP,http://www.ime.usp.br/~walter,NOSCHOLARPAGE
 Walter F. Tichy,Karlsruhe Institute of Technology (KIT),https://ps.ipd.kit.edu/176_376.php,23RPQBQAAAAJ
 Walter G. Kropatsch,TU Wien,https://www.prip.tuwien.ac.at/people/krw/more/index.php,NOSCHOLARPAGE
 Walter Guttmann,University of Canterbury,http://www.cosc.canterbury.ac.nz/walter.guttmann,NOSCHOLARPAGE
@@ -15253,7 +15253,7 @@ Waseem Ahmed,King Abdulaziz University,http://cegmr.kau.edu.sa/Content.aspx?Site
 Wassim El-Hajj,American University of Beirut,http://staff.aub.edu.lb/~we07,QidtvQgAAAAJ
 Wataru Takano,University of Tokyo,http://www.human.jst.go.jp/en/researcher/2ki_06.html,sVVPProAAAAJ
 Wayne B. Hayes,University of California - Irvine,http://www.cs.toronto.edu/~wayne,3z4VbdIAAAAJ
-Wayne D. Gray,Rensselaer Polytechnic Institute,http://www.rpi.edu/~grayw,h8ZzTWsAAAAJ
+Wayne D. Gray,Rensselaer Polytechnic Institute,http://www.rpi.edu/~grayw,cBqlbmEAAAAJ
 Wayne Eberly,University of Calgary,http://www.cpsc.ucalgary.ca/~eberly,NOSCHOLARPAGE
 Wayne Enright,University of Toronto,http://www.cs.toronto.edu/~enright,80eenyQAAAAJ
 Wayne Goddard,Clemson University,https://people.cs.clemson.edu/~goddard,bQYoSuUAAAAJ
@@ -15619,8 +15619,8 @@ Xiao Wang 0012,Northwestern University,http://eecs.northwestern.edu/~wangxiao,Qb
 Xiao-Chuan Cai,University of Colorado Boulder,https://www.cs.colorado.edu/~cai,NOSCHOLARPAGE
 Xiao-Dan Zhu,Queen’s University,http://my.ece.queensu.ca/People/x-zhu/index.html,a6MYnuUAAAAJ
 Xiao-Wen Chang,McGill University,http://cs.mcgill.ca/~chang,NOSCHOLARPAGE
-XiaoFeng Wang 0001,Indiana University,http://www.informatics.indiana.edu/xw7,u4dhRkQAAAAJ
-XiaoFeng Wang 0006,Indiana University,http://www.informatics.indiana.edu/xw7,u4dhRkQAAAAJ
+XiaoFeng Wang 0001,Indiana University,http://www.informatics.indiana.edu/xw7,pONu-5EAAAAJ
+XiaoFeng Wang 0006,Indiana University,http://www.informatics.indiana.edu/xw7,pONu-5EAAAAJ
 Xiaobai Sun,Duke University,http://www.cs.duke.edu/people/women/individual/sun.php,NOSCHOLARPAGE
 Xiaobo Hu,University of Notre Dame,http://www3.nd.edu/~shu,NOSCHOLARPAGE
 Xiaobo Sharon Hu,University of Notre Dame,http://www3.nd.edu/~shu,NOSCHOLARPAGE
@@ -15677,7 +15677,7 @@ Xiaoming Li,Peking University,http://net.pku.edu.cn/~lxm,tL9zHywAAAAJ
 Xiaoming Liu 0002,Michigan State University,https://www.cse.msu.edu/~liuxm,2V2YwCMAAAAJ
 Xiaoming Zhang,Beihang University,http://scse.buaa.edu.cn/info/1038/3052.htm,NOSCHOLARPAGE
 Xiaong-Dong Li,RMIT University,https://titan.csit.rmit.edu.au/~e46507,AQewL04AAAAJ
-Xiaoning Ding,NJIT,https://web.njit.edu/~dingxn,2lfRQF8AAAAJ
+Xiaoning Ding,NJIT,https://web.njit.edu/~dingxn,qIo7r_sAAAAJ
 Xiaoou Chen,Peking University,http://www.icst.pku.edu.cn/audioLab/researchgroup.htm,NOSCHOLARPAGE
 Xiaoping Chen,USTC,http://dsxt.ustc.edu.cn/zj_ywjs.asp?zzid=471,7_dDukkAAAAJ
 Xiaoping Jia,DePaul University,http://condor.depaul.edu/xjia,NOSCHOLARPAGE
@@ -15709,7 +15709,7 @@ Xibin Zhao,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/31
 Xifeng Gao,Florida State University,https://gaoxifeng.github.io,wSUVcN0AAAAJ
 Xifeng Yan,University of California - Santa Barbara,http://www.cs.ucsb.edu/~xyan,XZV2eogAAAAJ
 Xihong Wu,Peking University,http://www.cis.pku.edu.cn/auditory/Staff/Prof.Wu.html,NOSCHOLARPAGE
-Xike Xie,USTC,http://staff.ustc.edu.cn/~xkxie,_7me62sAAAAJ
+Xike Xie,USTC,http://staff.ustc.edu.cn/~xkxie,NOSCHOLARPAGE
 Xilin Chen,Chinese Academy of Sciences,http://vipl.ict.ac.cn/view_people.php?url=xlchen&id=13,vVx2v20AAAAJ
 Xin Cao,UNSW,https://www.engineering.unsw.edu.au/computer-science-engineering/staff/xin-cao,mvJ2rU8AAAAJ
 Xin Gao 0001,KAUST,https://www.kaust.edu.sa/en/study/faculty/xin-gao,0OJfPYYAAAAJ
@@ -15888,7 +15888,7 @@ Yannis Smaragdakis,University of Athens,https://yanniss.github.io,XCJuXcgAAAAJ
 Yannis Tzitzikas,University of Crete,http://users.ics.forth.gr/~tzitzik,J_QgqGsAAAAJ
 Yanqing Zhang,Georgia State University,https://grid.cs.gsu.edu/zhang,NOSCHOLARPAGE
 Yansong Feng,Peking University,https://sites.google.com/site/ysfeng/home,67qAw_wAAAAJ
-Yantian Hou,Boise State University,http://cs.boisestate.edu/~yhou,r_glIckAAAAJ
+Yantian Hou,Boise State University,http://cs.boisestate.edu/~yhou,UDwqCaoAAAAJ
 Yanwei Fu,Fudan University,https://yanweifu.github.io,Vg54TcsAAAAJ
 Yanwen Guo,Nanjing University,https://cs.nju.edu.cn/ywguo,NOSCHOLARPAGE
 Yanxi Liu,Pennsylvania State University,http://www.cse.psu.edu/~yul11,qYcG-q0AAAAJ
@@ -15904,12 +15904,12 @@ Yaochu Jin,University of Surrey,http://www.soft-computing.de/jin.html,B5WAkz4AAA
 Yaohang Li,Old Dominion University,http://www.cs.odu.edu/~yaohang,NOSCHOLARPAGE
 Yaoliang Yu,University of Waterloo,https://cs.uwaterloo.ca/~y328yu,zbXIQMsAAAAJ
 Yaoxue Zhang,Tsinghua University,http://media.cs.tsinghua.edu.cn/~zyxe,NOSCHOLARPAGE
-Yaoyun Shi,University of Michigan,https://web.eecs.umich.edu/~shiyy,0LS98DEAAAAJ
+Yaoyun Shi,University of Michigan,https://web.eecs.umich.edu/~shiyy,NOSCHOLARPAGE
 Yaqian Zhou,Fudan University,http://www.cs.fudan.edu.cn/?page_id=2319###,NOSCHOLARPAGE
 Yaqiong Xu,Vanderbilt University,http://eecs.vanderbilt.edu/people/yaqiongxu/group.html,NOSCHOLARPAGE
 Yarin Gal,University of Oxford,http://www.cs.ox.ac.uk/people/yarin.gal,SIayDoQAAAAJ
 Yaron Singer,Harvard University,http://seas.harvard.edu/~yaron,NOSCHOLARPAGE
-Yarui Peng,University of Arkansas,https://sites.uark.edu/yrpeng,IjBaWWcAAAAJ
+Yarui Peng,University of Arkansas,https://sites.uark.edu/yrpeng,NOSCHOLARPAGE
 Yaser P. Fallah,University of Central Florida,http://www.eecs.ucf.edu/~yfallah,Pni_ugMAAAAJ
 Yaser Pourmohammadi,University of Central Florida,http://www.eecs.ucf.edu/~yfallah,Pni_ugMAAAAJ
 Yaser Pourmohammadi Fallah,University of Central Florida,http://www.eecs.ucf.edu/~yfallah,Pni_ugMAAAAJ
@@ -15959,7 +15959,7 @@ Yi Shang,University of Missouri,https://engineering.missouri.edu/faculty/yi-shan
 Yi Wang 0003,Shenzhen University,http://www.escience.cn/people/yiwangszu/index.html,OPm4f_cAAAAJ
 Yi Yang 0001,University of Technology Sydney,https://www.uts.edu.au/staff/yi.yang,RMSuNFwAAAAJ
 Yi Zhang,University of Technology Sydney,https://www.uts.edu.au/staff/yi.zhang,Eu4GKM8AAAAJ
-Yi Zhang 0001,University of California - Santa Cruz,www.soe.ucsc.edu/~yiz,oyH8KMcAAAAJ
+Yi Zhang 0001,University of California - Santa Cruz,www.soe.ucsc.edu/~yiz,XnGXs7oAAAAJ
 Yi-Cheng Tu,University of South Florida,http://www.csee.usf.edu/~tuy,J7QqD2IAAAAJ
 Yi-Jen Chiang,New York University,http://engineering.nyu.edu/people/yi-jen-chiang,ZcDNvvEAAAAJ
 Yi-Ping Hung,National Taiwan University,https://www.csie.ntu.edu.tw/~hung,gUYquw0AAAAJ
@@ -16123,11 +16123,11 @@ Young-Joo Suh,POSTECH,http://monet.postech.ac.kr/yjsuh,MW-4uU4AAAAJ
 Young-Woo Kwon,Utah State University,https://advs.usu.edu/directory/faculty/Young-Min-Lee,ld-VWe8AAAAJ
 Young-ri Choi,UNIST,http://ychoi.unist.ac.kr,NOSCHOLARPAGE
 Youngjin Kwon,KAIST,https://sites.google.com/view/yjkwon/home,HvcmnF8AAAAJ
-Youngki Lee,Seoul National University,https://youngkilee.blogspot.com,Ltw2N1QAAAAJ
+Youngki Lee,Seoul National University,https://youngkilee.blogspot.com,qhKU0oMAAAAJ
 Yousef Saad,University of Minnesota,http://www-users.cs.umn.edu/~saad,90qiDCwAAAAJ
 Youssef Saab,University of Missouri,https://engineering.missouri.edu/faculty/youssef-saab,NOSCHOLARPAGE
 Youtao Zhang,University of Pittsburgh,http://people.cs.pitt.edu/~zhangyt,zvbUOD8AAAAJ
-Youyi Zheng,Zhejiang University,http://www.cad.zju.edu.cn/home/zyy/index.html,7gA-o6gAAAAJ
+Youyi Zheng,Zhejiang University,http://www.cad.zju.edu.cn/home/zyy/index.html,Nc5xuioAAAAJ
 Yu Cao,University of Massachusetts Lowell,https://www.uml.edu/Sciences/computer-science/faculty/Cao-Yu.aspx,mbnBXEwAAAAJ
 Yu Charlie Hu,Purdue University,https://engineering.purdue.edu/~ychu,r1Z8YhQAAAAJ
 Yu David Liu,Binghamton University,http://www.cs.binghamton.edu/~davidl,_KCqeIEAAAAJ
@@ -16397,7 +16397,7 @@ Zhisheng Yan,Georgia State University,https://grid.cs.gsu.edu/~zyan,i6ePuTMAAAAJ
 Zhiyi Huang 0001,University of Otago,http://www.cs.otago.ac.nz/staffpriv/hzy,rE1Y8DoAAAAJ
 Zhiyi Ma,Peking University,http://sei.pku.edu.cn/~mzy,NOSCHOLARPAGE
 Zhiyong Wang 0001,University of Sydney,http://www.it.usyd.edu.au/~zwan3293,DSbbGNIAAAAJ
-Zhiyuan Li,Purdue University,https://www.cs.purdue.edu/people/faculty/ci,ExE3z20AAAAJ
+Zhiyuan Li,Purdue University,https://www.cs.purdue.edu/people/faculty/ci,jnyf6oUAAAAJ
 Zhiyuan Liu 0001,Tsinghua University,http://nlp.csai.tsinghua.edu.cn/~lzy,dT0v5u0AAAAJ
 Zhiyun Qian,University of California - Riverside,http://www.cs.ucr.edu/~zhiyunq,NOSCHOLARPAGE
 Zhong Chen,Peking University,http://eecs.pku.edu.cn/EN/People/Faculty/Detail/?ID=6064,NOSCHOLARPAGE


### PR DESCRIPTION
Fixed 194 errors. The error are of two types:
1. Some links are not correct and gives error 404 not found. Those links have been changed to "NOSCHOLARPAGE".

2. Some available links are updated by Google. In which they will give be redirected to a new link (using status 302). I updated this to the new links in case you are using crawling because it is extremely hard to automate 302 detection and updating it to redirection, where if you try to automate it it will give you a 404 error code instead of redirecting.
