### PR TITLE
some missing profs

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -7821,6 +7821,10 @@ Karen Livescu,TTI Chicago,http://ttic.uchicago.edu/~klivescu,kCYbVq0AAAAJ
 Karen Renaud,University of Glasgow,http://www.dcs.gla.ac.uk/~karen,u6VeU9UAAAAJ
 Karen Vera Renaud,University of Glasgow,http://www.dcs.gla.ac.uk/~karen,u6VeU9UAAAAJ
 Kari Smolander,Aalto University,https://people.aalto.fi/new/kari.smolander,f1w2dAwAAAAJ
+Alan M. Frieze,Carnegie Mellon University,https://www.math.cmu.edu/~af1p/,EqKRQ4YAAAAJ
+Krishnendu Chakrabarty,Duke University,http://people.ee.duke.edu/~krish/,R_VPUyEAAAAJ
+Oscar H. Ibarra,University of California - Santa Barbara,https://sites.cs.ucsb.edu/~ibarra/,NOSCHOLARPAGE
+Baruch Awerbuch,Johns Hopkins University,http://www.cs.jhu.edu/~baruch/home.html,NOSCHOLARPAGE
 Karim Ali 0001,University of Alberta,http://karimali.ca,TC8495oAAAAJ
 Karin Becker,UFRGS,http://inf.ufrgs.br/~kbecker,aZA2pGQAAAAJ
 Karin Harbusch,University of Koblenz-Landau,https://www.uni-koblenz-landau.de/de/koblenz/fb4/icv/agharbusch/mitarbeiter/harbusch,NOSCHOLARPAGE


### PR DESCRIPTION
Frieze is [affiliated CS faculty](https://www.csd.cs.cmu.edu/people/faculty/alan-frieze). Chakrabarty is [affiliated CS](https://www.cs.duke.edu/people/faculty). Ibarra and Awerbuch are primary CS

# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [x] If the institution you are adding is not in the US,
update `country-info.csv`.

