### PR TITLE
Added Kijung Shin (KAIST)

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -8084,6 +8084,7 @@ Kien A. Hua,University of Central Florida,http://dsg.eecs.ucf.edu/Faculty.htm,Ej
 Kiev Gama,UFPE,http://www.cin.ufpe.br/~kiev,ZRq_UfUAAAAJ
 Kiev Santos da Gama,UFPE,http://www.cin.ufpe.br/~kiev,ZRq_UfUAAAAJ
 Kihong Park,Purdue University,https://www.cs.purdue.edu/homes/park,3sh3er0AAAAJ
+Kijung Shin,KAIST,https://kijungs.github.io/,Yp3Cz5AAAAAJ
 Kilian Q. Weinberger,Cornell University,http://www.cs.cornell.edu/~kilian,jsxk8vsAAAAJ
 Kim Binsted,University of Hawaii at Manoa,http://www2.hawaii.edu/~binsted,bd9-UG8AAAAJ
 Kim G. Larsen,Aalborg University,http://www.cs.aau.dk/~kgl,neDFD60AAAAJ


### PR DESCRIPTION
# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.
Please see [link](https://ee.kaist.ac.kr/professor_s2?language=en&filter_prefix=0&field_profile_position_tid=_none&field_profile_building_tid=_none&combine=Kijung) for eligibility.


**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [x] If the institution you are adding is not in the US,
update `country-info.csv`.

