### PR TITLE
automatically add dblp aliases

### DIFF
--- a/dblp-aliases.csv
+++ b/dblp-aliases.csv
@@ -2220,3 +2220,533 @@ João Coelho Garcia,João Garcia
 Oscar Cánovas Reverte,Óscar Cánovas Reverte
 Óscar Cánovas,Óscar Cánovas Reverte
 Oznur Tastan,Öznur Tastan
+Tyler W. Moore,Tyler Moore
+Ranga Rao Venkatesha Prasad,R. Venkatesha Prasad
+Tse-Hsun Peter Chen,Tse-Hsun (Peter) Chen
+Venkata Sriram Siddhardh Nadendla,V. Sriram Siddhardh Nadendla
+David Juedes,David W. Juedes
+Sanjay Jha 0001,Sanjay K. Jha
+Clinton Jeffery,Clinton L. Jeffery
+Ioannis Georgiou Katakis,Ioannis Katakis
+Hélio Côrtes Vieira Lopes,Hélio Lopes
+Joanna Bergström-Lehtovirta,Joanna Bergström
+Joanna Bergstrom-Lehtovirta,Joanna Bergström
+Ugur Dogrusöz,Ugur Dogrusoz
+Christopher Michael Homan,Christopher Homan
+Daniel Hughes 0001,Danny Hughes 0001
+Robert Harle,Robert K. Harle
+Lawrence E. Hunter,Lawrence Hunter
+Alfred Hero,Alfred O. Hero III
+Robert William Harper Jr.,Robert Harper 0001
+Seokhee Hong,Seok-Hee Hong
+Steve Homer,Steven Homer
+Richard Hartley 0001,Richard I. Hartley
+Steve R. Harrison,Steve Harrison
+Joe Halpern,Joseph Y. Halpern
+Ramzi Ahmed Haraty,Ramzi A. Haraty
+Seth A. Hutchinson,Seth Hutchinson
+Luke Zettlemoyer,Luke S. Zettlemoyer
+Paulo Rogério B. A. Pereira,Paulo Rogério Pereira
+Paulo Pereira 0001,Paulo Rogério Pereira
+Fernando Manuel Valente Ramos,Fernando M. V. Ramos
+Grant Robert Schoenebeck,Grant Schoenebeck
+Paulo Salgado Gomes de Mattos Neto,Paulo S. G. de Mattos Neto
+Raymund C. Sison,Raymund Sison
+Pedro Urbano Lima,Pedro U. Lima
+Guido Araújo,Guido Araujo
+Len Adleman,Leonard M. Adleman
+Mohammad Atiquzzaman,Mohammed Atiquzzaman
+Reda Ammar,Reda A. Ammar
+Hamid Reza Arabnia,Hamid R. Arabnia
+Shlomo Engelson Argamon,Shlomo Argamon
+Ronald Craig Arkin,Ronald C. Arkin
+David Andersen,David G. Andersen
+Ali Ghodsi Boushehri,Ali Ghodsi 0001
+Erik L. Andersen,Erik Andersen
+Jeffery J. Orchard,Jeff Orchard
+R. Sharathkumar,Sharath Raghvendra
+Diego Martínez Plasencia,Diego Martínez 0001
+Shannon P. Quinn,Shannon Quinn
+Claudia Lucía Jiménez-Guarín,Claudia Jiménez-Guarín
+Alex Dimakis,Alexandros G. Dimakis
+Pradeep Kumar Atrey,Pradeep K. Atrey
+Renu Rameshan,Renu M. Rameshan
+Paul Goldberg,Paul W. Goldberg
+Sumaya Almaadeed,Somaya Al-Máadeed
+Ahmed Elgammal,Ahmed M. Elgammal
+David E. Evans 0001,David Evans 0001
+Devorah Gurwitz Kletenik,Devorah Kletenik
+Geoff Bowker,Geoffrey C. Bowker
+Oliver A. Kennedy,Oliver Kennedy
+Alexandre de Morais Amory,Alexandre M. Amory
+KyungHyun Cho,Kyunghyun Cho
+Geraldo R. Mateus,Geraldo Robson Mateus
+Songul Albayrak,Songül Albayrak
+Euee Seon Jang,Euee S. Jang
+Michael Mior,Michael J. Mior
+Worthy Martin,Worthy N. Martin
+Karsten Øster Lundqvist,Karsten Lundqvist
+Christopher William Geib,Christopher W. Geib
+Linlin Shen,LinLin Shen
+Vineeth Balasubramanian,Vineeth N. Balasubramanian
+Michelle M. Kuttel,Michelle Kuttel
+Haidar Harmanani,Haidar M. Harmanani
+Shanika A. Karunasekera,Shanika Karunasekera
+Paulo J. P. Ferreira,Paulo Ferreira 0001
+David D. Feng,David Dagan Feng
+Dagan Feng,David Dagan Feng
+Steve Feiner,Steven K. Feiner
+Don Fussell,Donald S. Fussell
+Edward Alan Fox,Edward A. Fox
+Wolf-Dietrich Fellner,Dieter W. Fellner
+Jamie H. Morgenstern,Jamie Morgenstern
+Wesley J. Willett,Wesley Willett
+Doug Sicker,Douglas C. Sicker
+Walterio W. Mayol,Walterio W. Mayol-Cuevas
+Nuno C. G. Horta,Nuno Horta
+Nuno Cavaco Gomes Horta,Nuno Horta
+Eric C. Price,Eric Price
+Yezid Donoso Meisel,Yezid Donoso
+Henning Koehler,Henning Köhler
+C. Pandurangan,C. Pandu Rangan
+Jim Rehg,James M. Rehg
+Dan Rockmore,Daniel N. Rockmore
+William Robertson 0002,William K. Robertson
+Jen Rexford,Jennifer Rexford
+Alexander C. Russell,Alexander Russell
+José Fernando Rodrigues Jr.,José F. Rodrigues Jr.
+Ramamohanarao Kotagiri,Kotagiri Ramamohanarao
+Hady W. Lauw,Hady Wirawan Lauw
+Dolores DeGroff,Dolores F. De Groff
+Marco G. Valtorta,Marco Valtorta
+Antonio R. Nicolosi,Antonio Nicolosi
+Sérgio Castelo Branco Soares,Sérgio Soares
+N. Raja 0001,Raja Natarajan
+Moacir Antonelli Ponti,Moacir Ponti
+Don Mitchell Wilkes,D. Mitchell Wilkes
+Cláudio L. Amorim,Claudio Luis de Amorim
+Georgeta Elisabeta Marai,G. Elisabeta Marai
+Kalinka Castelo Branco,Kalinka Regina Lucas Jaquie Castelo Branco
+Kalinka Branco,Kalinka Regina Lucas Jaquie Castelo Branco
+Jinsoo Kim 0001,Jin-Soo Kim 0001
+Julie R. Williamson,Julie Rico Williamson
+Kimmo K. Kaski,Kimmo Kaski
+Franz W. Leberl,Franz Leberl
+Vinícius Menezes de Oliveira,Vinicius Menezes de Oliveira
+Ian David Bede Stark,Ian Stark
+Björn H. Menze,Bjoern H. Menze
+Ali Jannesari Ladani,Ali Jannesari
+Charles R. Wallace,Charles Wallace
+Max W. Libbrecht,Maxwell W. Libbrecht
+Diego Pérez-Liébana,Diego Perez Liebana
+Dale F. Reed,Dale Reed
+Luís F. M. de Moraes,Luís Felipe M. de Moraes
+David Emory Irwin,David E. Irwin
+Ralf Peeters,Ralf L. M. Peeters
+Taekyoung Kwon 0001,Ted Taekyoung Kwon
+João M. Lourenço,João Lourenço
+David John Hawkes,David J. Hawkes
+Giorgos Gousios,Georgios Gousios
+Russell L. Tedrake,Russ Tedrake
+Matthew Hammer,Matthew A. Hammer
+Gene Spafford,Eugene H. Spafford
+Ishwar Krishan Sethi,Ishwar K. Sethi
+S. Masoud Sadjadi,Seyed Masoud Sadjadi
+Cláudio Teixeira Silva,Cláudio T. Silva
+Smruti Ranjan Sarangi,Smruti R. Sarangi
+Milene Silveira,Milene Selbach Silveira
+Aaron Visaggio,Corrado Aaron Visaggio
+Eric John Koskinen,Eric Koskinen
+Eric E. Gilbert,Eric Gilbert
+Ralf Martin Zimmer,Ralf Zimmer
+Marco Zúñiga,Marco Zuniga
+David Dapeng Zhang,David Zhang 0001
+Hossam H. Hassanein,Hossam S. Hassanein
+En-Hong Chen,Enhong Chen
+Rolf H. Krause,Rolf Krause
+Nelson L. Duarte Filho,Nelson Duarte Filho
+Nelson Lopes Duarte Filho,Nelson Duarte Filho
+Leandro Marín Muñoz,Leandro Marín
+Senem Velipasalar Gursoy,Senem Velipasalar
+Jennifer Waycott,Jenny Waycott
+John Grundy 0001,John C. Grundy
+Thomas C. Nicholas Graham,T. C. Nicholas Graham
+Markus Gross 0001,Markus H. Gross
+David Gifford 0001,David K. Gifford
+William Gasarch,William I. Gasarch
+Ananth Y. Grama,Ananth Grama
+Tamas O. Gedeon,Tamás D. Gedeon
+Meister Eduard Gröller,M. Eduard Gröller
+Donald Greenberg,Donald P. Greenberg
+Jooyong Lee,Jooyong Yi
+Apostolos Zarras,Apostolis Zarras
+Rajesh Balan,Rajesh Krishna Balan
+Miguel Pessoa Monteiro,Miguel P. Monteiro 0001
+ZhiHui Lv,Zhihui Lu 0002
+ZhiHui Lu,Zhihui Lu 0002
+António Horta Branco,António Branco
+David F. Kotz,David Kotz
+Manolis G. H. Katevenis,Manolis Katevenis
+Martin Leopold Kersten,Martin L. Kersten
+Krishna Shankara Narayanan,Shankara Narayanan Krishna
+John D. Kubiatowicz,John Kubiatowicz
+Hsiang-Tsung Kung,H. T. Kung
+Marta Zofia Kwiatkowska,Marta Z. Kwiatkowska
+Orna Bernholtz,Orna Kupferman
+Anna Karlin,Anna R. Karlin
+Christoph E. Koch,Christoph Koch 0001
+Chongkwon Kim,Chong-kwon Kim
+Eileen T. Kraemer,Eileen Kraemer
+Laura Kovács,Laura Ildikó Kovács
+Purushotham V. Bangalore,Purushotham Bangalore
+Mark Zhandary,Mark Zhandry
+Sharon Xianghua Ding,Xianghua Ding
+Marcelo Fiore,Marcelo P. Fiore
+Greg W. Wasilkowski,Grzegorz W. Wasilkowski
+Éric Granger,Eric Granger
+Stephen Guy Pulman,Stephen G. Pulman
+David Duvenaud,David K. Duvenaud
+Siddhartha Srinivasa,Siddhartha S. Srinivasa
+Jeffrey Michael Heer,Jeffrey Heer
+Andrew C. Robb,Andrew Robb
+Ivan I. Garibay,Ivan Garibay
+Qian Kemao,Kemao Qian
+Tiago Coelho Ferreto,Tiago C. Ferreto
+Jugal Kumar Kalita,Jugal K. Kalita
+John Lafferty,John D. Lafferty
+Christopher Parnin,Chris Parnin
+Daniel Ratton Figueiredo,Daniel R. Figueiredo
+Kristy Boyer,Kristy Elizabeth Boyer
+V. Benjamin Livshits,Benjamin Livshits
+Mike Ferdman,Michael Ferdman
+Gil A. Tidhar,Gil Tidhar
+Hansen Andrew Schwartz,H. Andrew Schwartz
+Edwin B. Olson,Edwin Olson
+Angel Xuan Chang,Angel X. Chang
+Hatice Kose,Hatice Kose-Bagci
+Antonella DiLillo,Antonella Di Lillo
+Theophilus A. Benson,Theophilus Benson
+Paris Koutris,Paraschos Koutris
+Yiu-Ming Cheung,Yiu-ming Cheung
+Tam N. Vu,Tam Vu
+Dominic Orchard,Dominic A. Orchard
+Geoff Stuart Nitschke,Geoff S. Nitschke
+Geoff Nitschke,Geoff S. Nitschke
+Chalavadi Krishna Mohan,C. Krishna Mohan
+Julie Arnold Shah,Julie A. Shah
+Julie Shah,Julie A. Shah
+Donald Asogu Adjeroh,Donald A. Adjeroh
+L. C. Verbrugge,Rineke Verbrugge
+Vassilios Vassalos,Vasilis Vassalos
+Santosh S. Vempala,Santosh Vempala
+Geoff Voelker,Geoffrey M. Voelker
+Manuela Veloso,Manuela M. Veloso
+Peter M. Andreae,Peter Andreae
+Dan Zhao 0001,Danella Zhao
+Ahmet Celal Cem Say,A. C. Cem Say
+Pedro José Sousa da Fonseca,Pedro Fonseca 0001
+Gabe T. Sibley,Gabe Sibley
+Christine Lv,Qin Lv
+Christopher Jason Peikert,Chris Peikert
+M. Osama Alhalabi,Osama Halabi
+Shirish Krishnaj Shevade,Shirish K. Shevade
+Kerstin I. Eder,Kerstin Eder
+Pedro Manuel Moreira Vaz Antunes de Sousa,Pedro Manuel Antunes Sousa
+Ameet S. Talwalkar,Ameet Talwalkar
+Melissa Ho,Melissa Densmore
+Reeva M. Lederman,Reeva Lederman
+Anders Tychsen,Anders Drachen
+Marina Gavrilova,Marina L. Gavrilova
+Zheng Zhang 0012,Eddy Z. Zhang
+Belgin Ergenç Bostanoglu,Belgin Ergenç
+Belgin Ergenc,Belgin Ergenç
+Belgin Ozakar,Belgin Ergenç
+Lyle Ungar,Lyle H. Ungar
+Elissa M. Weeden,Elissa Weeden
+Roger Grosse,Roger B. Grosse
+Amy E. Ogan,Amy Ogan
+Tao A. Xiang,Tao Xiang
+Eno Tonisson,Eno Tõnisson
+Duncan D. A. Ruiz,Duncan Dubugras Alcoba Ruiz
+Huijia (Rachel) Lin,Huijia Lin
+Maja Mataric,Maja J. Mataric
+Erik S. Perrins,Erik Perrins
+Ragunathan Raj Rajkumar,Ragunathan Rajkumar
+Maria Wolters,Maria Klara Wolters
+Alan Loddon Yuille,Alan L. Yuille
+Danfeng Daphne Yao,Danfeng Yao
+Carlos M. Duarte,Carlos Duarte
+Daniel Kane,Daniel M. Kane
+Merlin Teodosia Suarez,Merlin Suarez
+Eva Kalyvianaki,Evangelia Kalyvianaki
+Stephen Bedrick,Steven Bedrick
+Mohamed El Baker Nassar,Mohamed Nassar
+Matthew Weinberg,S. Matthew Weinberg
+Daniela E. Herlea Damian,Daniela E. Damian
+Chris Ding,Chris H. Q. Ding
+Michel Justin Dumontier,Michel Dumontier
+William (Bill) J. Dally,William J. Dally
+Bill Dally,William J. Dally
+Costis Daskalakis,Constantinos Daskalakis
+Clodoveu Augusto Davis Jr.,Clodoveu A. Davis Jr.
+Saumya Debray,Saumya K. Debray
+Loren Terveen,Loren G. Terveen
+David J. Feil-Seifer,David Feil-Seifer
+Tiffany M. Barnes,Tiffany Barnes
+Igor Fabio Steinmacher,Igor Steinmacher
+Marcos Vaz Salles,Marcos Antonio Vaz Salles
+Robert Nowak 0001,Robert D. Nowak
+Joseph (Seffi) Naor,Joseph Naor
+José Marcos Silva Nogueira,José Marcos S. Nogueira
+Flavio Vinicius Diniz de Figueiredo,Flavio Figueiredo
+Ebru Aydin Göl,Ebru Aydin Gol
+José Francisco Morales,José F. Morales
+Wen-Mei W. Hwu,Wen-mei W. Hwu
+Wen-Mei Hwu,Wen-mei W. Hwu
+Patrick George Healey,Patrick G. T. Healey
+Seyed Abolfazl Motahari,Abolfazl S. Motahari
+Travis Desell,Travis J. Desell
+Tie-Jun Zhao,Tiejun Zhao
+Du Huynh,Du Q. Huynh
+Deshen Moodley,Deshendran Moodley
+R. Ramanujam,Ramaswamy Ramanujam
+Chatchavan Wacharamanotham,Chat Wacharamanotham
+Simon E. M. O'Keefe,Simon O'Keefe
+Justin M. Solomon,Justin Solomon
+Ulrik Larsen,Ulrik Nyman
+Simon Robert Arridge,Simon R. Arridge
+Mário Sérgio Alvim,Mário S. Alvim
+Joschka Bödecker,Joschka Boedecker
+Jessica R. Hullman,Jessica Hullman
+Peter Bartlett,Peter L. Bartlett
+Jennifer Leopold,Jennifer L. Leopold
+Aditya Thakur 0001,Aditya V. Thakur
+Alysson Bessani,Alysson Neves Bessani
+Fatima Abu Salem,Fatima K. Abu Salem
+Claire Jennifer Tomlin,Claire J. Tomlin
+Klaus J. Buchenrieder,Klaus Buchenrieder
+Georgios Fainekos,Georgios E. Fainekos
+Judith Jumig Azcarraga,Judith J. Azcarraga
+Neil Heffernan III,Neil T. Heffernan
+Charibeth K. Cheng,Charibeth Ko Cheng
+Gabi Dreo,Gabi Dreo Rodosek
+Raj S. Acharya,Raj Acharya
+Ruslan R. Salakhutdinov,Ruslan Salakhutdinov
+Brendan A. Juba,Brendan Juba
+Percy S. Liang,Percy Liang
+Mark John Batty,Mark Batty
+Vasco Moreira Amaral,Vasco Amaral
+Vasco Miguel Moreira do Amaral,Vasco Amaral
+Douglas Richard Hofstadter,Douglas Hofstadter
+Joshua G. Tanenbaum,Joshua Tanenbaum
+David Green 0002,David G. Green
+Yiannis Panagakis,Yannis Panagakis
+Ioannis Panagakis,Yannis Panagakis
+Miguel Leitão Bignolas Mira da Silva,Miguel Mira da Silva
+Marcel Jackowski,Marcel P. Jackowski
+Marcel Parolin Jackowski,Marcel P. Jackowski
+Geoff Kaufman,Geoff F. Kaufman
+Eric Xing,Eric P. Xing
+Lav Raj Varshney,Lav R. Varshney
+Tamara R. Sumner,Tamara Sumner
+Gorur Narayana Srinivasa Prasanna,G. N. Srinivasa Prasanna
+Vladimir Naumovich Vapnik,Vladimir Vapnik
+Thiago Alexandre Salgueiro Pardo,Thiago A. S. Pardo
+Martin v. Mohrenschildt,Martin von Mohrenschildt
+Robert W. J. Simmonds,Rob Simmonds
+Fish Wang,Ruoyu Wang 0001
+Jan Cederquist,J. G. Cederquist
+Roberto M. Cesar Jr.,Roberto Marcondes Cesar Junior
+Jack M. Carroll,John M. Carroll
+Nitesh Chawla,Nitesh V. Chawla
+R. Michael Young,Robert Michael Young
+Hany Girgis,Hani Girgis
+Alex Jung,Alexander Jung
+Inna V. Pivkina,Inna Pivkina
+Syed Mohammed Shamsul Islam,Syed M. S. Islam
+Nicole M. Beckage,Nicole Beckage
+Özcan Özturk 0001,Ozcan Ozturk 0001
+Dan Angus,Daniel Angus
+V. S. Anil Kumar 0001,Anil Vullikanti
+Jan Kretinsky,Jan Kretínský
+Vinay Namboodiri,Vinay P. Namboodiri
+Erwin P. Böttinger,Erwin P. Bottinger
+Bonnie Lynn Webber,Bonnie L. Webber
+Stefanie N. Lindstädt,Stefanie N. Lindstaedt
+Diego Raphael Amancio,Diego R. Amancio
+Jefferson Rodrigo de Souza,Jefferson R. Souza
+Shaghayegh (Sherry) Sahebi,Shaghayegh Sahebi
+Tingzhu Huang,Ting-Zhu Huang
+Kim Guldstrand Larsen,Kim G. Larsen
+Julio Cesar Sampaio P. Leite,Julio Cesar Sampaio do Prado Leite
+Xue Liu 0001,Xue (Steve) Liu
+Simon Sin-Sing Lam,Simon S. Lam
+Xiangyang Li 0001,Xiang-Yang Li 0001
+Claudia Linnhoff,Claudia Linnhoff-Popien
+João Alexandre Leite,João Leite
+Morgan Vigil,Morgan Vigil-Hayes
+Benjamin Stock,Ben Stock
+Corey E. Baker,Corey Baker
+Arno Rüdiger Wacker,Arno Wacker
+Jonathan K. Lazar,Jonathan Lazar
+George Robert Buchanan,George Buchanan
+Babis Tsourakakis,Charalampos E. Tsourakakis
+Julian McAuley,Julian J. McAuley
+Derry Tanti Wijaya,Derry Wijaya
+Silvia Botelho,Silvia Silva da Costa Botelho
+Thiago Ferreira Noronha,Thiago F. Noronha
+My Tra Thai,My T. Thai
+Conor J. Houghton,Conor Houghton
+Bruno A. N. Travençolo,Bruno Augusto Nassif Travençolo
+Vassilevska Williams,Virginia Vassilevska Williams
+Shyam Gollakota,Shyamnath Gollakota
+Katerina Stanková,Katerina Stankova
+Bjoern Schuller,Björn W. Schuller
+Lone Leth,Lone Leth Thomsen
+Sidney D'Mello,Sidney K. D'Mello
+James A. Clause,James Clause
+Elena Glassman,Elena L. Glassman
+Elena Leah Glassman,Elena L. Glassman
+Noah Goodman,Noah D. Goodman
+Weiyi Ian Shang,Weiyi Shang
+Jur van den Berg,Jur P. van den Berg
+Robert Lindeman,Robert W. Lindeman
+R. Inkulu,Rajasekhar Inkulu
+Xiaofeng Wang 0006,XiaoFeng Wang 0001
+Ravishankar Krishnan Iyer,Ravishankar K. Iyer
+Sundaraja Sitharama Iyengar,S. Sitharama Iyengar
+Aibek Musave,Aibek Musaev
+Aamena Al Shamsi,Aamena Alshamsi
+Jyotsna L. Bapat,Jyotsna Bapat
+Chittaranjan Mandal 0001,Chittaranjan A. Mandal
+Ana M. D. Moreira,Ana Moreira 0001
+Ana Maria Dinis Moreira,Ana Moreira 0001
+Tanja Mitrovic,Antonija Mitrovic
+Bruno Emanuel Martins,Bruno Martins 0001
+Thomas Meyer 0002,Thomas Andreas Meyer
+Tommie Meyer,Thomas Andreas Meyer
+T. Patrick Martin,Patrick Martin 0001
+Beth Mynatt,Elizabeth D. Mynatt
+Aloysius Ka-Lau Mok,Aloysius K. Mok
+Wolfgang Maaß 0001,Wolfgang Maass 0001
+Hermann Maurer,Hermann A. Maurer
+Aditya Mathur,Aditya P. Mathur
+Ana Almeida Matos,Ana Gualdina Almeida Matos
+Celina Miraglia Herrera de Figueiredo,Celina M. H. de Figueiredo
+Hassan Ali Artail,Hassan Artail
+Stenio Flavio Fernandes,Stenio F. L. Fernandes
+Ronald Dreslinski Jr.,Ronald G. Dreslinski
+Mukesh Saini,Mukesh Kumar Saini
+John Peter Lewis,John P. Lewis
+Joe Devietti,Joseph Devietti
+Aniruddha Gokhale,Aniruddha S. Gokhale
+Jeffrey Philip Bigham,Jeffrey P. Bigham
+Eunjung Kim 0001,Eun Jung Kim 0001
+Benjamin J. Belzer,Benjamin Belzer
+Kelly E. Caine,Kelly Caine
+Nicholas G. Feamster,Nick Feamster
+W. T. Tsai,Wei-Tek Tsai
+Matthew Craig Gombolay,Matthew C. Gombolay
+Chris Amato,Christopher Amato
+Manuel C. Lopes,Manuel Lopes 0001
+Manuel Cabido-Lopes,Manuel Lopes 0001
+Thomas Dyhre Nielsen,Thomas D. Nielsen
+Olav Bertelsen,Olav W. Bertelsen
+Frank Z. Wang,Frank Wang
+Dileep Aroor Dinesh,Aroor Dinesh Dileep
+Angela K. Demke,Angela Demke Brown
+Alfred Marcel Bruckstein,Alfred M. Bruckstein
+Srikanta Bedathur,Srikanta J. Bedathur
+Randy Berry,Randall Berry
+Magda Balazinska,Magdalena Balazinska
+Margaret Burnett,Margaret M. Burnett
+M. Cecília C. Baranauskas,Maria Cecília Calani Baranauskas
+Ryan Shaun Baker,Ryan Shaun Joazeiro de Baker
+Ryan S. Baker,Ryan Shaun Joazeiro de Baker
+Francis Bach,Francis R. Bach
+Kenneth Paul Baclawski,Kenneth Baclawski
+Ben Bederson,Benjamin B. Bederson
+Alexia Briasouli,Alexia Briassouli
+Alice Oh,Alice H. Oh
+Zhen Ming Jiang,Zhen Ming (Jack) Jiang
+Simon Mark Lucas,Simon M. Lucas
+Antonio Toral Ruiz,Antonio Toral
+Marco A. Wiering,Marco Wiering
+Assefaw H. Gebremedhin,Assefaw Hadish Gebremedhin
+Wadee Al-Halabi,Wadee Alhalabi
+Wadee S. Alhalabi,Wadee Alhalabi
+Anusha Indrajith Withana,Anusha I. Withana
+Paulo L. J. Drews-Jr,Paulo Drews Jr.
+Paulo Lilles Drews Jr.,Paulo Drews Jr.
+Paulo Jorge Lilles Drews Junior,Paulo Drews Jr.
+Hande Özgür Alemdar,Hande Alemdar
+Marcin Kaminski 0001,Marcin Jakub Kaminski
+Lana Yarosh,Svetlana Yarosh
+John L. Wyatt Jr.,John L. Wyatt
+Wu-Chun Feng,Wu-chun Feng
+Robert Alexander,Rob Alexander
+Patricia Jean Riddle,Patricia J. Riddle
+Burkhard Claus Wünsche,Burkhard Wünsche
+Michael Paul Wellman,Michael P. Wellman
+Dawn E. Wilkins,Dawn Wilkins
+Donald Wunsch,Donald C. Wunsch II
+Huub M. M. van de Wetering,Huub van de Wetering
+James M. Westall,James Westall
+Charles C. Weems Jr.,Charles C. Weems
+Daniel Sabby Weld,Daniel S. Weld
+Emily Morgan Hand,Emily M. Hand
+Bobak J. Mortazavi,Bobak Mortazavi
+Jos Uiterwijk,Jos W. H. M. Uiterwijk
+Ian Pratt 0002,Ian Pratt-Hartmann
+Gokhan Bilgin,Gökhan Bilgin
+Huseyin Levent Akin,H. Levent Akin
+Raymond Kwok-Kay Wong,Raymond K. Wong
+Glenn D. Reinman,Glenn Reinman
+Sotiris K. Moschoyiannis,Sotiris Moschoyiannis
+Alexandre N. Delbem,Alexandre C. B. Delbem
+Anna Zych-Pawlewicz,Anna Zych
+Hugo M. Miranda,Hugo Miranda
+Eric Yu 0001,Eric S. K. Yu
+Eduardo Nunes Borges,Eduardo N. Borges
+Lap-Fai Craig Yu,Lap-Fai Yu
+Teófilo E. de Campos,Teófilo Emídio de Campos
+James H. Morris Jr.,James H. Morris
+Nathaniel David Osgood,Nathaniel D. Osgood
+Ken Anderson 0001,Kenneth M. Anderson
+Philip Jia Guo,Philip J. Guo
+Anthony Kum Hoe Tung,Anthony K. H. Tung
+Niels A. Taatgen,Niels Taatgen
+Niels Anne Taatgen,Niels Taatgen
+A. Min Tjoa,A Min Tjoa
+Vanessa J. Teague,Vanessa Teague
+Caetano Traina,Caetano Traina Jr.
+Mirek Truszczynski,Miroslaw Truszczynski
+Leender van der Torre,Leon van der Torre
+Camillo Jose Taylor,Camillo J. Taylor
+Richard Taylor 0001,Richard N. Taylor
+Thushara Dheemantha Abhayapala,Thushara D. Abhayapala
+Leonid K. Reznik,Leon Reznik
+Bakh Khoussainov,Bakhadyr Khoussainov
+Judith Sheard,Judithe Sheard
+Suzan Uskudarli,Suzan Üsküdarli
+Miriah Meyer,Miriah D. Meyer
+Stelios Asteriadis,Stylianos Asteriadis
+Rafael F. Wyrembelski,Rafael F. Schaefer
+James B. Worrell,James Worrell 0001
+Ilias Manolakos,Elias S. Manolakos
+Tony Fan-Cheong Chan,Tony F. Chan
+Maurício Finavaro Aniche,Mauricio Finavaro Aniche
+Eric William Davis,Eric Rozier
+Zak Kincaid,Zachary Kincaid
+Giovanni V. Comarela,Giovanni Comarela
+Tim Baldwin,Timothy Baldwin
+Rym Z. Wenkstern,Rym Zalila-Wenkstern
+Hui Lv 0001,Hui Lu 0001
+Mario Linares Vásquez,Mario Linares-Vásquez
+C. David Page,David Page
+Stefan Wolfgang Pickl,Stefan Pickl
+Iain Phillips 0001,Iain C. C. Phillips
+David Pearce 0005,David J. Pearce
+Luíz Moniz Pereira,Luís Moniz Pereira
+Allen Parrish,Allen S. Parrish
+Janus A. Pouwelse,Johan A. Pouwelse


### PR DESCRIPTION
These are taken by parsing the dblp.xml.gz file and looking for matching names (e.g. the dblp "aka')