### PR TITLE
Fix a few dozen erroneous entries

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -1448,7 +1448,7 @@ Ashish Sharma 0001,Emory University,http://sharmalab.info,P3_s4W4AAAAJ
 Ashish Venkat,University of Virginia,http://www.cs.virginia.edu/venkat,wbhUDnIAAAAJ
 Ashit Talukder,UNC - Charlotte,https://analyticsfrontiers.uncc.edu/speakers/ashit-talukder-phd,NOSCHOLARPAGE
 Ashok K. Agrawala,University of Maryland - College Park,https://www.cs.umd.edu/users/agrawala,Ytr5Y78AAAAJ
-Ashok K. Goel,Georgia Institute of Technology,https://home.cc.gatech.edu/dil/3,VjNg25EAAAAJ
+Ashok K. Goel 0001,Georgia Institute of Technology,https://home.cc.gatech.edu/dil/3,VjNg25EAAAAJ
 Ashok Kumar,University of Louisiana - Lafayette,https://www.louisiana.edu/about-us/contact-information/telephone-directory,NOSCHOLARPAGE
 Ashok Kumar Das,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/ashokkdas,bToAUHMAAAAJ
 Ashok Narayanan Veeraraghavan,Rice University,https://www.ece.rice.edu/~av21,tI-oUmsAAAAJ
@@ -3392,8 +3392,7 @@ David Andrew Ross,University of Queensland,http://www.itee.uq.edu.au/contacts/sh
 David Andrews,University of Arkansas,http://www.csce.uark.edu/~dandrews,NOSCHOLARPAGE
 David Arnott,Monash University,http://monash.edu/research/explore/en/persons/david-arnott(fcc08d5c-a8cd-45ce-9cac-f2bfbbbb6dfe).html,A2fkR3QAAAAJ
 David Arthur Eppstein,University of California - Irvine,https://www.ics.uci.edu/~eppstein,QSY7ufMAAAAJ
-David Aspinall,University of Edinburgh,http://homepages.inf.ed.ac.uk/da,_pT1xEwAAAAJ
-David Aspinall II,University of Edinburgh,http://homepages.inf.ed.ac.uk/da,NOSCHOLARPAGE
+David Aspinall 0001,University of Edinburgh,http://homepages.inf.ed.ac.uk/da,_pT1xEwAAAAJ
 David B. Adams,University of Massachusetts Lowell,https://www.uml.edu/Sciences/computer-science/faculty/Adams-David.aspx,tiGxY4sAAAAJ
 David B. Brown,The University of Alabama,http://cs.ua.edu/people/dbrown,NOSCHOLARPAGE
 David B. Johnson,Rice University,https://www.cs.rice.edu/~dbj,6w_geF8AAAAJ
@@ -5459,7 +5458,7 @@ Guido A. Maier,Politecnico di Milano,http://home.deib.polimi.it/maier,PLEkIaAAAA
 Guido Araujo,UNICAMP,https://guidoaraujo.wordpress.com/guido-araujo-homepage,xjuoV4QAAAAJ
 Guido Araújo,UNICAMP,https://guidoaraujo.wordpress.com/guido-araujo-homepage,xjuoV4QAAAAJ
 Guido Gerig,New York University,http://engineering.nyu.edu/people/guido-gerig,P5CovF0AAAAJ
-Guido Germano,University College London,http://www0.cs.ucl.ac.uk/people/G.Germano.html,8zCKUmoAAAAJ
+Guido Germano 0001,University College London,http://www0.cs.ucl.ac.uk/people/G.Germano.html,8zCKUmoAAAAJ
 Guido Salvaneschi,TU Darmstadt,http://www.guidosalvaneschi.com,Hm0V7MUAAAAJ
 Guido Sanguinetti,University of Edinburgh,http://homepages.inf.ed.ac.uk/gsanguin,R4zLUksAAAAJ
 Guido Tack,Monash University,http://monash.edu/research/explore/en/persons/guido-tack(d73e55b3-3851-41de-9165-d175b58b6676).html,JHquQGoAAAAJ
@@ -9024,7 +9023,7 @@ Liting Hu,Florida International University,http://users.cis.fiu.edu/~lhu,jG2EBoo
 Liuba Shrira,Brandeis University,http://www.cs.brandeis.edu/~liuba,tyUShkAAAAAJ
 Liusheng Huang,USTC,http://dsxt.ustc.edu.cn/zj_ywjs.asp?zzid=36,1XHpROsAAAAJ
 Liwei Wang 0001,Peking University,http://www.cis.pku.edu.cn/faculty/vision/wangliwei,NOSCHOLARPAGE
-Lixia Zhang,University of California - Los Angeles,http://www.cs.ucla.edu/~lixia,CZyWk8kAAAAJ
+Lixia Zhang 0001,University of California - Los Angeles,http://www.cs.ucla.edu/~lixia,CZyWk8kAAAAJ
 Lixin Duan,UESTC,http://www.lxduan.info,inRIcS0AAAAJ
 Liyong Tang,Peking University,http://eecs.pku.edu.cn/EN/People/Faculty/Detail/?ID=6071,NOSCHOLARPAGE
 Liz Sonenberg,University of Melbourne,http://people.eng.unimelb.edu.au/lizs,w8EFH0IAAAAJ
@@ -9090,7 +9089,7 @@ Loïc Cerf,UFMG,http://homepages.dcc.ufmg.br/~lcerf,NOSCHOLARPAGE
 Loïc Denis,Université Jean Monnet,http://perso.univ-st-etienne.fr/deniloic,QGsZcgIAAAAJ
 Lu Feng 0001,University of Virginia,http://www.cs.virginia.edu/~lufeng,HiyMQzEAAAAJ
 Lu Qin,University of Technology Sydney,https://www.uts.edu.au/staff/lu.qin,DQHL47oAAAAJ
-Lu Ruan,Iowa State University,http://www.cs.iastate.edu/~ruan,3FrD14AAAAAJ
+Lu Ruan 0001,Iowa State University,http://www.cs.iastate.edu/~ruan,3FrD14AAAAAJ
 Lu Su,University at Buffalo,http://www.cse.buffalo.edu/people/?u=lusu,38RuCN4AAAAJ
 Lu Wang 0001,Northeastern University,http://www.ccs.neu.edu/home/luwang,uczqEdUAAAAJ
 Lu Zhang 0023,Peking University,http://sei.pku.edu.cn/~zhanglu,JUnz2VcAAAAJ
@@ -9856,7 +9855,7 @@ Martin White,University of Sussex,http://www.sussex.ac.uk/informatics/people/peo
 Martin Wirsing,LMU Munich,https://www.sosy-lab.org/people/wirsing,QonRHo8AAAAJ
 Martin Wollschlaeger,TU Dresden,https://tu-dresden.de/ing/informatik/institut-fuer-angewandte-informatik/professur-fuer-prozesskommunikation/die-professur/inhaber?set_language=en,FNwyHZ4AAAAJ
 Martin Wollschläger,TU Dresden,https://tu-dresden.de/ing/informatik/institut-fuer-angewandte-informatik/professur-fuer-prozesskommunikation/die-professur/inhaber?set_language=en,FNwyHZ4AAAAJ
-Martin Ziegler,KAIST,http://m.zie.de,wfD52B0AAAAJ
+Martin Ziegler 0001,KAIST,http://m.zie.de,wfD52B0AAAAJ
 Martin v. Mohrenschildt,McMaster University,http://www.cas.mcmaster.ca/~mohrens,NOSCHOLARPAGE
 Martin von Mohrenschildt,McMaster University,http://www.cas.mcmaster.ca/~mohrens,NOSCHOLARPAGE
 Martina A. Rau,University of Wisconsin - Madison,https://edpsych.education.wisc.edu/people/faculty-staff/martina-rau,bZQk_NkAAAAJ
@@ -10177,7 +10176,7 @@ Michael Bedford Taylor,University of Washington,http://cseweb.ucsd.edu/~mbtaylor
 Michael Beigl,Karlsruhe Institute of Technology (KIT),http://pcs.tm.kit.edu/21_beigl.php,9-WU64IAAAAJ
 Michael Ben-Or,Hebrew University of Jerusalem,http://www.cs.huji.ac.il/~benor,22dxhNQAAAAJ
 Michael Benedikt,University of Oxford,https://www.cs.ox.ac.uk/michael.benedikt,atL47L0AAAAJ
-Michael Berry,University of Tennessee,http://web.eecs.utk.edu/~mberry,TrSq1u8AAAAJ
+Michael W. Berry,University of Tennessee,http://web.eecs.utk.edu/~mberry,TrSq1u8AAAAJ
 Michael Blumenstein,University of Technology Sydney,https://www.uts.edu.au/staff/michael.blumenstein,4m2G-H8AAAAJ
 Michael Bowling,University of Alberta,https://webdocs.cs.ualberta.ca/~bowling,PYtPCHoAAAAJ
 Michael Brand,Monash University,https://theconversation.com/profiles/michael-brand-290376,0tVnI8QAAAAJ
@@ -10197,7 +10196,7 @@ Michael D. Bond,Ohio State University,http://web.cse.ohio-state.edu/~mikebond,zo
 Michael D. Ekstrand,Boise State University,https://coen.boisestate.edu/faculty-staff/michaelekstrand,YicUduAAAAAJ
 Michael D. Ernst,University of Washington,https://homes.cs.washington.edu/~mernst,oQ6AeyEAAAAJ
 Michael D. Jones,Brigham Young University,https://cs.byu.edu/faculty/jones,OLUt0kgAAAAJ
-Michael D. Smith,Harvard University,http://www.fas.harvard.edu/pages/dean-michael-smith,rzPlMfQAAAAJ
+Michael D. Smith 0001,Harvard University,http://www.fas.harvard.edu/pages/dean-michael-smith,rzPlMfQAAAAJ
 Michael D. Vose,University of Tennessee,http://www.eecs.utk.edu/people/faculty/mvose1,NOSCHOLARPAGE
 Michael Dennis,Australian National University,https://cecs.anu.edu.au/people/mike-dennis,4-7T68EAAAAJ
 Michael Dinitz,Johns Hopkins University,http://www.cs.jhu.edu/~mdinitz,Q2yN84AAAAAJ
@@ -10697,7 +10696,7 @@ Mohammed Bennamoun,University of Western Australia,http://staffhome.ecm.uwa.edu.
 Mohammed E. Hoque,University of Rochester,http://web.media.mit.edu/~mehoque,ZJrR0KQAAAAJ
 Mohammed El-Kebir,Univ. of Illinois at Urbana-Champaign,http://www.el-kebir.net,8mUzslcAAAAJ
 Mohammed Samaka,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/mohamed_samaka.php,iqiEX78AAAAJ
-Mohammed Zaki,Rensselaer Polytechnic Institute,http://www.cs.rpi.edu/~zaki,UmwJklEAAAAJ
+Mohammed J. Zaki,Rensselaer Polytechnic Institute,http://www.cs.rpi.edu/~zaki,UmwJklEAAAAJ
 Mohan Kumar,Rochester Institute of Technology,https://www.cs.rit.edu/~mjk,FoRBkdsAAAAJ
 Mohan S. Kankanhalli,National University of Singapore,http://www.comp.nus.edu.sg/~mohan,6Lx_eowAAAAJ
 Mohit Bansal,University of North Carolina,http://ttic.uchicago.edu/~mbansal,DN8QtscAAAAJ
@@ -12402,7 +12401,7 @@ Rajendra Mitharwal,DAIICT,http://faculty.daiict.ac.in/rmitharwal,NOSCHOLARPAGE
 Rajendra V. Boppana,University of Texas at San Antonio,http://www.cs.utsa.edu/faculty/boppana,bNOQrU0AAAAJ
 Rajesh Balan,Singapore Management University,https://apollo.smu.edu.sg,U1jLrJcAAAAJ
 Rajesh Gupta,University of California - San Diego,http://mesl.ucsd.edu/gupta,I1w51gUAAAAJ
-Rajesh K. Gupta,University of California - San Diego,http://mesl.ucsd.edu/gupta,I1w51gUAAAAJ
+Rajesh K. Gupta 0001,University of California - San Diego,http://mesl.ucsd.edu/gupta,I1w51gUAAAAJ
 Rajesh Krishna Balan,Singapore Management University,https://apollo.smu.edu.sg,U1jLrJcAAAAJ
 Rajesh P. N. Rao,University of Washington,https://homes.cs.washington.edu/~rao,02nHF0gAAAAJ
 Rajesh Ranganath,New York University,https://cims.nyu.edu/~rajeshr,kddKBCsAAAAJ
@@ -15197,7 +15196,7 @@ Tim Weninger,University of Notre Dame,https://www3.nd.edu/~tweninge,V1js0MUAAAAJ
 Tim Weyrich,University College London,http://www.cs.ucl.ac.uk/staff/t.weyrich,pUB0nnwhGVAC
 Tim Wilhelm Nattkemper,Bielefeld University,http://ekvv.uni-bielefeld.de/pers_publ/publ/PersonDetail.jsp?personId=11602,8SR1jMcAAAAJ
 Timo Kehrer,Humboldt University of Berlin,https://www.informatik.hu-berlin.de/de/forschung/gebiete/mse,WJw1SK0AAAAJ
-Timothy A. Davis,Texas A&M University,http://faculty.cse.tamu.edu/davis,v6zfjqMAAAAJ
+Timothy A. Davis 0001,Texas A&M University,http://faculty.cse.tamu.edu/davis,v6zfjqMAAAAJ
 Timothy A. Gonsalves,IIT Mandi,http://www.cse.iitm.ac.in/~tag,NOSCHOLARPAGE
 Timothy Baldwin,University of Melbourne,http://people.eng.unimelb.edu.au/tbaldwin,XJ3Sc4QAAAAJ
 Timothy Bourke,Ecole Normale Superieure,http://www.di.ens.fr/~bourke,XOi6VWwAAAAJ
@@ -16345,7 +16344,7 @@ Xiaoping Zhang,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/46
 Xiaoqing Liu,University of Arkansas,https://computer-science-and-computer-engineering.uark.edu/directory/index/uid/frankliu/name/Xiaoqing+Liu,NOSCHOLARPAGE
 Xiaoqing Lu,Peking University,https://www.researchgate.net/profile/Xiaoqing_Lu6,NOSCHOLARPAGE
 Xiaoqing Zheng,Fudan University,http://homepage.fudan.edu.cn/zhengxq,jDNLWHIAAAAJ
-Xiaoqiu Huang,Iowa State University,http://www.cs.iastate.edu/~xqhuang,h5gEfxsAAAAJ
+Xiaoqiu Huang 0001,Iowa State University,http://www.cs.iastate.edu/~xqhuang,h5gEfxsAAAAJ
 Xiaoru Yuan,Peking University,http://vis.pku.edu.cn/xiaoruyuan.html,mJJVqRYAAAAJ
 Xiaorui Sun,University of Illinois at Chicago,https://www.cs.uic.edu/k-Teacher/xiaorui-sun-phd,jq8VoFkAAAAJ
 Xiaosong Ma,Qatar Computing Research Institute,http://www.qcri.org.qa/page?name=Xiaosong_Ma&a=117&pid=154&lang=en-CA,xcs5JDIAAAAJ
@@ -16627,7 +16626,7 @@ Yi-Cheng Tu,University of South Florida,http://www.csee.usf.edu/~tuy,J7QqD2IAAAA
 Yi-Jen Chiang,New York University,http://engineering.nyu.edu/people/yi-jen-chiang,ZcDNvvEAAAAJ
 Yi-Ping Hung,National Taiwan University,https://www.csie.ntu.edu.tw/~hung,gUYquw0AAAAJ
 Yi-Shin Chen,National Tsing Hua University,http://www.yishin.net,0pm_SDoAAAAJ
-Yi-Ying Zhang,Purdue University,https://engineering.purdue.edu/~yiying,NOSCHOLARPAGE
+Yiying Zhang 0005,Purdue University,https://engineering.purdue.edu/~yiying,NOSCHOLARPAGE
 Yi-Zhe Song,University of Surrey,http://www.eecs.qmul.ac.uk/~yzs,irZFP_AAAAAJ
 Yiannis Aloimonos,University of Maryland - College Park,http://www.cfar.umd.edu/~yiannis,7QmEsOwAAAAJ
 Yiannis Cotronis,University of Athens,http://www.di.uoa.gr/eng/staff/1022,9IbOFmMAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -2801,7 +2801,6 @@ Christopher Musco,New York University,https://www.chrismusco.com,HXXSrNMAAAAJ
 Christopher Parnin,North Carolina State University,https://www.csc.ncsu.edu/people/cjparnin,Guzbr0kAAAAJ
 Christopher Piech,Stanford University,https://stanford.edu/~cpiech/bio/index.html,fpT49d8AAAAJ
 Christopher Power,University of York,https://www-users.cs.york.ac.uk/~cpower,1ZA0JtcAAAAJ
-Christopher R. Johnson,University of Utah,http://www.cs.utah.edu/~crj,NOSCHOLARPAGE
 Christopher R. Johnson 0001,University of Utah,http://www.cs.utah.edu/~crj,SS3tE_MAAAAJ
 Christopher Raphael,Indiana University,https://www.soic.indiana.edu/all-people/profile.html?profile_id=279,NOSCHOLARPAGE
 Christopher Rasmussen,University of Delaware,https://www.eecis.udel.edu/~cer,UMG3OGgAAAAJ
@@ -3089,7 +3088,7 @@ Daan Huybrechs,KU Leuven,https://people.cs.kuleuven.be/~daan.huybrechs,bT4V4uYAA
 Dabbala Rajagopal Reddy,Carnegie Mellon University,http://www.rr.cs.cmu.edu,6n7rzokAAAAJ
 Dacheng Tao,University of Sydney,https://sydney.edu.au/engineering/people/dacheng.tao.php,RwlJNLcAAAAJ
 Dae Hyun Kim,Washington State University,https://school.eecs.wsu.edu/people/faculty/dae-hyun-kim,nG4hcN4AAAAJ
-Dae Young Kim,KAIST,http://www.resl.kaist.ac.kr,encxuNcAAAAJ
+Daeyoung Kim 0001,KAIST,http://www.resl.kaist.ac.kr,encxuNcAAAAJ
 Dae-Kyoo Kim,Oakland University,https://oakland.edu/secs/directory/kim,IR_UyOgAAAAJ
 Daehyun Kim,Washington State University,https://school.eecs.wsu.edu/people/faculty/dae-hyun-kim,nG4hcN4AAAAJ
 Dafna Shahaf,Hebrew University of Jerusalem,http://www.cs.huji.ac.il/~dshahaf,AgyW_90AAAAJ
@@ -3490,7 +3489,6 @@ David J. Weir,University of Sussex,http://www.sussex.ac.uk/informatics/people/pe
 David J. Wu,University of Virginia,https://engineering.virginia.edu/faculty/david-wu,sow8PQYAAAAJ
 David Jao,University of Waterloo,https://djao.math.uwaterloo.ca,uj3Xx8IAAAAJ
 David John Hawkes,University College London,http://cmic.cs.ucl.ac.uk/staff/dave_hawkes,O42T24CT_GwC
-David Johnson,University of Kansas,https://eecs.ku.edu/david-johnson,LyEq7qEAAAAJ
 David Jones,University College London,http://www.cs.ucl.ac.uk/staff/D.Jones,yRb0DnQAAAAJ
 David Juedes,Ohio University,http://oucsace.cs.ohiou.edu/~juedes,eTFiw7wAAAAJ
 David Jurgens,University of Michigan,https://www.si.umich.edu/node/15080,sGFFr5kAAAAJ
@@ -4674,7 +4672,7 @@ Fei Chen 0003,Shenzhen University,https://sites.google.com/site/chenfeiorange,mr
 Fei Chiang,McMaster University,http://www.cas.mcmaster.ca/~fchiang,gbH5eZQAAAAJ
 Fei Fang,Carnegie Mellon University,https://www.andrew.cmu.edu/user/feif,VdZQ1EgAAAAJ
 Fei He 0001,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2010/20101219193526388181747/20101219193526388181747_.html,uTnP9v0AAAAJ
-Fei Li,George Mason University,https://cs.gmu.edu/~lifei,ql6BXwcAAAAJ
+Fei Li 0001,George Mason University,https://cs.gmu.edu/~lifei,ql6BXwcAAAAJ
 Fei Liu 0004,University of Central Florida,http://www.cs.ucf.edu/~feiliu,NB-SMk8AAAAJ
 Fei Sha,University of Southern California,http://www-bcf.usc.edu/~feisha,8rttV7kAAAAJ
 Fei Wang 0017,Fudan University,http://www.cs.fudan.edu.cn/?page_id=1948,NOSCHOLARPAGE
@@ -4701,7 +4699,7 @@ Feng Lin 0004,Zhejiang University,https://person.zju.edu.cn/person/flin,gyBxQOAA
 Feng Liu 0005,University of Queensland,http://researchers.uq.edu.au/researcher/951,NOSCHOLARPAGE
 Feng Liu 0015,Portland State University,http://web.cecs.pdx.edu/~fliu,uiqXutMAAAAJ
 Feng Lu 0005,Beihang University,http://shi.buaa.edu.cn/lufeng,NOSCHOLARPAGE
-Feng Luo,Clemson University,https://people.cs.clemson.edu/~luofeng,joROlFwAAAAJ
+Feng Luo 0001,Clemson University,https://people.cs.clemson.edu/~luofeng,joROlFwAAAAJ
 Feng Qian 0001,University of Minnesota,https://www-users.cs.umn.edu/~fengqian,NOSCHOLARPAGE
 Feng Qin,Ohio State University,http://web.cse.ohio-state.edu/~qin,kTh5nIIAAAAJ
 Feng Wang 0001,University of Mississippi,https://john.cs.olemiss.edu/~fwang/Home.htm,NOSCHOLARPAGE
@@ -6093,7 +6091,6 @@ Hui Wu,UNSW,http://www.cse.unsw.edu.au/~huiw,61DNIX0AAAAJ
 Hui Xiong,Rutgers University,http://datamining.rutgers.edu,cVDF1tkAAAAJ
 Hui Yang 0001,Georgetown University,http://infosense.cs.georgetown.edu/grace,nafo_HAAAAAJ
 Hui Zhang 0005,University College London,http://mig.cs.ucl.ac.uk/index.php?n=People.GHZhang,Ii9_OYMAAAAJ
-Hui Zhao,University of North Texas,http://www.cse.unt.edu/~huizhao,NOSCHOLARPAGE
 Huijia (Rachel) Lin,University of Washington,http://www.cs.ucsb.edu/~rachel.lin,h3gpLYAAAAAJ
 Huijia Lin,University of Washington,http://www.cs.ucsb.edu/~rachel.lin,h3gpLYAAAAAJ
 Huijing Zhao,Peking University,http://www.cis.pku.edu.cn/faculty/vision/zhaohj/index-e.htm,q-aZF-kAAAAJ
@@ -6664,7 +6661,7 @@ James Matthew Rehg,Georgia Institute of Technology,http://rehg.org,8kA3eDwAAAAJ
 James McCann,Carnegie Mellon University,http://www.cs.cmu.edu/~jmccann,NOSCHOLARPAGE
 James McHugh,NJIT,https://web.njit.edu/~mchugh/202,oi903pgAAAAJ
 James Mickens,Harvard University,http://mickens.seas.harvard.edu,7m5-SfEAAAAJ
-James Miller,University of Kansas,http://people.eecs.ku.edu/~miller,K5hmGHcAAAAJ
+James R. Miller,University of Kansas,http://people.eecs.ku.edu/~miller,K5hmGHcAAAAJ
 James Noble 0001,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/JamesNoble,SSUL-D8AAAAJ
 James P. Bagrow,University of Vermont,http://bagrow.com,krWnCYIAAAAJ
 James P. Callan,Carnegie Mellon University,http://www.cs.cmu.edu/~callan,Un5KXJ4AAAAJ
@@ -6799,7 +6796,7 @@ Jaroslaw R. Rossignac,Georgia Institute of Technology,http://www.cc.gatech.edu/~
 Jaroslaw Zola,University at Buffalo,http://www.cse.buffalo.edu/people/?u=jzola,bbfF1OwAAAAJ
 Jarred Ligatti,University of South Florida,http://www.cse.usf.edu/~ligatti,xmQREcEAAAAJ
 Jaruloj Eamsiri Chongstitvatana,Chulalongkorn University,http://65.54.113.26/Author/3358202/jaruloj-eamsiri-chongstitvatana,NOSCHOLARPAGE
-Jasleen Kaur,University of North Carolina,http://www.cs.unc.edu/~jasleen,K9_NT-MAAAAJ
+Jasleen Kaur 0001,University of North Carolina,http://www.cs.unc.edu/~jasleen,K9_NT-MAAAAJ
 Jason Cong,University of California - Los Angeles,http://vast.cs.ucla.edu/people/faculty/jason-cong,UVGe0gQAAAAJ
 Jason D. Bakos,University of South Carolina,https://cse.sc.edu/~jbakos,pXa_QqEAAAAJ
 Jason D. Hartline,Northwestern University,https://sites.northwestern.edu/hartline,AdAd4QIAAAAJ
@@ -7055,7 +7052,7 @@ Jia Deng,Princeton University,https://www.cs.princeton.edu/~jiadeng,U3Eub-EAAAAJ
 Jia Di,University of Arkansas,https://sites.uark.edu/jdi,NOSCHOLARPAGE
 Jia Jia 0001,Tsinghua University,http://media.cs.tsinghua.edu.cn/en/jiajia,NOSCHOLARPAGE
 Jia Li 0003,Beihang University,http://arts.buaa.edu.cn/staff/jiali/index.htm,BfWMlE4AAAAJ
-Jia Liu,Iowa State University,http://web.cs.iastate.edu/~jialiu,NOSCHOLARPAGE
+Jia Liu 0002,Iowa State University,http://web.cs.iastate.edu/~jialiu,NOSCHOLARPAGE
 Jia Rao,University of Texas at Arlington,http://ranger.uta.edu/~jrao,cLssJjcAAAAJ
 Jia Xu,York University,http://eecs.lassonde.yorku.ca/faculty/jia-xu,u8XzSF0AAAAJ
 Jia-Fu Xu,Nanjing University,https://cs.nju.edu.cn/58/2b/c2639a153643/page.htm,NOSCHOLARPAGE
@@ -7079,7 +7076,7 @@ Jian Lü 0001,Nanjing University,https://cs.nju.edu.cn/yuhuang,go8RGMkAAAAJ
 Jian Ma 0004,Carnegie Mellon University,http://www.cs.cmu.edu/~jianma,kDZcBhkAAAAJ
 Jian Pei,Simon Fraser University,http://www.cs.sfu.ca/~jpei,zIMEVKsAAAAJ
 Jian Peng 0001,Univ. of Illinois at Urbana-Champaign,http://web.engr.illinois.edu/~jianpeng,4wcAVXAAAAAJ
-Jian Tang,Syracuse University,http://www.ecs.syr.edu/faculty/tang,IirM9zMAAAAJ
+Jian Tang 0008,Syracuse University,http://www.ecs.syr.edu/faculty/tang,IirM9zMAAAAJ
 Jian Wang 0016,Fudan University,http://homepage.fudan.edu.cn/jianwang,5i7YIEgAAAAJ
 Jian Wu 0001,Zhejiang University,http://mypage.zju.edu.cn/0004274,VO9XIXYAAAAJ
 Jian Zhang,Louisiana State University - Baton Rouge,https://www.lsu.edu/eng/cse/people/faculty/zhang.php,NOSCHOLARPAGE
@@ -7222,7 +7219,6 @@ Jinbo Bi,University of Connecticut,http://www.engr.uconn.edu/~jinbo,fX-IFZsAAAAJ
 Jinbo Xu,TTI Chicago,http://ttic.uchicago.edu/~jinbo,nt2-TpIAAAAJ
 Jing (Selena) He,Old Dominion University,http://www.cs.odu.edu/~jhe,r4WtU2oAAAAJ
 Jing Chen 0001,Stony Brook University,http://www3.cs.stonybrook.edu/~jingchen,NLqcl5EAAAAJ
-Jing Gao,University at Buffalo,https://www.cse.buffalo.edu/~jing,jPBlSH4AAAAJ
 Jing He,Old Dominion University,http://www.cs.odu.edu/~jhe,r4WtU2oAAAAJ
 Jing Hua,Wayne State University,http://www.cs.wayne.edu/~jinghua,E0PGasMAAAAJ
 Jing Jiang 0001,Singapore Management University,http://www.mysmu.edu/faculty/jingjiang,hVTK2YwAAAAJ
@@ -7247,7 +7243,7 @@ Jingyi Yu,University of Delaware,https://www.eecis.udel.edu/~yu,R9L_AfQAAAAJ
 Jingyuan Zhang,The University of Alabama,http://zhang.cs.ua.edu,NOSCHOLARPAGE
 Jingyue Li,NTNU,https://www.ntnu.edu/employees/jingyue.li,ZeBM3ZAAAAAJ
 Jinho D. Choi,Emory University,http://www.mathcs.emory.edu/~choi,xdddblAAAAAJ
-Jinhui Xu,University at Buffalo,https://www.cse.buffalo.edu/~jinhui,NOSCHOLARPAGE
+Jinhui Xu 0001,University at Buffalo,https://www.cse.buffalo.edu/~jinhui,NOSCHOLARPAGE
 Jinlei Jiang,Tsinghua University,http://madsys.cs.tsinghua.edu.cn/~jinleijiang,Wx-JtQcAAAAJ
 Jinman Kim,University of Sydney,http://sydney.edu.au/engineering/people/jinman.kim.php,pLVaMiAAAAAJ
 Jinming Wen,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/jinming.wen,L_ssfM4AAAAJ
@@ -8068,7 +8064,7 @@ Kai Lawonn,University of Koblenz-Landau,https://www.uni-koblenz-landau.de/de/kob
 Kai Li 0001,Princeton University,http://www.cs.princeton.edu/~li,9MSpWOUAAAAJ
 Kai Salomaa,Queen’s University,http://research.cs.queensu.ca/~ksalomaa,N3AlqdYAAAAJ
 Kai Shen,University of Rochester,https://www.cs.rochester.edu/u/kshen,NOSCHOLARPAGE
-Kai Sun,University of Tennessee,http://web.eecs.utk.edu/~kaisun,O_2drywAAAAJ
+Kai Sun 0001,University of Tennessee,http://web.eecs.utk.edu/~kaisun,O_2drywAAAAJ
 Kai Xing,USTC,http://staff.ustc.edu.cn/~kxing,Z-UCpSoAAAAJ
 Kai Yu 0004,Shanghai Jiao Tong University,https://speechlab.sjtu.edu.cn/members/kai_yu,y5zkBeMAAAAJ
 Kai Zeng 0002,George Mason University,https://ece.gmu.edu/people/full-time-faculty/kai-zeng,ErabYRMAAAAJ
@@ -8593,7 +8589,7 @@ Kumiko Tanaka,University of Tokyo,http://www.rcast.u-tokyo.ac.jp/research/people
 Kumiko Tanaka-Ishii,University of Tokyo,http://www.rcast.u-tokyo.ac.jp/research/people/staff-tanaka-ishii_kumiko_en.html,NOSCHOLARPAGE
 Kun Cai,Australian National University,https://cecs.anu.edu.au/people/kun-cai,NOSCHOLARPAGE
 Kun Xu,Tsinghua University,http://cg.cs.tsinghua.edu.cn/people/~kun,dRlBzscAAAAJ
-Kun Zhang,Carnegie Mellon University,https://www.cmu.edu/dietrich/philosophy/people/faculty/zhang.html,RGoypN4AAAAJ
+Kun Zhang 0001,Carnegie Mellon University,https://www.cmu.edu/dietrich/philosophy/people/faculty/zhang.html,RGoypN4AAAAJ
 Kun Zhou,Zhejiang University,http://mypage.zju.edu.cn/kunzhou,N-iYby0AAAAJ
 Kun-Mao Chao,National Taiwan University,https://www.csie.ntu.edu.tw/~kmchao,rkpVQI4AAAAJ
 Kun-Pyo Lee,KAIST,http://dpl.kaist.ac.kr/people,NOSCHOLARPAGE
@@ -8947,7 +8943,7 @@ Lihi Zelnik-Manor,Technion,http://lihi.eew.technion.ac.il,E_ejWvYAAAAJ
 Lihua Yue,USTC,http://www.jucs.org/jucs_articles_by_author/Yue_Lihua,NOSCHOLARPAGE
 Lijie Wen,Tsinghua University,https://www.tsinghua.edu.cn/publish/soften/3131/2010/20101219194334615950081/20101219194334615950081_.html,f3C0jUIAAAAJ
 Lijun Chang,UNSW,https://www.cse.unsw.edu.au/~ljchang,SWYX6pgAAAAJ
-Lijun Chen,University of Colorado Boulder,http://spot.colorado.edu/~lich1539,p0rj1lEAAAAJ
+Lijun Chen 0001,University of Colorado Boulder,http://spot.colorado.edu/~lich1539,p0rj1lEAAAAJ
 Lijun Chen 0002,Peking University,http://eecs.pku.edu.cn/EN/People/Faculty/Detail/?ID=6011,NOSCHOLARPAGE
 Lijun Yin,Binghamton University,http://www.cs.binghamton.edu/~lijun,PYV9NvYAAAAJ
 Lila Kari,University of Waterloo,https://cs.uwaterloo.ca/about/people/lila,HqqZlPUAAAAJ
@@ -8964,7 +8960,6 @@ Lin Liu 0001,Tsinghua University,http://ise.thss.tsinghua.edu.cn/~liulin,0-SZSzg
 Lin Padgham,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/p/padgham-professor-lin,Bt3NOyAAAAAJ
 Lin Qiao,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101224001718934225189/20101224001718934225189_.html,zAQYGk4AAAAJ
 Lin Tan,Purdue University,https://www.cs.purdue.edu/homes/lintan,C6yankcAAAAJ
-Lin Zhong,Rice University,http://www.ruf.rice.edu/~lzhong,hJPN-G8AAAAJ
 Lin Zhong 0001,Rice University,http://www.ruf.rice.edu/~lzhong,HeHFFW8AAAAJ
 Lin-shan Lee,National Taiwan University,http://speech.ee.ntu.edu.tw/previous_version/lslNew.htm,NOSCHOLARPAGE
 LinLin Shen,Shenzhen University,http://csse.szu.edu.cn/en/people31dd.html?25226,AZ_y9HgAAAAJ
@@ -9097,7 +9092,7 @@ Lu Feng 0001,University of Virginia,http://www.cs.virginia.edu/~lufeng,HiyMQzEAA
 Lu Qin,University of Technology Sydney,https://www.uts.edu.au/staff/lu.qin,DQHL47oAAAAJ
 Lu Ruan,Iowa State University,http://www.cs.iastate.edu/~ruan,3FrD14AAAAAJ
 Lu Su,University at Buffalo,http://www.cse.buffalo.edu/people/?u=lusu,38RuCN4AAAAJ
-Lu Wang,Northeastern University,http://www.ccs.neu.edu/home/luwang,uczqEdUAAAAJ
+Lu Wang 0001,Northeastern University,http://www.ccs.neu.edu/home/luwang,uczqEdUAAAAJ
 Lu Zhang 0023,Peking University,http://sei.pku.edu.cn/~zhanglu,JUnz2VcAAAAJ
 Luay Nakhleh,Rice University,https://www.cs.rice.edu/~nakhleh,46HLWf8AAAAJ
 Lubomir Bic,University of California - Irvine,http://www.ics.uci.edu/~bic,NOSCHOLARPAGE
@@ -9757,7 +9752,7 @@ Markus Kuhn,University of Cambridge,https://www.cl.cam.ac.uk/~mgk25,4FSAZOsAAAAJ
 Markus Nebel,Bielefeld University,https://ekvv.uni-bielefeld.de/pers_publ/publ/PersonDetail.jsp?personId=71594916&lang=en,NOSCHOLARPAGE
 Markus Pauly,EPFL,http://lgg.epfl.ch/publications.php,TSGyT-EAAAAJ
 Markus Püschel,ETH Zurich,https://www.inf.ethz.ch/personal/markusp,az9ZryAAAAAJ
-Markus Schneider,University of Florida,http://www.cise.ufl.edu/~mschneid,lOhijLUAAAAJ
+Markus Schneider 0001,University of Florida,http://www.cise.ufl.edu/~mschneid,lOhijLUAAAAJ
 Markus Siegle,Bundeswehr University Munich,https://www.unibw.de/technische-informatik/mitarbeiter/professoren/siegle/entwurf-von-rechen-und-kommunikationssystemen,Sdh-toEAAAAJ
 Markus Steinberger,Graz University of Technology,https://www.markussteinberger.net,meRwdycAAAAJ
 Markus Wagner 0007,University of Adelaide,https://cs.adelaide.edu.au/~markus,DVbOu8MAAAAJ
@@ -10147,7 +10142,7 @@ Merlin Teodosia Suarez,De La Salle University,https://www.dlsu.edu.ph/colleges/c
 Merrick L. Furst,Georgia Institute of Technology,http://www.cc.gatech.edu/people/merrick-furst,NOSCHOLARPAGE
 Metin Sitti,Max Planck Institute,http://pi.is.mpg.de/person/sitti,YU4Ce_MAAAAJ
 Meysam Asgari,OHSU,http://cslu.ohsu.edu/~asgari,ZKlatu0AAAAJ
-Mi Zhang,Michigan State University,http://www.egr.msu.edu/~mizhang,r3A90uAAAAAJ
+Mi Zhang 0002,Michigan State University,http://www.egr.msu.edu/~mizhang,r3A90uAAAAAJ
 Mi Zhang 0001,Fudan University,http://homepage.fudan.edu.cn/zhangmi,NOSCHOLARPAGE
 Mian M. Awais,LUMS,https://lums.edu.pk/lums_employee/516,wkxlfFAAAAAJ
 Mian Muhammad Awais,LUMS,https://lums.edu.pk/lums_employee/516,wkxlfFAAAAAJ
@@ -10245,7 +10240,7 @@ Michael Hahsler,Southern Methodist University,https://www.smu.edu/Lyle/Departmen
 Michael Haney,University of Idaho,http://www.uidaho.edu/engr/departments/cs/our-people/faculty/michael-haney,yFPTY8wAAAAJ
 Michael Hatzopoulos,University of Athens,http://cgi.di.uoa.gr/~mike,NOSCHOLARPAGE
 Michael Henry Albert,University of Otago,http://www.cs.otago.ac.nz/staff/michael.html,oZL1wnUAAAAJ
-Michael Herrmann,University of Edinburgh,http://www.research.ed.ac.uk/portal/en/persons/michael-herrmann(cf1b7c31-3a87-4812-bf0a-05cf49b0120e).html,MJiOEy0AAAAJ
+J. Michael Herrmann,University of Edinburgh,http://www.research.ed.ac.uk/portal/en/persons/michael-herrmann(cf1b7c31-3a87-4812-bf0a-05cf49b0120e).html,MJiOEy0AAAAJ
 Michael Hicks 0001,University of Maryland - College Park,http://www.cs.umd.edu/~mwh,I9Vzs-4AAAAJ
 Michael Homer,Victoria University of Wellington,https://ecs.victoria.ac.nz/Main/MichaelHomer,ss2RKjoAAAAJ
 Michael Horsch,University of Saskatchewan,http://artsandscience.usask.ca/profile/MHorsch,NOSCHOLARPAGE
@@ -10562,7 +10557,7 @@ Ming Ouhyoung,National Taiwan University,https://www.csie.ntu.edu.tw/~ming,UmUdI
 Ming Ouyang,University of Massachusetts Boston,http://www.cs.umb.edu/people/Ming_Ouyang,pSvbXKQAAAAJ
 Ming Yin,Purdue University,https://www.cs.purdue.edu/people/faculty/mingyin,bgTGjecAAAAJ
 Ming Zhang 0004,Peking University,http://net.pku.edu.cn/dlib/mzhang,LbzoQBsAAAAJ
-Ming Zhao,Arizona State University,https://cidse.engineering.asu.edu/directory/zhao-ming,ZaB3G68AAAAJ
+Ming Zhao 0002,Arizona State University,https://cidse.engineering.asu.edu/directory/zhao-ming,ZaB3G68AAAAJ
 Ming-Deh A. Huang,University of Southern California,http://www-bcf.usc.edu/~mdhuang,NOSCHOLARPAGE
 Ming-Deh Huang,University of Southern California,http://www-bcf.usc.edu/~mdhuang,NOSCHOLARPAGE
 Ming-Deh Huang ,University of Southern California,http://www-bcf.usc.edu/~mdhuang,NOSCHOLARPAGE
@@ -10908,7 +10903,7 @@ Nam Nguyen,Towson University,https://www.towson.edu/fcsm/departments/computerinf
 Nan (Jonas) Yang,Australian National University,https://cecs.anu.edu.au/people/nan-yang,hVytXZ8AAAAJ
 Nan Guan,The Hong Kong Polytechnic University,http://www4.comp.polyu.edu.hk/~csguannan,3C7SPAgAAAAJ
 Nan Niu,University of Cincinnati,http://homepages.uc.edu/~niunn,Ag81t_4AAAAJ
-Nan Wang,University of Southern Mississippi,http://orca.st.usm.edu/~nwang,NOSCHOLARPAGE
+Nan Wang 0002,University of Southern Mississippi,http://orca.st.usm.edu/~nwang,NOSCHOLARPAGE
 Nan Zhang 0004,Pennsylvania State University,https://faculty.ist.psu.edu/nan,NOSCHOLARPAGE
 Nancy A. Day,University of Waterloo,https://cs.uwaterloo.ca/~nday,5iYmSzcAAAAJ
 Nancy A. Lynch,Massachusetts Institute of Technology,https://people.csail.mit.edu/lynch,LPTkkxUAAAAJ
@@ -12082,7 +12077,6 @@ Pinar Senkul,Middle East Technical University,http://user.ceng.metu.edu.tr/~kara
 Pinar Tözün,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/pinar-toezun(63342b24-28ec-40c5-a7d9-ec49867dc75d).html,JTmMb3kAAAAJ
 Pinar Yolum,Boğaziçi University,http://mas.cmpe.boun.edu.tr/pinar,lbdyKlYAAAAJ
 Pinar Öztürk,NTNU,https://www.ntnu.edu/employees/pinar,wL7HNLsAAAAJ
-Ping Ji,CUNY,http://jjcweb.jjay.cuny.edu/pji,tQiUbtEAAAAJ
 Ping Li 0001,Rutgers University,http://www.stat.rutgers.edu/home/pingli,vR8jj4YAAAAJ
 Ping Luo 0001,Chinese Academy of Sciences,http://mldm.ict.ac.cn/MLDM/luoping,d5L-OV4AAAAJ
 Ping Tan,Simon Fraser University,http://www.cs.sfu.ca/~pingtan,konovGYAAAAJ
@@ -12197,7 +12191,7 @@ Qi Cheng,University of Oklahoma,http://www.cs.ou.edu/%7Eqcheng,JhIUgjkAAAAJ
 Qi Han,Colorado School of Mines,http://inside.mines.edu/~qhan,CiPyIk4AAAAJ
 Qi Rose Yu,Rochester Institute of Technology,http://www.ist.rit.edu/~qyu,efV9EvoAAAAJ
 Qi Tian 0001,University of Texas at San Antonio,http://www.cs.utsa.edu/~qitian,61b6eYkAAAAJ
-Qi Wei,George Mason University,http://bioengineering.gmu.edu/faculty_page/wei,6otVU08AAAAJ
+Qi Wei 0003,George Mason University,http://bioengineering.gmu.edu/faculty_page/wei,6otVU08AAAAJ
 Qi Yu,Rochester Institute of Technology,http://www.ist.rit.edu/~qyu,efV9EvoAAAAJ
 Qi Zhang 0001,Fudan University,http://jkx.fudan.edu.cn/~qzhang,XfqR3yYAAAAJ
 Qi Zhu 0002,Northwestern University,http://eecs.northwestern.edu/~qzhu,TN09YMcAAAAJ
@@ -13350,7 +13344,7 @@ S. Srinivasa Rao 0001,Seoul National University,http://tcs.snu.ac.kr/members/ssr
 S. Sudarshan 0001,IIT Bombay,https://www.cse.iitb.ac.in/~sudarsha,KVbazsEAAAAJ
 S. V. N. Vishwanathan,University of California - Santa Cruz,https://www.soe.ucsc.edu/people/vishy,tqcSvFIAAAAJ
 S. V. Rao,IIT Guwahati,https://www.iitg.ernet.in/svrao,4NoqGCEAAAAJ
-S. Venkatesan,University of Texas at Dallas,https://www.utdallas.edu/~venky,l80_pjYAAAAJ
+S. Venkatesan 0001,University of Texas at Dallas,https://www.utdallas.edu/~venky,l80_pjYAAAAJ
 S. Venkatesh 0001,University of Victoria,http://www.cs.uvic.ca/~venkat,xn6BVdoAAAAJ
 S.-H. Gary Chan,HKUST,https://home.cse.ust.hk/~gchan,uiCSOycAAAAJ
 Saad Biaz,Auburn University,http://www.eng.auburn.edu/users/sbiaz,B4fHhe0AAAAJ
@@ -14196,7 +14190,7 @@ Song Han,University of Connecticut,http://engr.uconn.edu/~song,nO2uJ4YAAAAJ
 Song Jiang,University of Texas at Arlington,http://ranger.uta.edu/~sjiang,vhpbMX8AAAAJ
 Song Min Kim,KAIST,https://sites.google.com/view/smilelab,lBJc3B8AAAAJ
 Song Wang 0002,University of South Carolina,http://www.cse.sc.edu/~songwang,eycXl_QAAAAJ
-Song Zhang,Mississippi State University,http://web.cse.msstate.edu/~szhang/index.htm,NOSCHOLARPAGE
+Song Zhang 0004,Mississippi State University,http://web.cse.msstate.edu/~szhang/index.htm,NOSCHOLARPAGE
 Song-Chun Zhu,University of California - Los Angeles,http://www.stat.ucla.edu/~sczhu,Al8dyb4AAAAJ
 Song-Hai Zhang,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101225165936235350290/20101225165936235350290_.html,AWtV-EQAAAAJ
 Songqing Chen,George Mason University,https://cs.gmu.edu/~sqchen,T7IRM8EAAAAJ
@@ -15928,7 +15922,6 @@ Wei Cheng,Virginia Commonwealth University,http://www.people.vcu.edu/~wcheng3,Ti
 Wei Ding 0003,University of Massachusetts Boston,http://www.cs.umb.edu/~ding,eFeqk8EAAAAJ
 Wei Dong 0001,Zhejiang University,http://mypage.zju.edu.cn/dongw,NOSCHOLARPAGE
 Wei Hu 0003,Peking University,http://www.icst.pku.edu.cn/F/intro/huwei/index.html,5oFf8Q4AAAAJ
-Wei Jin,University of North Texas,http://www.cse.unt.edu/~weijin,NOSCHOLARPAGE
 Wei Le,Iowa State University,http://www.cs.iastate.edu/~weile,QjFu7LEAAAAJ
 Wei Lee Woon,Masdar Institute,https://www.masdar.ac.ae/aboutus/management/faculty-directory/item/5730-wei-lee-woon,cmHsRGoAAAAJ
 Wei Li 0012,Fudan University,https://dblp.uni-trier.de/pers/hd/l/Li_0012:Wei,NOSCHOLARPAGE
@@ -15956,7 +15949,6 @@ Wei Yu,Towson University,https://www.towson.edu/fcsm/departments/computerinfosci
 Wei Zeng,Florida International University,http://cis.fiu.edu/~wzeng,yKYRdd0AAAAJ
 Wei Zhang 0004,Peking University,http://sei.pku.edu.cn/~zhangw,NOSCHOLARPAGE
 Wei Zhang 0016,Fudan University,http://www.cs.fudan.edu.cn/?page_id=2019,NOSCHOLARPAGE
-Wei Zhu,Stony Brook University,http://www.ams.stonybrook.edu/~zhu,9jshr6QAAAAJ
 Wei-Chung Hsu,National Taiwan University,http://www.csie.ntu.edu.tw/~hsuwc,NOSCHOLARPAGE
 Wei-Kuan Shih,National Tsing Hua University,https://sites.google.com/site/rtlabnthu/project-definition,NOSCHOLARPAGE
 Wei-Ngan Chin,National University of Singapore,https://www.comp.nus.edu.sg/~chinwn,DO2x-J0AAAAJ
@@ -16242,7 +16234,6 @@ Xi Chen 0001,Columbia University,http://www.cs.columbia.edu/~xichen/Homepage/Wel
 Xi He,University of Waterloo,https://users.cs.duke.edu/~hexi88,DlTQ320AAAAJ
 Xi Li 0001,Zhejiang University,http://mypage.zju.edu.cn/xilics,TYNPJQMAAAAJ
 Xi Peng 0005,Binghamton University,https://sites.google.com/site/xipengcshomepage/home,DWw4v0kAAAAJ
-Xi Wang,University of Washington,https://homes.cs.washington.edu/~xi,6NMfUhAAAAAJ
 Xia Hu,Texas A&M University,http://faculty.cs.tamu.edu/xiahu,pcCS60IAAAAJ
 Xia Ning,IUPUI,http://cs.iupui.edu/~xning,FzhfFokAAAAJ
 Xia Yin,Tsinghua University,http://www.tsinghua.edu.cn/publish/csen/4623/2010/20101226110908587907841/20101226110908587907841_.html,SKxhz04AAAAJ
@@ -16280,7 +16271,7 @@ Xianhua Liu 0001,Peking University,http://eecs.pku.edu.cn/EN/People/Faculty/Deta
 Xianping Tao,Nanjing University,http://moon.nju.edu.cn/people/xianpingtao,F3mGYVoAAAAJ
 Xiao Bai 0001,Beihang University,http://scse.buaa.edu.cn/info/1014/2952.htm,NOSCHOLARPAGE
 Xiao Ding,Harbin Institute of Technology,http://ir.hit.edu.cn/~xding,Mi9XXuAAAAAJ
-Xiao Qin,Auburn University,http://www.eng.auburn.edu/~xqin,877mtdkAAAAJ
+Xiao Qin 0001,Auburn University,http://www.eng.auburn.edu/~xqin,877mtdkAAAAJ
 Xiao Shaun Wang,Northwestern University,http://eecs.northwestern.edu/~wangxiao,QbWLR8QAAAAJ
 Xiao Wang 0012,Northwestern University,http://eecs.northwestern.edu/~wangxiao,QbWLR8QAAAAJ
 Xiao-Chuan Cai,University of Colorado Boulder,https://www.cs.colorado.edu/~cai,NOSCHOLARPAGE
@@ -16387,7 +16378,7 @@ Xin Huang 0001,Hong Kong Baptist University,https://www.comp.hkbu.edu.hk/~xinhua
 Xin Jin 0008,Johns Hopkins University,https://www.cs.jhu.edu/~xinjin,NhsdGBUAAAAJ
 Xin Li 0006,Johns Hopkins University,http://www.cs.jhu.edu/~lixints,NOSCHOLARPAGE
 Xin Li 0028,HKUST,https://www.cse.ust.hk/~lixin,NOSCHOLARPAGE
-Xin Liu,University of California - Davis,http://www.cs.ucdavis.edu/~liu,F5I3cM4AAAAJ
+Xin Liu 0002,University of California - Davis,http://www.cs.ucdavis.edu/~liu,F5I3cM4AAAAJ
 Xin Peng 0001,Fudan University,http://www.se.fudan.edu.cn/pengxin,wATYGXEAAAAJ
 Xin Wang 0001,Stony Brook University,https://www.cs.stonybrook.edu/people/faculty/XinWang,5asO0a8AAAAJ
 Xin Wang 0002,Fudan University,http://homepage.fudan.edu.cn/xinw2013,4KcxzhoAAAAJ
@@ -16526,7 +16517,7 @@ Yang Xiang 0004,University of Guelph,https://www.uoguelph.ca/computing/people/ya
 Yang Xiao 0001,The University of Alabama,http://yangxiao.cs.ua.edu,HSxTENAAAAAJ
 Yang Yang 0002,UESTC,http://cfm.uestc.edu.cn/~yangyang,PVv2xDYAAAAJ
 Yang Yang 0009,Zhejiang University,http://yangy.org,NOSCHOLARPAGE
-Yang Yi,University of Kansas,http://www.ittc.ku.edu/~yangyi,5KpXoMMAAAAJ
+Yang Yi 0002,Virginia Tech,https://www.yangyi.ece.vt.edu,5KpXoMMAAAAJ
 Yang Yu,Tsinghua University,http://iiis.tsinghua.edu.cn/zh/yuy,NOSCHOLARPAGE
 Yang Zhou 0007,Shenzhen University,https://zhouyangvcc.github.io,9oXvA2IAAAAJ
 Yangdong Deng,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2014/20140115102144786540201/20140115102144786540201_.html,NOSCHOLARPAGE
@@ -16725,7 +16716,7 @@ Yolanda Becerra,Polytechnic University of Catalonia,http://people.ac.upc.edu/yol
 Yolande Berbers,KU Leuven,https://distrinet.cs.kuleuven.be/people/yolande,cjTQU8oAAAAJ
 Yonatan Aumann,Bar-Ilan University,http://cs.biu.ac.il/en/node/636,0BI-noIAAAAJ
 Yong Cao,Virginia Tech,http://people.cs.vt.edu/yongcao,Vb5nXFMAAAAJ
-Yong Chen,Texas Tech University,http://www.myweb.ttu.edu/yonchen,PHVKUhEAAAAJ
+Yong Chen 0001,Texas Tech University,http://www.myweb.ttu.edu/yonchen,PHVKUhEAAAAJ
 Yong Chiang Tay,National University of Singapore,http://www.math.nus.edu.sg/~mattyc,qAalyGsAAAAJ
 Yong Cui 0001,Tsinghua University,http://www.tsinghua.edu.cn/publish/csen/4623/2010/20101223231342918741150/20101223231342918741150_.html,5isoO_QAAAAJ
 Yong Deng,UESTC,http://en.uestc.edu.cn/index.php?m=content&c=index&a=show&catid=79&id=5320,8voeILsAAAAJ
@@ -16832,7 +16823,6 @@ Yuan Tian 0001,University of Virginia,https://www.ytian.info,ja0GtqgAAAAJ
 Yuan Tian 0008,Queen’s University,http://sophiaytian.com,wX4le_QAAAAJ
 Yuan Xie 0001,University of California - Santa Barbara,http://www.ece.ucsb.edu/~yuanxie,dK2ZuDcAAAAJ
 Yuan Zhang 0009,Fudan University,https://yuanxzhang.github.io,ZEgzyZcAAAAJ
-Yuan Zhou,Indiana University,https://www.soic.indiana.edu/all-people/profile.html?profile_id=442,aR34e1gAAAAJ
 Yuan-Fang Li,Monash University,http://monash.edu/research/explore/en/persons/yuanfang-li(45cfb4c4-99f3-4880-a1fd-b353372086b6).html,wufXO1kAAAAJ
 Yuan-Fang Wang,University of California - Santa Barbara,http://www.cs.ucsb.edu/~yfwang,9177npMAAAAJ
 Yuan-Shun Dai,UESTC,http://www.scse.uestc.edu.cn:8080/teacherteam-english/teacher/view.html?id=44,DRCdhcwAAAAJ

--- a/dblp-aliases.csv
+++ b/dblp-aliases.csv
@@ -493,8 +493,6 @@ Chris Pal,Christopher Joseph Pal
 Christopher J. Pal,Christopher Joseph Pal
 Christopher Kruegel,Christopher Krügel
 Christopher A. Leckie,Christopher Leckie
-Chris R. Johnson,Christopher R. Johnson
-Chris R. Johnson 0001,Christopher R. Johnson 0001
 Chris Scaffidi,Christopher Scaffidi
 Chris Umans,Christopher Umans
 Christopher William Geib,Christopher W. Geib
@@ -2233,7 +2231,6 @@ S. S. Iyengar,S. Sitharama Iyengar
 Sundaraja Sitharama Iyengar,S. Sitharama Iyengar
 Srinivasa Rao Satti,S. Srinivasa Rao 0001
 Vishy Vishwanathan,S. V. N. Vishwanathan
-Subbayyan Venkatesan,S. Venkatesan
 Venkatesh Srinivasan 0001,S. Venkatesh 0001
 Srinivasan Venkatesh 0001,S. Venkatesh 0001
 Sachin Rajsekhar Katti,Sachin Katti

--- a/old/industry.csv
+++ b/old/industry.csv
@@ -2,7 +2,7 @@ name,affiliation,homepage,scholarid,company
 Manuela M. Veloso,Carnegie Mellon University,https://www.cs.cmu.edu/~mmv/,2FbkAzYAAAAJ,TBD
 Luke S. Zettlemoyer,University of Washington,https://www.cs.washington.edu/people/faculty/lsz/,UjpbO6IAAAAJ,TBD
 Luke Zettlemoyer,University of Washington,https://www.cs.washington.edu/people/faculty/lsz/,UjpbO6IAAAAJ,TBD
-Abhinav Gupta,Carnegie Mellon University,http://www.cs.cmu.edu/~abhinavg/,bqL73OkAAAAJ,TBD
+Abhinav Gupta 0001,Carnegie Mellon University,http://www.cs.cmu.edu/~abhinavg/,bqL73OkAAAAJ,TBD
 Jessica K. Hodgins,Carnegie Mellon University,http://www.cs.cmu.edu/~jkh/,vswo4rQAAAAJ,TBD
 Noah A. Smith,University of Washington,https://www.cs.washington.edu/people/faculty/nasmith/,TjdFs3EAAAAJ,TBD
 Yejin Choi,University of Washington,http://homes.cs.washington.edu/~yejin/,vhP-tlcAAAAJ,TBD
@@ -21,7 +21,7 @@ Steven Myers,Indiana University,http://wphomes.soic.indiana.edu/samyers/,SQnCssw
 Benjamin Livshits,Imperial College London,http://www3.imperial.ac.uk/portal/page/portallive/0CC35F0D599A9668E050C69B473942D5/,jaITaUcAAAAJ,Brave
 Dieter Fox,University of Washington,http://homes.cs.washington.edu/~fox/,DqXsbPAAAAAJ,Nvidia
 V. Benjamin Livshits,Imperial College London,http://www.imperial.ac.uk/computing/people/alphabetical/academic-staff/,jaITaUcAAAAJ,Brave
-Hao Li,University of Southern California,http://www.hao-li.com/,pPutNUwAAAAJ,TBD
+Hao Li 0015,University of Southern California,http://www.hao-li.com/,pPutNUwAAAAJ,TBD
 J. Zico Kolter,Carnegie Mellon University,http://www.zicokolter.com/,NOSCHOLARPAGE,TBD
 Raquel Urtasun,University of Toronto,http://www.cs.toronto.edu/~urtasun/,jyxO2akAAAAJ,TBD
 Akshay Krishnamurthy,University of Massachusetts Amherst,https://www.cics.umass.edu/~akshay/,K0kaNvkAAAAJ,TBD
@@ -46,9 +46,7 @@ Daniel S. Weld,University of Washington,http://www.cs.washington.edu/people/facu
 Daniel Sabby Weld,University of Washington,http://www.cs.washington.edu/people/faculty/weld,IUZgJogAAAAJ,Allen Institute
 Charles A. Sutton,University of Edinburgh,http://homepages.inf.ed.ac.uk/csutton,hYtGXD0AAAAJ,Google
 Yannis Stylianou,University of Crete,https://www.csd.uoc.gr/index.jsp?custom=yannis_stylianou,6ZSjpdwAAAAJ,TBD
-Sebastian Riedel,University College London,http://www0.cs.ucl.ac.uk/people/S.Riedel.html,AcCtcrsAAAAJ,TBD
 Sebastian Riedel 0001,University College London,http://www0.cs.ucl.ac.uk/people/S.Riedel.html,AcCtcrsAAAAJ,TBD
-Sebastian Robert Riedel,University College London,http://www0.cs.ucl.ac.uk/people/S.Riedel.html,AcCtcrsAAAAJ,TBD
 Jur P. van den Berg,University of Utah,http://arl.cs.utah.edu,VjsNXysAAAAJ,TBD
 Jur van den Berg,University of Utah,http://arl.cs.utah.edu,VjsNXysAAAAJ,TBD
 Honglak Lee,University of Michigan,http://web.eecs.umich.edu/~honglak,fmSHtE8AAAAJ,TBD


### PR DESCRIPTION
I broke my previous pull request (featuring the DBLP alias detections script) by clobbering it. 

This is still now an issue to correct a bunch of ambiguous DBLP entries. I found these simply by checking R1 universities for entries where a '0001' version also exists in DBLP and then correcting them manually. 