### PR TITLE
add Marshini Chetty at University of Chicago, remove retired, moved, non-affiliated Princeton faculty

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -889,7 +889,6 @@ Andrea Lockerd,Georgia Institute of Technology,http://www.cc.gatech.edu/~athomaz
 Andrea Lockerd Thomaz,Georgia Institute of Technology,http://www.cc.gatech.edu/~athomaz,jIs-Y2gAAAAJ
 Andrea Maggiolo Schettini,University of Pisa,http://www.di.unipi.it/~maggiolo,NOSCHOLARPAGE
 Andrea Marino,University of Pisa,http://pages.di.unipi.it/marino,FUKaLzkAAAAJ
-Andrea S. LaPaugh,Princeton University,https://www.cs.princeton.edu/~aslp,NOSCHOLARPAGE
 Andrea Tagliasacchi,University of Victoria,http://gfx.uvic.ca,1RmD-YsAAAAJ
 Andrea Thomaz,Georgia Institute of Technology,http://www.cc.gatech.edu/~athomaz,jIs-Y2gAAAAJ
 Andreas Albrecht,Middlesex University,https://www.mdx.ac.uk/about-us/our-people/staff-directory/profile/albrecht-andreas,NOSCHOLARPAGE
@@ -14931,7 +14930,6 @@ Thierry Massart,Université libre de Bruxelles,http://www.ulb.ac.be/di/verif/tma
 Thinh Nguyen,Oregon State University,http://eecs.oregonstate.edu/people/nguyen-thinh,9flSED8AAAAJ
 Thirimachos Bourlai,West Virginia University,https://www.statler.wvu.edu/faculty-staff/faculty/thirimachos-bourlai,vBn6I3sAAAAJ
 Thomas A. DeFanti,University of Illinois at Chicago,https://www.cs.uic.edu/~tom,NOSCHOLARPAGE
-Thomas A. Funkhouser,Princeton University,http://www.cs.princeton.edu/~funk,BghVDhgAAAAJ
 Thomas A. Goldstein,University of Maryland - College Park,https://www.cs.umd.edu/~tomg,KmSuVtgAAAAJ
 Thomas A. Henzinger,IST Austria,http://pub.ist.ac.at/~tah,jpgplxUAAAAJ
 Thomas A. Horan,Claremont Graduate University,https://www.redlands.edu/study/schools-and-centers/business/staff/thomas-horan,2aFmaaAAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -9701,6 +9701,7 @@ Marnel Peradilla,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/fac
 Marouane Kessentini,University of Michigan-Dearborn,http://kessentini.net,5oW_MA8AAAAJ
 Marsha Chechik,University of Toronto,http://www.cs.toronto.edu/~chechik,CYfxRVIAAAAJ
 Marsha J. Berger,New York University,https://cs.nyu.edu/berger,NOSCHOLARPAGE
+Marshini Chetty,University of Chicago,https://marshini.net,eVJ6NTIAAAAJ
 Mart L. Molle,University of California - Riverside,http://www.cs.ucr.edu/~mart,NOSCHOLARPAGE
 Mart Molle,University of California - Riverside,http://www.cs.ucr.edu/~mart,NOSCHOLARPAGE
 Marta Jiménez,Polytechnic University of Catalonia,https://www.facebook.com/public/Marta-Jim%C3%A9nez-Delgado,7Ik08XAAAAAJ
@@ -11008,7 +11009,7 @@ Nianwen Xue,Brandeis University,http://www.cs.brandeis.edu/~xuen,KlVbOkMAAAAJ
 Nicholas D. Lane,University of Oxford,http://www.cs.ox.ac.uk/people/nicholas.lane,IleoLUgAAAAJ
 Nicholas Drivalos Matragkas,University of York,https://www-users.cs.york.ac.uk/~nikos,Dvp7fNoAAAAJ
 Nicholas Evans,EURECOM,http://www.eurecom.fr/~evans,NOSCHOLARPAGE
-Nicholas G. Feamster,University of Chicago,http://www.cs.princeton.edu/~feamster,xYfYnG4AAAAJ
+Nick Feamster,University of Chicago,http://www.cs.princeton.edu/~feamster,xYfYnG4AAAAJ
 Nicholas Hopper,University of Minnesota,https://www-users.cs.umn.edu/~hopper,4e2pnKYAAAAJ
 Nicholas J. A. Harvey,University of British Columbia,http://www.cs.ubc.ca/~nickhar,xdTtK9IAAAAJ
 Nicholas J. Hopper,University of Minnesota,https://www-users.cs.umn.edu/~hopper,4e2pnKYAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -13342,7 +13342,6 @@ Samir Ranjan Das,Stony Brook University,http://www3.cs.stonybrook.edu/~samir,NOS
 Samira Manabi Khan,University of Virginia,http://www.cs.virginia.edu/~smk9u,NOSCHOLARPAGE
 Samira Shaikh,UNC - Charlotte,https://analyticsfrontiers.uncc.edu/speakers/samira-shaikh,IM-64IoAAAAJ
 Samit Bhattacharya,IIT Guwahati,http://www.iitg.ernet.in/samit,oXu5o6gAAAAJ
-Samory Kpotufe,Columbia University,http://www.columbia.edu/~skk2175,NOSCHOLARPAGE
 Sampalli Srinivas,Dalhousie University,https://web.cs.dal.ca/~srini,NOSCHOLARPAGE
 Sampath Kannan,University of Pennsylvania,https://www.cis.upenn.edu/~kannan,aiPgs4oAAAAJ
 Sampsa Hyysalo,Aalto University,https://inuse.fi/people/sampsa-hyysalo,Uzl_pPYAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -7505,7 +7505,6 @@ Jonathan Sun,University of Southern Mississippi,http://www.cs.usm.edu/~jsun,NOSC
 Jonathan Turner,Washington University in St. Louis,http://www.arl.wustl.edu/~jst,Cgx9W6UAAAAJ
 Jonathan Ullman,Northeastern University,http://www.ccis.northeastern.edu/people/jonathan-ullman,WfS41RAAAAAJ
 Jonathan Ventura,Univ. of Colorado Colorado Springs,http://jventura.net,k0E68OgAAAAJ
-Jonathan W. Pillow,Princeton University,http://pillowlab.princeton.edu,NOSCHOLARPAGE
 Jonathan Walpole,Portland State University,http://web.cecs.pdx.edu/~walpole,-pS6P-oAAAAJ
 Jonathan Whittle,Monash University,https://research.monash.edu/en/persons/jon-whittle,igMJAZwAAAAJ
 Jonathan Zittrain,Harvard University,http://hls.harvard.edu/faculty/directory/10992/Zittrain,aWZ0YN4AAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -11009,7 +11009,7 @@ Nianwen Xue,Brandeis University,http://www.cs.brandeis.edu/~xuen,KlVbOkMAAAAJ
 Nicholas D. Lane,University of Oxford,http://www.cs.ox.ac.uk/people/nicholas.lane,IleoLUgAAAAJ
 Nicholas Drivalos Matragkas,University of York,https://www-users.cs.york.ac.uk/~nikos,Dvp7fNoAAAAJ
 Nicholas Evans,EURECOM,http://www.eurecom.fr/~evans,NOSCHOLARPAGE
-Nick Feamster,University of Chicago,http://www.cs.princeton.edu/~feamster,xYfYnG4AAAAJ
+Nicholas G. Feamster,University of Chicago,http://www.cs.princeton.edu/~feamster,xYfYnG4AAAAJ
 Nicholas Hopper,University of Minnesota,https://www-users.cs.umn.edu/~hopper,4e2pnKYAAAAJ
 Nicholas J. A. Harvey,University of British Columbia,http://www.cs.ubc.ca/~nickhar,xdTtK9IAAAAJ
 Nicholas J. Hopper,University of Minnesota,https://www-users.cs.umn.edu/~hopper,4e2pnKYAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -5526,7 +5526,6 @@ H. T. Kung,Harvard University,https://www.eecs.harvard.edu/htk,iLQqwosAAAAJ
 H. T. Mouftah,University of Ottawa,http://www.site.uottawa.ca/~mouftah,33FmwbwAAAAJ
 H. V. Jagadish,University of Michigan,http://web.eecs.umich.edu/~jag,SKVnHakAAAAJ
 H. Venkateswaran,Georgia Institute of Technology,http://www.cc.gatech.edu/~venkat,NOSCHOLARPAGE
-H. Vincent Poor,Princeton University,http://ee.princeton.edu/people/faculty/h-vincent-poor,NOSCHOLARPAGE
 Hadas Kress-Gazit,Cornell University,https://www.mae.cornell.edu/people/profile.cfm?netid=hk478,duOys3YAAAAJ
 Hadas Shachnai,Technion,http://www.cs.technion.ac.il/~hadas,NOSCHOLARPAGE
 Hadi Esmaeilzadeh,University of California - San Diego,http://www.cc.gatech.edu/~hadi,LnB5_AcAAAAJ
@@ -7484,7 +7483,6 @@ Jonathan Brumberg,University of Kansas,https://sanlab.ku.edu/jon-brumberg,k3QunH
 Jonathan C. L. Liu,University of Florida,https://www.cise.ufl.edu/~jcliu,NOSCHOLARPAGE
 Jonathan Cazalas,King Abdulaziz University,http://kau.cazalas.com,NOSCHOLARPAGE
 Jonathan Cook,New Mexico State University,http://www.cs.nmsu.edu/~jcook,6aXVf4oAAAAJ
-Jonathan D. Cohen,Princeton University,https://ncclab.princeton.edu,NCkkQAMAAAAJ
 Jonathan E. Cook,New Mexico State University,http://www.cs.nmsu.edu/~jcook,lznJTOEAAAAJ
 Jonathan F. Buss,University of Waterloo,https://cs.uwaterloo.ca/~jfbuss,68wU4zYAAAAJ
 Jonathan Gemmell,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=494,RIhZrvIAAAAJ
@@ -10905,7 +10903,6 @@ Nathan S. Netanyahu,Bar-Ilan University,http://cs.biu.ac.il/en/node/644,xPv701UA
 Nathan Schneider,Georgetown University,http://nathan.cl,3cozMf4AAAAJ
 Nathan Srebro,TTI Chicago,http://ttic.uchicago.edu/~nati,ZnT-QpMAAAAJ
 Nathan Sturtevant,University of Denver,http://web.cs.du.edu/~sturtevant,3utEUeoAAAAJ
-Nathaniel D. Daw,Princeton University,https://www.princeton.edu/~ndaw,BxlScrEAAAAJ
 Nathaniel D. Osgood,University of Saskatchewan,https://www.cs.usask.ca/~osgood,HWcKmQIAAAAJ
 Nathaniel David Osgood,University of Saskatchewan,https://www.cs.usask.ca/~osgood,HWcKmQIAAAAJ
 Nathaniel Nystrom,Università della Svizzera italiana,http://search.usi.ch/people/d666ae47e79dd3cbb2207e2607148c49/Nystrom-Nate,b4qip_0AAAAJ
@@ -11151,7 +11148,6 @@ Nir Friedman,Hebrew University of Jerusalem,http://www.cs.huji.ac.il/~nir,xjnef1
 Nir Lipovetzky,University of Melbourne,http://people.eng.unimelb.edu.au/nlipovetzky,us3IGxsAAAAJ
 Nir Shavit,Massachusetts Institute of Technology,http://people.csail.mit.edu/shanir,NOSCHOLARPAGE
 Nir Yosef,University of California - Berkeley,https://niryosef.wordpress.com,eQ8KEHoAAAAJ
-Niraj K. Jha,Princeton University,https://www.princeton.edu/~jha,qNMrc7IAAAAJ
 Niranjan Balasubramanian,Stony Brook University,http://www3.cs.stonybrook.edu/~niranjan,X3JCGVIAAAAJ
 Nirmala Shenoy,Rochester Institute of Technology,https://www.rit.edu/gccis/nirmala-shenoy,NOSCHOLARPAGE
 Nirupam Roy,University of Maryland - College Park,https://www.cs.umd.edu/~nirupam,kKyEuTcAAAAJ
@@ -11798,7 +11794,6 @@ Peter J. Downey,University of Arizona,https://www.cs.arizona.edu/~pete,NOSCHOLAR
 Peter J. Haas,University of Massachusetts Amherst,http://researcher.watson.ibm.com/researcher/view.php?person=us-phaas,PeCI8KcAAAAJ
 Peter J. Keleher,University of Maryland - College Park,https://www.cs.umd.edu/people/keleher,NOSCHOLARPAGE
 Peter J. Passmore,Middlesex University,https://www.mdx.ac.uk/about-us/our-people/staff-directory/profile/passmore-peter,NOSCHOLARPAGE
-Peter J. Ramadge,Princeton University,http://ee.princeton.edu/people/faculty/peter-j-ramadge,BOMboVoAAAAJ
 Peter J. Rodgers,University of Kent,https://www.cs.kent.ac.uk/people/staff/pjr,wu6mHBsAAAAJ
 Peter J. Sadowski,University of Hawaii at Manoa,https://www2.hawaii.edu/~psadow,5-s3bS8AAAAJ
 Peter J. Stuckey,University of Melbourne,http://people.eng.unimelb.edu.au/pstuckey,tvFekxwAAAAJ
@@ -13347,7 +13342,7 @@ Samir Ranjan Das,Stony Brook University,http://www3.cs.stonybrook.edu/~samir,NOS
 Samira Manabi Khan,University of Virginia,http://www.cs.virginia.edu/~smk9u,NOSCHOLARPAGE
 Samira Shaikh,UNC - Charlotte,https://analyticsfrontiers.uncc.edu/speakers/samira-shaikh,IM-64IoAAAAJ
 Samit Bhattacharya,IIT Guwahati,http://www.iitg.ernet.in/samit,oXu5o6gAAAAJ
-Samory Kpotufe,Princeton University,http://www.princeton.edu/~samory,NOSCHOLARPAGE
+Samory Kpotufe,Columbia University,http://www.columbia.edu/~skk2175,NOSCHOLARPAGE
 Sampalli Srinivas,Dalhousie University,https://web.cs.dal.ca/~srini,NOSCHOLARPAGE
 Sampath Kannan,University of Pennsylvania,https://www.cis.upenn.edu/~kannan,aiPgs4oAAAAJ
 Sampsa Hyysalo,Aalto University,https://inuse.fi/people/sampsa-hyysalo,Uzl_pPYAAAAJ
@@ -13761,7 +13756,6 @@ Shaowei Cai,Chinese Academy of Sciences,http://teacher.ucas.ac.cn/~caisw,mcuXqQo
 Shaowen Bardzell,Indiana University,https://www.soic.indiana.edu/all-people/profile.html?profile_id=160,aD5ev8QAAAAJ
 Shaowen Wang,Univ. of Illinois at Urbana-Champaign,http://www.cigi.illinois.edu/shaowen,qcUhJIcAAAAJ
 Shaoxu Song,Tsinghua University,http://ise.thss.tsinghua.edu.cn/sxsong,NOSCHOLARPAGE
-Sharad Malik,Princeton University,https://www.princeton.edu/~sharad,MV8KGT0AAAAJ
 Sharad Mehrotra,University of California - Irvine,https://www.ics.uci.edu/~sharad,MTZaRW4AAAAJ
 Sharat Chandran,IIT Bombay,https://www.cse.iitb.ac.in/~sharat,pRDtIYcAAAAJ
 Sharath Raghvendra,Virginia Tech,http://people.cs.vt.edu/~sharathr,kOfRa7MAAAAJ


### PR DESCRIPTION
# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [X] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.
