### PR TITLE
Added missing affiliations for some Technion faculty members.

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -17037,10 +17037,10 @@ Daniel Soudry,Technion,https://sites.google.com/site/danielsoudry/,AEBWEm8AAAAJ
 Ron Meir,Technion,https://ronmeir.net.technion.ac.il,r3NAa9oAAAAJ
 Ronny Meir,Technion,https://ronmeir.net.technion.ac.il,r3NAa9oAAAAJ
 R. S. Meir,Technion,https://ronmeir.net.technion.ac.il,r3NAa9oAAAAJ
-Nahum Shimkin,http://webee.technion.ac.il/Sites/People/shimkin/,YPptH48AAAAJ
+Nahum Shimkin,Technion,http://webee.technion.ac.il/Sites/People/shimkin/,YPptH48AAAAJ
 Aviv Tamar,Technion,https://people.eecs.berkeley.edu/~avivt/,kppa2vgAAAAJ
-Kfir Y. Levy,https://kfiryehud.wixsite.com/kfir-y-levy,dG7KSW0AAAAJ
-Kfir Yehuda Levy,https://kfiryehud.wixsite.com/kfir-y-levy,dG7KSW0AAAAJ
-Dana Drachsler-Cohen,https://www.sri.inf.ethz.ch/people/dana,XOiO5xgAAAAJ
-Dana Drachsler,https://www.sri.inf.ethz.ch/people/dana,XOiO5xgAAAAJ
+Kfir Y. Levy,Technion,https://kfiryehud.wixsite.com/kfir-y-levy,dG7KSW0AAAAJ
+Kfir Yehuda Levy,Technion,https://kfiryehud.wixsite.com/kfir-y-levy,dG7KSW0AAAAJ
+Dana Drachsler-Cohen,Technion,https://www.sri.inf.ethz.ch/people/dana,XOiO5xgAAAAJ
+Dana Drachsler,Technion,https://www.sri.inf.ethz.ch/people/dana,XOiO5xgAAAAJ
 Ümit V. Çatalyürek,Georgia Institute of Technology,https://www.cc.gatech.edu/~umit,OLDMURQAAAAJ


### PR DESCRIPTION
Added missing affiliations for some Technion faculty members.

# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [x] If the institution you are adding is not in the US,
update `country-info.csv`.
