### PR TITLE
Update affiliation of Hung-Wei Tseng

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -6114,7 +6114,7 @@ Hung Quang Ngo,University at Buffalo,http://www.cse.buffalo.edu/~hungngo,srP2ANo
 Hung Son Nguyen,University of Warsaw,http://www.mimuw.edu.pl/~son,uJ3EK_cAAAAJ
 Hung-Kuo Chu,National Tsing Hua University,http://cgv.cs.nthu.edu.tw/hkchu,XM4QrScAAAAJ
 Hung-Min Sun,National Tsing Hua University,http://is.cs.nthu.edu.tw/wiki/doku.php?id=advisor:main,NOSCHOLARPAGE
-Hung-Wei Tseng,North Carolina State University,http://cseweb.ucsd.edu/~h1tseng,j-Lk39cAAAAJ
+Hung-Wei Tseng,University of California - Riverside,https://intra.engr.ucr.edu/~htseng/,j-Lk39cAAAAJ
 Huseyin Levent Akin,Boğaziçi University,https://www.cmpe.boun.edu.tr/~akin,61aKNawAAAAJ
 Husheng Li,University of Tennessee,http://web.eecs.utk.edu/~husheng,pM3wc_YAAAAJ
 Hussein M. Alnuweiri,Texas A&M at Qatar,https://www.qatar.tamu.edu/programs/ecen/faculty-and-staff/duplicate-of-dr.-patrick-linke,NOSCHOLARPAGE


### PR DESCRIPTION
Fixes #1561 

**Inclusion criteria**

- [X] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [X] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.


