### PR TITLE
fixing NAACL 2019 and ISMB 2019 Proceedings

### DIFF
--- a/util/csrankings.py
+++ b/util/csrankings.py
@@ -180,7 +180,7 @@ areadict = {
 #            ],
     'emnlp': ['EMNLP', 'EMNLP-CoNLL', 'HLT/EMNLP'],
     'acl' : ['ACL', 'ACL (1)', 'ACL (2)', 'ACL/IJCNLP', 'COLING-ACL'],
-    'naacl' : ['NAACL', 'HLT-NAACL', 'NAACL-HLT'],
+    'naacl' : ['NAACL', 'HLT-NAACL', 'NAACL-HLT', 'NAACL-HLT (1)'],
 #    'vision': ['CVPR', 'CVPR (1)', 'CVPR (2)', 'ICCV', 'ECCV', 'ECCV (1)', 'ECCV (2)', 'ECCV (3)', 'ECCV (4)', 'ECCV (5)', 'ECCV (6)', 'ECCV (7)'],
     'cvpr': ['CVPR', 'CVPR (1)', 'CVPR (2)'],
     'iccv': ['ICCV'],
@@ -212,7 +212,8 @@ EMSOFT_TECS_PaperNumbers = { 2017: (163, 190) } # "pages" 163--190
 
 # ISMB proceedings are published as special issues of Bioinformatics.
 # Here is the list.
-ISMB_Bioinformatics = {2018: (34, 13),
+ISMB_Bioinformatics = {2019: (35, 14),
+                       2018: (34, 13),
                        2017: (33, 14),
                        2016: (32, 12),
                        2015: (31, 12),


### PR DESCRIPTION
I made two corrections:
1) NAACL 2019 proceedings is published as "NAACL-HLT (1) 2019".
2) ISMB 2019 proceedings is published in Bioinformatics, Vol. 35, Issue 14, 2019.
Thanks!