### PR TITLE
Adding KU Leuven Faculty

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,4 +1,0 @@
-csrankings.org
-www.csrankings.org
-csrankings.com
-www.csrankings.com

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -17287,3 +17287,4 @@ Jiajun Wu 0001,Stanford University,https://jiajunwu.com/,2efgcS0AAAAJ
 Seongkook Heo,University of Virginia,http://seongkookheo.com/,7r0_F0kAAAAJ
 Yongjoo Park,Univ. of Illinois at Urbana-Champaign,https://yongjoopark.com/,Pd7IdigAAAAJ
 Diyi Yang,Georgia Institute of Technology,https://www.cc.gatech.edu/~dyang888/,j9jhYqQAAAAJ
+Tinne Tuytelaars,KU Leuven,https://homes.esat.kuleuven.be/~tuytelaa/,EuFF9kUAAAAJ


### PR DESCRIPTION
Adding Faculty from KU Leuven, Belgium

# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

**Inclusion criteria**

- [ ] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [ ] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [ ] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

