### PR TITLE
Jonathan Katz moved to GMU

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -7541,7 +7541,7 @@ Jonathan F. Buss,University of Waterloo,https://cs.uwaterloo.ca/~jfbuss,68wU4zYA
 Jonathan Gemmell,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=494,RIhZrvIAAAAJ
 Jonathan I. Maletic,Kent State University,http://www.cs.kent.edu/~jmaletic,n9_W4kYAAAAJ
 Jonathan K. Lazar,Towson University,http://orion.towson.edu/~jlazar,CDpfbBsAAAAJ
-Jonathan Katz,University of Maryland - College Park,https://www.cs.umd.edu/~jkatz,H4rKFc8AAAAJ
+Jonathan Katz,George Mason University,https://www.cs.umd.edu/~jkatz,H4rKFc8AAAAJ
 Jonathan Lazar,Towson University,http://orion.towson.edu/~jlazar,CDpfbBsAAAAJ
 Jonathan Lee 0001,National Taiwan University,https://www.csie.ntu.edu.tw/~jlee,iYNIPS8AAAAJ
 Jonathan Mace,Max Planck Institute,https://cs.brown.edu/~jcmace,NOSCHOLARPAGE


### PR DESCRIPTION
# Contributing to CSrankings

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

Katz's Google Scholar page lists his new affiliation.