### PR TITLE
adding Qi Li to Iowa State University

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -17253,6 +17253,7 @@ Peter Ljunglöf,Chalmers University of Technology,https://www.chalmers.se/en/sta
 Peter Lundin,Chalmers University of Technology,https://www.chalmers.se/en/staff/Pages/peter-lundin.aspx,NOSCHOLARPAGE
 Philipp Leitner,Chalmers University of Technology,https://www.chalmers.se/en/staff/Pages/philipp-leitner.aspx,wZ9f8CAAAAAJ
 Philippas Tsigas,Chalmers University of Technology,https://www.chalmers.se/en/staff/Pages/philippas-tsigas.aspx,NOSCHOLARPAGE
+Qi Li 0012,Iowa State University,https://www.cs.iastate.edu/people/qi-li,NOSCHOLARPAGE
 Regina Hebig,Chalmers University of Technology,https://www.chalmers.se/en/staff/Pages/hebig.aspx,NOSCHOLARPAGE
 Riccardo Scandariato,Chalmers University of Technology,http://www.scandariato.org,NOSCHOLARPAGE
 Richard Berntsson Svensson,Chalmers University of Technology,https://www.chalmers.se/en/staff/Pages/ricbern.aspx,NOSCHOLARPAGE


### PR DESCRIPTION
Emery, Hope you are well. We would like to add our recent hire Qi Li to the CS rankings database. Best wishes, Hridesh

Relevant links:
https://www.cs.iastate.edu/people/qi-li
https://publish.illinois.edu/qili5/2019/06/28/i-will-join-iowa-state-university-cs-department-as-assistant-professor-in-aug-2019/