### PR TITLE
updates for University of Salerno

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -433,6 +433,7 @@ Alessandro Salandrino,University of Kansas,http://www.eecs.ku.edu/people/faculty
 Alessandro Veneziani,Emory University,http://www.mathcs.emory.edu/~ale,xjvr4yEAAAAJ
 Alessandro Vespignani,Northeastern University,http://www.mobs-lab.org/alessandro-vespignani.html,U3CXAPsAAAAJ
 Alessandro Vinciarelli,University of Glasgow,http://www.dcs.gla.ac.uk/vincia,XOnfkHIAAAAJ
+Alessia Saggese,University of Salerno,https://docenti.unisa.it/024950/home,OwHN05YAAAAJ
 Alessio Gaspar,University of South Florida,http://cereal.forest.usf.edu/alessio,8UtfjnIAAAAJ
 Alessio Guglielmi,University of Bath,http://alessio.guglielmi.name,1fq1YrMAAAAJ
 Alessio Lomuscio,Imperial College London,http://www.doc.ic.ac.uk/~alessio,xdWZkEEAAAAJ
@@ -1347,6 +1348,7 @@ Arash Termehchy,Oregon State University,http://eecs.oregonstate.edu/people/terme
 Aravind Prakash,Binghamton University,https://www.binghamton.edu/cs/people/aprakash.html,GqFjHVAAAAAJ
 Aravind Srinivasan,University of Maryland - College Park,https://www.cs.umd.edu/~srin,sPzla6IAAAAJ
 Aravindan Vijayaraghavan,Northwestern University,http://www.eecs.northwestern.edu/~aravindv,eR9vd3gAAAAJ
+Arcangelo Castiglione,University of Salerno,https://docenti.unisa.it/026260/home,Uh1YyVYAAAAJ
 Archan Misra,Singapore Management University,https://www.smu.edu.sg/faculty/profile/9632/Archan-MISRA,a0YC5VAAAAAJ
 Arcot Sowmya,UNSW,http://www.cse.unsw.edu.au/~sowmya,NOSCHOLARPAGE
 Arda Yurdakul,Boğaziçi University,https://www.cmpe.boun.edu.tr/~yurdakul,6UUbTP4AAAAJ
@@ -1861,6 +1863,7 @@ Bhojan Anand,National University of Singapore,http://www.comp.nus.edu.sg/~bhojan
 Bhubaneswar Mishra,New York University,https://cs.nyu.edu/mishra,kXVBr20AAAAJ
 Bhujanga Chakrabarti,Victoria University of Wellington,http://sms.victoria.ac.nz/Main/BhujangaChakrabarti,3VT_IZEAAAAJ
 Bhuvan Urgaonkar,Pennsylvania State University,http://www.cse.psu.edu/~buu1,ZoI6hPwAAAAJ
+Biagio Cosenza,University of Salerno,http://cosenza.eu/,gQCXas8AAAAJ
 Bianca Schroeder,University of Toronto,http://www.cs.toronto.edu/~bianca,TW4Th98AAAAJ
 Bianca Schröder,University of Toronto,http://www.cs.toronto.edu/~bianca,TW4Th98AAAAJ
 Biao Chen,Syracuse University,http://comlab.ecs.syr.edu/people/bchen,653GqXUAAAAJ
@@ -2946,6 +2949,7 @@ Clelia De Felice,University of Salerno,http://old.di.unisa.it/professori/defelic
 Clelia de Felice,University of Salerno,http://old.di.unisa.it/professori/defelice,mfe4sfsAAAAJ
 Clemens Beckstein,Friedrich Schiller University Jena,http://ki.informatik.uni-jena.de,NOSCHOLARPAGE
 Clement T. Yu,University of Illinois at Chicago,https://www.cs.uic.edu/~yu,buju2sYAAAAJ
+Clemente Galdi,University of Salerno,https://docenti.unisa.it/004543/home,yCdeJ2sAAAAJ
 Cliff C. Zou,University of Central Florida,http://www.cs.ucf.edu/~czou,bfK_0uwAAAAJ
 Cliff Changchun Zou,University of Central Florida,http://www.cs.ucf.edu/~czou,bfK_0uwAAAAJ
 Cliff Stein,Columbia University,http://www.columbia.edu/~cs2035,r49_E2cAAAAJ
@@ -3976,7 +3980,6 @@ Donald Sheehy,University of Connecticut,http://donsheehy.net,A5D1DF4AAAAJ
 Donald Wunsch,Missouri University of Technology,http://people.mst.edu/faculty/dwunsch/index.html,nML1gAwAAAAJ
 Donald Yeung,University of Maryland - College Park,https://ece.umd.edu/~yeung,HoDilBYAAAAJ
 Donatella Sciuto,Politecnico di Milano,http://home.deib.polimi.it/sciuto,NOSCHOLARPAGE
-Donatello Conte,University of Salerno,http://videolectures.net/donatello_conte,dAKCYJgAAAAJ
 Donatello Materassi,University of Tennessee,http://www.eecs.utk.edu/people/faculty/dmateras,_bjIGdIAAAAJ
 Dong Deng,Rutgers University,https://www.cs.rutgers.edu/faculty/dong-deng,mNUsQysAAAAJ
 Dong Jin,Illinois Institute of Technology,https://science.iit.edu/people/faculty/kevin-jin,-ln1Vp0AAAAJ
@@ -4366,7 +4369,6 @@ Eno Thereska,Imperial College London,https://enothereska.wordpress.com,Vxq3vksAA
 Eno Tonisson,University of Tartu,http://www.ut.ee/en/eno-tonisson,DrT8-oEAAAAJ
 Eno Tõnisson,University of Tartu,http://www.ut.ee/en/eno-tonisson,DrT8-oEAAAAJ
 Enrico Bertini,New York University,http://engineering.nyu.edu/user/5001,qFhoz68AAAAJ
-Enrico Fischetti,University of Salerno,http://www.unisa.it/docenti/enricofischetti/en/index,NOSCHOLARPAGE
 Enrico Pontelli,New Mexico State University,https://www.cs.nmsu.edu/wp13/enrico-pontelli,vEbcIKYAAAAJ
 Enrico Scala,Australian National University,https://cs.anu.edu.au/people/enrico-scala,QaTNO-UAAAAJ
 Enrique Carlos Segura,University of Buenos Aires,http://www-2.dc.uba.ar/profesores/segura/homepage.html,NOSCHOLARPAGE
@@ -4620,6 +4622,7 @@ Fabio Gadducci,University of Pisa,http://www.di.unipi.it/~gadducci,ugYkdyYAAAAJ
 Fabio Kon,USP,http://www.ime.usp.br/~kon,VE8BW84AAAAJ
 Fabio Luiz Usberti,UNICAMP,http://www.ic.unicamp.br/~fusberti,ELBC6qsAAAAJ
 Fabio Nemetz,University of Bath,http://www.bath.ac.uk/comp-sci/contacts,NOSCHOLARPAGE
+Fabio Palomba,University of Salerno,https://fpalomba.github.io/,hwcOgd4AAAAJ
 Fabio Ramos,University of Sydney,http://www-personal.acfr.usyd.edu.au/f.ramos/Fabio_Ramos_Homepage/Home.html,NOSCHOLARPAGE
 Fabio Salice,Politecnico di Milano,http://home.deib.polimi.it/salice,gf7sA4QAAAAJ
 Fabio T. Ramos,University of Sydney,http://www-personal.acfr.usyd.edu.au/f.ramos/Fabio_Ramos_Homepage/Home.html,NOSCHOLARPAGE
@@ -4794,7 +4797,6 @@ Filippo Bonchi,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/filippo
 Filippo Menczer,Indiana University,http://cnets.indiana.edu/fil,f_kGJwkAAAAJ
 Filippos Tzaferis,University of Athens,http://www.di.uoa.gr/eng/staff/1028,NOSCHOLARPAGE
 Fillia Makedon,University of Texas at Arlington,http://heracleia.uta.edu/~makedon,NOSCHOLARPAGE
-Filomena De Santis,University of Salerno,http://www.unisa.it/docenti/filomenadesantis/en/index,NOSCHOLARPAGE
 Filomena Ferrucci,University of Salerno,http://salerno.academia.edu/FilomenaFerrucci,6LDD4w0AAAAJ
 Finale Doshi,Harvard University,https://www.seas.harvard.edu/directory/finale,NOSCHOLARPAGE
 Finale Doshi-Velez,Harvard University,https://www.seas.harvard.edu/directory/finale,NOSCHOLARPAGE
@@ -4852,6 +4854,7 @@ Francesco Orabona,Boston University,http://francesco.orabona.com,g1ha-iYAAAAJ
 Francesco Orciuoli,University of Salerno,http://www.unisa.it/docenti/francescoorciuoli/en/index,hrsHqX4AAAAJ
 Francesco Palmieri,University of Salerno,http://www.unisa.it/docenti/francescopalmieri/en/index,Ly2epXgAAAAJ
 Francesco Romani,University of Pisa,http://www.di.unipi.it/~romani,NOSCHOLARPAGE
+Francesco Tortorella,University of Salerno,https://docenti.unisa.it/041789/home,-oi4h0QAAAAJ
 Francesco Zappa Nardelli,Ecole Normale Superieure,http://www.di.ens.fr/~zappa,pp1KBVQAAAAJ
 Francine Berman,Rensselaer Polytechnic Institute,http://www.cs.rpi.edu/~bermaf,NOSCHOLARPAGE
 Francis Bach,Ecole Normale Superieure,http://www.di.ens.fr/~fbach,6PJWcFEAAAAJ
@@ -5366,6 +5369,7 @@ Giuseppe Attardi,University of Pisa,https://www.di.unipi.it/~attardi,p86Ewsi7jXw
 Giuseppe Caire,TU Berlin,https://www.commit.tu-berlin.de/menue/mitarbeiter/fachgebietsleiter,g66ErTcAAAAJ
 Giuseppe Carenini,University of British Columbia,https://www.cs.ubc.ca/~carenini,HNNL22kAAAAJ
 Giuseppe Cattaneo,University of Salerno,http://www.di.unisa.it/~roscigno,PKs7M0gAAAAJ
+Giuseppe Fenza,University of Salerno,https://docenti.unisa.it/021699/home,0C3IjEIAAAAJ
 Giuseppe Pelagatti,Politecnico di Milano,http://home.deib.polimi.it/pelagatt,NOSCHOLARPAGE
 Giuseppe Persiano,University of Salerno,http://www.di.unisa.it/~giuper,wbQQcfQAAAAJ
 Giuseppe Polese,University of Salerno,http://docenti.unisa.it/004281/en/curriculum,F2YX_9gAAAAJ
@@ -9190,6 +9194,7 @@ Luca Barletta,Politecnico di Milano,http://home.deib.polimi.it/barletta,vu_mjR0A
 Luca Benini,ETH Zurich,https://www.ee.ethz.ch/the-department/people-a-z/person-detail.html?persid=194234,8riq3sYAAAAJ
 Luca Daniel,Massachusetts Institute of Technology,http://www.mit.edu/~dluca,JtPNrS8AAAAJ
 Luca Gemignani,University of Pisa,http://www.di.unipi.it/~lgemignani,PtMCtZsAAAAJ
+Luca Greco,University of Salerno,https://docenti.unisa.it/023586/home,bLphet8AAAAJ
 Luca Mottola,Politecnico di Milano,http://home.deib.polimi.it/mottola,VkFc88EAAAAJ
 Luca O. Breviglieri,Politecnico di Milano,https://www.deib.polimi.it/eng/people/details/110272,NOSCHOLARPAGE
 Luca P. Carloni,Columbia University,http://www.cs.columbia.edu/~luca,sEAoh3MAAAAJ
@@ -9584,6 +9589,7 @@ Marco Loog,TU Delft,http://prlab.tudelft.nl/users/marco-loog,2gmHmJYAAAAJ
 Marco Masseroli,Politecnico di Milano,http://home.deib.polimi.it/masseroli,IDkIyTcAAAAJ
 Marco Molinaro,PUC-RIO,www.inf.puc-rio.br/~mmolinaro,NOSCHOLARPAGE
 Marco Pedersoli,ETS Montreal,https://profs.etsmtl.ca/mpedersoli,aVfyPAoAAAAJ
+Marco Romano,University of Salerno,https://www.marcoromano.eu/,EEVgWLMAAAAJ
 Marco Serafini,University of Massachusetts Amherst,https://scholar.google.es/citations?user=IJECSdkAAAAJ&hl=en,IJECSdkAAAAJ
 Marco Servetto,Victoria University of Wellington,https://ecs.victoria.ac.nz/Main/MarcoServetto,X7AUaVIAAAAJ
 Marco Tagliasacchi,Politecnico di Milano,http://home.deib.polimi.it/tagliasa,zwH1rZQAAAAJ
@@ -9633,7 +9639,6 @@ Margaret Martonosi,Princeton University,http://www.princeton.edu/~mrm,tgYsFS0AAA
 Margaret S. Cheung,University of Houston,https://sites.google.com/nsm.uh.edu/cheung,6f9jHBUAAAAJ
 Margaret-Anne D. Storey,University of Victoria,https://margaretannestorey.wordpress.com,WhjQewkAAAAJ
 Margarida Mamede, Universidade NOVA de Lisboa, http://nova-lincs.di.fct.unl.pt/person/23, j8VugkYAAAAJ
-Margherita Napoli,University of Salerno,http://wpage.unina.it/m.faella/Download/curriculum_eng_faella.pdf,coUnYW8AAAAJ
 Margit Pohl,TU Wien,igw.tuwien.ac.at/hci/people/mpohl,NOSCHOLARPAGE
 Margo I. Seltzer,University of British Columbia,https://www.eecs.harvard.edu/margo,XeyiyUYAAAAJ
 Margo Seltzer,University of British Columbia,https://www.eecs.harvard.edu/margo,XeyiyUYAAAAJ
@@ -10514,6 +10519,7 @@ Michele Lanza,Università della Svizzera italiana,http://search.usi.ch/persone/8
 Michele Mosca,University of Waterloo,http://faculty.iqc.uwaterloo.ca/mmosca,HLUdAeUAAAAJ
 Michele Nappi,University of Salerno,http://www.biplab.unisa.it/portal/index.php/members/prof-michele-nappi,XNWhz4wAAAAJ
 Michele Parrinello,Università della Svizzera italiana,http://search.usi.ch/people/3b1efdf234d1c4d61794f89ef66ac885/Parrinello-Michele,lnkt9rgAAAAJ
+Michele Risi,University of Salerno,https://docenti.unisa.it/005637/home,9RatguwAAAAJ
 Michele Zito,University of Liverpool,https://www.liverpool.ac.uk/computer-science/staff/michele-zito,nZUs5w8AAAAJ
 Michelle A. Borkin,Northeastern University,http://www.ccis.northeastern.edu/people/michelle-borkin,m9F7mIgAAAAJ
 Michelle Borkin,Northeastern University,http://www.ccis.northeastern.edu/people/michelle-borkin,m9F7mIgAAAAJ
@@ -12449,6 +12455,7 @@ Rafail Ostrovsky,University of California - Los Angeles,http://www.cs.ucla.edu/~
 Rafal A. Angryk,Georgia State University,https://grid.cs.gsu.edu/~rangryk,Phw2RfEAAAAJ
 Rafal K. Mantiuk,University of Cambridge,https://www.cl.cam.ac.uk/~rkm38,pJEb8x4AAAAJ
 Rafal Mantiuk,University of Cambridge,https://www.cl.cam.ac.uk/~rkm38,pJEb8x4AAAAJ
+Raffaele Pizzolante,University of Salerno,https://docenti.unisa.it/025505/home,NOSCHOLARPAGE
 Raffaella Mirandola,Politecnico di Milano,http://home.deib.polimi.it/mirandol,_NqFoiYAAAAJ
 Ragesh Jaiswal,IIT Delhi,http://www.cse.iitd.ernet.in/~rjaiswal,hrbj92oAAAAJ
 Raghav Sampangi,Dalhousie University,https://www.dal.ca/academics/programs/graduate/computer-science/graduate-life/current-students/raghav-sampangi.html,x_Cy69EAAAAJ
@@ -15868,8 +15875,10 @@ Vincent Yun Shen,HKUST,https://www.cse.ust.hk/~shen,NOSCHOLARPAGE
 Vincenzo Ambriola,University of Pisa,http://www.di.unipi.it/~ambriola,NOSCHOLARPAGE
 Vincenzo Auletta,University of Salerno,http://www.unisa.it/docenti/vincenzoauletta/en/index,NOSCHOLARPAGE
 Vincenzo Caglioti,Politecnico di Milano,http://home.deib.polimi.it/caglioti,NOSCHOLARPAGE
+Vincenzo Carletti,University of Salerno,https://docenti.unisa.it/026104/home,1iQtvdsAAAAJ
 Vincenzo Deufemia,University of Salerno,http://www.unisa.it/docenti/vincenzodeufemia/index,HwOcqO8AAAAJ
 Vincenzo Gervasi,University of Pisa,http://www.di.unipi.it/~gervasi,4nMaoMEAAAAJ
+Vincenzo Iovino,University of Salerno,https://sites.google.com/site/vincenzoiovinoit,ALo6sX8AAAAJ
 Vincenzo Liberatore,Case Western Reserve University,http://engr.case.edu/liberatore_vincenzo,NOSCHOLARPAGE
 Vincenzo Loia,University of Salerno,http://www.unisa.it/docenti/vincenzoloia/en/index,izBsqU4AAAAJ
 Vincenzo Mancuso,IMDEA Networks Institute,http://people.networks.imdea.org/~vincenzo_mancuso,ydSIhokAAAAJ
@@ -15908,6 +15917,7 @@ Virendra Singh Shekhawat,BITS Pilani,http://universe.bits-pilani.ac.in/pilani/vs
 Virendrakumar C. Bhavsar,University of New Brunswick,http://www.cs.unb.ca/~bhavsar,fMno_04AAAAJ
 Virgil D. Gligor,Carnegie Mellon University,https://users.ece.cmu.edu/~virgil,NOSCHOLARPAGE
 Virgil Gligor,Carnegie Mellon University,https://users.ece.cmu.edu/~virgil,NOSCHOLARPAGE
+Virginia Giorno,University of Salerno,https://docenti.unisa.it/000781/home,H_qvxrIAAAAJ
 Virginia Torczon,College of William and Mary,http://www.wm.edu/as/computerscience/faculty/torczon_v.php,NOSCHOLARPAGE
 Virginia Vassilevska,Massachusetts Institute of Technology,http://theory.stanford.edu/~virgi,Wph6P_IAAAAJ
 Virginia Vassilevska Williams,Massachusetts Institute of Technology,http://theory.stanford.edu/~virgi,Wph6P_IAAAAJ


### PR DESCRIPTION
# Verification

The proposed names are extracted from the official database maintained by the Italian government. This is the link to the database: http://cercauniversita.cineca.it/php5/docenti/cerca.php

To verify the names proceed as follows:
    1) select "Tutti i ruoli" as Ruolo (this will include full, associate and assistant professors)
    2) select "SALERNO" as Ateneo
    3a) select "01/B1 Informatica" as macrosettore;
    3b) select "09/H Ingegneria Informatica" as macrosettore;
    4) finally click on "invio.

# Summary of changes

The following members have been removed (they either retired or changed affiliation): 
Donatello Conte, Enrico Fischetti, Filomena De Santis, Margherita Napoli

The following are new Faculty members:
Arcangelo Castiglione, Biagio Cosenza, Giuseppe Fenza, Clemente Galdi, Virginia Giorno, Vincenzo Iovino, Fabio Palomba, Raffaele Pizzolante, Michele Risi, Marco Romano, Vincenzo Carletti, Luca Greco, Alessia Saggese, Francesco Tortorella

