### PR TITLE
Eric Rozier moved to industry. Kris De Brabanter no longer has an app…

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -4448,7 +4448,6 @@ Eric Po Xing,Carnegie Mellon University,http://www.cs.cmu.edu/~epxing,5pKTRxEAAA
 Eric Postma,Tilburg University,https://www.tilburguniversity.edu/webwijs/show/e.o.postma.htm,EpsyWjIAAAAJ
 Eric Price,University of Texas at Austin,http://www.cs.utexas.edu/~ecprice,UiKzYNMAAAAJ
 Eric Roberts,Stanford University,http://cs.stanford.edu/people/eroberts,BgLKWLUAAAAJ
-Eric Rozier,Iowa State University,http://www.cs.iastate.edu/people/eric-rozier,IUkqD5YAAAAJ
 Eric Rozner,University of Colorado Boulder,http://www.ericrozner.com,z0KD3z4AAAAJ
 Eric Ruppert,York University,http://www.cs.yorku.ca/~ruppert,ficDn98AAAAJ
 Eric S. K. Yu,University of Toronto,http://www.cs.toronto.edu/~eric,c36OREEAAAAJ
@@ -4460,8 +4459,6 @@ Eric Van Wyk,University of Minnesota,http://www-users.cs.umn.edu/~evw,fMI1OlIAAA
 Eric Vigoda,Georgia Institute of Technology,http://www.cc.gatech.edu/home/vigoda,NOSCHOLARPAGE
 Eric W. Frew,University of Colorado Boulder,https://www.colorado.edu/faculty/frew,Tvmf6RAAAAAJ
 Eric Walkingshaw,Oregon State University,http://web.engr.oregonstate.edu/~walkiner,0kPwMDwAAAAJ
-Eric William Davis,Iowa State University,http://www.cs.iastate.edu/people/eric-rozier,IUkqD5YAAAAJ
-Eric William Davis Rozier,Iowa State University,http://www.cs.iastate.edu/people/eric-rozier,IUkqD5YAAAAJ
 Eric Wustrow,University of Colorado Boulder,https://ericw.us/trow,becbtxgAAAAJ
 Eric Xing,Carnegie Mellon University,http://www.cs.cmu.edu/~epxing,5pKTRxEAAAAJ
 Eric Yu 0001,University of Toronto,http://www.cs.toronto.edu/~eric,c36OREEAAAAJ
@@ -8619,7 +8616,6 @@ Kousha Etessami,University of Edinburgh,http://homepages.inf.ed.ac.uk/kousha,_rU
 Koushik Sen,University of California - Berkeley,http://www.eecs.berkeley.edu/Faculty/Homepages/ksen.html,Vn3L_ioAAAAJ
 Krasimir Angelov,Chalmers University of Technology,https://www.chalmers.se/en/staff/Pages/krasimir-angelov.aspx,NOSCHOLARPAGE
 Kris Bubendorfer,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/KrisBubendorfer,PufVt-8AAAAJ
-Kris De Brabanter,Iowa State University,http://kbrabant.public.iastate.edu,NOSCHOLARPAGE
 Kris Hauser,Univ. of Illinois at Urbana-Champaign,http://cs.illinois.edu/directory/profile/kkhauser,-sGaL8sAAAAJ
 Kris K. Hauser,Univ. of Illinois at Urbana-Champaign,http://cs.illinois.edu/directory/profile/kkhauser,-sGaL8sAAAAJ
 Kris Pister,University of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/pister.html,NOSCHOLARPAGE


### PR DESCRIPTION
Eric Rozier moved to industry. Kris De Brabanter no longer has an appointment in the Department of Computer Science.