### PR TITLE
Fix the typo in university name

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -9485,7 +9485,7 @@ M. Cecília C. Baranauskas,UNICAMP,http://bv.fapesp.br/pt/pesquisador/3391/maria
 M. D. Atkinson,University of Otago,http://www.cs.otago.ac.nz/staffpriv/mike/HomePages/newhome.html,C2oYWqgAAAAJ
 M. Eduard Gröller,TU Wien,https://www.cg.tuwien.ac.at/staff/EduardGroeller.html,eBsjFlIAAAAJ
 M. Elif Karsligil,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/elifk?lang=en,NOSCHOLARPAGE
-M. Engin Tozal,University of Louisiana at Lafayette,https://people.cmix.louisiana.edu/tozal/,NOSCHOLARPAGE
+M. Engin Tozal,University of Louisiana - Lafayette,https://people.cmix.louisiana.edu/tozal/,NOSCHOLARPAGE
 M. Fatih Amasyali,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/mfatih?lang=en,qTUSAy0AAAAJ
 M. Frans Kaashoek,Massachusetts Institute of Technology,https://pdos.csail.mit.edu/archive/kaashoek,NOSCHOLARPAGE
 M. G. J. van den Brand,TU Eindhoven,http://www.win.tue.nl/~mvdbrand,CZt-AsoAAAAJ
@@ -10997,7 +10997,7 @@ Mohan S. Kankanhalli,National University of Singapore,http://www.comp.nus.edu.sg
 Mohit Bansal,University of North Carolina,http://ttic.uchicago.edu/~mbansal,DN8QtscAAAAJ
 Mohit Gupta 0001,University of Wisconsin - Madison,https://www.cs.wisc.edu/people/mohitg,Y3wdd8oAAAAJ
 Mohit Iyyer,University of Massachusetts Amherst,https://cs.umd.edu/~miyyer,rBVA5tcAAAAJ
-Mohsen Amini Salehi,University of Louisiana at Lafayette,https://people.cmix.louisiana.edu/amini/,xOvIbXEAAAAJ
+Mohsen Amini Salehi,University of Louisiana - Lafayette,https://people.cmix.louisiana.edu/amini/,xOvIbXEAAAAJ
 Mohsen Ghaffari,ETH Zurich,http://people.csail.mit.edu/ghaffari,NOSCHOLARPAGE
 Mohsen Lesani,University of California - Riverside,http://www.cs.ucr.edu/%7Elesani,cVLicJYAAAAJ
 Mohsen Naderpour,University of Technology Sydney,https://www.uts.edu.au/staff/mohsen.naderpour,Ok8wAsIAAAAJ
@@ -16699,7 +16699,7 @@ Xia Ning,IUPUI,http://cs.iupui.edu/~xning,FzhfFokAAAAJ
 Xia Yin,Tsinghua University,http://www.tsinghua.edu.cn/publish/csen/4623/2010/20101226110908587907841/20101226110908587907841_.html,SKxhz04AAAAJ
 Xia Zhou,Dartmouth College,http://www.cs.dartmouth.edu/~xia,t_DFZvgAAAAJ
 Xiahai Zhuang,Fudan University,http://www.sdspeople.fudan.edu.cn/zhuangxiahai,XlavIMcAAAAJ
-Xiali Hei,University of Louisiana at Lafayette,http://www.xialihei.com,PzflF_cAAAAJ
+Xiali Hei,University of Louisiana - Lafayette,http://www.xialihei.com,PzflF_cAAAAJ
 Xian-He Sun,Illinois Institute of Technology,https://science.iit.edu/people/faculty/xian-he-sun,9h3JX7MAAAAJ
 XianPing Tao,Nanjing University,http://moon.nju.edu.cn/people/xianpingtao,F3mGYVoAAAAJ
 Xianfeng David Gu,Stony Brook University,http://www3.cs.stonybrook.edu/~gu,Y063_CIAAAAJ


### PR DESCRIPTION
There was a typo in the university name. It was "University of Louisiana at Lafayette", which should be : "University of Louisiana - Lafayette". 

Because of this typo, right now there are two entries for the same university, which are supposed to be single entry. 
