### PR TITLE
Update homepage links for 2 University of Sydney faculty members

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -15750,7 +15750,7 @@ Tom S. F. Haines,University of Bath,http://thaines.com,jg2HJ7QAAAAJ
 Tom Schrijvers,KU Leuven,https://people.cs.kuleuven.be/~tom.schrijvers,JVXShtsAAAAJ
 Tom Shrimpton,University of Florida,https://cise.ufl.edu/~teshrim,2Nz2U0kAAAAJ
 Tom Verhoeff,TU Eindhoven,http://www.win.tue.nl/~wstomv,Dz6KASIAAAAJ
-Tom Weidong Cai,University of Sydney,http://sydney.edu.au/engineering/it/about/people/staff/tomc.shtml,N8qTc2AAAAAJ
+Tom Weidong Cai,University of Sydney,https://sydney.edu.au/engineering/about/our-people/academic-staff/tom-cai.html,N8qTc2AAAAAJ
 Tom Williams 0001,Colorado School of Mines,http://inside.mines.edu/~twilliams,NOSCHOLARPAGE
 Tom Yeh,University of Colorado Boulder,http://tomyeh.info,mDNhPjAAAAAJ
 Tomas Olovsson,Chalmers University of Technology,https://www.chalmers.se/en/staff/Pages/tomas-olovsson.aspx,NOSCHOLARPAGE

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -6865,13 +6865,13 @@ James Purtilo,University of Maryland - College Park,https://seam.cs.umd.edu/purt
 James Pustejovsky,Brandeis University,http://www.brandeis.edu/facultyguide/person.html?emplid=dbbe2e6922a901a7151b3d83b6618450867207ae,56UT_6IAAAAJ
 James Quilty,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/JamesQuilty,NOSCHOLARPAGE
 James R. Cordy,Queen’s University,http://www.cs.queensu.ca/~cordy,t7IssBgAAAAJ
-James R. Curran,University of Sydney,http://sydney.edu.au/arts/history/staff/profiles/james.b.curran.php,CeNz_twAAAAJ
+James R. Curran,University of Sydney,https://sydney.edu.au/engineering/about/our-people/academic-staff/james-r-curran.html,CeNz_twAAAAJ
 James R. Larus,EPFL,https://people.epfl.ch/james.larus,xWZTGPUAAAAJ
 James R. Lee,University of Washington,https://homes.cs.washington.edu/~jrl,x7viPbgAAAAJ
 James R. Miller,University of Kansas,http://people.eecs.ku.edu/~miller,K5hmGHcAAAAJ
 James R. Warren,University of Auckland,https://www.cs.auckland.ac.nz/~jim,67P38dMAAAAJ
 James R. Wright,University of Alberta,http://jrwright.info,-BEP3TYAAAAJ
-James Richard Curran,University of Sydney,http://sydney.edu.au/arts/history/staff/profiles/james.b.curran.php,CeNz_twAAAAJ
+James Richard Curran,University of Sydney,https://sydney.edu.au/engineering/about/our-people/academic-staff/james-r-curran.html,CeNz_twAAAAJ
 James Riely,DePaul University,http://fpl.cs.depaul.edu/jriely,P_76K3wAAAAJ
 James Rowland,University of Kansas,http://www.eecs.ku.edu/people/faculty/jrowland,NOSCHOLARPAGE
 James S. Collofello,Arizona State University,https://cidse.engineering.asu.edu/directory/collofello-james,NOSCHOLARPAGE


### PR DESCRIPTION
# Updates
- The current link for James R. Curran actually goes to a different [James Curran in the Faculty of Arts](https://sydney.edu.au/arts/about/our-people/academic-staff/james-b-curran.html), so corrected this to link to the correct [James Curran profile in Faculty of Engineering & IT](https://sydney.edu.au/engineering/about/our-people/academic-staff/james-r-curran.html)
- The current link for Tom Weidong Cai is broken (redirects to [generic school staff page](https://sydney.edu.au/engineering/about/school-of-computer-science/school-staff.html)); corrected to the right profile

# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

_Do not use Excel to edit any .csv files; Excel incorrectly tries to
convert some Google Scholar entries to formulas, corrupting the
database. Use a text editor like emacs or NotePad instead._

**Inclusion criteria**

- [ ] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [ ] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

