### PR TITLE
NLP faculty member additions and affiliation changes

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -213,6 +213,7 @@ University of Freiburg,europe
 University of Glasgow,europe
 University of Groningen,europe
 University of Guelph,canada
+University of Hamburg,europe
 University of Helsinki,europe
 University of Hong Kong,asia
 University of Jordan,asia

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -2828,7 +2828,7 @@ Chris Amato,Northeastern University,http://www.ccs.neu.edu/home/camato,-8-sD-sAA
 Chris Bailey,University of York,https://www-users.cs.york.ac.uk/~chrisb,QQ_dWtcAAAAJ
 Chris Bailey-Kellogg,Dartmouth College,http://www.cs.dartmouth.edu/~cbk,NOSCHOLARPAGE
 Chris Bartone,Ohio University,https://www.ohio.edu/engineering/about/people/profiles.cfm?profile=bartone,NOSCHOLARPAGE
-Chris Biemann,TU Darmstadt,https://www.lt.tu-darmstadt.de/de/people/prof-dr-chris-biemann,NOSCHOLARPAGE
+Chris Biemann,University of Hamburg,https://www.inf.uni-hamburg.de/en/inst/ab/lt/people/chris-biemann.html,BdwP-3QAAAAJ
 Chris Bystroff,Rensselaer Polytechnic Institute,http://www.bioinfo.rpi.edu/bystrc,ZHK-ewYAAAAJ
 Chris Callison-Burch,University of Pennsylvania,http://www.cis.upenn.edu/~ccb,nv-MV58AAAAJ
 Chris Chitty,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=106050,NOSCHOLARPAGE
@@ -3514,6 +3514,7 @@ Daniel Grosu,Wayne State University,http://www.cs.wayne.edu/~dgrosu,LhsomaUAAAAJ
 Daniel Gruss,Graz University of Technology,https://gruss.cc,JmCg4uQAAAAJ
 Daniel Gusfield,University of California - Davis,http://www.cs.ucdavis.edu/~gusfield,VoAHydgAAAAJ
 Daniel H. Huson,University of Tübingen,https://uni-tuebingen.de/fakultaeten/mathematisch-naturwissenschaftliche-fakultaet/fachbereiche/informatik/lehrstuehle/algorithms-in-bioinformatics/people/daniel-huson,hLTZTG4AAAAJ
+Daniel Hershcovich,University of Copenhagen,https://danielhers.github.io/,479qIucAAAAJ
 Daniel Hirschkoff,Ecole Normale Superieure de Lyon,https://perso.ens-lyon.fr/daniel.hirschkoff,NOSCHOLARPAGE
 Daniel Hughes,KU Leuven,https://distrinet.cs.kuleuven.be/people/dannyh,PhAY-GwAAAAJ
 Daniel Hughes 0001,KU Leuven,https://distrinet.cs.kuleuven.be/people/dannyh,PhAY-GwAAAAJ
@@ -14516,7 +14517,7 @@ Ruzena Bajcsy,University of California - Berkeley,https://www.eecs.berkeley.edu/
 Ruzica Piskac,Yale University,http://www.cs.yale.edu/~piskac,71RQt3sAAAAJ
 Ryan B. Hayward,University of Alberta,https://webdocs.cs.ualberta.ca/~hayward,h-VFYuUAAAAJ
 Ryan C. N. D'Arcy,Simon Fraser University,http://www.sfu.ca/engineering/people/faculty/ryan_darcy.html,APPBnh4AAAAJ
-Ryan Cotterell,University of Cambridge,https://ryancotterell.github.io,DexOqtoAAAAJ
+Ryan Cotterell,ETH Zurich,https://ryancotterell.github.io,DexOqtoAAAAJ
 Ryan Farrell,Brigham Young University,https://faculty.cs.byu.edu/~farrell,56EZh6YAAAAJ
 Ryan Hayward,University of Alberta,https://webdocs.cs.ualberta.ca/~hayward,h-VFYuUAAAAJ
 Ryan Henry,University of Calgary,http://homes.soic.indiana.edu/henry,kj6ctNwAAAAJ


### PR DESCRIPTION
New faculty member: Daniel Hershcovich, https://danielhers.github.io/
Chris Biemann -> University of Hamburg, https://www.inf.uni-hamburg.de/en/inst/ab/lt/people/chris-biemann.html
Ryan Cotterell -> ETH, https://inf.ethz.ch/news-and-events/spotlights/2020/02/welcome-prof-ryan-cotterell.html
