### PR TITLE
add three German universities

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -161,6 +161,7 @@ TU Darmstadt,europe
 TU Delft,europe
 TU Dresden,europe
 TU Eindhoven,europe
+TU Kaiserslautern,europe
 TU Munich,europe
 TU Wien,europe
 Tata Institute of Fundamental Research,asia

--- a/country-info.csv
+++ b/country-info.csv
@@ -215,6 +215,7 @@ University of Copenhagen,europe
 University of Crete,europe
 University of Dundee,europe
 University of Edinburgh,europe
+University of Erlangen–Nuremberg,europe
 University of Exeter,europe
 University of Freiburg,europe
 University of Glasgow,europe

--- a/country-info.csv
+++ b/country-info.csv
@@ -159,6 +159,7 @@ TU Berlin,europe
 TU Braunschweig,europe
 TU Darmstadt,europe
 TU Delft,europe
+TU Dortmund,europe
 TU Dresden,europe
 TU Eindhoven,europe
 TU Kaiserslautern,europe

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -1005,6 +1005,7 @@ Andreas Haeberlen,University of Pennsylvania,http://www.cis.upenn.edu/~ahae,kqPh
 Andreas Hellander,Uppsala University,https://andreashellander.se,NOSCHOLARPAGE
 Andreas Henschel,Masdar Institute,https://www2.masdar.ac.ae/aboutus/management/faculty-directory/item/5665-andreas-henschel,jenl24IAAAAJ
 Andreas Hotho,University of Würzburg,http://www.dmir.uni-wuerzburg.de/staff/hotho,eWTzXFAAAAAJ
+Andreas K. Maier,University of Erlangen–Nuremberg,https://lme.tf.fau.de/person/maier,MA6SDuEAAAAJ
 Andreas Karcher,Bundeswehr University Munich,https://www.unibw.de/ia,NOSCHOLARPAGE
 Andreas Keller,Saarland University,http://www.ccb.uni-saarland.de/people/prof-dr-andreas-keller,QooMeTMAAAAJ
 Andreas Klappenecker,Texas A&M University,http://faculty.cs.tamu.edu/klappi,QKzwvNgAAAAJ
@@ -2134,6 +2135,7 @@ Bjoern Schuller,University of Passau,http://www.schuller.it,TxKNCSoAAAAJ
 Björn B. Brandenburg [SWS],Max Planck Society,http://www.mpi-sws.org/~bbb,xRuGtp4AAAAJ
 Björn Bernhard Brandenburg [SWS],Max Planck Society,http://www.mpi-sws.org/~bbb,xRuGtp4AAAAJ
 Björn E. Ottersten,University of Luxembourg,http://wwwen.uni.lu/snt/people/bjoern_ottersten,OAWYhh0AAAAJ
+Björn Eskofier,University of Erlangen–Nuremberg,https://www.mad.tf.fau.de/person/bjoern-eskofier,7ems5nYAAAAJ
 Björn Franke,University of Edinburgh,http://homepages.inf.ed.ac.uk/bfranke,Y6aTqRQAAAAJ
 Björn H. Menze,TU Munich,http://people.csail.mit.edu/menze,Kv2QrQgAAAAJ
 Björn Hartmann,University of California - Berkeley,https://people.eecs.berkeley.edu/~bjoern,aZMY6_UAAAAJ
@@ -3034,6 +3036,7 @@ Christoph M. Hoffmann,Purdue University,https://www.cs.purdue.edu/people/cmh,bR-
 Christoph M. Kirsch,University of Salzburg,http://cs.uni-salzburg.at/~ck,jk3kRKAAAAAJ
 Christoph Meinel,Hasso Plattner Institute,https://hpi.de/en/meinel/chair.html,9WN2Ho0AAAAJ
 Christoph Meyer 0001,University of Salzburg,http://cs.uni-salzburg.at/~ck,jk3kRKAAAAAJ
+Christoph Pflaum,University of Erlangen–Nuremberg,https://www.cs10.tf.fau.de/person/christoph-pflaum,NOSCHOLARPAGE
 Christoph Reichenbach,Lund University,https://creichen.net,xRdVrfAAAAAJ
 Christoph Riedl,Northeastern University,https://christophriedl.net,9yFBqIgAAAAJ
 Christoph Scholl,University of Freiburg,http://www2.informatik.uni-freiburg.de/~scholl,NBHMsgkAAAAJ
@@ -4198,6 +4201,7 @@ Dieter Zoebel,University of Koblenz-Landau,https://www.uni-koblenz-landau.de/de/
 Dieter Zöbel,University of Koblenz-Landau,https://www.uni-koblenz-landau.de/de/koblenz/fb4/ist/AGZoebel/Personen/dieter-zoebel,NOSCHOLARPAGE
 Dieter van Melkebeek,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~dieter,NOSCHOLARPAGE
 Dietmar Berwanger,Ecole Normale Superieure de Cachan,http://www.lsv.ens-cachan.fr/~dwb,VWEg9YQAAAAJ
+Dietmar Fey,University of Erlangen–Nuremberg,https://de.www3.cs.fau.de/person/prof-dr-ing-dietmar-fey,NOSCHOLARPAGE
 Dietmar Pfahl,University of Tartu,http://sep.cs.ut.ee,xvo0RJcAAAAJ
 Dietmar Saupe,University of Konstanz,https://www.mmsp.uni-konstanz.de/people/overview/prof-dr-dietmar-saupe,9CK8xEgAAAAJ
 Dietmar Seipel,University of Würzburg,http://www1.informatik.uni-wuerzburg.de/mitarbeiterinnen/seipel-dietmar,NOSCHOLARPAGE
@@ -4298,6 +4302,7 @@ Dirk Nuyens,KU Leuven,https://people.cs.kuleuven.be/~dirk.nuyens,QurueO4AAAAJ
 Dirk Oliver Theis,University of Tartu,http://ac.cs.ut.ee/people/dot,b1nM_OUAAAAJ
 Dirk Pattinson,Australian National University,https://cs.anu.edu.au/people/dirk-pattinson,_QbFzhkAAAAJ
 Dirk Pflüger,University of Stuttgart,https://www.ipvs.uni-stuttgart.de/abteilungen/sgs/abteilung/mitarbeiter/Dirk.Pflueger,bKhHWxMAAAAJ
+Dirk Riehle,University of Erlangen–Nuremberg,https://oss.cs.fau.de/person/riehle-dirk,LUd2FkUAAAAJ
 Dirk Roose,KU Leuven,https://people.cs.kuleuven.be/~dirk.roose/Site/Home.html,SI8RNDwAAAAJ
 Dirk Schnieders,University of Hong Kong,https://i.cs.hku.hk/~sdirk,QsExWUcAAAAJ
 Dirk Slock,EURECOM,http://www.eurecom.fr/en/people/slock-dirk,xV6lEzEAAAAJ
@@ -4337,6 +4342,7 @@ Dominik Scheder,Shanghai Jiao Tong University,http://users-cs.au.dk/dscheder/dsc
 Dominik Slezak,University of Warsaw,http://dominikslezak.org,OdfFoKkAAAAJ
 Dominik Wojtczak,University of Liverpool,https://www.csc.liv.ac.uk/~dominik,NOSCHOLARPAGE
 Dominique Chu,University of Kent,https://www.cs.kent.ac.uk/people/staff/dfc,8QcZWTsAAAAJ
+Dominique Schröder,University of Erlangen–Nuremberg,https://www.chaac.tf.fau.de/person/dominique-schroder,JOeLEGcAAAAJ
 Dominique Unruh,University of Tartu,http://kodu.ut.ee/~unruh,EROP4tsAAAAJ
 Don Adjeroh,West Virginia University,https://www.statler.wvu.edu/faculty-staff/faculty/donald-a-adjeroh,NOSCHOLARPAGE
 Don Cleland,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=535300,2fWJcgsAAAAJ
@@ -4734,6 +4740,7 @@ Elliot Soloway,University of Michigan,http://www.soe.umich.edu/people/profile/el
 Ellis Horowitz,University of Southern California,http://www.ellishorowitz.com,NOSCHOLARPAGE
 Elmar Eder,University of Salzburg,https://www.cosy.sbg.ac.at/~eder/eder.html,NOSCHOLARPAGE
 Elmar Eisemann,TU Delft,https://graphics.tudelft.nl/~eisemann,SFj3QkQAAAAJ
+Elmar Nöth,University of Erlangen–Nuremberg,https://lme.tf.fau.de/person/noeth,QAo7nTUAAAAJ
 Elmootazbellah (Mootaz) Elnozahy,KAUST,https://www.kaust.edu.sa/en/study/faculty/mootaz-elnozahy,3jLwtgkAAAAJ
 Ely Porat,Bar-Ilan University,http://u.cs.biu.ac.il/~porately,uqTfLEgAAAAJ
 Emad Sami Jaha,King Abdulaziz University,http://ejaha.kau.edu.sa/CVEn.aspx?Site_ID=0009137&Lng=EN,NOSCHOLARPAGE
@@ -5206,6 +5213,7 @@ Felipe Rech Meneguzzi,PUC-RS,http://www.inf.pucrs.br/felipe.meneguzzi/site,uFEbo
 Felisa J. Vázquez-Abad,CUNY,http://www.hunter.cuny.edu/csci/people/faculty,NOSCHOLARPAGE
 Felix A. Wichmann,University of Tübingen,https://uni-tuebingen.de/en/faculties/faculty-of-science/departments/computer-science/lehrstuehle/neural-information-processing/people/members,NxrQ794AAAAJ
 Felix Brandt 0001,TU Munich,http://dss.in.tum.de/staff/brandt,fVnXdaQAAAAJ
+Felix C. Freiling,University of Erlangen–Nuremberg,https://www.cs1.tf.fau.de/person/felix-freiling,NOSCHOLARPAGE
 Felix Freitag,Polytechnic University of Catalonia,http://people.ac.upc.edu/felix,6wJ4ZdQAAAAJ
 Felix Naumann,Hasso Plattner Institute,https://hpi.de/en/the-hpi/people/professors/prof-dr-felix-naumann.html,Pqf21y0AAAAJ
 Felix Wolf 0001,TU Darmstadt,https://www.informatik.tu-darmstadt.de/parallel/parallel_programming/parallel_team/felix_wolf/index.en.jsp,aCGTNt0AAAAJ
@@ -5332,6 +5340,7 @@ Fragkiskos Papadopoulos,Cyprus University of Technology,https://www.cut.ac.cy/fa
 Fran Berman,Rensselaer Polytechnic Institute,http://www.cs.rpi.edu/~bermaf,NOSCHOLARPAGE
 Franca Garzotto,Politecnico di Milano,http://home.deib.polimi.it/garzotto,P6uIlrAAAAAJ
 Francesca Levi,University of Pisa,http://www.di.unipi.it/~levifran,NOSCHOLARPAGE
+Francesca Saglietti,University of Erlangen–Nuremberg,http://www11.informatik.uni-erlangen.de/index.html,NOSCHOLARPAGE
 Francesca Spezzano,Boise State University,https://sites.google.com/site/francescaspezzano,u_5TCGoAAAAJ
 Francesca Toni,Imperial College London,http://www.doc.ic.ac.uk/~ft,L9dwO2cAAAAJ
 Francesco A. N. Palmieri,University of Salerno,http://www.unisa.it/docenti/francescopalmieri/en/index,Ly2epXgAAAAJ
@@ -5794,6 +5803,7 @@ Gerhard W. Dueck,University of New Brunswick,http://www.cs.unb.ca/~gdueck,lozv7b
 Gerhard Weber,TU Dresden,https://tu-dresden.de/ing/informatik/institut-fuer-angewandte-informatik/mci,eoQw-CMAAAAJ
 Gerhard Weikum [INF],Max Planck Society,http://www.mpi-inf.mpg.de/~weikum,vNAD0mAAAAAJ
 Gerhard Weiss,Maastricht University,http://www.weiss-gerhard.info,3TofHnIAAAAJ
+Gerhard Wellein,University of Erlangen–Nuremberg,https://hpc.fau.de/person/gerhard-wellein,1fQ6-mEAAAAJ
 Gerhard Widmer,JKU Linz,https://www.jku.at/en/institute-of-computational-perception/about-us/people/gerhard-widmer,dyGS5YYAAAAJ
 Germán Bravo,Universidad de los Andes,https://sistemasacademico.uniandes.edu.co/~gbravo/dokuwiki/doku.php,MnWyaMQAAAAJ
 Germán Enrique Bravo Córdoba,Universidad de los Andes,https://sistemasacademico.uniandes.edu.co/~gbravo/dokuwiki/doku.php,MnWyaMQAAAAJ
@@ -6172,6 +6182,7 @@ Gösta Grahne,Concordia University,http://www.cs.concordia.ca/~grahne,NOSCHOLARP
 Gözde B. Ünal,Istanbul Technical University,http://akademi.itu.edu.tr/en/unalgo,soanB6MAAAAJ
 Gülsen Eryigit,Istanbul Technical University,http://web.itu.edu.tr/gulsenc,25CpSdkAAAAJ
 Günter Rote,Freie Universitaet Berlin,http://page.mi.fu-berlin.de/rote,NOSCHOLARPAGE
+Günther Greiner,University of Erlangen–Nuremberg,https://www.lgdv.tf.fau.de/person/guenther-greiner,NOSCHOLARPAGE
 Günther R. Raidl,TU Wien,https://www.ac.tuwien.ac.at/people/raidl,NOSCHOLARPAGE
 Günther Raidl,TU Wien,https://www.ac.tuwien.ac.at/people/raidl,NOSCHOLARPAGE
 Günther Ruhe,University of Calgary,http://ruhe.cpsc.ucalgary.ca,5nL_z0oAAAAJ
@@ -6350,6 +6361,7 @@ Hans-Peter Kriegel,LMU Munich,http://www.dbs.ifi.lmu.de/cms/personen/professoren
 Hans-Peter Lenhof,Saarland University,https://www.bioinf.uni-sb.de/people/prof-dr-hans-peter-lenhof.html,yLUE8lkAAAAJ
 Hans-Peter Seidel [INF],Max Planck Society,https://www.mpi-inf.mpg.de/~hpseidel,s2Ibok8AAAAJ
 Hans-Ulrich Heiﬂ,TU Berlin,https://www.kbs.tu-berlin.de/menue/personen/prof_dr_hans-ulrich_heiss,NOSCHOLARPAGE
+Hans-Ulrich Prokosch,University of Erlangen–Nuremberg,https://www.imi.med.fau.de/team/prof-dr-hans-ulrich-prokosch,NOSCHOLARPAGE
 Hans-Werner Güsgen,Massey University,http://seat.massey.ac.nz/h.w.guesgen,QwXZ99YAAAAJ
 Hans-Wolfgang Loidl,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/hans-wolfgang-loidl.htm,lwb1Va0AAAAJ
 Hansen Andrew Schwartz,Stony Brook University,http://www3.cs.stonybrook.edu/~has,Na16PsUAAAAJ
@@ -6385,6 +6397,7 @@ Harald F. O. von Korflesch,University of Koblenz-Landau,https://www.uni-koblenz-
 Harald Gjermundrod,University of Nicosia,https://www.unic.ac.cy/gjermundrod-harald,sRPAAHcAAAAJ
 Harald Janovjak,IST Austria,https://ist.ac.at/research/research-groups/janovjak-group,NOSCHOLARPAGE
 Harald Kosch,University of Passau,http://www.fim.uni-passau.de/en/distributed-information-systems,WnWkNTsAAAAJ
+Harald Köstler,University of Erlangen–Nuremberg,https://www.cs10.tf.fau.de/person/harald-koestler,FaKJ6WEAAAAJ
 Harald Pretl,JKU Linz,http://iic.jku.at/analog/team/pretl,yDlMlR0AAAAJ
 Harald Reiterer,University of Konstanz,http://hci.uni-konstanz.de/index.php?a=staff&b=Reiterer,nIYeV-wAAAAJ
 Harald Räcke,TU Munich,http://www.professoren.tum.de/en/raecke-harald,NOSCHOLARPAGE
@@ -8154,6 +8167,7 @@ Joachim Denzler,Friedrich Schiller University Jena,http://www.inf-cv.uni-jena.de
 Joachim Fischer,Humboldt University of Berlin,https://www.informatik.hu-berlin.de/de/forschung/gebiete/sam,NOSCHOLARPAGE
 Joachim Giesen,Friedrich Schiller University Jena,http://theinf2.informatik.uni-jena.de,NOSCHOLARPAGE
 Joachim Gudmundsson,University of Sydney,http://sydney.edu.au/engineering/it/~joachim,uECC9_gAAAAJ
+Joachim Hornegger,University of Erlangen–Nuremberg,https://lme.tf.fau.de/person/joachim-hornegger,s7A4ZYgAAAAJ
 Joachim M. Buhmann,ETH Zurich,http://www.ml.inf.ethz.ch,zQWbCzYAAAAJ
 Joachim Niehren,CRIStAL,http://researchers.lille.inria.fr/niehren,sG4pk9cAAAAJ
 Joachim Parrow,Uppsala University,http://user.it.uu.se/~joachim,AjzWAu4AAAAJ
@@ -8985,6 +8999,7 @@ Jürgen Giesl,RWTH Aachen,http://verify.rwth-aachen.de/giesl,dh9YNEoAAAAJ
 Jürgen Sachau,University of Luxembourg,http://wwwen.uni.lu/snt/people/juergen_sachau,NOSCHOLARPAGE
 Jürgen Schmidhuber,Università della Svizzera italiana,http://search.usi.ch/people/855dfcba3eaf6e94156db5ff991ba300/schmidhuber-juergen,gLnCTgIAAAAJ
 Jürgen Steimle,Saarland University,https://hci.cs.uni-saarland.de/people/juergen-steimle,Cz_S3u8AAAAJ
+Jürgen Teich,University of Erlangen–Nuremberg,https://www.cs12.tf.fau.de/person/juergen-teich,Hj3eizAAAAAJ
 K. Anton Feenstra,VU Amsterdam,http://www.few.vu.nl/~feenstra,NOSCHOLARPAGE
 K. Brent Venable,Tulane University,http://www2.tulane.edu/sse/cs/faculty/k-brent-venable.cfm,iqkTonoAAAAJ
 K. C. Sivaramakrishnan,IIT Madras,http://kcsrk.info,Kc2cHqYAAAAJ
@@ -9487,6 +9502,7 @@ Klaus Kabitzsch,TU Dresden,https://tu-dresden.de/cdd/leitung_und_beteiligte/mitg
 Klaus Marius Hansen,University of Copenhagen,http://www.diku.dk/~klausmh,6yJ09KwAAAAJ
 Klaus Meer,Brandenburg University of Technology,https://www.b-tu.de/fg-theoretische-informatik/team/lehrstuhlinhaber,NOSCHOLARPAGE
 Klaus Meißner,TU Dresden,https://mmt.inf.tu-dresden.de/Team/mitarbeiter.xhtml?id=66,NOSCHOLARPAGE
+Klaus Meyer-Wegener,University of Erlangen–Nuremberg,https://www.cs6.tf.fau.de/lehrstuhl/personen/klaus-meyer-wegener,0Td2SfoAAAAJ
 Klaus Miesenberger,JKU Linz,https://www.jku.at/institut-integriert-studieren/team/auniv-dr-klaus-miesenberger,hw-8_h4AAAAJ
 Klaus Mueller,Stony Brook University,http://www3.cs.stonybrook.edu/~mueller,uya_Zb4AAAAJ
 Klaus Obermayer,TU Berlin,https://www.ni.tu-berlin.de/menue/mitarbeiter/leiter_der_forschungsgruppe/obermayer_klaus/parameter/de,pGKzaMMAAAAJ
@@ -10294,6 +10310,7 @@ Luoyi Fu,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/~fu-ly/index.ht
 Luqi,Naval Postgraduate School,http://faculty.nps.edu/luqi,OJBm5MYAAAAJ
 Lutz Maicher,Friedrich Schiller University Jena,http://tt.uni-jena.de,8k5_f7cAAAAJ
 Lutz Prechelt,Freie Universitaet Berlin,http://www.mi.fu-berlin.de/w/Main/LutzPrechelt,ZY2MP7QAAAAJ
+Lutz Schröder,University of Erlangen–Nuremberg,https://www8.cs.fau.de/schroeder,buulfpEAAAAJ
 Luyi Xing,Indiana University,https://luyixing.weebly.com,xTjH_GAAAAAJ
 Luís C. Lamb,UFRGS,http://www.inf.ufrgs.br/~lamb,NOSCHOLARPAGE
 Luís Caires,Universidade NOVA de Lisboa,http://ctp.di.fct.unl.pt/~lcaires,mzi8n0QAAAAJ
@@ -10543,6 +10560,7 @@ Manya Ghobadi,Massachusetts Institute of Technology,http://people.csail.mit.edu/
 Maosong Sun,Tsinghua University,http://www.tsinghua.edu.cn/publish/csen/4623/2010/20101224193416561782037/20101224193416561782037_.html,zIgT0HMAAAAJ
 Mara Abel,UFRGS,http://inf.ufrgs.br/bdi,0yuOx18AAAAJ
 Marc Alexa,TU Berlin,https://www.cg.tu-berlin.de/team/prof-dr-marc-alexa,KNwXLLsAAAAJ
+Marc Berges,University of Erlangen–Nuremberg,https://ddi.cs.fau.de/staff/berges,-YSGTtMAAAAJ
 Marc Bernard,Université Jean Monnet,http://perso.univ-st-etienne.fr/mbernard,zO1nhO8AAAAJ
 Marc Buchner,Case Western Reserve University,http://engineering.case.edu/eecs/faculty-staff,NOSCHOLARPAGE
 Marc Dacier,EURECOM,http://www.eurecom.fr/en/people/dacier-marc,V62JMEYAAAAJ
@@ -10565,6 +10583,7 @@ Marc Pomplun,University of Massachusetts Boston,http://www.cs.umb.edu/~marc,k7cI
 Marc Pouzet,Ecole Normale Superieure,https://www.di.ens.fr/~pouzet,NOSCHOLARPAGE
 Marc Sebban,Université Jean Monnet,http://perso.univ-st-etienne.fr/sebbanma,EGZ3i1MAAAAJ
 Marc Snir,Univ. of Illinois at Urbana-Champaign,http://snir.cs.illinois.edu,HaI6LesAAAAJ
+Marc Stamminger,University of Erlangen–Nuremberg,https://www.lgdv.tf.fau.de/person/marc-stamminger,cx4AaqoAAAAJ
 Marc Stevens,CWI,https://marc-stevens.nl,Zhnqx9IAAAAJ
 Marc Streit,JKU Linz,https://www.jku.at/en/institute-of-computer-graphics/about-us/team/marc-streit,l7TTSP0AAAAJ
 Marc Tommasi,CRIStAL,http://researchers.lille.inria.fr/tommasi,IRyM3b8AAAAJ
@@ -10648,6 +10667,7 @@ Marco Masseroli,Politecnico di Milano,http://home.deib.polimi.it/masseroli,IDkIy
 Marco Molinaro,PUC-RIO,www.inf.puc-rio.br/~mmolinaro,NOSCHOLARPAGE
 Marco Pedersoli,ETS Montreal,https://profs.etsmtl.ca/mpedersoli,aVfyPAoAAAAJ
 Marco Platzner,Paderborn University,https://cs.uni-paderborn.de/ceg/team/group/people/platzner,nsVl5OYAAAAJ
+Marco Pruckner,University of Erlangen–Nuremberg,https://www.cs7.tf.fau.de/person/pruckner,NOSCHOLARPAGE
 Marco Romano,University of Salerno,https://www.marcoromano.eu,EEVgWLMAAAAJ
 Marco Serafini,University of Massachusetts Amherst,https://scholar.google.es/citations?user=IJECSdkAAAAJ&hl=en,IJECSdkAAAAJ
 Marco Servetto,Victoria University of Wellington,https://ecs.victoria.ac.nz/Main/MarcoServetto,X7AUaVIAAAAJ
@@ -11538,6 +11558,7 @@ Michael King,Florida Institute of Technology,https://www.fit.edu/faculty-profile
 Michael Kirkedal Thomsen,University of Copenhagen,https://di.ku.dk/english/staff/?pure=en%2Fpersons%2Fmichael-kirkedal-thomsen(28018e5c-9ddb-46b8-80e5-dca51151710c).html,3VsQv0sAAAAJ
 Michael Kirley,University of Melbourne,http://people.eng.unimelb.edu.au/mkirley,te9wVHwAAAAJ
 Michael Koch 0001,Bundeswehr University Munich,http://www.unibw.de/michael.koch,knY18cEAAAAJ
+Michael Kohlhase,University of Erlangen–Nuremberg,https://kwarc.info/people/mkohlhase,H0xjVyoAAAAJ
 Michael Krone,University of Tübingen,https://uni-tuebingen.de/en/faculties/faculty-of-science/departments/computer-science/lehrstuehle/big-data-visual-analytics-in-life-sciences/group-members/jun-prof-dr-michael-krone,srDA4dAAAAAJ
 Michael Kwok-Po Ng,Hong Kong Baptist University,http://www.math.hkbu.edu.hk/~mng,BBpjLiIAAAAJ
 Michael Kölling,University of Kent,https://www.cs.kent.ac.uk/people/staff/mik,NOSCHOLARPAGE
@@ -11585,6 +11606,7 @@ Michael P. Wellman,University of Michigan,http://www.eecs.umich.edu/ai/people/we
 Michael Paul Fourman,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Michael_Fourman.html,psO0rckAAAAJ
 Michael Paul Wellman,University of Michigan,http://www.eecs.umich.edu/ai/people/wellman,UruIct4AAAAJ
 Michael Pedersen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
+Michael Philippsen,University of Erlangen–Nuremberg,https://www.cs2.tf.fau.de/person/philippsen,hvfbNg0AAAAJ
 Michael Posa,University of Pennsylvania,https://dair.seas.upenn.edu/michael-posa,DCSFMuAAAAAJ
 Michael Pradel,University of Stuttgart,http://software-lab.org/people/Michael_Pradel.html,V-850TAAAAAJ
 Michael R. Berthold,University of Konstanz,https://www.bison.uni-konstanz.de/members/prof-dr-m-berthold,NOSCHOLARPAGE
@@ -12733,6 +12755,7 @@ Oliver Diessel,UNSW,http://www.cse.unsw.edu.au/~odiessel,mVtckacAAAAJ
 Oliver Eulenstein,Iowa State University,http://www.cs.iastate.edu/~oeulenst,HWF6UxgAAAAJ
 Oliver Hohlfeld,Brandenburg University of Technology,http://www.ohohlfeld.com,2dy3cC4AAAAJ
 Oliver Kennedy,University at Buffalo,http://www.cse.buffalo.edu/people/?u=okennedy,9Q9tiCsAAAAJ
+Oliver Keszöcze,University of Erlangen–Nuremberg,https://www.cs12.tf.fau.de/person/oliver-keszoecze,mGiqyPMAAAAJ
 Oliver Kohlbacher,University of Tübingen,https://kohlbacherlab.org/oliver_kohlbacher,8sb5XNIAAAAJ
 Oliver Lemon,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/oliver-lemon.htm,YYWptO4AAAAJ
 Oliver Matias van Kaick,Carleton University,http://people.scs.carleton.ca/~olivervankaick,IfvyBBUAAAAJ
@@ -14163,6 +14186,7 @@ Reimo Palm,University of Tartu,http://www.ut.ee/en/reimo-palm,NOSCHOLARPAGE
 Reinder J. Bril,TU Eindhoven,http://www.win.tue.nl/~rbril,kOwzhloAAAAJ
 Reiner Hähnle,TU Darmstadt,https://www.se.tu-darmstadt.de/se/group-members/reiner-haehnle,NOSCHOLARPAGE
 Reiner Kolla,University of Würzburg,https://www.informatik.uni-wuerzburg.de/lehrstuehleprofessuren/info5/mitarbeiter/kolla-reiner,NOSCHOLARPAGE
+Reinhard German,University of Erlangen–Nuremberg,https://www.cs7.tf.fau.de/person/german,NOSCHOLARPAGE
 Reinhard Gotzhein,TU Kaiserslautern,https://vs.informatik.uni-kl.de/people/gotzhein,NOSCHOLARPAGE
 Reinhard Pichler,TU Wien,https://www.dbai.tuwien.ac.at/staff/pichler,OiYGd-IAAAAJ
 Reinhard Wilhelm,Saarland University,http://rw4.cs.uni-saarland.de/people/wilhelm.shtml,cmvUbRUAAAAJ
@@ -14313,6 +14337,7 @@ Richard J. Lipton,Georgia Institute of Technology,http://www.cc.gatech.edu/peopl
 Richard J. Trefler,University of Waterloo,https://cs.uwaterloo.ca/~trefler,NOSCHOLARPAGE
 Richard Jay Lipton,Georgia Institute of Technology,http://www.cc.gatech.edu/people/richard-lipton,f8B4yewAAAAJ
 Richard Johansson,Chalmers University of Technology,https://www.chalmers.se/en/staff/Pages/richard-johansson.aspx,FvhWYU8AAAAJ
+Richard Lenz,University of Erlangen–Nuremberg,https://www.cs6.tf.fau.de/lehrstuhl/personen/richard-lenz,pN7nt2gAAAAJ
 Richard M. Everson,University of Exeter,http://emps.exeter.ac.uk/computer-science/staff/reverson,2XJDEWUAAAAJ
 Richard M. Fujimoto,Georgia Institute of Technology,http://www.cc.gatech.edu/~fujimoto,q1bkP7AAAAAJ
 Richard M. Karp,University of California - Berkeley,https://www.eecs.berkeley.edu/Faculty/Homepages/karp.html,NOSCHOLARPAGE
@@ -14662,6 +14687,7 @@ Rolf Krause,Università della Svizzera italiana,http://search.usi.ch/people/385e
 Rolf Niedermeier,TU Berlin,https://www.akt.tu-berlin.de/index.php?id=110570,NC3NEUkAAAAJ
 Rolf Snedsböl,Chalmers University of Technology,https://www.chalmers.se/en/staff/Pages/rolf.aspx,NOSCHOLARPAGE
 Rolf Stadler,KTH Royal Institute of Technology,https://www.kth.se/profile/stadler,y7lELJMAAAAJ
+Rolf Wanka,University of Erlangen–Nuremberg,https://www12.informatik.uni-erlangen.de/people/rwanka,GU_nblQAAAAJ
 Romain Rouvoy,CRIStAL,http://romain.rouvoy.fr,U3217h0AAAAJ
 Roman Belavkin,Middlesex University,http://www.eis.mdx.ac.uk/staffpages/rvb,EYJhJ1oAAAAJ
 Roman Dumitrescu,Paderborn University,http://www.hni.uni-paderborn.de/ase,KS0eiXYAAAAJ
@@ -16061,6 +16087,7 @@ Stefan M. Schmid,University of Vienna,https://cs.univie.ac.at/stefan.schmid,NOSC
 Stefan Manegold,CWI,http://homepages.cwi.nl/~manegold,BauIS1IAAAAJ
 Stefan Mangard,Graz University of Technology,https://www.iaik.tugraz.at/content/about_iaik/people/mangard_stefan,d2LyJ8gAAAAJ
 Stefan Marr,University of Kent,http://stefan-marr.de,h7WXkAoAAAAJ
+Stefan Milius,University of Erlangen–Nuremberg,https://www8.cs.fau.de/doku.php?id=milius,d2StQHQAAAAJ
 Stefan Monnier,University of Montreal,https://www.iro.umontreal.ca/~monnier,NOSCHOLARPAGE
 Stefan Müller 0002,University of Koblenz-Landau,https://www.uni-koblenz-landau.de/de/koblenz/fb4/icv/agmueller/personen/stefanm/stefanm,NOSCHOLARPAGE
 Stefan Nilsson,KTH Royal Institute of Technology,http://www.csc.kth.se/~snilsson,NOSCHOLARPAGE
@@ -17325,6 +17352,7 @@ Ulrich Günther,University of Auckland,http://www.tcs.auckland.ac.nz/~ulrich,NOS
 Ulrich K. Sorger,University of Luxembourg,http://wwwen.uni.lu/recherche/fstc/computer_science_and_communications_research_unit/members/ulrich_sorger,NOSCHOLARPAGE
 Ulrich Kremer,Rutgers University,http://www.cs.rutgers.edu/~uli,NOSCHOLARPAGE
 Ulrich Neumann,University of Southern California,http://graphics.usc.edu/cgit/un.html,NOSCHOLARPAGE
+Ulrich Rüde,University of Erlangen–Nuremberg,https://www.cs10.tf.fau.de/person/ulrich-ruede,CizztzwAAAAJ
 Ulrich Schmid 0001,TU Wien,https://ti.tuwien.ac.at/ecs/people/schmid,NOSCHOLARPAGE
 Ulrich Sorger,University of Luxembourg,http://wwwen.uni.lu/recherche/fstc/computer_science_and_communications_research_unit/members/ulrich_sorger,NOSCHOLARPAGE
 Ulrich Speidel,University of Auckland,http://www.tcs.auckland.ac.nz/~ulrich,NOSCHOLARPAGE
@@ -18119,6 +18147,7 @@ Wolfgang Mulzer,Freie Universitaet Berlin,https://www.mi.fu-berlin.de/inf/groups
 Wolfgang Pree,University of Salzburg,http://www.softwareresearch.net/home,NOSCHOLARPAGE
 Wolfgang Prinz,RWTH Aachen,http://dbis.rwth-aachen.de/cms/staff/prinz,QWWLOGQAAAAJ
 Wolfgang Reinhardt 0002,Bundeswehr University Munich,https://websrv.rz.unibw-muenchen.de/inf4/professuren/geoinformatik/index_html,Xar_GqcAAAAJ
+Wolfgang Schröder-Preikschat,University of Erlangen–Nuremberg,https://www4.cs.fau.de/~wosch,NOSCHOLARPAGE
 Wolfgang Slany,Graz University of Technology,http://www.ist.tugraz.at/wolfgang_slany.html,yCR2h98AAAAJ
 Wolfgang Thomas,RWTH Aachen,https://www.lii.rwth-aachen.de/en/mitarbeiter/13-mitarbeiter/professoren/7-wolfgang-thomas.html,NOSCHOLARPAGE
 Wolfgang W. Bein,University of Nevada Las Vegas,http://web.cs.unlv.edu/bein,oUwEYt4AAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -1847,6 +1847,7 @@ Bastian Goldluecke,University of Konstanz,https://www.cvia.uni-konstanz.de/perso
 Bastian Goldlücke,University of Konstanz,https://www.cvia.uni-konstanz.de/personen/prof-dr-bastian-goldluecke,r6HOvnoAAAAJ
 Bastian Leibe,RWTH Aachen,http://www.vision.rwth-aachen.de/persons,ZcULDB0AAAAJ
 Beata Stahre Wästberg,Chalmers University of Technology,https://www.chalmers.se/en/staff/Pages/beata-wastberg.aspx,NOSCHOLARPAGE
+Beate Bollig,TU Dortmund,https://ls2-www.cs.tu-dortmund.de/grav/de/grav_files/people/bollig,NOSCHOLARPAGE
 Beatriz Otero,Polytechnic University of Catalonia,http://directori.upc.edu/directori/dadesPersona.jsp?id=1003427,DYV7AzEAAAAJ
 Beatriz Vicoso,IST Austria,https://ist.ac.at/research/research-groups/vicoso-group,4Wqy1IcAAAAJ
 Bechir Hamdaoui,Oregon State University,http://eecs.oregonstate.edu/~hamdaoui,GRjhMD8AAAAJ
@@ -1992,6 +1993,7 @@ Bernhard Reus,University of Sussex,http://www.sussex.ac.uk/informatics/people/pe
 Bernhard Rumpe,RWTH Aachen,http://www.se-rwth.de/~rumpe,nED1C7QAAAAJ
 Bernhard Scholz,University of Sydney,http://web.it.usyd.edu.au/~scholz,0z6_oNEAAAAJ
 Bernhard Schölkopf [IS],Max Planck Society, https://is.mpg.de/~bs,DZ-fHPgAAAAJ
+Bernhard Steffen,TU Dortmund,http://ls5-www.cs.tu-dortmund.de/cms/de/mitarbeiter/prof/Bernhard_Steffen.html,YFGsf1YAAAAJ
 Bernhard Thomaszewski,University of Montreal,http://www-labs.iro.umontreal.ca/~bernhard,Qtzmow0AAAAJ
 Bernt Schiele [INF],Max Planck Society,https://www.mpi-inf.mpg.de/departments/computer-vision-and-multimodal-computing/people/bernt-schiele,z76PBfYAAAAJ
 Berrin A. Yanikoglu,Sabancı University,http://people.sabanciuniv.edu/berrin,CyWTeecAAAAJ
@@ -4908,6 +4910,7 @@ Eric Yu 0001,University of Toronto,http://www.cs.toronto.edu/~eric,c36OREEAAAAJ
 Erich Grädel,RWTH Aachen,https://logic.rwth-aachen.de/~graedel,4TbxnY0AAAAJ
 Erich P. Ippen,Massachusetts Institute of Technology,http://web.mit.edu/physics/people/faculty/ippen_erich.html,5RfBYzcAAAAJ
 Erich Schikuta,University of Vienna,https://cs.univie.ac.at/erich.schikuta,MluSpmIAAAAJ
+Erich Schubert,TU Dortmund,https://www-ai.cs.tu-dortmund.de/PERSONAL/schubert.html,Ca8f9TEAAAAJ
 Erickson R. Nascimento,UFMG,http://homepages.dcc.ufmg.br/~erickson,GTWCJkQAAAAJ
 Erickson R. do Nascimento,UFMG,http://homepages.dcc.ufmg.br/~erickson,GTWCJkQAAAAJ
 Erickson Rangel do Nascimento,UFMG,http://homepages.dcc.ufmg.br/~erickson,GTWCJkQAAAAJ
@@ -5129,6 +5132,7 @@ Faith Ellen,University of Toronto,http://www.cs.toronto.edu/~faith,NOSCHOLARPAGE
 Faith Ellen Fich,University of Toronto,http://www.cs.toronto.edu/~faith,NOSCHOLARPAGE
 Faith Fich,University of Toronto,http://www.cs.toronto.edu/~faith,NOSCHOLARPAGE
 Fakhrul Alam,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=499830,qyFUJVsAAAAJ
+Falk Howar,TU Dortmund,https://ls14-www.cs.tu-dortmund.de/cms/de/mitarbeiter/profs/Howar.html,pUqp2yIAAAAJ
 Falk Scholer,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/s/scholer-associate-professor-falk,qOLjlqsAAAAJ
 Falk Schreiber,University of Konstanz,https://www.cls.uni-konstanz.de/members/falk-schreiber,ThdRhdYAAAAJ
 Fan Cheng,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/~chengfan,aECSCPUAAAAJ
@@ -5419,6 +5423,7 @@ Frank Tip,Northeastern University,http://www.franktip.org,siQDY4gAAAAJ
 Frank Vahid,University of California - Riverside,http://www.cs.ucr.edu/~vahid,qu3rpc0AAAAJ
 Frank Vetere,University of Melbourne,http://people.eng.unimelb.edu.au/fv,_30-AxUAAAAJ
 Frank Wang,University of Kent,https://www.cs.kent.ac.uk/people/staff/fzw,7kY-804AAAAJ
+Frank Weichert,TU Dortmund,https://ls7-www.cs.tu-dortmund.de/cms/de/weichert,NOSCHOLARPAGE
 Frank Wolter,University of Liverpool,http://www.csc.liv.ac.uk/~frank,A6cSqMUAAAAJ
 Frank Wood,University of British Columbia,https://www.cs.ubc.ca/~fwood,d4yNzXIAAAAJ
 Frank Y. Shih,NJIT,https://web.njit.edu/~shih,uXEp3MIAAAAJ
@@ -5551,6 +5556,7 @@ Gabriela Montoya,Aalborg University,https://vbn.aau.dk/en/persons/gabriela-valen
 Gabriele Anderst-Kotsis,JKU Linz,https://www.jku.at/institut-fuer-telekooperation/ueber-uns/team/gabriele-anderst-kotsis,9QhutOMAAAAJ
 Gabriele Bavota,Università della Svizzera italiana,http://search.usi.ch/people/e63382729ce424274797f0c45f4bc7e8/Bavota-Gabriele,inc2FLEAAAAJ
 Gabriele E. Danninger-Uchida,University of Vienna,https://cs.univie.ac.at/gabriele.uchida,NOSCHOLARPAGE
+Gabriele Kern-Isberner,TU Dortmund,https://ls1-www.cs.tu-dortmund.de/de/kontakt-gabriele-kern-isberner,NOSCHOLARPAGE
 Gabriele Meiselwitz,Towson University,https://www.towson.edu/fcsm/departments/computerinfosci/facultystaff/gmeiselwitz.html,NOSCHOLARPAGE
 Gabriele Mencagli,University of Pisa,http://www.di.unipi.it/~mencagli,V7hWtykAAAAJ
 Gabriele Tolomei,Sapienza University of Rome,https://www.di.uniroma1.it/~tolomei,Y2R2DXEAAAAJ
@@ -5808,6 +5814,7 @@ Gerhard Widmer,JKU Linz,https://www.jku.at/en/institute-of-computational-percept
 Germán Bravo,Universidad de los Andes,https://sistemasacademico.uniandes.edu.co/~gbravo/dokuwiki/doku.php,MnWyaMQAAAAJ
 Germán Enrique Bravo Córdoba,Universidad de los Andes,https://sistemasacademico.uniandes.edu.co/~gbravo/dokuwiki/doku.php,MnWyaMQAAAAJ
 Germán Santos-Boada,Polytechnic University of Catalonia,http://directori.upc.edu/directori/dadesPersona.jsp?id=1000418,wO06QeIAAAAJ
+Gernot A. Fink,TU Dortmund,http://patrec.cs.tu-dortmund.de/cms/en/home/People/Staff/fink.html,g0snsxsAAAAJ
 Gernot Heiser,UNSW,https://www.cse.unsw.edu.au/~gernot,0e0Vw3kAAAAJ
 Gernot R. Müller,Graz University of Technology,https://www.tugraz.at/institute/ine/people/gernot-mueller-putz,NkODKfIAAAAJ
 Gernot R. Müller-Putz,Graz University of Technology,https://www.tugraz.at/institute/ine/people/gernot-mueller-putz,NkODKfIAAAAJ
@@ -6182,6 +6189,7 @@ Gösta Grahne,Concordia University,http://www.cs.concordia.ca/~grahne,NOSCHOLARP
 Gözde B. Ünal,Istanbul Technical University,http://akademi.itu.edu.tr/en/unalgo,soanB6MAAAAJ
 Gülsen Eryigit,Istanbul Technical University,http://web.itu.edu.tr/gulsenc,25CpSdkAAAAJ
 Günter Rote,Freie Universitaet Berlin,http://page.mi.fu-berlin.de/rote,NOSCHOLARPAGE
+Günter Rudolph,TU Dortmund,http://ls11-www.cs.tu-dortmund.de/people/rudolph,NOSCHOLARPAGE
 Günther Greiner,University of Erlangen–Nuremberg,https://www.lgdv.tf.fau.de/person/guenther-greiner,NOSCHOLARPAGE
 Günther R. Raidl,TU Wien,https://www.ac.tuwien.ac.at/people/raidl,NOSCHOLARPAGE
 Günther Raidl,TU Wien,https://www.ac.tuwien.ac.at/people/raidl,NOSCHOLARPAGE
@@ -6513,6 +6521,7 @@ Heike Wehrheim,Paderborn University,https://cs.uni-paderborn.de/index.php?id=706
 Heiki-Jaan Kaalep,University of Tartu,http://www.ut.ee/en/heiki-jaan-kaalep,mWr3RasAAAAJ
 Heikki Mannila,Aalto University,https://users.ics.aalto.fi/mannila,NOSCHOLARPAGE
 Heiko Horst Hornung,UNICAMP,https://www.ic.unicamp.br/pessoas/docentes/heiko,NOSCHOLARPAGE
+Heiko Krumm,TU Dortmund,https://ls4-www.cs.tu-dortmund.de/home/krumm/pi.html,NOSCHOLARPAGE
 Heiko Mantel,TU Darmstadt,http://www.mais.informatik.tu-darmstadt.de/Heiko_Mantel.html,NOSCHOLARPAGE
 Heiko Paulheim,University of Mannheim,https://www.uni-mannheim.de/dws/people/professors/prof-dr-heiko-paulheim,SkSl3NkAAAAJ
 Heiko Vogler,TU Dresden,http://www.inf.tu-dresden.de/?node_id=1567,NOSCHOLARPAGE
@@ -6520,6 +6529,7 @@ Heiner Litz,University of California - Santa Cruz,https://web.stanford.edu/~hlit
 Heiner Stuckenschmidt,University of Mannheim,https://www.uni-mannheim.de/dws/people/professors/prof-dr-heiner-stuckenschmidt,oqpT1YUAAAAJ
 Heinrich Hussmann,LMU Munich,http://www.medien.ifi.lmu.de/team/heinrich.hussmann,kwha-i8AAAAJ
 Heinrich Hußmann,LMU Munich,http://www.medien.ifi.lmu.de/team/heinrich.hussmann,kwha-i8AAAAJ
+Heinrich Müller,TU Dortmund,https://ls7-www.cs.tu-dortmund.de/cms/en/node/676,NOSCHOLARPAGE
 Heinrich-Wilhelm Schmidt,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/s/schmidt-professor-heinrich,FEgaS_sAAAAJ
 Heinz W. Schmidt,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/s/schmidt-professor-heinrich,FEgaS_sAAAAJ
 Heji Zhao,Shandong University,http://www.cs.sdu.edu.cn/info/1091/2351.htm,NOSCHOLARPAGE
@@ -7347,6 +7357,7 @@ Jakob Eg Larsen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Jakob Eriksson,University of Illinois at Chicago,https://www.cs.uic.edu/Jakob,kLUW0psAAAAJ
 Jakob Grue Simonsen,University of Copenhagen,http://www.diku.dk/~simonsen,JFhAzosAAAAJ
 Jakob Nordström,KTH Royal Institute of Technology,http://www.csc.kth.se/~jakobn,YSFwWNIAAAAJ
+Jakob Rehof,TU Dortmund,https://ls14-www.cs.uni-dortmund.de/cms/de/home,lhc6Jn4AAAAJ
 Jakub Kowalski,University of Wroclaw,http://ii.uni.wroc.pl/instytut/pracownicy/64,31AWuosAAAAJ
 Jakub Michaliszyn,University of Wroclaw,http://www.ii.uni.wroc.pl/~jmi,KxpyIIYAAAAJ
 Jakub Pawlewicz,University of Warsaw,https://chessprogramming.wikispaces.com/Jakub+Pawlewicz,95JYFDQAAAAJ
@@ -7817,6 +7828,7 @@ Jens Lambrecht,TU Berlin,https://www.ignc.tu-berlin.de/menue/ueber_uns/team/para
 Jens Palsberg,University of California - Los Angeles,http://www.cs.ucla.edu/~palsberg,Gx8Rpr4AAAAJ
 Jens Petersen,University of Copenhagen,https://di.ku.dk/english/staff/vip/?pure=en/persons/178402,J3L5JdQAAAAJ
 Jens Stoye,Bielefeld University,https://www.techfak.uni-bielefeld.de/~stoye,d7rMd3YAAAAJ
+Jens Teubner,TU Dortmund,http://dbis.cs.tu-dortmund.de/cms/en/people/faculty/teubner.html,SdGU2bMAAAAJ
 Jens Zander,KTH Royal Institute of Technology,https://www.kth.se/profile/jenz,GjXOu5wAAAAJ
 Jens-Peter Dittrich,Saarland University,https://infosys.cs.uni-saarland.de/people/dittrich.php,fykfPiwAAAAJ
 Jens-Peter Redlich,Humboldt University of Berlin,http://sar.informatik.hu-berlin.de/main/main_page.htm,NOSCHOLARPAGE
@@ -7936,6 +7948,7 @@ Jian Wu 0001,Zhejiang University,http://mypage.zju.edu.cn/0004274,VO9XIXYAAAAJ
 Jian Zhang 0004,Louisiana State University - Baton Rouge,https://www.lsu.edu/eng/cse/people/faculty/zhang.php,NOSCHOLARPAGE
 Jian Zhao 0010,University of Waterloo,https://jeffjianzhao.bitbucket.io,5v0elikAAAAJ
 Jian-Hua Chen,Louisiana State University - Baton Rouge,https://www.lsu.edu/eng/cse/people/faculty/chen.j.php,NOSCHOLARPAGE
+Jian-Jia Chen,TU Dortmund,https://ls12-www.cs.tu-dortmund.de/daes/de/daes/mitarbeiter/jjchen.html,_kx4s9QAAAAJ
 Jian-Xin Wu,Nanjing University,https://cs.nju.edu.cn/wujx,NOSCHOLARPAGE
 Jian-Yun Nie,University of Montreal,http://rali.iro.umontreal.ca/nie/jian-yun-nie-en,W7uYg0UAAAAJ
 Jian-bin Hu,Peking University,http://eecs.pku.edu.cn/EN/People/Faculty/Detail/?ID=6086,NOSCHOLARPAGE
@@ -8265,6 +8278,7 @@ Johannes Blömer,Paderborn University,http://cs.uni-paderborn.de/cuk/personal/jo
 Johannes Borgström,Uppsala University,https://katalog.uu.se/empinfo/?id=N10-775,xXcsqJ4AAAAJ
 Johannes C. van Vliet,VU Amsterdam,http://www.cs.vu.nl/~hans,4YAdfEsAAAAJ
 Johannes Fink,IST Austria,https://ist.ac.at/research/research-groups/fink-group,4Ot68t8AAAAJ
+Johannes Fischer 0001,TU Dortmund,https://ls11-www.cs.tu-dortmund.de/staff/fischer,ldpdi_gAAAAJ
 Johannes Fürnkranz,TU Darmstadt,http://www.ke.tu-darmstadt.de/staff/juffi,sfTn4wEAAAAJ
 Johannes Kinder,Bundeswehr University Munich,https://www.unibw.de/systemsicherheit/kinder,rnDHTKYAAAAJ
 Johannes Köbler,Humboldt University of Berlin,https://www.informatik.hu-berlin.de/forschung/gebiete/algorithmenII,NOSCHOLARPAGE
@@ -9195,6 +9209,7 @@ Katerina Stankova,Maastricht University,http://www.stankova.net,wYupkOAAAAAJ
 Katerina Stanková,Maastricht University,http://www.stankova.net,wYupkOAAAAAJ
 Katharina Anna Zweig,TU Kaiserslautern,http://aalab.cs.uni-kl.de/en/gruppe/zweig,UyG7biIAAAAJ
 Katharina Krombholz,CISPA Helmholtz Center,https://cispa.saarland/people/katharina.krombholz,BkeawyUAAAAJ
+Katharina Morik,TU Dortmund,https://www-ai.cs.tu-dortmund.de/PERSONAL/morik.html,LfmjF2UAAAAJ
 Katharina Reinecke,University of Washington,https://www.cs.washington.edu/people/faculty/reinecke,_4EISRwAAAAJ
 Katherine A. Yelick,University of California - Berkeley,https://www.cs.berkeley.edu/~yelick,93yNuV0AAAAJ
 Katherine E. Isaacs,University of Arizona,http://cgi.cs.arizona.edu/~kisaacs,sYt1rjsAAAAJ
@@ -13321,6 +13336,7 @@ Peter Bodorik,Dalhousie University,https://www.cs.dal.ca/~bodorik,NOSCHOLARPAGE
 Peter Brass,CUNY,http://www-cs.ccny.cuny.edu/~peter,ZTGVnVkAAAAJ
 Peter Braß,CUNY,http://www-cs.ccny.cuny.edu/~peter,ZTGVnVkAAAAJ
 Peter Brusilovsky,University of Pittsburgh,http://www.pitt.edu/~peterb,s6RpNfAAAAAJ
+Peter Buchholz 0001,TU Dortmund,https://ls4-www.cs.tu-dortmund.de/cms/de/home/buchholz,NOSCHOLARPAGE
 Peter Buneman,University of Edinburgh,http://homepages.inf.ed.ac.uk/opb,d9bq04sAAAAJ
 Peter C. J. Graham,University of Manitoba,http://www.cs.umanitoba.ca/~pgraham,5suVxUYAAAAJ
 Peter C. Rigby,Concordia University,http://users.encs.concordia.ca/~pcr,lGVxz58AAAAJ
@@ -13450,6 +13466,7 @@ Petr Svenda,Masaryk University,https://crocs.fi.muni.cz/people/svenda,sAA8_ysAAA
 Petra Berenbrink,Simon Fraser University,http://www.cs.sfu.ca/~petra,NOSCHOLARPAGE
 Petra Hofstedt,Brandenburg University of Technology,https://www.b-tu.de/fg-programmiersprachen-compilerbau/team/professorin/petra-hofstedt,NOSCHOLARPAGE
 Petra Schubert,University of Koblenz-Landau,https://www.uni-koblenz-landau.de/de/koblenz/fb4/iwvi/agschubert/team/petra-schubert/petra-schubert,RvlHMVUAAAAJ
+Petra Wiederkehr,TU Dortmund,https://ls14-www.cs.tu-dortmund.de/cms/de/home,NOSCHOLARPAGE
 Petre Stoica,Uppsala University,http://user.it.uu.se/~ps/ps.html,g8rknqcAAAAJ
 Petri Myllymäki,University of Helsinki,https://www.cs.helsinki.fi/u/myllymak,iisp1qgAAAAJ
 Petri Vuorimaa,Aalto University,https://people.aalto.fi/petri_vuorimaa,Bcg93pAAAAAJ
@@ -16938,6 +16955,7 @@ Thomas Sauerwald,University of Cambridge,https://www.cl.cam.ac.uk/~tms41,lidwLWI
 Thomas Schmid,University of Utah,https://faculty.utah.edu/u0729347-Thomas_Schmid/biography/index.hml,puOEoqoAAAAJ
 Thomas Schneider 0003,TU Darmstadt,https://www.thomaschneider.de,E31PR1oAAAAJ
 Thomas Schwarz,University of California - Santa Cruz,http://www.ssrc.ucsc.edu/person/tschwarz.html,BF_pzdoAAAAJ
+Thomas Schwentick,TU Dortmund,https://ls1-www.cs.tu-dortmund.de/de/kontakt-thomas-schwentick,fC1PD_8AAAAJ
 Thomas Seidl 0001,LMU Munich,http://www.dbs.ifi.lmu.de/cms/personen/professoren/seidl/index.html,0fOi9KkAAAAJ
 Thomas Sfikopoulos,University of Athens,http://www.di.uoa.gr/eng/staff/1158,NOSCHOLARPAGE
 Thomas Shrimpton,University of Florida,https://cise.ufl.edu/~teshrim,2Nz2U0kAAAAJ
@@ -17406,6 +17424,7 @@ Uwe Petersohn,TU Dresden,https://www.inf.tu-dresden.de/content/institutes/ki/awv
 Uwe R. Zimmer,Australian National University,https://cs.anu.edu.au/people/uwe-r-zimmer,NOSCHOLARPAGE
 Uwe Reyle,University of Stuttgart,http://www.ims.uni-stuttgart.de/institut/mitarbeiter/uwe,NOSCHOLARPAGE
 Uwe Röhm,University of Sydney,http://www.it.usyd.edu.au/~roehm,hJjASywAAAAJ
+Uwe Schwiegelshohn,TU Dortmund,http://www.irf.tu-dortmund.de/cms/en/Institute/Staff/Head/Prof__Dr_-Ing__Uwe_Schwiegelshohn.html,Wz5HfLYAAAAJ
 Uwe Zdun,University of Vienna,https://cs.univie.ac.at/uwe.zdun,jLm9DCkAAAAJ
 Uwe Zimmer,Australian National University,https://cs.anu.edu.au/people/uwe-r-zimmer,NOSCHOLARPAGE
 Uyen Trang Nguyen,York University,http://www.cse.yorku.ca/~utn,eo1FpKIAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -135,6 +135,7 @@ Abyayananda Maiti,IIT Patna,https://iitp.ac.in/index.php/departments/computer-ce
 Achille Pattavina,Politecnico di Milano,http://home.deib.polimi.it/pattavina,NOSCHOLARPAGE
 Achim Blumensath,Masaryk University,https://www.muni.cz/en/people/237782,NOSCHOLARPAGE
 Achim D. Brucker,University of Exeter,http://emps.exeter.ac.uk/computer-science/staff/ab1185,ZWePF1QAAAAJ
+Achim Ebert,TU Kaiserslautern,https://hci.uni-kl.de/people/achim-ebert,tnoNj9gAAAAJ
 Achim Streit,Karlsruhe Institute of Technology (KIT),http://www.scc.kit.edu/personen/achim.streit.php,i72A44MAAAAJ
 Achutavarrier Prasad Vinod,Nanyang Technological University,http://www.ntu.edu.sg/home/asvinod,NOSCHOLARPAGE
 Ada Gavrilovska,Georgia Institute of Technology,http://www.cc.gatech.edu/home/ada,OlRjTCIAAAAJ
@@ -995,6 +996,7 @@ Andreas Alexander Albrecht,Middlesex University,https://www.mdx.ac.uk/about-us/o
 Andreas Baum,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Andreas Bulling,University of Stuttgart,https://www.vis.uni-stuttgart.de/institut/mitarbeiter/Bulling-00004,QURZIzUAAAAJ
 Andreas Butz,LMU Munich,http://www.medien.ifi.lmu.de/team/andreas.butz,8_z5YpQAAAAJ
+Andreas Dengel 0001,TU Kaiserslautern,https://agd.informatik.uni-kl.de/en/team/teaching/prof-dr-prof-hc-andreas-dengel,p3YP0DMAAAAJ
 Andreas Dräger,University of Tübingen,https://uni-tuebingen.de/en/faculties/faculty-of-science/departments/computer-science/lehrstuehle/systems-biology/team/jun-prof-dr-andreas-draeger,Q2FPugYAAAAJ
 Andreas Fell,Australian National University,https://cs.anu.edu.au/people/andreas-fell,rK8h_U4AAAAJ
 Andreas G. Veneris,University of Toronto,http://www.eecg.utoronto.ca/~veneris/AndreasVeneris.htm,NOSCHOLARPAGE
@@ -1350,8 +1352,8 @@ Anthony T. C. Tam,University of Hong Kong,https://i.cs.hku.hk/~atctam,NOSCHOLARP
 Anthony Tang 0001,University of Calgary,http://hcitang.org,RG1EQowAAAAJ
 Anthony V. Robins,University of Otago,http://www.cs.otago.ac.nz/staff/anthony.html,COuPSxYAAAAJ
 Anthony W. Lin,University of Oxford,https://anthonywlin.github.io,__5nnYUAAAAJ
-Anthony Widjaja Lin,University of Oxford,https://anthonywlin.github.io,__5nnYUAAAAJ
-Anthony Widjaja To,University of Oxford,https://anthonywlin.github.io,__5nnYUAAAAJ
+Anthony Widjaja Lin,TU Kaiserslautern,http://arg.informatik.uni-kl.de/gruppe/lin,__5nnYUAAAAJ
+Anthony Widjaja To,TU Kaiserslautern,http://arg.informatik.uni-kl.de/gruppe/lin,__5nnYUAAAAJ
 Anthony Wirth,University of Melbourne,http://people.eng.unimelb.edu.au/awirth,qVuN4MIAAAAJ
 Antinisca Di Marco,University of L'Aquila,http://people.disim.univaq.it/adimarco,QVzuSyIAAAAJ
 Antoaneta Serguieva,University College London,http://www0.cs.ucl.ac.uk/people/A.Serguieva.html,hgThGaQAAAAJ
@@ -1523,6 +1525,7 @@ Arnaldo de Albuquerque Araújo,UFMG,http://homepages.dcc.ufmg.br/~arnaldo,AitxvQ
 Arnaud Lefray,Ecole Normale Superieure de Lyon,http://ens-lyon.academia.edu/ArnaudLeveau,RSqq_fIAAAAJ
 Arnaud Liefooghe,CRIStAL,https://sites.google.com/site/arnaudliefooghe,Y2kuG1sAAAAJ
 Arnav Jhala,North Carolina State University,https://games.soe.ucsc.edu/arnav-jhala,8x0RJd0AAAAJ
+Arnd Poetzsch-Heffter,TU Kaiserslautern,https://softech.cs.uni-kl.de/homepage/de/staff/PoetzschHeffter,284TJ1IAAAAJ
 Arndt Bode,TU Munich,https://www.lrr.in.tum.de/mitarbeiter/bode,NOSCHOLARPAGE
 Arndt von Staa,PUC-RIO,http://www.inf.puc-rio.br/blog/professor/arndt-von-staa,NOSCHOLARPAGE
 Arne Linde,Chalmers University of Technology,https://www.chalmers.se/en/staff/Pages/Arne-Linde-.aspx,NOSCHOLARPAGE
@@ -3020,6 +3023,8 @@ Christoph Csallner,University of Texas at Arlington,http://ranger.uta.edu/~csall
 Christoph E. Koch,EPFL,https://people.epfl.ch/christoph.koch,JYt9T_sAAAAJ
 Christoph Eick,University of Houston,http://www2.cs.uh.edu/~ceick,qfCKBuoAAAAJ
 Christoph F. Breidbach,University of Melbourne,http://www.findanexpert.unimelb.edu.au/display/person660107,K0Tg_xMAAAAJ
+Christoph Garth,TU Kaiserslautern,https://vis.uni-kl.de/people/garth,IkKWoSIAAAAJ
+Christoph Grimm 0001,TU Kaiserslautern,https://cps.cs.uni-kl.de/mitarbeiter/christoph-grimm-prof-dr,NOSCHOLARPAGE
 Christoph H. Lampert,IST Austria,http://ist.ac.at/~chl,iCf3SwgAAAAJ
 Christoph Johann Feinauer,Bocconi University,didattica.unibocconi.it/docenti/cv.php?rif=225287,b_svo9QAAAAJ
 Christoph Koch 0001,EPFL,https://people.epfl.ch/christoph.koch,JYt9T_sAAAAJ
@@ -4169,6 +4174,7 @@ Dianne Foreback,Kent State University,https://www.kent.edu/ehhs/hs/profile/dr-di
 Dianxiang Xu,Boise State University,http://cs.boisestate.edu/~dxu,FqBb3CMAAAAJ
 Dick H. J. Epema,TU Delft,http://www.ds.ewi.tudelft.nl/epema,NOSCHOLARPAGE
 Didem Unat,Koç University,http://home.ku.edu.tr/~dunat,JQ1n--oAAAAJ
+Didier Stricker,TU Kaiserslautern,https://av.dfki.de/members/stricker,ImhXfxgAAAAJ
 Diego Cattaruzza,CRIStAL,https://www.cristal.univ-lille.fr/profil/dcattaru,vNvqTXoAAAAJ
 Diego F. Aranha,UNICAMP,https://twitter.com/dfaranha?lang=en,FF26-mIAAAAJ
 Diego Fernández Slezak,University of Buenos Aires,https://neuro.org.ar/profile/70,nvVcDr4AAAAJ
@@ -5776,6 +5782,7 @@ Gerasimos Spanakis,Maastricht University,https://dke.maastrichtuniversity.nl/jer
 Gerd Hirzinger,TU Munich,http://www6.in.tum.de/Main/Hirzinge,NOSCHOLARPAGE
 Gerd Wagner 0001,Brandenburg University of Technology,https://www.b-tu.de/fg-internet-technologie/team/professor,zna3SeQAAAAJ
 Gerda Janssens,KU Leuven,https://people.cs.kuleuven.be/~gerda.janssens,JTZxGp0AAAAJ
+Gerhard Fohler,TU Kaiserslautern,https://rts.eit.uni-kl.de/index.php?id=18&people_action=detail&people_id=3,NOSCHOLARPAGE
 Gerhard Hirzinger,TU Munich,http://www6.in.tum.de/Main/Hirzinge,NOSCHOLARPAGE
 Gerhard Holzapfel,Graz University of Technology,https://www.biomech.tugraz.at/people/gerhard_holzapfel,TCfOWgUAAAAJ
 Gerhard Jäger,University of Bern,http://www.ltg.unibe.ch/staff/jaeger,lg0l9REAAAAJ
@@ -6172,6 +6179,7 @@ H. Altay Guvenir,Bilkent University,http://www.cs.bilkent.edu.tr/~guvenir,zRvIRV
 H. Altay Güvenir,Bilkent University,http://www.cs.bilkent.edu.tr/~guvenir,zRvIRVUAAAAJ
 H. Andrew Schwartz,Stony Brook University,http://www3.cs.stonybrook.edu/~has,Na16PsUAAAAJ
 H. Bast 0001,University of Freiburg,https://ad.informatik.uni-freiburg.de/staff/bast,hqSjLE8AAAAJ
+H. Dieter Rombach,TU Kaiserslautern,http://wwwagse.informatik.uni-kl.de/staff/rombach,OpsrHLAAAAAJ
 H. Harry Zhou,Towson University,https://www.towson.edu/fcsm/departments/computerinfosci/facultystaff/hzhou.html,NOSCHOLARPAGE
 H. Howie Huang,George Washington University,https://www2.seas.gwu.edu/~howie,maC331oAAAAJ
 H. K. Dai 0001,Oklahoma State University,http://cs.okstate.edu/%7Edai,NOSCHOLARPAGE
@@ -6318,6 +6326,7 @@ Hanqi Zhuang,Florida Atlantic University,http://www.eng.fau.edu/directory/facult
 Hanqiu Sun,Chinese University of Hong Kong,http://www.cse.cuhk.edu.hk/~hanqiu,ezvIdPEAAAAJ
 Hans Akkermans,VU Amsterdam,http://www.cs.vu.nl/~hansa,tRT8oQYAAAAJ
 Hans Burg,VU Amsterdam,http://www.cs.vu.nl/en/research/information-management-software-engineering/people/dr-hans-burg/index.aspx,NOSCHOLARPAGE
+Hans Hagen,TU Kaiserslautern,https://hci.uni-kl.de/people/hans-hagen,g0dxfJMAAAAJ
 Hans Hallez,KU Leuven,https://distrinet.cs.kuleuven.be/people/hans,CWF_wV8AAAAJ
 Hans Henrik Løvengreen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Hans Hüttel,Aalborg University,http://people.cs.aau.dk/~hans/index-eng.html,Wf7-agQAAAAJ
@@ -6486,6 +6495,7 @@ Heggere S. Ranganath,University of Alabama - Huntsville,https://www.uah.edu/scie
 Hehua Zhang,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2013/20130409104953529576785/20130409104953529576785_.html,NOSCHOLARPAGE
 Heidi Christensen,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/heidi-christensen,5ccB6BcAAAAJ
 Heidi Tscherning,University of Melbourne,http://www.cis.unimelb.edu.au/people,M1FWCaYAAAAJ
+Heike Leitte,TU Kaiserslautern,https://via.cs.uni-kl.de/mitarbeiter/prof-dr-heike-leitte,DuiWf98AAAAJ
 Heike Wehrheim,Paderborn University,https://cs.uni-paderborn.de/index.php?id=70604,EmnW98wAAAAJ
 Heiki-Jaan Kaalep,University of Tartu,http://www.ut.ee/en/heiki-jaan-kaalep,mWr3RasAAAAJ
 Heikki Mannila,Aalto University,https://users.ics.aalto.fi/mannila,NOSCHOLARPAGE
@@ -7778,6 +7788,7 @@ Jennifer Widom,Stanford University,http://infolab.stanford.edu/~widom,zdKmnYwAAA
 Jenny Coady,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/jenny-coady.htm,NOSCHOLARPAGE
 Jenny Waycott,University of Melbourne,http://findanexpert.unimelb.edu.au/display/person52243,kc5Fr-0AAAAJ
 Jenq-Kuen Lee,National Tsing Hua University,http://pllab.cs.nthu.edu.tw/~jklee,cIxlQU4AAAAJ
+Jens B. Schmitt,TU Kaiserslautern,https://disco.cs.uni-kl.de/index.php/people/jens-schmitt,lmEldBwAAAAJ
 Jens Dietrich 0001,Victoria University of Wellington,https://sites.google.com/site/jensdietrich,wMsX0w4AAAAJ
 Jens Dittrich,Saarland University,https://infosys.cs.uni-saarland.de/people/dittrich.php,fykfPiwAAAAJ
 Jens Gravesen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
@@ -9129,6 +9140,7 @@ Karol Myszkowski [INF],Max Planck Society,https://people.mpi-inf.mpg.de/~karol,e
 Karon E. MacLean,University of British Columbia,https://www.cs.ubc.ca/~maclean,qANkJFwAAAAJ
 Karrie G. Karahalios,Univ. of Illinois at Urbana-Champaign,https://cs.illinois.edu/directory/profile/kkarahal,xyHrRFUAAAAJ
 Karrie Karahalios,Univ. of Illinois at Urbana-Champaign,https://cs.illinois.edu/directory/profile/kkarahal,xyHrRFUAAAAJ
+Karsten Berns,TU Kaiserslautern,https://agrosy.informatik.uni-kl.de/lehrstuhl/lehrstuhl-leiter,KFlzbrUAAAAJ
 Karsten Lundqvist,Victoria University of Wellington,https://ecs.victoria.ac.nz/Main/KarstenLundqvist,aLfZJJQAAAAJ
 Karsten Weihe,TU Darmstadt,https://www.algo.informatik.tu-darmstadt.de/algorithmik/mitarbeiter/karsten-weihe,NOSCHOLARPAGE
 Karsten Øster Lundqvist,Victoria University of Wellington,https://ecs.victoria.ac.nz/Main/KarstenLundqvist,aLfZJJQAAAAJ
@@ -9166,6 +9178,7 @@ Katerina Goseva-Popstojanova,West Virginia University,https://www.statler.wvu.ed
 Katerina J. Argyraki,EPFL,https://people.epfl.ch/katerina.argyraki,TvV_SVwAAAAJ
 Katerina Stankova,Maastricht University,http://www.stankova.net,wYupkOAAAAAJ
 Katerina Stanková,Maastricht University,http://www.stankova.net,wYupkOAAAAAJ
+Katharina Anna Zweig,TU Kaiserslautern,http://aalab.cs.uni-kl.de/en/gruppe/zweig,UyG7biIAAAAJ
 Katharina Krombholz,CISPA Helmholtz Center,https://cispa.saarland/people/katharina.krombholz,BkeawyUAAAAJ
 Katharina Reinecke,University of Washington,https://www.cs.washington.edu/people/faculty/reinecke,_4EISRwAAAAJ
 Katherine A. Yelick,University of California - Berkeley,https://www.cs.berkeley.edu/~yelick,93yNuV0AAAAJ
@@ -9479,6 +9492,7 @@ Klaus Mueller,Stony Brook University,http://www3.cs.stonybrook.edu/~mueller,uya_
 Klaus Obermayer,TU Berlin,https://www.ni.tu-berlin.de/menue/mitarbeiter/leiter_der_forschungsgruppe/obermayer_klaus/parameter/de,pGKzaMMAAAAJ
 Klaus Ostermann,University of Tübingen,http://ps.informatik.uni-tuebingen.de/team/ostermann,doJ07f8oUtQC
 Klaus Schilling,University of Würzburg,http://www7.informatik.uni-wuerzburg.de/mitarbeiter/schilling,NOSCHOLARPAGE
+Klaus Schneider 0001,TU Kaiserslautern,https://es.cs.uni-kl.de/people/schneider,NOSCHOLARPAGE
 Klaus Turowski,University of Magdeburg,http://www.mrcc.ovgu.de/agwi/home,NOSCHOLARPAGE
 Klaus Tönnies,University of Magdeburg,http://isgwww.cs.uni-magdeburg.de/bv,cXR4lJkAAAAJ
 Klaus U. Schulz,LMU Munich,https://www.cis.uni-muenchen.de/people/schulz.html,NOSCHOLARPAGE
@@ -10539,6 +10553,7 @@ Marc Fischlin,TU Darmstadt,https://www.cryptoplexity.informatik.tu-darmstadt.de/
 Marc González,Polytechnic University of Catalonia,http://rbertran.site.ac.upc.edu,HBsqrO8AAAAJ
 Marc González Tallada,Polytechnic University of Catalonia,http://rbertran.site.ac.upc.edu,HBsqrO8AAAAJ
 Marc H. Scholl,University of Konstanz,https://dbis.uni-konstanz.de/people/people/scholl,741oZZ0AAAAJ
+Marc Herrlich,TU Kaiserslautern,https://sge.eit.uni-kl.de/startseite,eVYyNUMAAAAJ
 Marc J van Kreveld,Utrecht University,http://www.staff.science.uu.nl/~kreve101,Q_d-0KAAAAAJ
 Marc Langheinrich,Università della Svizzera italiana,http://uc.inf.usi.ch/team/langheinrich,y6ztFvsAAAAJ
 Marc Lelarge,Ecole Normale Superieure,http://www.di.ens.fr/~lelarge,cLGOIdMAAAAJ
@@ -10796,6 +10811,7 @@ Marios Christou,University of Nicosia,https://www.unic.ac.cy/christou-marios,NOS
 Marios Fokaefs,Polytechnique Montreal,https://www.polymtl.ca/expertises/en/fokaefs-marios-eleftherios,CFKjCQQAAAAJ
 Marios Kountouris,EURECOM,http://www.eurecom.fr/en/people/kountouris-marios,QG9iXtUAAAAJ
 Maristella Matera,Politecnico di Milano,http://home.deib.polimi.it/matera,NScXYC0AAAAJ
+Marius Kloft,TU Kaiserslautern,https://ml.informatik.uni-kl.de,l-BJCdAAAAAJ
 Marius Portmann,University of Queensland,http://staff.itee.uq.edu.au/marius,hiYVpa0AAAAJ
 Marius Ungarish,Technion,http://www.cs.technion.ac.il/people/unga,NOSCHOLARPAGE
 Marius Zimand,Towson University,https://www.towson.edu/fcsm/departments/computerinfosci/facultystaff/mzimand.html,_7Mz5cQAAAAJ
@@ -12461,6 +12477,7 @@ Nicolas Louvet,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/nicolas
 Nicolas Markey,Ecole Normale Superieure de Cachan,http://www.lsv.ens-cachan.fr/~markey,wWzobj4AAAAJ
 Nicolas Navet,University of Luxembourg,http://nicolas.navet.eu,dhYgyRUAAAAJ
 Nicolas Pugeault,University of Exeter,http://emps.exeter.ac.uk/computer-science/staff/np331,O9mKQacAAAAJ
+Nicolas R. Gauger,TU Kaiserslautern,https://www.scicomp.uni-kl.de/team/gauger,RUZ-k4YAAAAJ
 Nicolas T. Courtois,University College London,http://www0.cs.ucl.ac.uk/staff/n.courtois,sTwMEA8AAAAJ
 Nicolas Trotignon,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/nicolas.trotignon/indexFr.html,NOSCHOLARPAGE
 Nicolas Wu,University of Bristol,http://www.bris.ac.uk/engineering/people/nicolas-wu/index.html,nlNpvqYAAAAJ
@@ -12617,6 +12634,7 @@ Noora Fetais,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/
 Nora Ayanian,University of Southern California,http://www-bcf.usc.edu/~ayanian,ke2MEF0AAAAJ
 Nora Houari,Concordia University,https://www.concordia.ca/encs/computer-science-software-engineering/faculty.html.html?fpid=nora-houari,NOSCHOLARPAGE
 Norbert Dojer,University of Warsaw,http://bioputer.mimuw.edu.pl,NOSCHOLARPAGE
+Norbert Wehn,TU Kaiserslautern,https://ems.eit.uni-kl.de/mitarbeiter/norbert-wehn,sJ9btGAAAAAJ
 Norbert Zeh,Dalhousie University,https://web.cs.dal.ca/~nzeh,GoTWlmgAAAAJ
 Noriko Hara,Indiana University,http://norikohara.org,l13_u9wAAAAJ
 Noriko Tomuro,DePaul University,http://condor.depaul.edu/~ntomuro,NOSCHOLARPAGE
@@ -12961,7 +12979,7 @@ Pascal Hitzler,Kansas State University,http://www.pascal-hitzler.de,EkwfQcMAAAAJ
 Pascal Koiran,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/pascal.koiran,EQwChR4AAAAJ
 Pascal Matsakis,University of Guelph,http://www.cis.uoguelph.ca/~matsakis,NOSCHOLARPAGE
 Pascal Poupart,University of Waterloo,https://cs.uwaterloo.ca/~ppoupart,KhAJWroAAAAJ
-Pascal Schweitzer,RWTH Aachen,https://www.lii.rwth-aachen.de/en/mitarbeiter/13-mitarbeiter/professoren/22-prof-dr-schweitzer.html,NOSCHOLARPAGE
+Pascal Schweitzer,TU Kaiserslautern,http://alg.informatik.uni-kl.de/team/schweitzer,NOSCHOLARPAGE
 Pascale Fung,HKUST,http://www.ee.ust.hk/~pascale,QEMJWzEAAAAJ
 Pasquale Foggia,University of Salerno,http://mivia.unisa.it/people/foggia,P9eeLD8AAAAJ
 Pat Hanrahan,Stanford University,https://graphics.stanford.edu/~hanrahan,RzEnQmgAAAAJ
@@ -13080,6 +13098,7 @@ Paul Klint,CWI,http://homepages.cwi.nl/~paulk,auuOyXoAAAAJ
 Paul Krause,University of Surrey,https://www.surrey.ac.uk/people/paul-krause,6d3d0vwAAAAJ
 Paul L. Lewin,University of Southampton,https://www.ecs.soton.ac.uk/people/pll,vS7Qs0MAAAAJ
 Paul Lu,University of Alberta,https://webdocs.cs.ualberta.ca/~paullu,nEmFpMkAAAAJ
+Paul Lukowicz,TU Kaiserslautern,http://ei.informatik.uni-kl.de,1FIyc9kAAAAJ
 Paul Macklin,Indiana University,http://mathcancer.org,zUorXGEAAAAJ
 Paul Marshall,University of Bristol,http://www.bristol.ac.uk/engineering/people/paul-e-marshall/index.html,54plaOQAAAAJ
 Paul Medvedev,Pennsylvania State University,http://bmb.psu.edu/directory/pzm11,Gwd6p_8AAAAJ
@@ -13332,6 +13351,7 @@ Peter King,University of Manitoba,http://www.cs.umanitoba.ca/~prking,jENQurUAAAA
 Peter Krogstrup,IST Austria,https://ist.ac.at/research/research-groups/krogstrup-group,_tAV9MMAAAAJ
 Peter L. Bartlett,University of California - Berkeley,http://www.stat.berkeley.edu/~bartlett,UPVvV6kAAAAJ
 Peter Langendörfer,Brandenburg University of Technology,https://www.b-tu.de/fg-sicherheit-in-pervasiven-systemen/team/professor,giUyxgYAAAAJ
+Peter Liggesmeyer,TU Kaiserslautern,https://seda.informatik.uni-kl.de/staff-members/prof-liggesmeyer,mztSTlYAAAAJ
 Peter Ljunglöf,Chalmers University of Technology,https://www.chalmers.se/en/staff/Pages/peter-ljunglof.aspx,8GVoEBgAAAAJ
 Peter Lundin,Chalmers University of Technology,https://www.chalmers.se/en/staff/Pages/peter-lundin.aspx,NOSCHOLARPAGE
 Peter Lutz,Rochester Institute of Technology,http://www.ist.rit.edu/~phl,Z2E0SisAAAAJ
@@ -13937,6 +13957,7 @@ Rakesh Verma,University of Houston,http://www2.cs.uh.edu/~rmverma,va3JOtYAAAAJ
 Rakesh Vohra,University of Pennsylvania,https://economics.sas.upenn.edu/faculty/rakesh-vohra,JnWSU4oAAAAJ
 Rakeshbabu Bobba,Oregon State University,http://eecs.oregonstate.edu/people/bobba-rakesh,_0x5unAAAAAJ
 Ralf H. Reussner,Karlsruhe Institute of Technology (KIT),http://sdq.ipd.kit.edu/people/ralf_reussner,wsPDe4IAAAAJ
+Ralf Hinze,TU Kaiserslautern,https://pl.cs.uni-kl.de/homepage/de/staff/RalfHinze,SGND_ocAAAAJ
 Ralf Hofestädt,Bielefeld University,https://ekvv.uni-bielefeld.de/pers_publ/publ/PersonDetail.jsp?personId=161045,NOSCHOLARPAGE
 Ralf Küsters,University of Stuttgart,https://sec.informatik.uni-stuttgart.de/people/kuesters,NOSCHOLARPAGE
 Ralf L. M. Peeters,Maastricht University,https://www.maastrichtuniversity.nl/ralf.peeters,4gv6c1sAAAAJ
@@ -14142,6 +14163,7 @@ Reimo Palm,University of Tartu,http://www.ut.ee/en/reimo-palm,NOSCHOLARPAGE
 Reinder J. Bril,TU Eindhoven,http://www.win.tue.nl/~rbril,kOwzhloAAAAJ
 Reiner Hähnle,TU Darmstadt,https://www.se.tu-darmstadt.de/se/group-members/reiner-haehnle,NOSCHOLARPAGE
 Reiner Kolla,University of Würzburg,https://www.informatik.uni-wuerzburg.de/lehrstuehleprofessuren/info5/mitarbeiter/kolla-reiner,NOSCHOLARPAGE
+Reinhard Gotzhein,TU Kaiserslautern,https://vs.informatik.uni-kl.de/people/gotzhein,NOSCHOLARPAGE
 Reinhard Pichler,TU Wien,https://www.dbai.tuwien.ac.at/staff/pichler,OiYGd-IAAAAJ
 Reinhard Wilhelm,Saarland University,http://rw4.cs.uni-saarland.de/people/wilhelm.shtml,cmvUbRUAAAAJ
 Reinhold Haux,TU Braunschweig,https://plri.de/mitarbeiter/reinhold-haux,6_4K9QsAAAAJ
@@ -15297,6 +15319,7 @@ Sebastian Hack,Saarland University,http://compilers.cs.uni-saarland.de/people/ha
 Sebastian Krinninger,University of Salzburg,https://www.cosy.sbg.ac.at/~forster,Ic9r-5sAAAAJ
 Sebastian Link,University of Auckland,https://www.cs.auckland.ac.nz/people/s-link,_goLCI4AAAAJ
 Sebastian Maneth,University of Edinburgh,http://homepages.inf.ed.ac.uk/smaneth,GyklaXkAAAAJ
+Sebastian Michel 0001,TU Kaiserslautern,https://dbis.informatik.uni-kl.de/index.php/en/people/michel,5_e2f04AAAAJ
 Sebastian Möller,TU Berlin,https://www.qu.tu-berlin.de/v-menue/team/professur,BC_qcg0AAAAJ
 Sebastian Padó,University of Stuttgart,http://www.ims.uni-stuttgart.de/~pado,vKqag_AAAAAJ
 Sebastian Rudolph,TU Dresden,https://iccl.inf.tu-dresden.de/web/Sebastian_Rudolph/en,b3qVb6IAAAAJ
@@ -16015,6 +16038,7 @@ Stefan Brunthaler,Bundeswehr University Munich,https://www.unibw.de/systemsicher
 Stefan Böttcher,Paderborn University,http://cs.uni-paderborn.de/ecdb,7ZjDsGAAAAAJ
 Stefan C. Kremer,University of Guelph,https://www.uoguelph.ca/computing/people/stefan-kremer,ECQMeb0AAAAJ
 Stefan Decker,RWTH Aachen,http://www.stefandecker.org,uhVkSswAAAAJ
+Stefan Deßloch,TU Kaiserslautern,http://wwwlgis.informatik.uni-kl.de/cms/his/staff/dessloch,XJ7AvACBkB8C
 Stefan Dziembowski,University of Warsaw,http://www.crypto.edu.pl/Dziembowski,VgiXQ2YAAAAJ
 Stefan Engblom,Uppsala University,http://user.it.uu.se/~stefane,M368s5AAAAAJ
 Stefan Funke,University of Stuttgart,http://www.fmi.uni-stuttgart.de/alg,YgSxvV4AAAAJ
@@ -18085,6 +18109,7 @@ Wolfgang J. Paul,Saarland University,http://www-wjp.cs.uni-saarland.de/leute/ind
 Wolfgang Karl,Karlsruhe Institute of Technology (KIT),http://capp.itec.kit.edu/~karl/?lang=d,NOSCHOLARPAGE
 Wolfgang Kastner,TU Wien,https://www.auto.tuwien.ac.at/index.php/projectsites/142-wolfgang-kastner,HXWWcJYAAAAJ
 Wolfgang Klas,University of Vienna,https://cs.univie.ac.at/wolfgang.klas,NOSCHOLARPAGE
+Wolfgang Kunz,TU Kaiserslautern,https://www.eit.uni-kl.de/eis/people/kunz,NOSCHOLARPAGE
 Wolfgang Küchlin,University of Tübingen,https://uni-tuebingen.de/en/faculties/faculty-of-science/departments/computer-science/lehrstuehle/symbolisches-rechnen/arbeitsbereich/prof-wolfgang-kuechlin,NOSCHOLARPAGE
 Wolfgang Lehner,TU Dresden,https://wwwdb.inf.tu-dresden.de/team/head/wolfgang-lehner,YYzvyMQAAAAJ
 Wolfgang Maass 0001,Graz University of Technology,https://igi-web.tugraz.at/people/maass,2WpvdH0AAAAJ


### PR DESCRIPTION
Added the faculty of three German universities: 

- TU Kaiserslautern
- TU Dortmund
- University of Erlangen-Nuremberg

Two people moved: 

- Anthony Lin (Oxford -> TU Kaiserslautern)
- Pascal Schweitzer (RWTH Aachen -> TU Kaiserslautern) 

---

**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [x] If the institution you are adding is not in the US,
update `country-info.csv`.
