### PR TITLE
Added new NYU faculty

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -10561,6 +10561,7 @@ Leonidas J. Guibas,Stanford University,http://geometry.stanford.edu/member/guiba
 Leopoldo E. Bertossi,Carleton University,http://www.scs.carleton.ca/~bertossi,TeBUgNcAAAAJ
 Leopoldo Teixeira,UFPE,http://www.cin.ufpe.br/~lmt,kCcCrNMAAAAJ
 Lerina Aversano,University of Sannio,https://www.unisannio.it/it/users/lerina-aversano,j7iOkqsAAAAJ
+Lerrel Pinto,New York University,https://cs.nyu.edu/~lp91/,pmVPj94AAAAJ
 Les A. Piegl,University of South Florida,http://www.piegl.com,yvA23lcAAAAJ
 Les Carr,University of Southampton,https://www.ecs.soton.ac.uk/people/lac,OK59DcoAAAAJ
 Leslie A. Henderson,University of Oxford,https://www.cs.ox.ac.uk/people/leslieann.goldberg,rXpctjYAAAAJ


### PR DESCRIPTION
Added Lerrel Pinto (https://cs.nyu.edu/~lp91/) to NYU

# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

_Do not use Excel to edit any .csv files; Excel incorrectly tries to
convert some Google Scholar entries to formulas, corrupting the
database. Use a text editor like emacs or NotePad instead._

**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [x] If the institution you are adding is not in the US,
update `country-info.csv`.
