### PR TITLE
A faculty member was missing his middle name initial causing dblp to mis-identify him

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -11645,7 +11645,7 @@ Martijn Stam,University of Bristol,http://www.bristol.ac.uk/engineering/people/m
 Martijn van Otterlo,Tilburg University,https://www.tilburguniversity.edu/webwijs/show/m.vanotterlo.htm,NOSCHOLARPAGE
 Martin A. Siegel,Indiana University,https://www.soic.indiana.edu/all-people/profile.html?profile_id=298,sZ_nSuIAAAAJ
 Martin A. Styner,University of North Carolina,http://www.cs.unc.edu/~styner,waEzpjgAAAAJ
-Martin Albrecht,Royal Holloway University of London,https://pure.royalholloway.ac.uk/portal/en/persons/martin-albrecht(ab997512-d7f9-4d99-92e1-33967032502b).html,t9Eteq4AAAAJ
+Martin R. Albrecht,Royal Holloway University of London,https://pure.royalholloway.ac.uk/portal/en/persons/martin-albrecht(ab997512-d7f9-4d99-92e1-33967032502b).html,t9Eteq4AAAAJ
 Martin Andreas Styner,University of North Carolina,http://www.cs.unc.edu/~styner,waEzpjgAAAAJ
 Martin Andrews,University of Oxford,https://www.cs.ox.ac.uk/andrew.martin,si3UgDwAAAAJ
 Martin Atzmueller,Tilburg University,https://www.tilburguniversity.edu/webwijs/show/m.atzmuller.htm,PSxBcWwAAAAJ


### PR DESCRIPTION
# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

_Do not use Excel to edit any .csv files; Excel incorrectly tries to
convert some Google Scholar entries to formulas, corrupting the
database. Use a text editor like emacs or NotePad instead._

**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [x] If the institution you are adding is not in the US,
update `country-info.csv`.

