### PR TITLE
Adding Martin Kong (new Tenure-Track Assistant Prof. at University of…

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -11840,6 +11840,7 @@ Martin Jaggi,EPFL,https://people.epfl.ch/martin.jaggi,r1TJBr8AAAAJ
 Martin Johns,TU Braunschweig,http://www.martinjohns.com,a-_ZVzEAAAAJ
 Martin Jägersand,University of Alberta,https://webdocs.cs.ualberta.ca/~jag,kxAlIY4AAAAJ
 Martin Karsten,University of Waterloo,https://cs.uwaterloo.ca/~mkarsten,ieXJpBkAAAAJ
+Martin Kong,University of Oklahoma,https://www.cs.ou.edu/~mkong,A08cGJAAAAAJ
 Martin Kreuzer,University of Passau,http://staff.fim.uni-passau.de/kreuzer,0ZDLSpkAAAAJ
 Martin L. Kersten,CWI,http://homepages.cwi.nl/~mk,Kr6jppsAAAAJ
 Martin Lange,University of Kassel,https://carrick.fm.cs.uni-kassel.de/~mlange,cQuaayUAAAAJ


### PR DESCRIPTION
… Oklahoma)

# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

_Do not use Excel to edit any .csv files; Excel incorrectly tries to
convert some Google Scholar entries to formulas, corrupting the
database. Use a text editor like emacs or NotePad instead._

**Inclusion criteria**

- [ ] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [ ] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [ ] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

