### PR TITLE
Update Affiliation of Johannes Fürnkranz

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -8885,7 +8885,7 @@ Johannes Borgström,Uppsala University,https://katalog.uu.se/empinfo/?id=N10-775
 Johannes C. van Vliet,VU Amsterdam,http://www.cs.vu.nl/~hans,4YAdfEsAAAAJ
 Johannes Fink,IST Austria,https://ist.ac.at/research/research-groups/fink-group,4Ot68t8AAAAJ
 Johannes Fischer 0001,TU Dortmund,https://ls11-www.cs.tu-dortmund.de/staff/fischer,ldpdi_gAAAAJ
-Johannes Fürnkranz,TU Darmstadt,http://www.ke.tu-darmstadt.de/staff/juffi,sfTn4wEAAAAJ
+Johannes Fürnkranz,JKU Linz,https://www.jku.at/en/faw/about-us/team/johannes-fuernkranz/,sfTn4wEAAAAJ
 Johannes Kinder,Bundeswehr University Munich,https://www.unibw.de/systemsicherheit/kinder,rnDHTKYAAAAJ
 Johannes Kirchmair,University of Hamburg,https://www.zbh.uni-hamburg.de/personen/acm/jkirchmair.html,s7By7lIAAAAJ
 Johannes Köbler,Humboldt University of Berlin,https://www.informatik.hu-berlin.de/forschung/gebiete/algorithmenII,NOSCHOLARPAGE


### PR DESCRIPTION
Updated Affiliation of Johannes Fürnkranz in csrankings.csv from TU Darmstadt to JKU Linz, following Google Scholar and DBLP where this update has already been made.
