### PR TITLE
Fixed Eduard Eiben's affiliation, that changed by mistake in recent updates/commits.

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -4958,7 +4958,7 @@ Eduard Ayguadé,Polytechnic University of Catalonia,http://people.ac.upc.edu/edu
 Eduard Ayguadé Parra,Polytechnic University of Catalonia,http://people.ac.upc.edu/eduard,lEho8pkAAAAJ
 Eduard C. Dragut,Temple University,https://cis.temple.edu/~edragut,NOSCHOLARPAGE
 Eduard Constantin Dragut,Temple University,https://cis.temple.edu/~edragut,NOSCHOLARPAGE
-Eduard Eiben,Royal Holloway University of London,https://pure.royalholloway.ac.uk/portal/en/persons/eduard-eiben(9ee8fd8f-cbc6-4365-bda4-79850f62e36d).html
+Eduard Eiben,Royal Holloway University of London,https://pure.royalholloway.ac.uk/portal/en/persons/eduard-eiben(9ee8fd8f-cbc6-4365-bda4-79850f62e36d).html,VzCxpJcAAAAJ
 Eduard Gröller,TU Wien,https://www.cg.tuwien.ac.at/staff/EduardGroeller.html,eBsjFlIAAAAJ
 Eduard Mehofer,University of Vienna,https://cs.univie.ac.at/eduard.mehofer,NOSCHOLARPAGE
 Eduardo Alonso,City University of London,https://www.city.ac.uk/people/academics/eduardo-alonso#profile=publications,b48-mXoAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -4958,7 +4958,7 @@ Eduard Ayguadé,Polytechnic University of Catalonia,http://people.ac.upc.edu/edu
 Eduard Ayguadé Parra,Polytechnic University of Catalonia,http://people.ac.upc.edu/eduard,lEho8pkAAAAJ
 Eduard C. Dragut,Temple University,https://cis.temple.edu/~edragut,NOSCHOLARPAGE
 Eduard Constantin Dragut,Temple University,https://cis.temple.edu/~edragut,NOSCHOLARPAGE
-Eduard Eiben,University of Bergen,https://www.uib.no/en/persons/Eduard.Eiben,NOSCHOLARPAGE
+Eduard Eiben,Royal Holloway University of London,https://pure.royalholloway.ac.uk/portal/en/persons/eduard-eiben(9ee8fd8f-cbc6-4365-bda4-79850f62e36d).html
 Eduard Gröller,TU Wien,https://www.cg.tuwien.ac.at/staff/EduardGroeller.html,eBsjFlIAAAAJ
 Eduard Mehofer,University of Vienna,https://cs.univie.ac.at/eduard.mehofer,NOSCHOLARPAGE
 Eduardo Alonso,City University of London,https://www.city.ac.uk/people/academics/eduardo-alonso#profile=publications,b48-mXoAAAAJ


### PR DESCRIPTION
# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

_Do not use Excel to edit any .csv files; Excel incorrectly tries to
convert some Google Scholar entries to formulas, corrupting the
database. Use a text editor like emacs or NotePad instead._

**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [ ] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [ ] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [ ] If the institution you are adding is not in the US,
update `country-info.csv`.

