### PR TITLE
Change Affiliation for Jimeng Sun

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -8839,7 +8839,7 @@ Jim Warren 0001,University of Auckland,https://www.cs.auckland.ac.nz/~jim,67P38d
 Jim Whitehead,University of California - Santa Cruz,https://www.soe.ucsc.edu/people/ejw,_2UkAYEAAAAJ
 Jim Woodcock,University of York,https://www-users.cs.york.ac.uk/~jim,bO-FeTIAAAAJ
 Jim X. Chen,George Mason University,https://cs.gmu.edu/~jchen,929ovoAAAAAJ
-Jimeng Sun,Georgia Institute of Technology,http://www.cc.gatech.edu/people/jimeng-sun,9jmmp5sAAAAJ
+Jimeng Sun,Univ. of Illinois at Urbana-Champaign,http://sunlab.org,9jmmp5sAAAAJ
 Jiming Liu 0001,Hong Kong Baptist University,http://www.comp.hkbu.edu.hk/~jiming,Il6ArO0AAAAJ
 Jimmy Ba,University of Toronto,https://jimmylba.github.io,ymzxRhAAAAAJ
 Jimmy H. M. Lee,Chinese University of Hong Kong,https://www.coursera.org/instructor/jlee,NOSCHOLARPAGE


### PR DESCRIPTION

**Updating an affiliation or home page**

- [x] 

Change affiliation from GT to UIUC for Jimeng Sun, and update his homepage


