### PR TITLE
University of Tübingen: added 7 faculty and updated one affiliation.

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -2253,6 +2253,7 @@ Betsy James DiSalvo,Georgia Institute of Technology,http://betsydisalvo.com,NOSC
 Bettina Berendt,KU Leuven,https://people.cs.kuleuven.be/~bettina.berendt,NOSCHOLARPAGE
 Bettina Grün,JKU Linz,https://www.jku.at/institut-fuer-angewandte-statistik/ueber-uns/team/assoz-univ-profin-dipl-ingin-drin-bettina-gruen,Tl-eVmoAAAAJ
 Bettina Kemme,McGill University,http://www.cs.mcgill.ca/~kemme,vLbmweYAAAAJ
+Bettina Rolke,University of Tübingen,https://fit.uni-tuebingen.de/Portfolio/Details?id=495,NOSCHOLARPAGE
 Bettina Schnor,University of Potsdam,https://www.cs.uni-potsdam.de/~schnor,NOSCHOLARPAGE
 Bettina Speckmann,TU Eindhoven,http://www.win.tue.nl/~speckman,NOSCHOLARPAGE
 Betty H. C. Cheng,Michigan State University,http://www.cse.msu.edu/~chengb,qABYFOIAAAAJ
@@ -8139,6 +8140,7 @@ Jakob Bohr,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Jakob Eg Larsen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Jakob Eriksson,University of Illinois at Chicago,https://www.cs.uic.edu/Jakob,kLUW0psAAAAJ
 Jakob Grue Simonsen,University of Copenhagen,http://www.diku.dk/~simonsen,JFhAzosAAAAJ
+Jakob H. Macke,University of Tübingen,https://uni-tuebingen.de/en/research/core-research/cluster-of-excellence-machine-learning/research/research/cluster-research-groups/professorships/machine-learning-in-science,FKOqtF8AAAAJ
 Jakob Nordström,KTH Royal Institute of Technology,http://www.csc.kth.se/~jakobn,YSFwWNIAAAAJ
 Jakob Rehof,TU Dortmund,https://ls14-www.cs.uni-dortmund.de/cms/de/home,lhc6Jn4AAAAJ
 Jakub Kowalski,University of Wroclaw,http://ii.uni.wroc.pl/instytut/pracownicy/64,31AWuosAAAAJ
@@ -11579,6 +11581,7 @@ Manas Khatua,IIT Jodhpur,http://manaskhatua.github.io,TQshktIAAAAJ
 Maneesh Agrawala,Stanford University,http://graphics.stanford.edu/~maneesh,YPzKczYAAAAJ
 Manel Guerrero Zapata,Polytechnic University of Catalonia,http://personals.ac.upc.edu/guerrero/my_cv.html,eFe60BoAAAAJ
 Manel Medina,Polytechnic University of Catalonia,http://personals.ac.upc.edu/medina,pPqLc2MAAAAJ
+Manfred Claassen,University of Tübingen,https://www.medizin.uni-tuebingen.de/de/das-klinikum/mitarbeiter/profil/2147,NOSCHOLARPAGE
 Manfred Droste,University of Leipzig,http://www.informatik.uni-leipzig.de/~droste,RNhcC7UAAAAJ
 Manfred Hauswirth,TU Berlin,https://www.ods.tu-berlin.de/menue/chair_for_open_distributed_systems/about_us/professor,WwjTJ3YAAAAJ
 Manfred Huber,University of Texas at Arlington,http://ranger.uta.edu/~huber,2lIq2nMAAAAJ
@@ -12143,6 +12146,7 @@ Marti A. Hearst,University of California - Berkeley,http://people.ischool.berkel
 Martial Hebert,Carnegie Mellon University,http://www.cs.cmu.edu/~./hebert,0ytii2EAAAAJ
 Martijn Stam,Simula UiB,Bristol,http://www.bristol.ac.uk/engineering/people/martijn-stam/index.html
 Martijn van Otterlo,Tilburg University,https://www.tilburguniversity.edu/webwijs/show/m.vanotterlo.htm,NOSCHOLARPAGE
+Martin A. Giese,University of Tübingen,http://www.compsens.uni-tuebingen.de/compsens/index.php/people?view=member&task=show&id=1,ebo0Qn4AAAAJ
 Martin A. Siegel,Indiana University,https://www.soic.indiana.edu/all-people/profile.html?profile_id=298,sZ_nSuIAAAAJ
 Martin A. Styner,University of North Carolina,http://www.cs.unc.edu/~styner,waEzpjgAAAAJ
 Martin Andreas Styner,University of North Carolina,http://www.cs.unc.edu/~styner,waEzpjgAAAAJ
@@ -14981,6 +14985,7 @@ Philip W. Trinder,University of Glasgow,http://www.dcs.gla.ac.uk/~trinder,3Bs_EA
 Philip Wadler,University of Edinburgh,http://homepages.inf.ed.ac.uk/wadler,Iz-3VFQAAAAJ
 Philip Wilsey,University of Cincinnati,http://www.ece.uc.edu/~paw,L3lqaIsAAAAJ
 Philip Zimmerman,TU Delft,https://www.tudelft.nl/staff/p.r.zimmermann,NOSCHOLARPAGE
+Philipp Berens,University of Tübingen,http://www.eye-tuebingen.de/berens,lPQLk3QAAAAJ
 Philipp Cimiano,Bielefeld University,http://ekvv.uni-bielefeld.de/pers_publ/publ/PersonDetail.jsp?personId=15020699,ZyR3798AAAAJ
 Philipp Haller,KTH Royal Institute of Technology,http://www.csc.kth.se/~phaller,sDt5PL4AAAAJ
 Philipp Hennig,University of Tübingen,https://uni-tuebingen.de/en/faculties/faculty-of-science/departments/computer-science/lehrstuehle/methods-of-machine-learning/personen/philipp-hennig,UeG5w08AAAAJ
@@ -15720,6 +15725,7 @@ Reiner Hähnle,TU Darmstadt,https://www.se.tu-darmstadt.de/se/group-members/rein
 Reiner Kolla,University of Würzburg,https://www.informatik.uni-wuerzburg.de/lehrstuehleprofessuren/info5/mitarbeiter/kolla-reiner,NOSCHOLARPAGE
 Reinhard German,University of Erlangen–Nuremberg,https://www.cs7.tf.fau.de/person/german,NOSCHOLARPAGE
 Reinhard Gotzhein,TU Kaiserslautern,https://vs.informatik.uni-kl.de/people/gotzhein,NOSCHOLARPAGE
+Reinhard Kahle,University of Tübingen,https://uni-tuebingen.de/en/faculties/faculty-of-science/departments/interfaculty-facilities/philosophy-and-history-of-science/#c840039,NOSCHOLARPAGE
 Reinhard Klein,University of Bonn,https://cg.cs.uni-bonn.de/de/mitarbeiter/prof-dr-reinhard-klein,NOSCHOLARPAGE
 Reinhard Koch,University of Kiel,https://www.mip.informatik.uni-kiel.de/en/team/prof.-dr.-ing.-reinhard-koch,xgjKDqAAAAAJ
 Reinhard Pichler,TU Wien,https://www.dbai.tuwien.ac.at/staff/pichler,OiYGd-IAAAAJ
@@ -17892,6 +17898,7 @@ Stephan Mandt,University of California - Irvine,http://www.stephanmandt.com,HOrG
 Stephan Meisel,University of Münster,https://www.wi.uni-muenster.de/de/institut/qm-logistik,wZzAcgkAAAAJ
 Stephan Olariu,Old Dominion University,http://www.cs.odu.edu/~olariu,TfbH_mEAAAAJ
 Stephan Olbrich,University of Hamburg,https://www.rrz.uni-hamburg.de/ueber-uns/personen/direktor/olbrich.html,NOSCHOLARPAGE
+Stephan Ossowski,University of Tübingen,http://www.medgen-tuebingen.de/en/f-computational-genomics-group-leader.html,imRxrJ4AAAAJ
 Stephan Vogel,Qatar Computing Research Institute,http://www.qcri.org/our-people/bio?pid=12&amp;par=acc&amp;name=StephanVogel,BffFdd0AAAAJ
 Stephan Waack,University of Göttingen,https://user.informatik.uni-goettingen.de/~waack,D3noPisAAAAJ
 Stephane Durocher,University of Manitoba,http://www.cs.umanitoba.ca/~durocher,rixCVNoAAAAJ
@@ -21155,7 +21162,7 @@ Zhaohui Wu 0001,Zhejiang University,http://mypage.zju.edu.cn/wuzhaohui,qV631P8AA
 Zhaojun Bai,University of California - Davis,http://www.cs.ucdavis.edu/~bai,soiDQbQAAAAJ
 Zhaolei Zhang,University of Toronto,http://sites.utoronto.ca/zhanglab,WvJIvxQAAAAJ
 Zhaonian Zou,Harbin Institute of Technology,http://homepage.hit.edu.cn/zou,KMYONIEAAAAJ
-Zhaoping Li,University College London,http://www0.cs.ucl.ac.uk/staff/Zhaoping.Li,V3sgCS0AAAAJ
+Zhaoping Li,University of Tübingen,https://webdav.tuebingen.mpg.de/u/zli/bio.html,V3sgCS0AAAAJ
 Zhaoran Wang,Northwestern University,https://www.princeton.edu/~zhaoran,HSx0BgQAAAAJ
 Zhaoxian Zhou,University of Southern Mississippi,http://orca.st.usm.edu/~zzhou,NOSCHOLARPAGE
 Zhaoyan Shen,Shandong University,http://www.cs.sdu.edu.cn/info/1090/2945.htm,9my0HgIAAAAJ


### PR DESCRIPTION
Renewed pull request (was https://github.com/emeryberger/CSrankings/pull/2833).

Added the following faculty of the University of Tübingen:

Jakob H. Macke,University of Tübingen,https://uni-tuebingen.de/en/research/core-research/cluster-of-excellence-machine-learning/research/research/cluster-research-groups/professorships/machine-learning-in-science/ ,FKOqtF8AAAAJ
Zhaoping Li,University of Tübingen,https://webdav.tuebingen.mpg.de/u/zli/bio.html ,V3sgCS0AAAAJ
Philipp Berens,University of Tübingen,http://www.eye-tuebingen.de/berens/ ,lPQLk3QAAAAJ
Reinhard Kahle,University of Tübingen,https://uni-tuebingen.de/en/faculties/faculty-of-science/departments/interfaculty-facilities/philosophy-and-history-of-science/#c840039 ,NOSCHOLARPAGE
Martin A. Giese,University of Tübingen,http://www.compsens.uni-tuebingen.de/compsens/index.php/people?view=member&task=show&id=1 ,ebo0Qn4AAAAJ
Stephan Ossowski,University of Tübingen,http://www.medgen-tuebingen.de/en/f-computational-genomics-group-leader.html ,imRxrJ4AAAAJ
Bettina Rolke,University of Tübingen,https://fit.uni-tuebingen.de/Portfolio/Details?id=495 ,NOSCHOLARPAGE
Manfred Claassen,University of Tübingen,https://www.medizin.uni-tuebingen.de/de/das-klinikum/mitarbeiter/profil/2147 ,NOSCHOLARPAGE

Removed entry with former institution:

Zhaoping Li,University College London,http://www0.cs.ucl.ac.uk/staff/Zhaoping.Li,V3sgCS0AAAAJ

All faculty appear on the CS department's faculty page:
https://uni-tuebingen.de/en/faculties/faculty-of-science/departments/computer-science/research-groups/

# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

_Do not use Excel to edit any .csv files; Excel incorrectly tries to
convert some Google Scholar entries to formulas, corrupting the
database. Use a text editor like emacs or NotePad instead._

**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department.

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [x] If the institution you are adding is not in the US,
update `country-info.csv`.

