### PR TITLE
Add faculty members from Brno University of Technology, Faculty of Information Technology

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -21,6 +21,7 @@ Birkbeck University of London,europe
 Bocconi University,europe
 Boğaziçi University,europe
 Brandenburg University of Technology,europe
+Brno University of Technology,europe
 Brunel University London,europe
 Bundeswehr University Munich,europe
 CISPA Helmholtz Center,europe

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -11530,6 +11530,7 @@ Lukasz Kowalik,University of Warsaw,http://www.mimuw.edu.pl/~kowalik,etDDW8sAAAA
 Lukasz Ziarek,University at Buffalo,http://www.cse.buffalo.edu/people/?u=lziarek,Bi8bhC0AAAAJ
 Lukás Burget,Brno University of Technology,https://www.fit.vut.cz/person/burget,pRBbU7wAAAAJ
 Lukás Holík,Brno University of Technology,https://www.fit.vut.cz/person/holik,0cPbvY0AAAAJ
+Lukás Sekanina,Brno University of Technology,https://www.fit.vut.cz/person/sekanina,-fLMT2cAAAAJ
 Luke Huan,University of Kansas,https://www.ittc.ku.edu/~jhuan,j2PH0Y0AAAAJ
 Luke J. Lee,Univ. of California - Berkeley,http://biopoets.berkeley.edu,xADN4DUAAAAJ
 Luke N. Olson,Univ. of Illinois at Urbana-Champaign,http://lukeo.cs.illinois.edu,o43oc6AAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -160,6 +160,7 @@ Adam D. Smith,Boston University,http://www.cse.psu.edu/~ads22,fkGi-JMAAAAJ
 Adam Doupé,Arizona State University,http://adamdoupe.com,hsJqhNAAAAAJ
 Adam Finkelstein,Princeton University,https://www.cs.princeton.edu/~af,a959F6AAAAAJ
 Adam Hahn,Washington State University,http://www.eecs.wsu.edu/~ahahn/index.html,nGBlVWwAAAAJ
+Adam Herout,Brno University of Technology,https://www.fit.vut.cz/person/herout,qQDbJDMAAAAJ
 Adam J. Aviv,George Washington University,https://adamaviv.com,ExgxufEAAAAJ
 Adam J. Lee,University of Pittsburgh,http://people.cs.pitt.edu/~adamlee,1IoFK0oAAAAJ
 Adam Klivans,University of Texas at Austin,https://www.cs.utexas.edu/~klivans,UD87zMYAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -11529,6 +11529,7 @@ Lukasz Jez,University of Wroclaw,https://www.enterprisetimes.co.uk/2017/04/28/in
 Lukasz Kowalik,University of Warsaw,http://www.mimuw.edu.pl/~kowalik,etDDW8sAAAAJ
 Lukasz Ziarek,University at Buffalo,http://www.cse.buffalo.edu/people/?u=lziarek,Bi8bhC0AAAAJ
 Lukás Burget,Brno University of Technology,https://www.fit.vut.cz/person/burget,pRBbU7wAAAAJ
+Lukás Holík,Brno University of Technology,https://www.fit.vut.cz/person/holik,0cPbvY0AAAAJ
 Luke Huan,University of Kansas,https://www.ittc.ku.edu/~jhuan,j2PH0Y0AAAAJ
 Luke J. Lee,Univ. of California - Berkeley,http://biopoets.berkeley.edu,xADN4DUAAAAJ
 Luke N. Olson,Univ. of Illinois at Urbana-Champaign,http://lukeo.cs.illinois.edu,o43oc6AAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -12340,6 +12340,7 @@ Martin C. Rinard,Massachusetts Institute of Technology,http://people.csail.mit.e
 Martin Caminada,Cardiff University,https://www.cardiff.ac.uk/people/view/473184-caminada-martin,PyfFzdUAAAAJ
 Martin D. F. Wong,Univ. of Illinois at Urbana-Champaign,https://www.ece.illinois.edu/directory/profile/mdfwong,WPhoQiUAAAAJ
 Martin Dietzfelbinger,TU Ilmenau,https://www.tu-ilmenau.de/ktea/mitarbeiter/univ-prof-dr-martin-dietzfelbinger,jabdPAwAAAAJ
+Martin Drahanský,Brno University of Technology,https://www.fit.vut.cz/person/drahan,NOSCHOLARPAGE
 Martin Dugas,University of Münster,https://www.medizin.uni-muenster.de/fakultaet/fakultaet/personen-preise/details/?uid=92&L=0,NOSCHOLARPAGE
 Martin E. Dyer,University of Leeds,https://eps.leeds.ac.uk/computing/staff/52/professor-martin-dyer,caPvMq0AAAAJ
 Martin Ebner,Graz University of Technology,https://elearningblog.tugraz.at/page/martinebner//?lng=de&sct=home,dnnkxkcAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -19296,6 +19296,7 @@ Tomás Bures,Charles University,https://d3s.mff.cuni.cz/people/tomasbures,V5ILAx
 Tomás García Ferrari,University of Waikato,http://www.cms.waikato.ac.nz/people/tomasgf,U5v_QA0AAAAJ
 Tomás Lozano-Pérez,Massachusetts Institute of Technology,http://people.csail.mit.edu/tlp,NOSCHOLARPAGE
 Tomás Pitner,Masaryk University,https://www.muni.cz/en/people/94,bX-cpaoAAAAJ
+Tomás Vojnar,Brno University of Technology,https://www.fit.vut.cz/person/vojnar,YbSGwKwAAAAJ
 Tona Henderson,Rochester Institute of Technology,https://www.rit.edu/gccis/igm/tona-henderson,NOSCHOLARPAGE
 Tong Lin,Peking University,http://www.cis.pku.edu.cn/faculty/vision/lintong/default.htm,NOSCHOLARPAGE
 Tong Lu,Nanjing University,https://cs.nju.edu.cn/lutong,NOSCHOLARPAGE

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -8419,6 +8419,7 @@ Jan Bækgaard Pedersen,University of Nevada Las Vegas,http://www.egr.unlv.edu/~m
 Jan C. van Gemert,TU Delft,https://www.tudelft.nl/ewi/over-de-faculteit/afdelingen/intelligent-systems/pattern-recognition-bioinformatics/computer-vision-lab/people/jan-van-gemert,JUdMRGcAAAAJ
 Jan Carlo Barca,Monash University,http://monash.edu/research/explore/en/persons/jan-barca(b809a264-a966-4c49-b3b3-1425a47f97ee).html,bZQ0r6YAAAAJ
 Jan Cederquist,Universidade de Lisboa,http://web.ist.utl.pt/~ist24691,ImQ41W0AAAAJ
+Jan Cernocký,Brno University of Technology,https://www.fit.vut.cz/person/cernocky,BnfCLXcAAAAJ
 Jan Chomicki,University at Buffalo,https://www.cse.buffalo.edu/~chomicki,twwFv3QAAAAJ
 Jan Chorowski,University of Wroclaw,http://ii.uni.wroc.pl/instytut/pracownicy/15,Yc94070AAAAJ
 Jan Ehlers,Bauhaus University Weimar,https://www.uni-weimar.de/en/media/chairs/computer-science-department/usability-research-group/group/vertretungs-professor-dr-jan-ehlers,NOSCHOLARPAGE

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -174,6 +174,7 @@ Adam P. Chester,University of Warwick,https://warwick.ac.uk/fac/sci/dcs/people/a
 Adam Przepiórkowski,IPI PAN,ipipan.waw.pl/instytut/pracownicy/adam-przepiorkowski,volQDFMAAAAJ
 Adam Prügel-Bennett,University of Southampton,https://www.ecs.soton.ac.uk/people/apb1,oQgxYjkAAAAJ
 Adam R. Klivans,University of Texas at Austin,https://www.cs.utexas.edu/~klivans,UD87zMYAAAAJ
+Adam Rogalewicz,Brno University of Technology,https://www.fit.vut.cz/person/rogalew,NOSCHOLARPAGE
 Adam Steele,DePaul University,http://facweb.cs.depaul.edu/asteele,NOSCHOLARPAGE
 Adam W. Bargteil,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~adamb,fArWdfAAAAAJ
 Adam Wierman,California Institute of Technology,http://www.cs.caltech.edu/~adamw,4OvOdSgAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -11528,6 +11528,7 @@ Lukasz Golab,University of Waterloo,https://www.engineering.uwaterloo.ca/~lgolab
 Lukasz Jez,University of Wroclaw,https://www.enterprisetimes.co.uk/2017/04/28/infor-donates-erp-to-wroclaw-university,TJ4i9WQAAAAJ
 Lukasz Kowalik,University of Warsaw,http://www.mimuw.edu.pl/~kowalik,etDDW8sAAAAJ
 Lukasz Ziarek,University at Buffalo,http://www.cse.buffalo.edu/people/?u=lziarek,Bi8bhC0AAAAJ
+Lukás Burget,Brno University of Technology,https://www.fit.vut.cz/person/burget,pRBbU7wAAAAJ
 Luke Huan,University of Kansas,https://www.ittc.ku.edu/~jhuan,j2PH0Y0AAAAJ
 Luke J. Lee,Univ. of California - Berkeley,http://biopoets.berkeley.edu,xADN4DUAAAAJ
 Luke N. Olson,Univ. of Illinois at Urbana-Champaign,http://lukeo.cs.illinois.edu,o43oc6AAAAAJ

--- a/dblp-aliases.csv
+++ b/dblp-aliases.csv
@@ -1,4 +1,6 @@
 alias,name
+Honza Cernocký,Jan Cernocký
+Jan Honza Cernocký,Jan Cernocký
 Kylie A. Peppler, Kylie Peppler
 William Steiger, William L. Steiger
 A. Min Tjoa,A Min Tjoa


### PR DESCRIPTION
**Inclusion criteria**

- [X] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department. Faculty should also have a 75%+ time appointment (check
`old/industry.csv` for faculty who are now more than 25% in industry).

**Updating an affiliation or home page**

- [X] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings.csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [X] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [X] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [X] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [X] If the institution you are adding is not in the US,
update `country-info.csv`.

