### PR TITLE
Add Diomidis Spinellis, AUEB

### DIFF
--- a/csrankings.csv
+++ b/csrankings.csv
@@ -4800,6 +4800,7 @@ Dino Mandrioli,Politecnico di Milano,http://home.deib.polimi.it/mandriol,NOSCHOL
 Dino Pedreschi,University of Pisa,http://kdd.isti.cnr.it/homes/pedreschi,5efz6osAAAAJ
 Diodato Ferraioli,University of Salerno,http://www.di-srv.unisa.it/~ferraioli,kShuH_AAAAAJ
 Diogo R. Ferreira,Universidade de Lisboa,http://web.tecnico.ulisboa.pt/diogo.ferreira,CSEqKy8AAAAJ
+Diomidis Spinellis,AUEB,https://www.dmst.aueb.gr/dds/,RjXNgA8AAAAJ
 Dionisios N. Pnevmatikatos,NTUA,http://www.cslab.ntua.gr/~pnevmati,TKtxe-UAAAAJ
 Dionisis N. Pnevmatikatos,NTUA,http://www.cslab.ntua.gr/~pnevmati,TKtxe-UAAAAJ
 Dionysis Athanasopoulos,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/IntroducingDionysisAthanasopoulosToTheICTGraduateSchool,pOjDM48AAAAJ


### PR DESCRIPTION
**Inclusion criteria**

- [X] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department. Faculty should also have a 75%+ time appointment (check
`old/industry.csv` for faculty who are now more than 25% in industry).

**Adding one or more faculty members (including an entire department)**

- [X] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings.csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.
