### PR TITLE
fix Bocconi University's country info

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -18,7 +18,7 @@ Ben-Gurion University of the Negev,europe,il
 Bielefeld University,europe,de
 Bilkent University,europe,tr
 Birkbeck University of London,europe,uk
-Bocconi University,europe,il
+Bocconi University,europe,it
 Boğaziçi University,europe,tr
 Brandenburg University of Technology,europe,de
 Brno University of Technology,europe,cz


### PR DESCRIPTION
Bocconi University is in Itally (it) and was incorrectly listed as in Israel (il). (https://en.wikipedia.org/wiki/Bocconi_University)