### PR TITLE
Correct the TVCG issue for VIS 2020 papers

### DIFF
--- a/util/csrankings.py
+++ b/util/csrankings.py
@@ -274,7 +274,7 @@ TOG_SIGGRAPH_Asia_Volume = {2021: (40, 6),
                             }
 
 # TVCG special handling to count only IEEE VIS
-TVCG_Vis_Volume = {2021: (27, 1),
+TVCG_Vis_Volume = {2021: (27, 2),
                    2020: (26, 1),
                    2019: (25, 1),
                    2018: (24, 1),


### PR DESCRIPTION
Emery,

The VIS 2020 papers have been published in the second issue of IEEE TVCG, Vol. 27, instead of the first issue.
- DBLP page for Vol. 27: https://dblp.org/db/journals/tvcg/tvcg27.html
- Preface by PC chairs: https://doi.org/10.1109/TVCG.2020.3033678

This PR doesn't include the regeneration of the DBLP and generated-author-info.csv files. I'm guessing you will be able to more easily regenerate them with the commands.

Thank you!

Cheers,
Minsuk

--
Minsuk Kahng
Assistant Professor
School of Electrical Engineering and Computer Science
Oregon State University
https://minsuk.com