### PR TITLE
Update Faculty at SYSU in csrankings-9.csv

### DIFF
--- a/csrankings-9.csv
+++ b/csrankings-9.csv
@@ -1040,6 +1040,7 @@ Xiaohong Jiang,Zhejiang University,http://mypage.zju.edu.cn/jiangxh,NOSCHOLARPAG
 Xiaohong W. Gao,Middlesex University,http://www.mitime.org,D4AqjAcAAAAJ
 Xiaohu Guo,University of Texas at Dallas,https://www.utdallas.edu/~xxg061000,Y4SdsvsAAAAJ
 Xiaohua Jia,City University of Hong Kong,https://www.cs.cityu.edu.hk/~jia/,L5iEhq0AAAAJ
+Xiaohua Xie,Sun Yat-sen University,http://sdcs.sysu.edu.cn/content/2478,5YZ3kvoAAAAJ
 Xiaohui Gu,North Carolina State University,https://www.csc2.ncsu.edu/faculty/xgu,6K6lvxAAAAAJ
 Xiaohui Liang,University of Massachusetts Boston,http://www.cs.umb.edu/people/Xiaohui_Liang,fzX2e3sAAAAJ
 Xiaohui Liu 0001,Brunel University London,https://www.brunel.ac.uk/people/xiaohui-liu,G9UHfbwAAAAJ


### PR DESCRIPTION
# Contributing to CSrankings

I have added the faculty named Xiaohua Xie at SYSU in csrankings-9.csv. Dr. Xie is a full-time, tenure-track faculty who can solely advise a PhD student in Computer Science.