### PR TITLE
"by country" to "by country/region"

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
 		  Rank 
 		  <label for="regions">institutions in</label>
 		  <select id="regions" name="regions">
-		    <optgroup label="by country">
+		    <optgroup label="by country/region">
 		      <!-- at least 5 institutions in the DB -->
 		      <option value="au">Australia</option>
 		      <option value="at">Austria</option>


### PR DESCRIPTION
Since Hong Kong SAR is not an independent country. 

This may cause ambiguity since the second group is labed by "by region", I recommend change it to "by continent" or "by area",  or change "Hong Kong" to "Hong Kong SAR"


