### PR TITLE
Update csrankings-6.csv

### DIFF
--- a/csrankings-6.csv
+++ b/csrankings-6.csv
@@ -766,6 +766,7 @@ Nalini K. Ratha,University at Buffalo,https://nalini-ratha.github.io,mIPd9DkAAAA
 Nalini Venkatasubramanian,Univ. of California - Irvine,https://www.ics.uci.edu/~nalini,qfCah3sAAAAJ
 Nalvo F. de Almeida Jr,UFMS,https://www.facom.ufms.br/~nalvo,kU9d-GIAAAAJ
 Nam Nguyen,Towson University,https://www.towson.edu/fcsm/departments/computerinfosci/facultystaff/nnguyen.html,aJcBWkgAAAAJ
+Nam Sung Kim,Univ. of Illinois at Urbana-Champaign,https://fast.ece.illinois.edu,iccBxJIAAAAJ&hl
 Nam Wook Kim,Boston College,https://www.namwkim.org,puTV6X0AAAAJ
 Namhoon Lee,UNIST,https://www.robots.ox.ac.uk/~namhoon/,wi9q5T8AAAAJ
 Nan Cao,Tongji University,http://nancao.org,5I0mFcsAAAAJ


### PR DESCRIPTION
Add Nam Sung Kim at the Univ. of Illinois at Urbana-Champaign. Nam Sung Kim was on leave until 12/31/2020 and returned to the full time faculty job at both ECE (and CS affiliate with privilege to be a sole advisor of CS students).
