### PR TITLE
Added Computer Engineering @ University of Peradeniya (ce.pdn.ac.lk)

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -322,6 +322,7 @@ University of Otago,australasia,nz
 University of Ottawa,canada,ca
 University of Oxford,europe,uk
 University of Passau,europe,de
+University of Peradeniya,asia,lk
 University of Pisa, europe,it
 University of Potsdam,europe,de
 University of Queensland,australasia,au

--- a/csrankings-0.csv
+++ b/csrankings-0.csv
@@ -1861,6 +1861,7 @@ Asim Banerjee,DAIICT,http://www.daiict.ac.in/daiict/people/faculty.html,NOSCHOLA
 Asim Karim,LUMS,http://web.lums.edu.pk/~akarim,NXFekJ4AAAAJ
 Asim Zia,University of Vermont,http://www.uvm.edu/~azia,6pQUsD0AAAAJ
 Asish Mukhopadhyay,University of Windsor,http://www.uwindsor.ca/science/computerscience/1053/dr-asish-mukhopadhyay,Up_ZDaAAAAAJ
+Asitha U. Bandaranayake,University of Peradeniya,http://www.ce.pdn.ac.lk/academic-staff/asitha-bandaranayake/,sf6MaF4AAAAJ
 Aslan Askarov,Aarhus University,http://askarov.net,VV78_dMAAAAJ
 Asma Adnane,Loughborough University,https://www.lboro.ac.uk/departments/compsci/staff/academic-teaching/asma-adnane,yNx6iUwAAAAJ
 Assaf J. Kfoury,Boston University,http://www.cs.bu.edu/~kfoury,VpdYemsAAAAJ

--- a/csrankings-1.csv
+++ b/csrankings-1.csv
@@ -1731,6 +1731,7 @@ Dale Reed,University of Illinois at Chicago,https://sites.google.com/site/dalere
 Dale Schuurmans,University of Alberta,https://webdocs.cs.ualberta.ca/~dale,xaQuPloAAAAJ
 Daltro José Nunes,UFRGS,http://inf.ufrgs.br/prosoft,OuE-elAAAAAJ
 Damal Kandadai Arvind,University of Edinburgh,http://www.dcs.ed.ac.uk/home/dka,bfF6L30AAAAJ
+Damayanthi Herath,University of Peradeniya,http://www.ce.pdn.ac.lk/academic-staff/damayanthi-herath/,G2jUV5IAAAAJ
 Damian Dechev,University of Central Florida,http://cse.eecs.ucf.edu/bios/damiandechev.html,qv9FTaIAAAAJ
 Damian Niwinski,University of Warsaw,http://www.mimuw.edu.pl/~niwinski,JZ4771IAAAAJ
 Damiano Spina,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/s/spina-dr-damiano,sLzYrNYAAAAJ

--- a/csrankings-2.csv
+++ b/csrankings-2.csv
@@ -300,6 +300,7 @@ Dexter Kozen,Cornell University,http://www.cs.cornell.edu/~kozen,LV1qWjgAAAAJ
 Deying Li,Renmin University of China,http://info.ruc.edu.cn/academic_professor.php?teacher_id=60,NOSCHOLARPAGE
 Dezhen Song,Texas A&M University,http://faculty.cs.tamu.edu/dzsong,jdSlREMAAAAJ
 Dhabaleswar K. Panda,Ohio State University,http://web.cse.ohio-state.edu/~panda,7FXtL98AAAAJ
+Dhammika Elkaduwe,University of Peradeniya,http://www.ce.pdn.ac.lk/academic-staff/dhammika-elkaduwe/,zLUPMFkAAAAJ
 Dhananjay M. Dhamdhere,IIT Bombay,https://www.cse.iitb.ac.in/~dmd,NOSCHOLARPAGE
 Dhananjay Phatak,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~phatak,NOSCHOLARPAGE
 Dharanipragada Janakiram,IIT Madras,http://dos.iitm.ac.in/djwebsite,zxpFxq8AAAAJ

--- a/csrankings-3.csv
+++ b/csrankings-3.csv
@@ -1567,6 +1567,7 @@ Issa Batarseh,University of Central Florida,http://www.cecs.ucf.edu/faculty/issa
 Issei Fujishiro,Keio University,https://www.st.keio.ac.jp/en/tprofile/ics/fujishiro.html,0bnysWMAAAAJ
 Issei Sato,University of Tokyo,http://www.ms.k.u-tokyo.ac.jp/sato,NOSCHOLARPAGE
 István Gergely Czibula,Babeș-Bolyai University,http://www.cs.ubbcluj.ro/~istvanc,eSWofb8AAAAJ
+Isuru Nawinne,University of Peradeniya,http://www.ce.pdn.ac.lk/academic-staff/isuru-nawinne/,8qqGvuwAAAAJ
 Itai Arieli,Technion,https://web.iem.technion.ac.il/en/people/userprofile/iarieli.html,NVteqa8AAAAJ
 Itamar Arel,University of Tennessee,http://www.eecs.utk.edu/people/faculty/ielhanan,wivIgKkAAAAJ
 Itaru Kitahara,University of Tsukuba,https://sites.google.com/image.iit.tsukuba.ac.jp/kitahara,mphxDdYAAAAJ
@@ -2001,6 +2002,7 @@ Jana Koehler,Saarland University,https://www.dfki.de/en/web/about-us/employee/pe
 Jana Kosecka,George Mason University,https://cs.gmu.edu/~kosecka,sQ6l4sMAAAAJ
 Jana Kosecká,George Mason University,https://cs.gmu.edu/~kosecka,sQ6l4sMAAAAJ
 Janaina Mourão Miranda,University College London,https://iris.ucl.ac.uk/iris/browse/profile?upi=JMOUR63,CeWaBjcAAAAJ
+Janaka Alawatugoda,University of Peradeniya,http://www.ce.pdn.ac.lk/academic-staff/janaka-alawatugoda/,TJWRzj4AAAAJ
 Janaki Srinivasan,IIIT Bangalore,https://janakisrinivasan.wordpress.com,_SN8PK8AAAAJ
 Janakiram Dharanipragada,IIT Madras,http://dos.iitm.ac.in/djwebsite,zxpFxq8AAAAJ
 Janardhan Rao Doppa,Washington State University,http://eecs.wsu.edu/~jana,x2mdFuwAAAAJ

--- a/csrankings-4.csv
+++ b/csrankings-4.csv
@@ -1522,6 +1522,7 @@ Kamal Deep Singh,Université Jean Monnet,https://laboratoirehubertcurien.univ-st
 Kamal Lodaya,IMSc,http://www.imsc.res.in/%7Ekamal,NOSCHOLARPAGE
 Kamal M. Jambi,King Abdulaziz University,http://www.kau.edu.sa/CVEn.aspx?Site_ID=0001480&Lng=EN,NOSCHOLARPAGE
 Kamalakar Karlapalem,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/kamal,bEZqpLsAAAAJ
+Kamalanath Samarakoon,University of Peradeniya,http://samarakoon.info,DsG-K0sAAAAJ
 Kamalika Chaudhuri,Univ. of California - San Diego,http://cseweb.ucsd.edu/~kamalika,I-DJ7EsAAAAJ
 Kambiz Ghazinour,Kent State University,https://www.kent.edu/cs/profile/kambiz-ghazinour,S5Dabo0AAAAJ
 Kamer Kaya,Sabancı University,http://people.sabanciuniv.edu/kaya,cFJGW7gAAAAJ

--- a/csrankings-5.csv
+++ b/csrankings-5.csv
@@ -963,6 +963,7 @@ Manish Shrivastava 0001,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/m.s
 Manish Singh 0001,Rutgers University,https://ruccs.rutgers.edu/manish,9XRvM88AAAAJ
 Manish Singh 0002,IIT Hyderabad,https://www.iith.ac.in/~msingh,I1jX5vgAAAAJ
 Manja Marz,Friedrich Schiller University Jena,http://www.rna.uni-jena.de,NOSCHOLARPAGE
+Manjula Sandirigama,University of Peradeniya,http://www.ce.pdn.ac.lk/academic-staff/manjula-sandirigama/,qpmlrL0AAAAJ
 Manjunath V. Joshi,DAIICT,http://www.daiict.ac.in/daiict/people/faculty.html,iDqnnKkAAAAJ
 Manmohan Chandraker,Univ. of California - San Diego,http://cseweb.ucsd.edu/~mkchandraker,oPFCNk4AAAAJ
 Manmohan Krishna Chandraker,Univ. of California - San Diego,http://cseweb.ucsd.edu/~mkchandraker,oPFCNk4AAAAJ

--- a/csrankings-7.csv
+++ b/csrankings-7.csv
@@ -1453,6 +1453,7 @@ Rose Yu,Univ. of California - San Diego,http://roseyu.com,4HTITaMAAAAJ
 Roseli A. F. Romero,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/rafrance,pdtTa-8AAAAJ
 Roseli A. Francelin Romero,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/rafrance,pdtTa-8AAAAJ
 Roseli Aparecida Francelin Romero,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/rafrance,pdtTa-8AAAAJ
+Roshan G. Ragel,University of Peradeniya,http://roshan.ragel.net,UTYj8usAAAAJ
 Rosli Salleh,University of Malaya,https://umexpert.um.edu.my/rosli_salleh,6SFSABkAAAAJ
 Ross Anderson,University of Cambridge,https://www.cl.cam.ac.uk/~rja14,WgyDcoUAAAAJ
 Ross D. King,University of Manchester,https://www.research.manchester.ac.uk/portal/ross.king.html,BgZp7XcAAAAJ
@@ -1627,6 +1628,7 @@ S. Bapi Raju,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/rajubapi,bbSYy
 S. Ben Slimane,KTH Royal Institute of Technology,https://www.kth.se/profile/slimane,zSfzj6sAAAAJ
 S. C. Cheung,HKUST,https://www.cse.ust.hk/~scc,5RIgb3wAAAAJ
 S. C. Mukhopadhyay,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=265530,fsu2yL8AAAAJ
+S. D. Dewasurendra,University of Peradeniya,http://www.ce.pdn.ac.lk/academic-staff/shirley-devapriya-dewasurendra/,tRp6g8EAAAAJ
 S. Dov Gordon,George Mason University,http://cs.gmu.edu/~gordon,NOSCHOLARPAGE
 S. E. M. O'Keefe,University of York,https://www-users.cs.york.ac.uk/~sok,QL1JHlUAAAAJ
 S. Hamed Hassani,University of Pennsylvania,https://www.seas.upenn.edu/~hassani,NOSCHOLARPAGE
@@ -1767,6 +1769,7 @@ Samira Sadaoui,University of Regina,http://www.cs.uregina.ca/People/Profiles/Sam
 Samira Shaikh,UNC - Charlotte,https://analyticsfrontiers.uncc.edu/speakers/samira-shaikh,IM-64IoAAAAJ
 Samit Bhattacharya,IIT Guwahati,http://www.iitg.ernet.in/samit,oXu5o6gAAAAJ
 Sampalli Srinivas,Dalhousie University,https://web.cs.dal.ca/~srini,NOSCHOLARPAGE
+Sampath Deegalla,University of Peradeniya,http://www.ce.pdn.ac.lk/academic-staff/d-s-deegalla/,QDoeGtYAAAAJ
 Sampath Kannan,University of Pennsylvania,https://www.cis.upenn.edu/~kannan,aiPgs4oAAAAJ
 Sampsa Hyysalo,Aalto University,https://inuse.fi/people/sampsa-hyysalo,Uzl_pPYAAAAJ
 Samrat Mondal,IIT Patna,https://iitp.ac.in/index.php/departments/engineering/computer-science-a-engineering/people/faculty/dr-samrat-mondal.html,NOSCHOLARPAGE

--- a/csrankings-8.csv
+++ b/csrankings-8.csv
@@ -1120,6 +1120,7 @@ Sundaram Suresh,Nanyang Technological University,http://www.ntu.edu.sg/home/ssun
 Sundaresan Raman,BITS Pilani,http://www.bits-pilani.ac.in/pilani/sundaresanraman/profile,NOSCHOLARPAGE
 Sune Darkner,University of Copenhagen,http://www.diku.dk/english/staff/?pure=en/persons/383640,Z_bvPmcAAAAJ
 Sune Lehmann Jørgensen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
+Suneth Namal,University of Peradeniya,http://www.ce.pdn.ac.lk/academic-staff/suneth-namal-karunarathna/,G39TP7EAAAAJ
 Sung Ju Hwang,KAIST,http://www.sungjuhwang.com,RP4Qx3QAAAAJ
 Sung Whan Yoon,UNIST,https://sites.google.com/view/swyoon89,6RwONs0AAAAJ
 Sung Woo Chung,Korea University,http://smrl.korea.ac.kr/bbs/professor_biographical_sketch.php,njN9VcoAAAAJ
@@ -1259,6 +1260,7 @@ Swamit S. Tannu,University of Wisconsin - Madison,https://swamittannu.com/,ODZP7
 Swapna Gokhale,University of Connecticut,http://www.cse.uconn.edu/~ssg,2wOZImMAAAAJ
 Swaprava Nath,IIT Kanpur,https://www.cse.iitk.ac.in/users/swaprava,NOSCHOLARPAGE
 Swarat Chaudhuri,University of Texas at Austin,https://www.cs.utexas.edu/~swarat,9j6RBYQAAAAJ
+Swarnalatha Radhakrishnan,University of Peradeniya,http://www.ce.pdn.ac.lk/academic-staff/swarnalatha-radhakrishnan/,SN6DXkUAAAAJ
 Swarun Kumar,Carnegie Mellon University,https://swarunkumar.com,WfaqxlgAAAAJ
 Swastik Kopparty,Rutgers University,http://www.math.rutgers.edu/~sk1233,NOSCHOLARPAGE
 Swen Jacobs,CISPA Helmholtz Center,https://www.react.uni-saarland.de/people/jacobs.html,pofIiPIAAAAJ

--- a/csrankings-9.csv
+++ b/csrankings-9.csv
@@ -22,6 +22,7 @@ Umut A. Acar,Carnegie Mellon University,http://www.umut-acar.org,wJ4NywgAAAAJ
 Un-Ku Moon,Oregon State University,http://web.engr.oregonstate.edu/~moon,NOSCHOLARPAGE
 Unaizah Hanum Binti Obaidellah,University of Malaya,https://umexpert.um.edu.my/unaizah,NOSCHOLARPAGE
 Uno Holmer,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/holmer.aspx,NOSCHOLARPAGE
+Upul Jayasinghe,University of Peradeniya,http://www.ce.pdn.ac.lk/upul/,9nBn4b0AAAAJ
 Upulee Kanewala,Montana State University,https://www.cs.montana.edu/directory/1812043/upulee-kanewala,WIG-usAAAAAJ
 Uri C. Weiser,Technion,http://webee.technion.ac.il/people/weiser,ctN8BtoAAAAJ
 Uri M. Ascher,University of British Columbia,https://www.cs.ubc.ca/~ascher,eX08ztMAAAAJ


### PR DESCRIPTION
Added University of Peradeniya to the country-info.csv. Added the academic staff of the Department of Computer Engineering, University of Peradeniya www.ce.pdn.ac.lk (PhD holders who can supervise a student for a CS PhD) to the respective csv files. TO DO: Add the academic staff of the Department of Statistics and Computer Science to the files.