### PR TITLE
Add R. Stuart Geiger (UC San Diego)

### DIFF
--- a/csrankings-7.csv
+++ b/csrankings-7.csv
@@ -381,6 +381,7 @@ R. Ryan Williams,Massachusetts Institute of Technology,http://web.stanford.edu/~
 R. S. Meir,Technion,https://ronmeir.net.technion.ac.il,r3NAa9oAAAAJ
 R. Sekar 0001,Stony Brook University,http://seclab.cs.sunysb.edu/sekar,FBIbhGoAAAAJ
 R. Sharathkumar,Virginia Tech,http://people.cs.vt.edu/~sharathr,kOfRa7MAAAAJ
+R. Stuart Geiger,Univ. of California - San Diego,https://stuartgeiger.com,0AvWi3wAAAAJ 
 R. V. Dantu,University of North Texas,http://www.cse.unt.edu/~rdantu/index.html,NOSCHOLARPAGE
 R. Venkatesha Prasad,TU Delft,http://homepage.tudelft.nl/w5p50,9RVkIfsAAAAJ
 R.C. Hansdah,IISc Bangalore,http://www.csa.iisc.ac.in/people/people-faculty-hansdah.html,ZxBF_lUAAAAJ


### PR DESCRIPTION
**Inclusion criteria**

- [X] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track research
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department. Faculty should also have a 75%+ time appointment (check
`old/industry.csv` for faculty who are now more than 25% in industry).

See: https://cse.ucsd.edu/people/faculty-profiles/affiliated

**Updating an affiliation or home page**

- [N/A] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings-[0-9].csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [N/A] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [X] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings-[0-9].csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [N/A] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [N/A] If the institution you are adding is not in the US,
update `country-info.csv`.


