### PR TITLE
Updated faculty at Goethe University Frankfurt.

### DIFF
--- a/csrankings-3.csv
+++ b/csrankings-3.csv
@@ -939,6 +939,7 @@ Hien Quoc Ngo,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Con
 Hilbert J. Kappen,Radboud University,http://www.snn.ru.nl/~bertk,JSkBINwAAAAJ
 Hilda Tellioglu,TU Wien,http://hildatellioglu.com,NOSCHOLARPAGE
 Hilda Tellioğlu,TU Wien,http://hildatellioglu.com,NOSCHOLARPAGE
+Hilde Kuehne,Goethe University Frankfurt,https://hildekuehne.github.io/,pxhCcH0AAAAJ
 Hilmi R. Dajani,University of Ottawa,https://engineering.uottawa.ca/eecs/people/dajani-hilmi,NOSCHOLARPAGE
 Himanshu Gupta,Stony Brook University,http://www3.cs.stonybrook.edu/~hgupta,3a-0dbMAAAAJ
 Hing Leung,New Mexico State University,http://www.cs.nmsu.edu/~hleung,LunDJDMAAAAJ
@@ -986,7 +987,7 @@ Hoda Naghibijouybari,Binghamton University,https://www.binghamton.edu/computer-s
 Hoeteck Wee,Ecole Normale Superieure,http://www.di.ens.fr/~wee,lG7aUrkAAAAJ
 Hojung Cha,Yonsei University,https://mobed.yonsei.ac.kr/index.php?mid=People,B3CtxsAAAAAJ
 Holger Blume,University of Hannover,https://www.ims.uni-hannover.de/blume.html?&no_cache=1,CnRN40sAAAAJ
-Holger Dell,IT University of Copenhagen,https://pure.itu.dk/portal/da/persons/holger-dell(ef9b447a-d6c4-4250-a506-093730db84d6).html,zcZSZ4MAAAAJ
+Holger Dell,Goethe University Frankfurt,https://holgerdell.com,zcZSZ4MAAAAJ
 Holger Fröning,Heidelberg University,http://www.ziti.uni-heidelberg.de/ziti/en/ce-home,zToBrYIAAAAJ
 Holger Giese,Hasso Plattner Institute,https://hpi.de/en/the-hpi/people/professors/prof-dr-holger-giese.html,tbVxns0AAAAJ
 Holger H. Hoos,University of British Columbia,http://www.cs.ubc.ca/~hoos,l6c85tMAAAAJ

--- a/csrankings-5.csv
+++ b/csrankings-5.csv
@@ -264,6 +264,7 @@ Leliane Nunes de Barros,USP,http://www.ime.usp.br/~leliane,CqqZ8b0AAAAJ
 Len Adleman,University of Southern California,https://www.usc.edu/dept/molecular-science/fm-adleman.htm,NOSCHOLARPAGE
 Lena Mashayekhy,University of Delaware,https://www.eecis.udel.edu/lena,b9gs2WYAAAAJ
 Lena Peterson,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/lenap.aspx,NOSCHOLARPAGE
+Lena Wiese,Goethe University Frankfurt,http://wiese.free.fr/,NOSCHOLARPAGE
 Lenhart K. Schubert,University of Rochester,https://www.cs.rochester.edu/~schubert,NOSCHOLARPAGE
 Lennart Johnsson,University of Houston,http://www2.cs.uh.edu/~johnsson,Sm6LugIAAAAJ
 Lenore Blum,Carnegie Mellon University,http://www.cs.cmu.edu/~lblum,NOSCHOLARPAGE
@@ -1054,6 +1055,7 @@ Marc de Kamps,University of Leeds,https://eps.leeds.ac.uk/computing/staff/390/dr
 Marcel A. J. van Gerven,Radboud University,https://www.ru.nl/english/people/gerven-m-van,sX0ZypwAAAAJ
 Marcel Böhme,Monash University,https://mboehme.github.io,cWmLE6oAAAAJ
 Marcel Campen,University of Osnabrück,http://graphics.cs.uos.de,KMgjzh4AAAAJ
+Marcel H. Schulz,Goethe University Frankfurt,https://schulzlab.github.io/MS.html,HgLyxaEAAAAJ
 Marcel J. T. Reinders,TU Delft,https://www.tudelft.nl/ewi/over-de-faculteit/afdelingen/intelligent-systems/pattern-recognition-bioinformatics/the-delft-bioinformatics-lab/people/marcel-reinders,h52_bg0AAAAJ
 Marcel Jackowski,USP,https://www.ime.usp.br/~mjack/Welcome.html,WEBkqvcAAAAJ
 Marcel Kenji de Carli Silva,USP,http://www.ime.usp.br/~mkenji,NOSCHOLARPAGE


### PR DESCRIPTION
**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track research
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department. Faculty should also have a 75%+ time appointment (check
`old/industry.csv` for faculty who are now more than 25% in industry).

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings-[0-9].csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings-[0-9].csv`; include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [x] If the institution you are adding is not in the US,
update `country-info.csv`.
