### PR TITLE
Affiliation change for Lior Wolf: from industry to Tal Aviv University

### DIFF
--- a/csrankings-5.csv
+++ b/csrankings-5.csv
@@ -492,6 +492,7 @@ Lionel Robert Morel,Ecole Normale Superieure de Lyon,http://lionel.morel.ouvaton
 Lionel Seinturier,CRIStAL,http://chercheurs.lille.inria.fr/~seinturi,XmiDIkYAAAAJ
 Lior Pachter,California Institute of Technology,http://pachterlab.github.io/biography.html,DKfEcuEAAAAJ
 Lior Shamir,Kansas State University,http://people.cs.ksu.edu/~lshamir,mP-0XmYAAAAJ
+Lior Wolf,Tel Aviv University,http://www.cs.tau.ac.il/~wolf/,UbFrXTsAAAAJ
 Liping Shen,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/~shen-lp,NOSCHOLARPAGE
 Lipyeow Lim,University of Hawaii at Manoa,http://www2.hawaii.edu/~lipyeow,_ILTBg0AAAAJ
 Liqiang Nie,Shandong University,http://ir.sdu.edu.cn/~liqiangnie/index.html,yywVMhUAAAAJ

--- a/old/industry.csv
+++ b/old/industry.csv
@@ -3,7 +3,6 @@ Manuela M. Veloso,Carnegie Mellon University,https://www.cs.cmu.edu/~mmv/,2FbkAz
 Abhinav Gupta 0001,Carnegie Mellon University,http://www.cs.cmu.edu/~abhinavg/,bqL73OkAAAAJ,TBD
 Jessica K. Hodgins,Carnegie Mellon University,http://www.cs.cmu.edu/~jkh/,vswo4rQAAAAJ,TBD
 Pascal Vincent,University of Montreal,https://www.iro.umontreal.ca/~vincentp/,WBCKQMsAAAAJ,TBD
-Lior Wolf,Tel Aviv University,http://www.cs.tau.ac.il/~wolf/,UbFrXTsAAAAJ,TBD
 Robert Fergus,New York University,http://cs.nyu.edu/fergus/,GgQ9GEkAAAAJ,TBD
 KyungHyun Cho,New York University,http://www.kyunghyuncho.me/,0RAmmIAAAAAJ,TBD
 Kyunghyun Cho,New York University,http://www.kyunghyuncho.me/,0RAmmIAAAAAJ,TBD


### PR DESCRIPTION
Updating csranking-5.csv to add Lior Wolf, and removing Lior from old/industry.csv