### PR TITLE
Add or modify some professors into Harbin Institute of Technology. 

### DIFF
--- a/csrankings-1.csv
+++ b/csrankings-1.csv
@@ -514,7 +514,7 @@ Burkhard Stiller,University of Zurich,http://www.csg.uzh.ch/staff/stiller.html,N
 Burkhard Wuensche,University of Auckland,https://www.cs.auckland.ac.nz/~burkhard,pgBZIHYAAAAJ
 Burkhard Wünsche,University of Auckland,https://www.cs.auckland.ac.nz/~burkhard,pgBZIHYAAAAJ
 Burton Rosenberg,University of Miami,http://www.cs.miami.edu/~burt,NOSCHOLARPAGE
-Buzou Tang,Harbin Institute of Technology,http://www.hitsz.edu.cn/teacher/view/id-1166.html,5oGXsxUAAAAJ
+Buzhou Tang,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/tangbuzhou,5oGXsxUAAAAJ
 Byoung-Tak Zhang,Seoul National University,https://bi.snu.ac.kr/~btzhang,sYTUOu8AAAAJ
 Byoungyoung Lee,Seoul National University,https://lifeasageek.github.io,AoDgrKIAAAAJ
 Byrav Ramamurthy,University of Nebraska,http://cse.unl.edu/~byrav,Moj2TLMAAAAJ
@@ -1050,6 +1050,7 @@ Chong-kwon Kim,Seoul National University,http://popeye.snu.ac.kr,KRykCKkAAAAJ
 Chongjie Zhang,Tsinghua University,http://iiis.tsinghua.edu.cn/~zhang,LjxqXycAAAAJ
 Chongjun Wang,Nanjing University,https://hpi.de/en/research/research-school/international-branches/nanjing-university.html,NOSCHOLARPAGE
 Chongkwon Kim,Seoul National University,http://popeye.snu.ac.kr,KRykCKkAAAAJ
+Chonglin Gu,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/guchonglin,U-IvTQYAAAAJ
 Chongyan Gu,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=C.Gu,Vz8tGc8AAAAJ
 Choonhwa Lee,Hanyang University,http://dcc.hanyang.ac.kr/members.htm,NOSCHOLARPAGE
 Chris Amato,Northeastern University,http://www.ccs.neu.edu/home/camato,-8-sD-sAAAAJ
@@ -1367,6 +1368,7 @@ Chuan Lu,Aberystwyth University,https://www.aber.ac.uk/en/cs/staff-profiles/list
 Chuan Wu 0001,University of Hong Kong,https://i.cs.hku.hk/~cwu,mY7MWXMAAAAJ
 Chuan Yue,Colorado School of Mines,https://inside.mines.edu/~chuanyue,r4nMOKsAAAAJ
 Chuan-Ching Sue,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/depmember/teacherdetail/id/20,NOSCHOLARPAGE
+Chuanyi Liu,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/liuchuanyi,Aec7FSQAAAAJ
 Chubo Liu,Hunan University,http://csee.hnu.edu.cn/people/liuchubo,NOSCHOLARPAGE
 Chuck Hansen,University of Utah,https://www.cs.utah.edu/~hansen,UqyaAQQAAAAJ
 Chuck Yoo,Korea University,https://os.korea.ac.kr/?page_id=184,NOSCHOLARPAGE
@@ -1639,6 +1641,7 @@ Cruz Izu,University of Adelaide,http://www.adelaide.edu.au/directory/cruz.izu,7H
 Crystal Hepp,Northern Arizona University,https://nau.edu/siccs/faculty/crystal-hepp,sZUrRioAAAAJ
 Csaba Szepesvári,University of Alberta,https://www.ualberta.ca/~szepesva,zvC19mQAAAAJ
 Csilla Farkas,University of South Carolina,https://cse.sc.edu/~farkas,rDJjJgoAAAAJ
+Cuiyun Gao,Harbin Institute of Technology,https://cuiyungao.github.io/,9I2hTmQAAAAJ
 Cuncong Zhong,University of Kansas,http://www.eecs.ku.edu/people/faculty,p19oGdoAAAAJ
 Cuneyt Gurcan Akcora,University of Manitoba,https://cakcora.github.io,QZLZSb8AAAAJ
 Cunjin Luo,University of Essex,https://www.essex.ac.uk/people/luocu65405/cunjin-luo,NOSCHOLARPAGE

--- a/csrankings-2.csv
+++ b/csrankings-2.csv
@@ -1438,6 +1438,7 @@ Fang Li 0001,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/~li-fang,U3
 Fang Liu 0002,Hunan University,http://design.hnu.edu.cn/info/1023/5787.htm,PXo2aVUAAAAJ
 Fang Song 0001,Portland State University,https://fangsong.info,A6C3geAAAAAJ
 Fangju Wang,University of Guelph,https://www.uoguelph.ca/computing/people/fangju-wang,NOSCHOLARPAGE
+Fanglin Chen,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/chenfanglin,viaT8ZMAAAAJ
 Fangmin Song,Nanjing University,http://www.easychair.org/smart-program/VSL2014/person4653.html,NOSCHOLARPAGE
 Fangtian Ying,Zhejiang University,http://mypage.zju.edu.cn/0094123,NOSCHOLARPAGE
 Fangxing Li,University of Tennessee,http://web.eecs.utk.edu/~fli6,Xlzr3HMAAAAJ

--- a/csrankings-3.csv
+++ b/csrankings-3.csv
@@ -279,6 +279,7 @@ Guang Song,Iowa State University,http://www.cs.iastate.edu/people/guang-song,wB7
 Guang-Zhong Yang,Imperial College London,http://www.imperial.ac.uk/people/g.z.yang,NOSCHOLARPAGE
 Guanghui Liu,UESTC,http://faculty.uestc.edu.cn/liuguanghui/en/index.htm,AjfD95EAAAAJ
 Guanghui Wang,University of Kansas,http://www.ittc.ku.edu/~ghwang,i3-AnE0AAAAJ
+Guangming Lu,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/luguangming,fhwB7UwAAAAJ
 Guangquan Zhang 0001,University of Technology Sydney,https://www.uts.edu.au/staff/guangquan.zhang,_1RMrhsAAAAJ
 Guangtao Xue,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/~xue-gt,vTC9TSQAAAAJ
 Guangwen Yang,Tsinghua University,http://www.tsinghua.edu.cn/publish/csen/4623/2010/20101224195554390212530/20101224195554390212530_.html,NOSCHOLARPAGE
@@ -480,6 +481,7 @@ Haifeng Liu,Zhejiang University,http://mypage.zju.edu.cn/hfliu,oW108fUAAAAJ
 Haifeng Xu,University of Virginia,https://engineering.virginia.edu/faculty/haifeng-xu,nLgg388AAAAJ
 Haifeng Yu,National University of Singapore,https://www.comp.nus.edu.sg/~yuhf,IDxePZ0AAAAJ
 Haijun Xia,Univ. of California - San Diego,https://haijunxia.ucsd.edu,8U4q0sIAAAAJ
+Haijun Zhang,Harbin Institute of Technology,https://www.dl2link.com/,XEiWEDAAAAAJ
 Haiko Müller,University of Leeds,https://eps.leeds.ac.uk/computing/staff/241/dr-haiko-muller,NOSCHOLARPAGE
 Hailong Sun 0001,Beihang University,http://act.buaa.edu.cn/hsun,HWOWCdcAAAAJ
 Hailong Yao,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101225165537258353872/20101225165537258353872_.html,n0NwuegAAAAJ
@@ -806,6 +808,7 @@ Heinz Handels,University of Lübeck,https://www.imi.uni-luebeck.de/~handels,39hY
 Heinz Ulrich Hoppe,University of Duisburg-Essen,https://www.collide.info/de/mitarbeiter,NOSCHOLARPAGE
 Heinz W. Schmidt,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/s/schmidt-professor-heinrich,FEgaS_sAAAAJ
 Heji Zhao,Shandong University,http://www.cs.sdu.edu.cn/info/1091/2351.htm,NOSCHOLARPAGE
+Hejiao Huang,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/huanghejiao,PmzR0l0AAAAJ
 Helen C. Miles,Aberystwyth University,https://www.aber.ac.uk/en/cs/staff-profiles/listing/profile/hem23,OWuu1f0AAAAJ
 Helen C. Purchase,University of Glasgow,http://www.dcs.gla.ac.uk/~hcp,4I7Q3nEAAAAJ
 Helen C. Shen,HKUST,http://repository.ust.hk/ir/AuthorProfile/shen-helen-c-m,NOSCHOLARPAGE
@@ -1048,6 +1051,7 @@ Hongping Cai,University of Exeter,http://emps.exeter.ac.uk/computer-science/staf
 Hongseok Yang,KAIST,https://cs.kaist.ac.kr/people/view?idx=552&kind=faculty&menu=167,cLuwH14AAAAJ
 Hongtao Lu,Shanghai Jiao Tong University,http://english.seiee.sjtu.edu.cn/english/detail/841_674.htm,GtNuBJcAAAAJ
 Hongteng Xu,Renmin University of China,https://sites.google.com/view/hongtengxu,7gYVOO8AAAAJ
+Hongwei Du,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/duhongwei,sObwxHAAAAAJ
 Hongwei Li,UESTC,http://222.197.183.99/TutorDetails.aspx?id=3637,-o6u2gwAAAAJ
 Hongwei Xi,Boston University,https://www.cs.bu.edu/~hwxi,1mMmqs4AAAAJ
 Hongxin Hu,University at Buffalo,https://cse.buffalo.edu/~hongxinh/,fQQXj1oAAAAJ

--- a/csrankings-4.csv
+++ b/csrankings-4.csv
@@ -239,6 +239,7 @@ Jiang Yu Zheng,IUPUI,http://cs.iupui.edu/~jzheng,Gih-kpUAAAAJ
 Jiangchuan Liu,Simon Fraser University,http://www.cs.sfu.ca/~jcliu,VU2Jw1YAAAAJ
 Jiangfan Yi,Peking University,http://eecs.pku.edu.cn/EN/People/Faculty/Detail/?ID=6016,NOSCHOLARPAGE
 Jiangfeng Li,Tongji University,https://sse.tongji.edu.cn/lijiangfeng,NOSCHOLARPAGE
+Jianghong Ma,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/majianghong,9ZQQqasAAAAJ
 Jiangtao Wang,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/people/jiangtao-wang,9uIhuHkAAAAJ
 Jiangtao Wen,Tsinghua University,http://media.cs.tsinghua.edu.cn/en/wenjt,KTYQRzYAAAAJ
 Jianguo Lu,University of Windsor,http://www.uwindsor.ca/science/computerscience/1051/dr-jianguo-lu,PfF0D0sAAAAJ
@@ -317,6 +318,7 @@ Jie Shen 0005,Stevens Institute of Technology,https://sites.google.com/site/jies
 Jie Tang 0001,Tsinghua University,http://keg.cs.tsinghua.edu.cn/jietang,n1zDCkQAAAAJ
 Jie Wang 0002,University of Massachusetts Lowell,http://www.cs.uml.edu/~wang,5tvHmuMAAAAJ
 Jie Wei,CUNY,https://www.ccny.cuny.edu/profiles/jie-wei,VOuKF7sAAAAJ
+Jie Wen,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/majianghong,https://sites.google.com/view/jerry-wen-hit/home,bsTnbo4AAAAJ
 Jie Wu 0001,Temple University,https://cis.temple.edu/~wu,BVlfmXMAAAAJ
 Jie Wu 0003,Fudan University,http://www.cs.fudan.edu.cn/en/?page_id=2258,NOSCHOLARPAGE
 Jie Xiong 0001,University of Massachusetts Amherst,https://people.cs.umass.edu/~jxiong,GR9VzaMAAAAJ
@@ -433,6 +435,7 @@ Jinguang Han,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Conn
 Jingwei Li,UESTC,https://jingwei87.github.io,uSv67rIAAAAJ
 Jingwen Leng,Shanghai Jiao Tong University,http://www.jingwenleng.com/home/me.html,L1y8y2MAAAAJ
 Jingyi Yu,ShanghaiTech University,http://www.yu-jingyi.com/cv/,R9L_AfQAAAAJ
+Jingyong Su,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/sujingyong,T8YbHBwAAAAJ
 Jingyuan Wang,Beihang University,https://www.bigscity.com/jingyuan-wang,qsLImx8AAAAJ
 Jingyuan Zhang,The University of Alabama,http://zhang.cs.ua.edu,NOSCHOLARPAGE
 Jingyue Li,NTNU,https://www.ntnu.edu/employees/jingyue.li,ZeBM3ZAAAAAJ
@@ -455,6 +458,7 @@ Jinwoo Shin,KAIST,http://alinlab.kaist.ac.kr/shin.html,m3eDp7kAAAAJ
 Jinwook Seo,Seoul National University,http://hcil.snu.ac.kr,K1GtDBEAAAAJ
 Jinxi Zhao,Nanjing University,https://cs.nju.edu.cn/zhaojinxi,NOSCHOLARPAGE
 Jinxiang Chai,Texas A&M University,http://faculty.cs.tamu.edu/jchai,OcN1_gwAAAAJ
+Jinxing Li,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/lijinxing,i4I4hIEAAAAJ
 Jinya Su,University of Essex,https://www.essex.ac.uk/people/sujin68001/jinya-su,tTfMHMoAAAAJ
 Jinyang Li 0001,New York University,http://www.cs.nyu.edu/~jinyang,MrWIWNwAAAAJ
 Jinyoung Yeo,Yonsei University,http://convei.weebly.com/people.html,Qzv5wTAAAAAJ
@@ -1324,6 +1328,7 @@ Junichi Suzuki,University of Massachusetts Boston,https://www.umb.edu/academics/
 Junichi Yamaoka,Keio University,https://www.junichiyamaoka.net,x21UmG0AAAAJ
 Junier B. Oliva,University of North Carolina,https://sites.google.com/cs.unc.edu/joliva/home,CqH_t6MAAAAJ
 Junior Barrera,USP,http://www.ime.usp.br/~jb,NbfbLAwAAAAJ
+Junjie Chen,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/chenjunjie,JbR3hSwAAAAJ
 Junjie Wang 0001,Chinese Academy of Sciences,http://people.ucas.edu.cn/~jwang2015,FkLKCRMAAAAJ
 Junliang Xing,Chinese Academy of Sciences,https://sites.google.com/site/junliangxing,jSwNd3MAAAAJ
 Junlin Lu,Peking University,http://eecs.pku.edu.cn/EN/People/Faculty/Detail/?ID=5937,NOSCHOLARPAGE
@@ -1334,6 +1339,7 @@ Junqing Zhang,University of Liverpool,https://liverpool.ac.uk/electrical-enginee
 Junsong Yuan,University at Buffalo,https://cse.buffalo.edu/~jsyuan,fJ7seq0AAAAJ
 Junwei Han,NWPU,http://www.escience.cn/people/JunweiHan/index.html,xrqsoesAAAAJ
 Junya Honda,University of Tokyo,http://www.it.k.u-tokyo.ac.jp/~honda/index_e.html,NOSCHOLARPAGE
+Junyi Li,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/lijunyi,jOaVp9oAAAAJ
 Junyong Noh,KAIST,https://ct.kaist.ac.kr/people/sub01.php,NOSCHOLARPAGE
 Junyu Niu,Fudan University,http://www.cs.fudan.edu.cn/?page_id=2132,NOSCHOLARPAGE
 Junyu Xuan,University of Technology Sydney,https://www.uts.edu.au/staff/junyu.xuan,POQ_yJUAAAAJ
@@ -1460,6 +1466,7 @@ K. V. Rashmi,Carnegie Mellon University,http://www.cs.cmu.edu/~rvinayak,gUO59T8A
 K. V. S. Prasad,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/prasad.aspx,NOSCHOLARPAGE
 K. V. Subrahmanyam 0001,CMI,http://www.cmi.ac.in/~kv,pxVeS_IAAAAJ
 K. Vijay-Shanker,University of Delaware,https://www.eecis.udel.edu/~vijay,O1l6JGkAAAAJ
+Ka-Cheong Leung,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/liangjiachang,SIW8KEcAAAAJ
 Ka-Chun Wong,City University of Hong Kong,http://www.cs.utoronto.ca/~wkc/,nZH_Ws8AAAAJ
 Ka-man Lam,University of Hong Kong,https://www.cs.hku.hk/index.php/people/academic-staff/kmlam,NOSCHOLARPAGE
 Kadangode K. Ramakrishnan,Univ. of California - Riverside,http://www.cs.ucr.edu/~kk,Da-s1FQAAAAJ

--- a/csrankings-7.csv
+++ b/csrankings-7.csv
@@ -315,6 +315,7 @@ Qing Gu,Nanjing University,https://www.facebook.com/public/Qing-Gu/city/Shanghai
 Qing He 0003,Chinese Academy of Sciences,http://people.ucas.edu.cn/~0000964?language=en,zT-zZucAAAAJ
 Qing Hu,Massachusetts Institute of Technology,http://www.rle.mit.edu/thz/people/qing-hu,wYOf7YQAAAAJ
 Qing Li 0001,The Hong Kong Polytechnic University,https://www.comp.polyu.edu.hk/en-us/staffs/detail/7394,D1LEg-YAAAAJ
+Qing Liao,Harbin Institute of Technology,http://liaoqing.me/,umEIUwwAAAAJ
 Qing Ling,Sun Yat-sen University,http://home.ustc.edu.cn/~qingling,u70vRDYAAAAJ
 Qing Qu,University of Michigan,https://qingqu.engin.umich.edu/,JfblW3MAAAAJ
 Qing Wang 0001,Chinese Academy of Sciences,http://people.ucas.ac.cn/~wangqing,t1DbhhoAAAAJ
@@ -323,7 +324,7 @@ Qing Wang 0007,TU Delft,https://www.st.ewi.tudelft.nl/qing,fqE36d0AAAAJ
 Qing Yang 0003,Montana State University,https://www.cs.montana.edu/yang,NOSCHOLARPAGE
 Qing Yi,UCCS,http://www.cs.uccs.edu/~qyi,jDXlUyQAAAAJ
 Qing'an Li,Wuhan University,http://cs.whu.edu.cn/teacherinfo.aspx?id=195,1nFUcMIAAAAJ
-Qingcai chen,Harbin Institute of Technology,http://www.hitsz.edu.cn/teacher/view/id-236.html,7aR5D4sAAAAJ
+Qingcai Chen,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/chenqingcai1,7aR5D4sAAAAJ
 Qingfeng Du,Tongji University,https://sse.tongji.edu.cn/Data/View/2817,NOSCHOLARPAGE
 Qingfu Zhang 0001,City University of Hong Kong,https://www.cs.cityu.edu.hk/~qzhan7/index.html,nhL9PHwAAAAJ
 Qinggang Meng,Loughborough University,https://www.lboro.ac.uk/departments/compsci/staff/academic-teaching/qinggang-meng,OWGXbooAAAAJ

--- a/csrankings-9.csv
+++ b/csrankings-9.csv
@@ -640,6 +640,7 @@ Weiyi Ian Shang,Concordia University,http://users.encs.concordia.ca/~shang,ZnERy
 Weiyi Meng,Binghamton University,http://www.cs.binghamton.edu/~meng,C-wDOskAAAAJ
 Weiyi Shang,Concordia University,http://users.encs.concordia.ca/~shang,ZnERyl4AAAAJ
 Weiying Dai,Binghamton University,https://www.binghamton.edu/cs/people/wdai.html,r6DIjzUAAAAJ
+Weizhe Zhang,Harbin Institute of Technology,https://dblp.uni-trier.de/pid/z/WeizheZhang.html,GOQFn7sAAAAJ
 Weizhen Mao,College of William and Mary,http://www.cs.wm.edu/~wm,NOSCHOLARPAGE
 Weizhi Meng,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Weizhong Shao,Peking University,http://www.sei.pku.edu.cn/people/shaowz,NOSCHOLARPAGE
@@ -648,6 +649,7 @@ Wen Gao 0001,Peking University,http://www.jdl.ac.cn/htm-gaowen,b0vWahYAAAAJ
 Wen Hu,UNSW,https://www.engineering.unsw.edu.au/computer-science-engineering/staff/wen-hu,nHE4ylYAAAAJ
 Wen Li 0001,UESTC,https://wenli-vision.github.io,yjG4Eg4AAAAJ
 Wen Sun 0002,Cornell University,https://wensun.github.io,iOLC30YAAAAJ
+Wen Xia,Harbin Institute of Technology,https://cswxia.github.io/,TRmOudAAAAAJ
 Wen-Chieh Lin,National Chiao Tung University,http://www.cs.nctu.edu.tw/~wclin,v3l_oYkAAAAJ
 Wen-Chih Peng,National Chiao Tung University,https://sites.google.com/site/wcpeng,T5Rs-ngAAAAJ
 Wen-Chin Chen,National Taiwan University,http://www.cmlab.csie.ntu.edu.tw/~wcchen,NOSCHOLARPAGE
@@ -684,8 +686,10 @@ Weng Poo Kang,Vanderbilt University,http://engineering.vanderbilt.edu/bio/weng-p
 Weng-Fai Wong,National University of Singapore,https://www.comp.nus.edu.sg/~wongwf,SL1cTsIAAAAJ
 Weng-Keen Wong,Oregon State University,http://eecs.oregonstate.edu/people/wong-weng-keen,NOSCHOLARPAGE
 Wenguang Chen,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101224173045136934573/20101224173045136934573_.html,NOSCHOLARPAGE
+Wenjian Luo,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/luowenjian,L6cDi54AAAAJ
 Wenjian Yu,Tsinghua University,http://numbda.cs.tsinghua.edu.cn,hGfUQZYAAAAJ
 Wenjie Li 0002,The Hong Kong Polytechnic University,http://www4.comp.polyu.edu.hk/~cswjli,Rx5swD4AAAAJ
+Wenjie Pei,Harbin Institute of Technology,https://wenjiepei.github.io/,wX3avNkAAAAJ
 Wenjie Ruan,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/people/wenjie-ruan,VTASFGEAAAAJ
 Wenjie Zhang 0001,UNSW,http://www.cse.unsw.edu.au/~zhangw,yHTJo1kAAAAJ
 Wenjin Zhou,University of Massachusetts Lowell,https://www.uml.edu/FAHSS/Philosophy/faculty/default.aspx,M09EoNMAAAAJ
@@ -1032,6 +1036,7 @@ Xiaofei He 0001,Zhejiang University,http://people.cs.uchicago.edu/~xiaofei,QLLFo
 Xiaofeng Gao,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/~gao-xf,YfMPjhAAAAAJ
 Xiaofeng Meng 0001,Renmin University of China,http://idke.ruc.edu.cn/xfmeng/index.html,PTwcvk4AAAAJ
 Xiaofeng Wang 0006,Indiana University,http://www.informatics.indiana.edu/xw7,u4dhRkQAAAAJ
+Xiaofeng Zhang,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/zhangxiaofeng,AYg0RiQAAAAJ
 Xiaogang Jin 0001,Zhejiang University,http://www.cad.zju.edu.cn/home/jin,yryOvLwAAAAJ
 Xiaogang Jin 0002,Zhejiang University,http://mypage.zju.edu.cn/0096364,tYqG3CAAAAAJ
 Xiaogang Ma,University of Idaho,http://www.uidaho.edu/engr/departments/cs/our-people/faculty/xiaogang-ma,o4v-pvoAAAAJ
@@ -1208,10 +1213,11 @@ Xu He,Hunan University,http://csee.hnu.edu.cn/people/hexu,NOSCHOLARPAGE
 Xu Liu 0001,North Carolina State University,https://xl10.github.io,qhLT67EAAAAJ
 Xu Sun 0001,Peking University,https://xusun.org,NOSCHOLARPAGE
 Xu Wang 0016,University of Michigan,http://www.cs.cmu.edu/~xuwang,Fa0scckAAAAJ
+Xutao Li,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/lixutao,hPm6fo8AAAAJ
 Xu Yu,Chinese University of Hong Kong,http://www.se.cuhk.edu.hk/people/yu.html,iHevumsAAAAJ
 Xu Zhu 0001,University of Liverpool,https://liverpool.ac.uk/electrical-engineering-and-electronics/staff/xu-zhu,NycCVyoAAAAJ
 Xuan Guo,University of North Texas,http://www.cse.unt.edu/~xuanguo,4tqv2FYAAAAJ
-Xuan Wang 0002,Harbin Institute of Technology,http://homepage.hit.edu.cn/wangxuan,NOSCHOLARPAGE
+Xuan Wang 0002,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/wangxuan,NOSCHOLARPAGE
 Xuandong Li,Nanjing University,https://cs.nju.edu.cn/lixuandong,NOSCHOLARPAGE
 Xuanjing Huang,Fudan University,http://www.cs.fudan.edu.cn/?page_id=1836,RGsMgZA4H78C
 Xuanzhe Liu,Peking University,http://sei.pku.edu.cn/~liuxzh,eOhSVi8AAAAJ
@@ -1319,6 +1325,7 @@ Yang Liu 0004,University of Texas at Dallas,http://www.hlt.utdallas.edu/~yangl,N
 Yang Liu 0005,Tsinghua University,http://nlp.csai.tsinghua.edu.cn/~ly,NOSCHOLARPAGE
 Yang Liu 0018,Univ. of California - Santa Cruz,http://www.yliuu.com,jKrIVCIAAAAJ
 Yang Liu 0084,Sun Yat-sen University,https://yangliu9208.github.io/home,l0z2QNQAAAAJ
+Yang Liu 0085,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/liuyang,j1bxjYgAAAAJ
 Yang Long 0001,Durham University,https://www.dur.ac.uk/computer.science/staff/profile/?id=18350,IrkuknEAAAAJ
 Yang Richard Yang,Yale University,http://www.cs.yale.edu/~yry,AQ6AppgAAAAJ
 Yang Shi 0002,Tongji University,https://sse.tongji.edu.cn/Data/View/2818,NOSCHOLARPAGE
@@ -1497,6 +1504,7 @@ Yici Cai,Tsinghua University,http://www.tsinghua.edu.cn/publish/csen/4623/2010/2
 Yifan Sun,Stony Brook University,https://sites.google.com/site/yifansunwebsite,o3fSb1YAAAAJ
 Yifan Zhang 0002,Binghamton University,http://www.cs.binghamton.edu/~zhangy,sPZZB4UAAAAJ
 Yifeng Chen,Peking University,http://eecs.pku.edu.cn/EN/People/Faculty/Detail/?ID=6054,NOSCHOLARPAGE
+Yifeng Zheng,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/zhengyifeng,QtAO6K0AAAAJ
 Yih-Chun Hu,Univ. of Illinois at Urbana-Champaign,https://www.ece.illinois.edu/directory/profile/yihchun,VvvjMCgAAAAJ
 Yih-Fang Huang,University of Notre Dame,http://www3.nd.edu/~huang,NOSCHOLARPAGE
 Yih-Lang Li,National Chiao Tung University,http://people.cs.nctu.edu.tw/~ylli,NOSCHOLARPAGE
@@ -1620,12 +1628,14 @@ Yong Suk Choi,Hanyang University,http://ai.hanyang.ac.kr/member,NOSCHOLARPAGE
 Yong Wang 0021,Singapore Management University,https://sis.smu.edu.sg/faculty/profile/167376/WANG-Yong,ux1ii1gAAAAJ
 Yong Xia,NWPU,https://teacher.nwpu.edu.cn/en/yongxia.html,Usw1jeMAAAAJ
 Yong Xiang 0002,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101224195501579371325/20101224195501579371325_.html,YySlI2oAAAAJ
+Yong Xu 0003,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/xuyong,zOVgYQYAAAAJ
 Yong Yu 0001,Shanghai Jiao Tong University,http://english.seiee.sjtu.edu.cn/english/detail/841_695.htm,-84M1m0AAAAJ
 Yong-Jin Liu,Tsinghua University,http://media.cs.tsinghua.edu.cn/en/liuyj,GNDtwWQAAAAJ
 Yong-Lae Park,Carnegie Mellon University,http://www.cs.cmu.edu/~ylpark,kBsTE7AAAAAJ
 Yong-Liang Yang,University of Bath,http://www.yongliangyang.net,v2etATwAAAAJ
 Yong-Sheng Chen,National Chiao Tung University,http://www.cs.nctu.edu.tw/~yschen,kUCM_aEAAAAJ
 Yong-Yeol Ahn,Indiana University,http://yongyeol.com,US7OSNgAAAAJ
+Yongbing Zhang,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/zhangyongbing,0KlvTEYAAAAJ
 YongHong Tian,Peking University,http://idm.pku.edu.cn/staff/yhtian.html,fn6hJx0AAAAJ
 Yongcai Wang,Renmin University of China,https://yongcaiwang.github.io/about,ZOHWbl8AAAAJ
 Yongchuan Tang,Zhejiang University,http://mypage.zju.edu.cn/yongchuan,NOSCHOLARPAGE
@@ -1657,6 +1667,7 @@ Yongwei Wu,Tsinghua University,http://madsys.cs.tsinghua.edu.cn/~yongweiwu,ld3ax
 Yongxin Tong,Beihang University,http://sites.nlsde.buaa.edu.cn/~yxtong,aeCHfDIAAAAJ
 Yongxin Yang,University of Surrey,https://yang.ac,F7PtrL8AAAAJ
 Yongyi Mao,University of Ottawa,http://www.site.uottawa.ca/~yymao,jM5l70wAAAAJ
+Yongyong Chen,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/chenyongyong,ny2mn-cAAAAJ
 Yongzhen Huang,Chinese Academy of Sciences,http://www.cripac.ia.ac.cn/irds/People/yzhuang.html,OH7-k7oAAAAJ
 Yongzhi Cao,Peking University,http://eecs.pku.edu.cn/EN/People/Faculty/Detail/?ID=6066,VEhLdikAAAAJ
 Yonina C. Eldar,Weizmann Institute of Science,https://www.weizmann.ac.il/pages/search/people?language=english&single=1&person_id=67601,vyX6kpwAAAAJ
@@ -1987,7 +1998,7 @@ Zeki Erkin,TU Delft,https://www.tudelft.nl/staff/z.erkin,eXQzgZUAAAAJ
 Zen-Chung Shih,National Chiao Tung University,http://cgvr.cs.nctu.edu.tw,NOSCHOLARPAGE
 Zena M. Ariola,University of Oregon,https://www.cs.uoregon.edu/People/Faculty/Zena_Ariola.php,LmLKjyYAAAAJ
 Zengfeng Huang,Fudan University,http://www.cse.ust.hk/~huangzf,FwNBuXUAAAAJ
-Zenglin Xu,UESTC,http://smilelab.uestc.edu.cn,gF0H9nEAAAAJ
+Zenglin Xu,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/xuzenglin,gF0H9nEAAAAJ
 Zerrin Yumak,Utrecht University,http://www.zerrinyumak.com,nX3oM4oAAAAJ
 Zexuan Zhu,Shenzhen University,http://csse.szu.edu.cn/staff/zhuzx,kqHaIGEAAAAJ
 Zeyar Aung,Masdar Institute,https://www2.masdar.ac.ae/aboutus/management/faculty-directory/item/5734-zeyar-aung,FPTI7B4AAAAJ
@@ -2035,6 +2046,7 @@ Zheng Yan 0001,University of Technology Sydney,https://www.uts.edu.au/staff/yan.
 Zheng Yang 0002,Tsinghua University,http://tns.thss.tsinghua.edu.cn/~yangzheng,ExRe-64AAAAJ
 Zheng Zhang 0003,NYU Shanghai,https://shanghai.nyu.edu/academics/faculty/directory/zheng-zhang,Fqi0PiYAAAAJ
 Zheng Zhang 0012,Rutgers University,http://www.cs.rutgers.edu/~zz124,uL470LwAAAAJ
+Zheng Zhang 0013,Harbin Institute of Technology,http://zhengzhang.vip/,tpVOb2EAAAAJ
 Zhenfeng Zhang,Chinese Academy of Sciences,http://people.ucas.ac.cn/~zfzhang,KQB-cKAAAAAJ
 Zhengfeng Ji,University of Technology Sydney,https://www.uts.edu.au/staff/zhengfeng.ji,2uXdu7AAAAAJ
 Zhenghao Zhang,Florida State University,http://www.cs.fsu.edu/~zzhang,sfCo01gAAAAJ
@@ -2057,6 +2069,7 @@ Zhennan Sun,Chinese Academy of Sciences,http://www.cbsr.ia.ac.cn/users/znsun,PuZ
 Zhentao Li,Ecole Normale Superieure,http://www.di.ens.fr/~zhentao,NOSCHOLARPAGE
 Zhenying He,Fudan University,http://homepage.fudan.edu.cn/zhenying,NOSCHOLARPAGE
 Zhenyu Chen,Nanjing University,http://www.iselab.cn/faculty/ZhenyuChen,HQWxCnkAAAAJ
+Zhenyu He,Harbin Institute of Technology,http://www.hezhenyu.cn/,cv8_7usAAAAJ
 Zhenzhong Chen,Wuhan University,http://iip.whu.edu.cn/~zzchen,w_BcpK8AAAAJ
 Zhewei Wei,Renmin University of China,http://weizhewei.com,qZ7dj4gAAAAJ
 Zhezhi He,Shanghai Jiao Tong University,https://elliothe.github.io,QzDf7GoAAAAJ
@@ -2136,6 +2149,7 @@ Zhong Zhou,Beihang University,http://scse.buaa.edu.cn/info/1078/2679.htm,sWbTqxE
 Zhongfei (Mark) Zhang,Binghamton University,http://www.cs.binghamton.edu/~zhongfei,RM7y-rcAAAAJ
 Zhongfei Zhang,Binghamton University,http://www.cs.binghamton.edu/~zhongfei,RM7y-rcAAAAJ
 Zhongjie Ba,Zhejiang University,https://person.zju.edu.cn/zhongjieba,dO2kc6kAAAAJ
+Zhongyun Hua,Harbin Institute of Technology,http://www.huazhongyun.cn/,Sl0BI_IAAAAJ
 Zhongyu Wei,Fudan University,http://www.sdspeople.fudan.edu.cn/zywei,AjLDxxgAAAAJ
 Zhongzhi Zhang,Fudan University,http://homepage.fudan.edu.cn/zhangzz,DrcEuSkAAAAJ
 Zhou Li 0001,Univ. of California - Irvine,https://faculty.sites.uci.edu/zhouli,zxJYEVwAAAAJ


### PR DESCRIPTION
I find that many professors in HITsz and HITwh are not included in HIT(Harbin Institute of Technology). Because, HIT has three schools in China and they make research together. So, this time I add many professors from CS of HITsz into HIT(Harbin Institute of Technology).
