### PR TITLE
Add University College Dublin

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -240,6 +240,7 @@ Universidade Federal de Viçosa,southamerica,br
 Universidade NOVA de Lisboa,europe,pt
 Universidade de Brasília,southamerica,br
 Universidade de Lisboa,europe,pt
+University College Dublin,europe,ie
 University College London,europe,uk
 University of A Coruña,europe,es
 University of Aberdeen,europe,uk

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -1785,6 +1785,7 @@ Anxiao Jiang,Texas A&M University,http://faculty.cse.tamu.edu/ajiang,Av9OoKMAAAA
 Anya Helene Bagge,University of Bergen,https://www.ii.uib.no/~anya,NOSCHOLARPAGE
 Anyi Liu,Oakland University,http://secs.oakland.edu/~anyiliu,KfveCmIAAAAJ
 Anys Bacha,University of Michigan-Dearborn,https://umdearborn.edu/users/anysbacha,8I9z_70AAAAJ
+Aonghus Lawlor,University College Dublin,https://people.ucd.ie/aonghus.lawlor,kyrXm8EAAAAJ
 Apan Qasem,Texas State University,http://www.cs.txstate.edu/~aq10,CxAVF0YAAAAJ
 Aparna Bharati,Lehigh University,https://sites.google.com/view/aparna-bharati,3SuzNJ4AAAAJ
 Aparna Chandramowlishwaran,Univ. of California - Irvine,http://newport.eecs.uci.edu/~amowli,7ASJ6JoAAAAJ

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -765,6 +765,7 @@ Alexei Lisitsa,University of Liverpool,https://www.csc.liv.ac.uk/~alexei,S0VAEqU
 Alexei P. Lisitsa,University of Liverpool,https://www.csc.liv.ac.uk/~alexei,S0VAEqUAAAAJ
 Alexei Sourin,Nanyang Technological University,http://www.ntu.edu.sg/home/assourin,8A7kHCYAAAAJ
 Alexey Gotsman,IMDEA Software Institute,http://software.imdea.org/~gotsman,NOSCHOLARPAGE
+Alexey L. Lastovetsky,University College Dublin,https://people.ucd.ie/alexey.lastovetsky,28VrkNcAAAAJ
 Alexey Onufriev,Virginia Tech,http://people.cs.vt.edu/onufriev,b7TXx40AAAAJ
 Alexey Tumanov,Georgia Institute of Technology,https://www.cc.gatech.edu/~atumanov,7P-gZioAAAAJ
 Alexey V. Onufriev,Virginia Tech,http://people.cs.vt.edu/onufriev,b7TXx40AAAAJ

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -1151,6 +1151,7 @@ Anastassia Ailamaki,EPFL,https://people.epfl.ch/anastasia.ailamaki,YdrkeNwAAAAJ
 Anat Paskin,Ariel University,http://www.ariel.ac.il/Projects/trp/GeneralInformation.asp?numRec=483&numtafrit=1&id_lang=1&d=,XcyQbAYAAAAJ
 Anat Paskin-Cherniavsky,Ariel University,http://www.ariel.ac.il/Projects/trp/GeneralInformation.asp?numRec=483&numtafrit=1&id_lang=1&d=,XcyQbAYAAAAJ
 Anca D. Dragan,Univ. of California - Berkeley,http://www.eecs.berkeley.edu/~anca,UgHB5oAAAAAJ
+Anca Jurcut,University College Dublin,https://people.ucd.ie/anca.jurcut,rzHu7gYAAAAJ
 Anca L. Ralescu,University of Cincinnati,http://uc.academia.edu/AncaRalescu,eFiFA9cAAAAJ
 Anca Ralescu,University of Cincinnati,http://uc.academia.edu/AncaRalescu,eFiFA9cAAAAJ
 Anders B. Dahl,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -1354,6 +1354,7 @@ Andrew Gordon Wilson,New York University,https://cims.nyu.edu/~andrewgw,twWX2LIA
 Andrew H. Fagg,University of Oklahoma,http://www.ou.edu/coe/cs/people/fagg,bv_o8b0AAAAJ
 Andrew H. Sung,University of Southern Mississippi,https://www.usm.edu/computing/faculty/andrew-h-sung,UMf3YBMAAAAJ
 Andrew Hamilton-Wright,University of Guelph,https://www.uoguelph.ca/computing/people/andrew-hamilton-wright,nWoiQrQAAAAJ
+Andrew Hines,University College Dublin,https://people.ucd.ie/andrew.hines,IJ_bu7gAAAAJ
 Andrew Hopper,University of Cambridge,https://www.cl.cam.ac.uk/~ah12,WBr_GXUAAAAJ
 Andrew Howes,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/howes-andrew.aspx,iswtssoAAAAJ
 Andrew Ian Coles,King's College London,https://www.kcl.ac.uk/people/andrew-coles,EMiUE40AAAAJ

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -146,6 +146,7 @@ Abolfazl S. Motahari,Sharif University of Technology,http://ce.sharif.edu/facult
 Abolfazl Seyed Motahari,Sharif University of Technology,http://ce.sharif.edu/faculty/abolfazl-motahari,rJ-biB0AAAAJ
 Abraham Bernstein,University of Zurich,http://www.ifi.uzh.ch/ddis/people/bernstein.html,ZYNjTykAAAAJ
 Abraham Duarte,Universidad Rey Juan Carlos,http://grafo.etsii.urjc.es/group-member/abrahamduarte,wsBEPbYAAAAJ
+Abraham G. Campbell,University College Dublin,https://people.ucd.ie/abey.campbell,TWRYXGMAAAAJ
 Abraham Silberschatz,Yale University,http://www.cs.yale.edu/~avi,-YvgZDEAAAAJ
 Abram Hindle,University of Alberta,http://softwareprocess.es,vuT1ZlUAAAAJ
 Abtin Rahimian,University of Colorado Boulder,http://home.cs.colorado.edu/~abra3237,2iXwFdsAAAAJ

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -1660,6 +1660,7 @@ Anthony Steed,University College London,http://wp.cs.ucl.ac.uk/anthonysteed,mPvF
 Anthony T. C. Tam,University of Hong Kong,https://i.cs.hku.hk/~atctam,NOSCHOLARPAGE
 Anthony Tang 0001,University of Calgary,http://hcitang.org,RG1EQowAAAAJ
 Anthony V. Robins,University of Otago,http://www.cs.otago.ac.nz/staff/anthony.html,COuPSxYAAAAJ
+Anthony Ventresque,University College Dublin,https://people.ucd.ie/anthony.ventresque,I16yTcgAAAAJ
 Anthony Vickers,University of Essex,https://www.essex.ac.uk/people/vicke53909/anthony-vickers,BtqGWtwAAAAJ
 Anthony W. Lin,TU Kaiserslautern,https://anthonywlin.github.io,__5nnYUAAAAJ
 Anthony Widjaja Lin,TU Kaiserslautern,https://anthonywlin.github.io,__5nnYUAAAAJ

--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -706,6 +706,7 @@ Brian Kulis,Boston University,http://people.bu.edu/bkulis,okcbLqoAAAAJ
 Brian L. Curless,University of Washington,http://homes.cs.washington.edu/~curless,tlh8i7gAAAAJ
 Brian Logan,University of Nottingham,https://www.nottingham.ac.uk/computerscience/people/brian.logan,tnSWU68AAAAJ
 Brian M. Tomaszewski,Rochester Institute of Technology,https://people.rit.edu/bmtski,hcIpln4AAAAJ
+Brian Mac Namee,University College Dublin,https://people.ucd.ie/brian.macnamee,rZ3_vb0AAAAJ
 Brian Mak,HKUST,https://www.cse.ust.hk/~mak,Zx8p8RsAAAAJ
 Brian Murphy,CUNY,http://www.baruch.cuny.edu/wsas/academics/history/bmurphy.htm,d9mX-Q4AAAAJ
 Brian Neil Levine,University of Massachusetts Amherst,https://people.cs.umass.edu/~brian,oHbIF48AAAAJ

--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -679,6 +679,7 @@ Brent Seales,University of Kentucky,https://www.cs.uky.edu/people/faculty/bseale
 Brent Waters,University of Texas at Austin,http://www.cs.utexas.edu/~bwaters,VEKxHOAAAAAJ
 Bret Michael,Naval Postgraduate School,http://faculty.nps.edu/vitae/cgi-bin/vita.cgi?p=display_vita&id=1023567701,JYxa6eYAAAAJ
 Bret Michael 0001,Naval Postgraduate School,http://faculty.nps.edu/vitae/cgi-bin/vita.cgi?p=display_vita&id=1023567701,JYxa6eYAAAAJ
+Brett A. Becker,University College Dublin,https://people.ucd.ie/brett.becker,GlnJXAwAAAAJ
 Brett J. Borghetti,Air Force Institute of Technology,https://www.afit.edu/BIOS/bio.cfm?facID=18,Z6vGQasAAAAJ
 Brett McKinney,University of Tulsa,https://faculty.utulsa.edu/~/brett-mckinney,3M1gxVsAAAAJ
 Brian A. Barsky,Univ. of California - Berkeley,http://www.cs.berkeley.edu/~barsky,NOSCHOLARPAGE

--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -103,6 +103,7 @@ Barry Jay,University of Technology Sydney,https://www.uts.edu.au/staff/barry.jay
 Barry McCollum,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=b.mccollum,LJCwMOEAAAAJ
 Barry Porter,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/people/barry-porter,bzBKAYwAAAAJ
 Barry Smith 0001,University at Buffalo,http://ontology.buffalo.edu/smith,icGNWj4AAAAJ
+Barry Smyth,University College Dublin,https://people.ucd.ie/barry.smyth,UxqudeoAAAAJ
 Barry W. Boehm,University of Southern California,http://csse.usc.edu/new/barry-w-boehm,EyAD66UAAAAJ
 Bart De Decker,KU Leuven,https://people.cs.kuleuven.be/~bart.dedecker/index.html,6_505coAAAAJ
 Bart Demoen,KU Leuven,https://people.cs.kuleuven.be/~bart.demoen,NFqnq4wAAAAJ

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -599,6 +599,7 @@ Chris Harrison 0001,Carnegie Mellon University,http://www.chrisharrison.net,36HR
 Chris Heunen,University of Edinburgh,http://homepages.inf.ed.ac.uk/cheunen,K_LnaH0AAAAJ
 Chris Hundhausen,Washington State University,http://www.eecs.wsu.edu/~hundhaus,jdmx_E8AAAAJ
 Chris J. Barter,University of Adelaide,https://cs.adelaide.edu.au/~chris,NOSCHOLARPAGE
+Chris J. Bleakley,University College Dublin,https://people.ucd.ie/chris.bleakley,pr1c99UAAAAJ
 Chris J. Maddison,University of Toronto,https://www.cs.toronto.edu/~cmaddis,WjCG3owAAAAJ
 Chris J. Price,Aberystwyth University,https://www.aber.ac.uk/en/cs/staff-profiles/listing/profile/cjp,NOSCHOLARPAGE
 Chris Jermaine,Rice University,https://www.cs.rice.edu/~cmj4,D2P2B0MAAAAJ

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -219,6 +219,7 @@ Catherine Combes,Université Jean Monnet,http://perso.univ-st-etienne.fr/combes,
 Catherine Holloway,University College London,https://uclic.ucl.ac.uk/people/catherine-holloway,y6TvZdIAAAAJ
 Catherine McCartin,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=104630,NOSCHOLARPAGE
 Catherine Mills Olschanowsky,Boise State University,http://coen.boisestate.edu/catherineolschan,NOSCHOLARPAGE
+Catherine Mooney,University College Dublin,https://people.ucd.ie/catherine.mooney,_OdojvIAAAAJ
 Catherine Olschanowsky,Boise State University,http://coen.boisestate.edu/catherineolschan,NOSCHOLARPAGE
 Catherine Plaisant,University of Maryland - College Park,https://www.umiacs.umd.edu/people/plaisant,VnwWgwIAAAAJ
 Catherine S. Holloway,University College London,https://uclic.ucl.ac.uk/people/catherine-holloway,y6TvZdIAAAAJ

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -1116,6 +1116,7 @@ Collin Lynch,North Carolina State University,http://people.engr.ncsu.edu/cflynch
 Collin M. Stultz,Massachusetts Institute of Technology,https://imes.mit.edu/people/faculty/stultz-collin,NOSCHOLARPAGE
 Collin McMillan,University of Notre Dame,http://www.cse.nd.edu/~cmc,xaoz3-gAAAAJ
 Collin Stultz,Massachusetts Institute of Technology,http://www.rle.mit.edu/stultz,NOSCHOLARPAGE
+Colm Ryan,University College Dublin,https://people.ucd.ie/colm.ryan,1CX1kd8AAAAJ
 Concepción Vidal,University of A Coruña,https://pdi.udc.es/en/File/Pdi/TD3AF,GwivtyAAAAAJ
 Concettina Guerra,Georgia Institute of Technology,http://www.cc.gatech.edu/~guerra,NOSCHOLARPAGE
 Cong Liu 0005,University of Texas at Dallas,http://www.utdallas.edu/~cxl137330,8bcbEOAAAAAJ

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -595,6 +595,7 @@ David L. Wehlau,Royal Military College of Canada,https://www.rmc-cmr.ca/en/mathe
 David Lazer,Northeastern University,https://www.northeastern.edu/cssh/faculty/david-lazer,gMndACUAAAAJ
 David Leake,Indiana University,https://www.cs.indiana.edu/~leake,CidT-JAAAAAJ
 David Lie,University of Toronto,http://www.eecg.toronto.edu/~lie,Qm_3B70AAAAJ
+David Lillis,University College Dublin,https://people.ucd.ie/david.lillis,AoVi6qkAAAAJ
 David Lo 0001,Singapore Management University,http://www.mysmu.edu/faculty/davidlo,IFg0H1wAAAAJ
 David M. Blei,Columbia University,http://www.cs.columbia.edu/~blei,8OYE6iEAAAAJ
 David M. Bortz,University of Colorado Boulder,https://www.colorado.edu/amath/david-bortz,7wkmJU8AAAAJ

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -848,6 +848,7 @@ Derek Eager,University of Saskatchewan,https://www.cs.usask.ca/faculty/eager,Xww
 Derek F. Reilly,Dalhousie University,https://www.dal.ca/faculty/computerscience/faculty-staff/derek-reilly.html,fZ56s2EAAAAJ
 Derek G. Corneil,University of Toronto,http://worldcat.org/identities/lccn-n90726664,XiTfJCsAAAAJ
 Derek Gordon Corneil,University of Toronto,http://worldcat.org/identities/lccn-n90726664,XiTfJCsAAAAJ
+Derek Greene,University College Dublin,https://people.ucd.ie/derek.greene,htlibRwAAAAJ
 Derek Groen,Brunel University London,https://www.brunel.ac.uk/people/derek-groen,lK4WTUsAAAAJ
 Derek Hoiem,Univ. of Illinois at Urbana-Champaign,http://dhoiem.cs.illinois.edu,HoQtR3cAAAAJ
 Derek Long,King's College London,https://www.kcl.ac.uk/people/derek-long,lsk6TF4AAAAJ

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -761,6 +761,7 @@ Deborah Stacey,University of Guelph,https://www.uoguelph.ca/computing/people/deb
 Debra J. Richardson,Univ. of California - Irvine,http://www.ics.uci.edu/~djr,vL6ubpMAAAAJ
 Deendayal Dinakarpandian,University of Missouri - Kansas City,https://info.umkc.edu/scenews/tag/deendayal-dinakarpandian,1UpkUvQAAAAJ
 Deep Medhi,University of Missouri - Kansas City,http://sce2.umkc.edu/csee/dmedhi,17e2M2AAAAAJ
+Deepak Ajwani,University College Dublin,https://people.ucd.ie/deepak.ajwani,3B9ZJUIAAAAJ
 Deepak B. Phatak,IIT Bombay,https://www.cse.iitb.ac.in/~dbp,NOSCHOLARPAGE
 Deepak D'Souza,IISc Bangalore,http://www.csa.iisc.ac.in/~deepakd,qDmD8DsAAAAJ
 Deepak Ganesan,University of Massachusetts Amherst,https://people.cs.umass.edu/~dganesan,cbTB5-EAAAAJ

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -479,6 +479,7 @@ David Churchill,Memorial University of Newfoundland,http://www.cs.mun.ca/~dchurc
 David Clark,University College London,http://www0.cs.ucl.ac.uk/people/D.Clark.html,Vch_do8AAAAJ
 David Cordes,The University of Alabama,http://cordes.cs.ua.edu,NOSCHOLARPAGE
 David Corne,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/david-wolfe-corne.htm,6jNgTK4AAAAJ
+David Coyle,University College Dublin,https://people.ucd.ie/d.coyle,9d9bOOUAAAAJ
 David Culler,Univ. of California - Berkeley,https://www.cs.berkeley.edu/~culler,urTiL7QAAAAJ
 David D. Cox,Harvard University,http://www.coxlab.org,Pb5mcIYAAAAJ
 David D. Feng,University of Sydney,http://sydney.edu.au/engineering/it/about/people/staff/feng.shtml,89py58oAAAAJ

--- a/csrankings-e.csv
+++ b/csrankings-e.csv
@@ -218,6 +218,7 @@ Elena Troubitsyna,KTH Royal Institute of Technology,https://www.kth.se/profile/e
 Elena Zheleva,University of Illinois at Chicago,https://www.cs.uic.edu/~elena,Ug7VoyQAAAAJ
 Eleni C. Akrida,Durham University,https://www.dur.ac.uk/computer.science/staff/profile/?id=18445,pjlwmS8AAAAJ
 Eleni Ch. Akrida,Durham University,https://www.dur.ac.uk/computer.science/staff/profile/?id=18445,pjlwmS8AAAAJ
+Eleni E. Mangina,University College Dublin,https://people.ucd.ie/eleni.mangina,50-QeIUAAAAJ
 Eleni Stroulia,University of Alberta,https://webdocs.cs.ualberta.ca/~stroulia/index.old.html,TyM1dLwAAAAJ
 Eleni Vasilaki,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/eleni-vasilaki,hqK2AG0AAAAJ
 Elf Eldridge,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/ElfEldridge,NOSCHOLARPAGE

--- a/csrankings-f.csv
+++ b/csrankings-f.csv
@@ -498,6 +498,7 @@ Fred A. Hamprecht,Heidelberg University,https://hci.iwr.uni-heidelberg.de/people
 Fred B. Schneider,Cornell University,https://www.cs.cornell.edu/fbs,sxjynOsAAAAJ
 Fred Brown,University of Adelaide,http://www.adelaide.edu.au/directory/fred.brown,NOSCHOLARPAGE
 Fred Chong,University of Chicago,http://people.cs.uchicago.edu/~ftchong,U6OVPVMAAAAJ
+Fred Cummins,University College Dublin,https://people.ucd.ie/fred.cummins,E-vg2zQAAAAJ
 Fred G. Martin,University of Massachusetts Lowell,http://www.cs.uml.edu/~fredm,rqpdaP0AAAAJ
 Fred H. Hamker,TU Chemnitz,https://www.tu-chemnitz.de/informatik/KI/fhamker.php,LjZJA1sAAAAJ
 Fred Henrik Hamker,TU Chemnitz,https://www.tu-chemnitz.de/informatik/KI/fhamker.php,LjZJA1sAAAAJ

--- a/csrankings-f.csv
+++ b/csrankings-f.csv
@@ -277,6 +277,7 @@ Finale Doshi,Harvard University,https://www.seas.harvard.edu/directory/finale,NO
 Finale Doshi-Velez,Harvard University,https://www.seas.harvard.edu/directory/finale,NOSCHOLARPAGE
 Finn Årup Nielsen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Finn Kensing,University of Copenhagen,http://www.diku.dk/Ansatte/?pure=da/persons/43656,m_e3GYkAAAAJ
+Fintan Costello,University College Dublin,https://people.ucd.ie/fintan.costello,3z-gY18AAAAJ
 Fiona Jennet McNeill,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/fiona-mcneill.htm,535ZsJMAAAAJ
 Fiona McNeill,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/fiona-mcneill.htm,535ZsJMAAAAJ
 Fiora Pirri,Sapienza University of Rome,http://www.diag.uniroma1.it/pirri,VkYspW0AAAAJ

--- a/csrankings-f.csv
+++ b/csrankings-f.csv
@@ -129,6 +129,7 @@ Faruk Polat,Middle East Technical University,http://user.ceng.metu.edu.tr/~polat
 Farzad Farnoud,University of Virginia,https://engineering.virginia.edu/faculty/farzad-farnoud,s1NC4EMAAAAJ
 Farzad Farnoud Hassanzadeh,University of Virginia,https://engineering.virginia.edu/faculty/farzad-farnoud,s1NC4EMAAAAJ
 Fatemeh Afghah,Northern Arizona University,https://nau.edu/siccs/faculty/fatemeh-afghah,67mA71QAAAAJ
+Fatemeh Golpayegani,University College Dublin,https://people.ucd.ie/fatemeh.golpayegani,TW6apHcAAAAJ
 Fatih Alagöz,Boğaziçi University,https://www.cmpe.boun.edu.tr/~alagoz,5Nku4S8AAAAJ
 Fatima A. Merchant,University of Houston,https://www.uh.edu/technology/departments/et/people/?l=merchant&f=fatima,fUCDUOoAAAAJ
 Fatima Abu Salem,American University of Beirut,http://www.cs.aub.edu.lb/fa21,NOSCHOLARPAGE

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -654,6 +654,7 @@ Gregory Hooper,University of Queensland,https://www.uq.edu.au/study/course.html?
 Gregory J. E. Rawlins,Indiana University,http://www.cs.indiana.edu/~rawlins,NOSCHOLARPAGE
 Gregory J. Stein,George Mason University,https://volgenau.gmu.edu/profile/view/587166,4djS86UAAAAJ
 Gregory J. Zelinsky,Stony Brook University,https://www.stonybrook.edu/commcms/psychology/faculty/faculty_profiles/gzelinsky,5uC1slsAAAAJ
+Gregory M. P. O'Hare,University College Dublin,https://people.ucd.ie/gregory.ohare,egeLiWkAAAAJ
 Gregory Mentzas,NTUA,http://imu.ntua.gr/users/gmentzas,WdybrQYAAAAJ
 Gregory Michael Bodwin,University of Michigan,https://bodwin.engin.umich.edu,NWpUSd4AAAAJ
 Gregory Peterson,University of Tennessee,https://www.eecs.utk.edu/people/faculty/gdp,3Zg-7o4AAAAJ

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -129,6 +129,7 @@ Gautam Das 0001,University of Texas at Arlington,http://ranger.uta.edu/~gdas,ole
 Gautam Kamath 0001,University of Waterloo,http://www.gautamkamath.com,MK6zHkYAAAAJ
 Gavin Brown 0001,University of Manchester,https://www.research.manchester.ac.uk/portal/Gavin.Brown.html,bdugqKUAAAAJ
 Gavin Lowe,University of Oxford,http://www.cs.ox.ac.uk/gavin.lowe,NOSCHOLARPAGE
+Gavin McArdle,University College Dublin,https://people.ucd.ie/gavin.mcardle,07pHQ-IAAAAJ
 Gavriil Tsechpenakis,IUPUI,http://cs.iupui.edu/people/gavriil-tsechpenakis,y7uuI7gAAAAJ
 Gavrill Tsechpenakis,IUPUI,http://cs.iupui.edu/people/gavriil-tsechpenakis,y7uuI7gAAAAJ
 Ge Li 0001,Peking University,http://sei.pku.edu.cn/~lige,NOSCHOLARPAGE

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -274,6 +274,7 @@ George Xylomenos,AUEB,http://pages.cs.aueb.gr/~xgeorge,f7tP8gcAAAAJ
 Georgeta Elisabeta Marai,University of Illinois at Chicago,https://www.evl.uic.edu/marai,xPCVtawAAAAJ
 Georgi Gaydadjiev,University of Groningen,https://www.rug.nl/staff/g.gaydadjiev/?lang=en,IL5KrG4AAAAJ
 Georgi Nedeltchev Gaydadjiev,University of Groningen,https://www.rug.nl/staff/g.gaydadjiev/?lang=en,IL5KrG4AAAAJ
+Georgiana Ifrim,University College Dublin,https://people.ucd.ie/georgiana.ifrim,MHs3X9YAAAAJ
 Georgina Cosma,Loughborough University,https://www.lboro.ac.uk/departments/compsci/staff/academic-teaching/georgina-cosma,OpHkDDIAAAAJ
 Georgios A. Dafoulas,Middlesex University,http://www.cs.mdx.ac.uk/people/george-dafoulas,NOSCHOLARPAGE
 Georgios Alexandros Kavvos,University of Bristol,https://www.lambdabetaeta.eu,yWerYFkAAAAJ

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -699,6 +699,7 @@ Guanhua Yan,Binghamton University,https://www.binghamton.edu/cs/people/ghyan.htm
 Guanpeng Li,University of Iowa,http://homepage.cs.uiowa.edu/~guanpli,hIoeKKkAAAAJ
 Gudmund Skovbjerg Frandsen,Aarhus University,http://cs.au.dk/~gudmund,bHvSLToAAAAJ
 Gudula Rünger,TU Chemnitz,https://www.tu-chemnitz.de/informatik/PI/professur/inhaber/index.php,NOSCHOLARPAGE
+Guénolé C. Silvestre,University College Dublin,https://ieeexplore.ieee.org/author/37281610100,NOSCHOLARPAGE
 Guenter Schaefer,TU Ilmenau,https://www.tu-ilmenau.de/telematik/mitarbeiter/prof-guenter-schaefer,xpFu880AAAAJ
 Guenther Ruhe,University of Calgary,http://ruhe.cpsc.ucalgary.ca,5nL_z0oAAAAJ
 Guevara Noubir,Northeastern University,http://www.ccs.neu.edu/home/noubir,pUaHHjUAAAAJ

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -413,6 +413,7 @@ Gianluca Bontempi,Université libre de Bruxelles,http://www.ulb.ac.be/di/map/gbo
 Gianluca De Marco,University of Salerno,http://www.unisa.it/docenti/gianlucademarco/index,NOSCHOLARPAGE
 Gianluca Memoli,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/390809,ticqPMYAAAAJ
 Gianluca Palermo,Politecnico di Milano,http://home.deib.polimi.it/gpalermo,A5GSaaoAAAAJ
+Gianluca Pollastri,University College Dublin,https://people.ucd.ie/gianluca.pollastri,YFUQzzokG40C
 Gianluca Stringhini,Boston University,https://seclab.bu.edu/people/gianluca,fM-s2vQAAAAJ
 Gianluigi Ferrari,University of Pisa,http://www.di.unipi.it/~giangi,F2bbBksAAAAJ
 Gianna Del Corso,University of Pisa,http://www.di.unipi.it/~delcorso,AGDMVeIAAAAJ

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -1482,6 +1482,7 @@ John McDonald,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/fac
 John McGregor,Clemson University,https://people.cs.clemson.edu/~johnmc,Tw739kgAAAAJ
 John Millar Carroll,Pennsylvania State University,https://jcarroll.ist.psu.edu,7Mg8JZMAAAAJ
 John Monaco,Naval Postgraduate School,http://www.vmonaco.com,iG64YJUAAAAJ
+John Murphy 0001,University College Dublin,https://people.ucd.ie/j.murphy,hRzqMboAAAAJ
 John Musacchio,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~johnm,NOSCHOLARPAGE
 John N. Tsitsiklis,Massachusetts Institute of Technology,http://www.mit.edu/~jnt/home.html,bWTPrLEAAAAJ
 John O'Donnell,University of Glasgow,http://www.dcs.gla.ac.uk/~jtod,NOSCHOLARPAGE

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -2006,6 +2006,7 @@ Julie A. McCann,Imperial College London,http://wp.doc.ic.ac.uk/aese/person/julie
 Julie A. Shah,Massachusetts Institute of Technology,http://people.csail.mit.edu/julie_a_shah,NOSCHOLARPAGE
 Julie Ann McCann,Imperial College London,http://wp.doc.ic.ac.uk/aese/person/julie-a-mccann,S6wyzdwAAAAJ
 Julie Arnold Shah,Massachusetts Institute of Technology,http://people.csail.mit.edu/julie_a_shah,NOSCHOLARPAGE
+Julie Carson-Berndsen,University College Dublin,https://people.ucd.ie/julie.berndsen,NOSCHOLARPAGE
 Julie Dorsey,Yale University,http://graphics.cs.yale.edu/julie,IYXVU-QAAAAJ
 Julie Fisher,Monash University,http://www.sims.monash.edu.au/staff/jfisher,hLCaPfAAAAAJ
 Julie Fukuyama,Indiana University,https://jfukuyama.github.io,NOSCHOLARPAGE

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -1407,6 +1407,7 @@ John Daugman,University of Cambridge,https://www.cl.cam.ac.uk/~jgd1000,D0Q3owUAA
 John Derrick,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/john-derrick,UjKdePoAAAAJ
 John Dickerson 0001,University of Maryland - College Park,http://jpdickerson.com,QgDpfCQAAAAJ
 John Dowell,University College London,http://www0.cs.ucl.ac.uk/people/J.Dowell.html,NOSCHOLARPAGE
+John Dunnion,University College Dublin,https://www.researchgate.net/profile/John-Dunnion,NOSCHOLARPAGE
 John Durrett,Texas State University,https://cs.txstate.edu/accounts/profiles/hd01,NOSCHOLARPAGE
 John E. Anderson,University of Manitoba,http://www.cs.umanitoba.ca/~andersj,PGcc-RIAAAAJ
 John E. Hopcroft,Cornell University,http://www.cs.cornell.edu/jeh,NOSCHOLARPAGE

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -1282,6 +1282,7 @@ Jochen Trumpf,Australian National University,http://users.cecs.anu.edu.au/~trump
 Jodi Forlizzi,Carnegie Mellon University,https://www.hcii.cmu.edu/people/jodi-forlizzi,Hyhp_zUAAAAJ
 Jodi L. Forlizzi,Carnegie Mellon University,https://www.hcii.cmu.edu/people/jodi-forlizzi,Hyhp_zUAAAAJ
 Joe B. Wells,Heriot-Watt University,https://researchportal.hw.ac.uk/en/persons/joseph-brian-wells,NOSCHOLARPAGE
+Joe Carthy,University College Dublin,https://people.ucd.ie/joe.carthy,NOSCHOLARPAGE
 Joe Cavallaro,Rice University,http://cavallaro.rice.edu,yi-l0zkAAAAJ
 Joe Cecil,Oklahoma State University,http://cs.okstate.edu/~j.cecil,7A-cBUoAAAAJ
 Joe D. Warren,Rice University,https://www.cs.rice.edu/~jwarren,PVvU3TsAAAAJ

--- a/csrankings-l.csv
+++ b/csrankings-l.csv
@@ -583,6 +583,7 @@ Lorna K. Stewart,University of Alberta,http://webdocs.cs.ualberta.ca/~stewart,NO
 Lorna MacDonald,University of Queensland,https://researchers.uq.edu.au/researcher/1071,NOSCHOLARPAGE
 Lorna Stewart,University of Alberta,http://webdocs.cs.ualberta.ca/~stewart,NOSCHOLARPAGE
 Lorne Olfman,Claremont Graduate University,https://www.cgu.edu/people/lorne-olfman,fXqjPDUAAAAJ
+Lorraine McGinty,University College Dublin,https://people.ucd.ie/lorraine.mcginty,ArXHFdYAAAAJ
 Lorrie Faith Cranor,Carnegie Mellon University,http://lorrie.cranor.org,kIUqgbcAAAAJ
 Lothar Thiele,ETH Zurich,https://www.tec.ee.ethz.ch,OaAKHewAAAAJ
 Lotus Goldberg,Brandeis University,http://www.brandeis.edu/facultyguide/person.html?emplid=19717dba85e7e7d919456954c1c56642a52e0740,bx2LquQAAAAJ

--- a/csrankings-l.csv
+++ b/csrankings-l.csv
@@ -417,6 +417,7 @@ Lili Qiu,University of Texas at Austin,https://www.cs.utexas.edu/~lili,16posrQAA
 Lili Shan,Harbin Institute of Technology,http://homepage.hit.edu.cn/shanlili,8NObiJAAAAAJ
 Lilia Georgieva,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/lilia-georgieva.htm,NOSCHOLARPAGE
 Lilian Blot,University of York,https://www-users.cs.york.ac.uk/~lblot,Enkx56UAAAAJ
+Liliana Pasquale,University College Dublin,https://people.ucd.ie/liliana.pasquale,N8uPjssAAAAJ
 Lillian Lee,Cornell University,http://www.cs.cornell.edu/home/llee,oJESe-cAAAAJ
 Lilly C. Irani,Univ. of California - San Diego,https://quote.ucsd.edu/lirani,FGWYdYUAAAAJ
 Lilly Irani,Univ. of California - San Diego,https://quote.ucsd.edu/lirani,FGWYdYUAAAAJ

--- a/csrankings-l.csv
+++ b/csrankings-l.csv
@@ -368,6 +368,7 @@ Li-Yan Yuan,University of Alberta,https://webdocs.cs.ualberta.ca/~yuan,NOSCHOLAR
 Li-Yang Tan,Stanford University,http://theory.stanford.edu/~liyang,NOSCHOLARPAGE
 LiGuo Huang,Southern Methodist University,http://lyle.smu.edu/~lghuang,NOSCHOLARPAGE
 Liam D. Turner,Cardiff University,https://www.cardiff.ac.uk/people/view/473239-turner-liam,YO4cVgsAAAAJ
+Liam Murphy 0001,University College Dublin,https://people.ucd.ie/liam.murphy,h4bGPQQAAAAJ
 Liam Paull,University of Montreal,http://people.csail.mit.edu/lpaull,H9xADK0AAAAJ
 Liam Peyton,University of Ottawa,http://www.site.uottawa.ca/~lpeyton,jKBUKKgAAAAJ
 Liam Roditty,Bar-Ilan University,https://u.cs.biu.ac.il/~liamr,UY5xtq0AAAAJ

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -718,6 +718,7 @@ Mark Levene,Birkbeck University of London,https://www.dcs.bbk.ac.uk/about/people
 Mark Liberman,University of Pennsylvania,http://www.ling.upenn.edu/~myl,R--JjPoAAAAJ
 Mark M. Hall,Open University UK,http://stem.open.ac.uk/people/mmh352,4f_t86EAAAAJ
 Mark Manulis,University of Surrey,http://manulis.eu,MdmQAVkAAAAJ
+Mark Matthews,University College Dublin,https://people.ucd.ie/mark.matthews,rhv5sLgAAAAJ
 Mark Micallef,University of Malta,https://www.um.edu.mt/profile/markmicallef,NvaH6uYAAAAJ
 Mark Michael Hall,Open University UK,http://stem.open.ac.uk/people/mmh352,4f_t86EAAAAJ
 Mark Minas,Bundeswehr University Munich,https://www.unibw.de/inf2/personen/professoren/minas,NOSCHOLARPAGE

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -742,6 +742,7 @@ Mark S. Nixon,University of Southampton,https://www.ecs.soton.ac.uk/people/msn,h
 Mark Samuel Drew,Simon Fraser University,http://www.cs.sfu.ca/~mark,ZeJn22YAAAAJ
 Mark Sanderson,RMIT University,http://marksanderson.org,HmqvvQkAAAAJ
 Mark Sandler 0001,Queen Mary University of London,http://www.eecs.qmul.ac.uk/people/view/3114/prof-mark-sandler,W-gexv0AAAAJ
+Mark Scanlon,University College Dublin,https://people.ucd.ie/mark.scanlon,85qShC8AAAAJ
 Mark Schmidt 0001,University of British Columbia,http://www.cs.ubc.ca/~schmidtm,5BtEUJcAAAAJ
 Mark Scott Johnson,Macquarie University,http://web.science.mq.edu.au/~mjohnson,Z_kok3sAAAAJ
 Mark Silberstein,Technion,https://sites.google.com/site/silbersteinmark,E4DS2foAAAAJ

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -1326,6 +1326,7 @@ Meina Kan,Chinese Academy of Sciences,http://vipl.ict.ac.cn/homepage/mnkan/index
 Meir Kalech,Ben-Gurion University of the Negev,http://www.ise.bgu.ac.il/faculty/kalech,vo5iW3wAAAAJ
 Meister Eduard Gröller,TU Wien,https://www.cg.tuwien.ac.at/staff/EduardGroeller.html,eBsjFlIAAAAJ
 Meiyappan Nagappan,University of Waterloo,https://cs.uwaterloo.ca/~m2nagapp,QKpkZx0AAAAJ
+Mel Ó Cinnéide,University College Dublin,https://people.ucd.ie/mel.ocinneide,Cr8S0BwAAAAJ
 Mel Slater,University College London,http://www0.cs.ucl.ac.uk/staff/m.slater/Mel_Slaters_Home_Page/Home.html,5gGSgcUAAAAJ
 Melanie Baljko,York University,http://www.cse.yorku.ca/~mb,VdrPPMsAAAAJ
 Melanie E. Moses,University of New Mexico,https://www.cs.unm.edu/~melaniem,WFZ4azsAAAAJ

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -37,6 +37,7 @@ M. Salman Asif,Univ. of California - Riverside,http://www.ece.ucr.edu/~sasif,Dl0
 M. Satyanarayanan,Carnegie Mellon University,https://www.cs.cmu.edu/~satya,0y6JDD4AAAAJ
 M. Sheelagh T. Carpendale,Simon Fraser University,https://www.cs.sfu.ca/~sheelagh,43LLX2kAAAAJ
 M. Sohel Rahman,BUET,http://msrahman.buet.ac.bd,IUwFD9gAAAAJ
+M. Tahar Kechadi,University College Dublin,https://people.ucd.ie/tahar.kechadi,N-0-CjwAAAAJ
 M. Tamer Özsu,University of Waterloo,https://cs.uwaterloo.ca/~tozsu,dwxm_CoAAAAJ
 M. Ümit Uyar,CUNY,http://bioinspired.ccny.cuny.edu/uyar,tF0lurkAAAAJ
 M. V. N. Ashwin Kumar,Duke University,https://users.cs.duke.edu/~ashwin,A0hv6xwAAAAJ

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -67,6 +67,7 @@ Madhu Mutyam,IIT Madras,http://www.cse.iitm.ac.in/~madhu,HS4VEdYAAAAJ
 Madhu Sudan,Harvard University,http://madhu.seas.harvard.edu,D-RwB3YAAAAJ
 Madhur Behl,University of Virginia,https://engineering.virginia.edu/faculty/madhur-behl,bj_imaYAAAAJ
 Madhur Tulsiani,TTI Chicago,http://ttic.uchicago.edu/~madhurt,5ZTO0uMAAAAJ
+Madhusanka Liyanage,University College Dublin,https://people.ucd.ie/madhusanka,p1n0ioUAAAAJ
 Madhusudhan Govindaraju,Binghamton University,http://www.cs.binghamton.edu/~mgovinda,cuA3CkgAAAAJ
 Madjid Fathi,University of Siegen,https://www.eti.uni-siegen.de/ws/mitarbeiter/m_fathi/index.html?lang=de,NOSCHOLARPAGE
 Madjid Fathi-Torbaghan,University of Siegen,https://www.eti.uni-siegen.de/ws/mitarbeiter/m_fathi/index.html?lang=de,NOSCHOLARPAGE

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -1722,6 +1722,7 @@ Michel R. V. Chaudron,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/michel-
 Michel Steuwer,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Michel_Steuwer.html,XdXJRZEAAAAJ
 Michel Wermelinger,Open University UK,http://stem.open.ac.uk/people/mw4687,ESvfE58AAAAJ
 Michel Westenberg,TU Eindhoven,http://www.win.tue.nl/~mwestenb,5eK84bMAAAAJ
+Michela Bertolotto,University College Dublin,https://people.ucd.ie/michela.bertolotto,ONyrJuwAAAAJ
 Michela Taufer,University of Delaware,https://gcl.cis.udel.edu/personal/taufer,3DWI0HcAAAAJ
 Michelangelo Grigni,Emory University,http://www.mathcs.emory.edu/~mic,61uuS7YAAAAJ
 Michele Benzi,Emory University,http://www.mathcs.emory.edu/~benzi,SiPqtAEAAAAJ

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -747,6 +747,7 @@ Mark Smotherman,Clemson University,https://people.cs.clemson.edu/~mark,KADbB0cAA
 Mark Springett,Middlesex University,https://www.mdx.ac.uk/about-us/our-people/staff-directory/profile/springett-mark,rwQJxtUAAAAJ
 Mark Steedman,University of Edinburgh,http://homepages.inf.ed.ac.uk/steedman,ccCd0_YAAAAJ
 Mark Stevenson,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/mark-stevenson,tXe1lgkAAAAJ
+Mark T. Keane,University College Dublin,https://people.ucd.ie/mark.keane,bBozfc4AAAAJ
 Mark V. Springett,Middlesex University,https://www.mdx.ac.uk/about-us/our-people/staff-directory/profile/springett-mark,rwQJxtUAAAAJ
 Mark Vella,University of Malta,http://staff.um.edu.mt/mvel3,KjZUnkMAAAAJ
 Mark W. Craven,University of Wisconsin - Madison,https://www.biostat.wisc.edu/~craven,6VuiGBQAAAAJ

--- a/csrankings-n.csv
+++ b/csrankings-n.csv
@@ -278,6 +278,7 @@ Ney Laert Vilar Calazans,PUC-RS,http://www.inf.pucrs.br/~calazans,s3vzk7cAAAAJ
 Ngai-Man Cheung,SUTD,https://sites.google.com/site/mancheung0407,vJQArFkAAAAJ
 Ngoc Thang Vu,University of Stuttgart,http://www.ims.uni-stuttgart.de/institut/mitarbeiter/thangvu/index.en.html,Nxbi5YgAAAAJ
 Ngok Lam,HKUST,https://www.cse.ust.hk/~lamngok,brfERGEAAAAJ
+Nhien-An Le-Khac,University College Dublin,https://people.ucd.ie/an.lekhac,e6nKl6kAAAAJ
 Ni Trieu,Arizona State University,https://nitrieu.github.io,esITaOoAAAAJ
 Nian-Feng Tzeng,University of Louisiana - Lafayette,https://people.cmix.louisiana.edu/tzeng,6zq-c5cAAAAJ
 Niangjun Chen,SUTD,https://istd.sutd.edu.sg/people/faculty/niangjun-chen,mOmPukcAAAAJ

--- a/csrankings-n.csv
+++ b/csrankings-n.csv
@@ -210,6 +210,7 @@ Neil D. Lawrence,University of Cambridge,http://inverseprobability.com,r3SJcvoAA
 Neil Dantam,Colorado School of Mines,http://inside.mines.edu/~ndantam,J-6Ch9sAAAAJ
 Neil F. Stewart,University of Montreal,http://www.iro.umontreal.ca/~stewart,G1phNfoAAAAJ
 Neil Heffernan III,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/nth.html,dmCZvnsAAAAJ
+Neil Hurley,University College Dublin,https://people.ucd.ie/neil.hurley,Xy75cgsW65QC
 Neil Immerman,University of Massachusetts Amherst,https://people.cs.umass.edu/~immerman,DbZWZr8AAAAJ
 Neil M. White,University of Southampton,https://www.ecs.soton.ac.uk/people/neilw,-KqNHGQAAAAJ
 Neil Mac Parthaláin,Aberystwyth University,https://www.aber.ac.uk/en/cs/staff-profiles/listing/profile/ncm,Um3skD0AAAAJ

--- a/csrankings-n.csv
+++ b/csrankings-n.csv
@@ -490,6 +490,7 @@ Nils Thuerey,TU Munich,https://wwwcg.in.tum.de/group/persons/thuerey.html,GEehwv
 Nils Thürey,TU Munich,https://wwwcg.in.tum.de/group/persons/thuerey.html,GEehwv8AAAAJ
 Nils Urbach,University of Bayreuth,https://www.sim.uni-bayreuth.de/de/team/nils-urbach/index.php,H7D9_EkAAAAJ
 Nilufer Onder,Michigan Technological University,https://www.mtu.edu/cs/department/faculty-staff/faculty/n-onder,BZi6Z08AAAAJ
+Nima Afraz,University College Dublin,https://people.ucd.ie/nima.afraz,Ps84vZkAAAAJ
 Nima Honarmand,Stony Brook University,http://compas.cs.stonybrook.edu/~nhonarmand,Zg6T9tgAAAAJ
 Nima Khademi Kalantari,Texas A&M University,http://nkhademi.com,0TGDhHsAAAAJ
 Nina Amenta,Univ. of California - Davis,http://www.cs.ucdavis.edu/~amenta,ZzNrbIUAAAAJ

--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -403,6 +403,7 @@ Paulo Veríssimo,KAUST,https://cemse.kaust.edu.sa/people/person/paulo-verissimo,
 Pavel A. Pevzner,Univ. of California - San Diego,http://cseweb.ucsd.edu/~ppevzner,0fq5QeIAAAAJ
 Pável Calado,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist14497,7Udj_YAAAAAJ
 Pavel Celeda,Masaryk University,https://www.muni.cz/en/people/206086,19TG5q8AAAAJ
+Pavel Gladyshev,University College Dublin,https://people.ucd.ie/pavel.gladyshev,Gd8AvzoAAAAJ
 Pavel Hubácek,Charles University,https://iuuk.mff.cuni.cz/~hubacek,1kM7gtQAAAAJ
 Pavel Matula,Masaryk University,https://www.muni.cz/en/people/2927,NOSCHOLARPAGE
 Pavel Panchekha,University of Utah,https://pavpanchekha.com,dIOCe1UAAAAJ

--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -40,6 +40,7 @@ Padmanabhan Rajan,IIT Mandi,https://faculty.iitmandi.ac.in/~padman,3sZ-nzAAAAAJ
 Padmini Srinivasan,University of Iowa,https://cs.uiowa.edu/people/padmini-srinivasan,NOSCHOLARPAGE
 Padraic Edgington,University of Connecticut,http://www.cse.uconn.edu/people/faculty,eivODg0AAAAJ
 Padraig Corcoran,Cardiff University,https://www.cardiff.ac.uk/people/view/155896-corcoran-padraig,eoqE1OEAAAAJ
+Padraig Cunningham,University College Dublin,https://people.ucd.ie/padraig.cunningham,HqGgUVAAAAAJ
 Pai H. Chou,National Tsing Hua University,http://epl.tw/people/phchou,r7I9N5cAAAAJ
 Paige Rodeghero,Clemson University,http://paigerodeghero.com,vTZVpdqxruwC
 Pak Ching Li,University of Manitoba,http://www.cs.umanitoba.ca/~lipakc,NOSCHOLARPAGE

--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -448,6 +448,7 @@ Reinhard von Hanxleden,University of Kiel,https://www.rtsys.informatik.uni-kiel.
 Reinhold Haux,TU Braunschweig,https://plri.de/mitarbeiter/reinhold-haux,6_4K9QsAAAAJ
 Reinhold Plösch,JKU Linz,http://www.se.jku.at/ploesch,29YTNJgAAAAJ
 Reinhold Scherer,University of Essex,https://www.essex.ac.uk/people/scher51108/reinhold-scherer,E_wVwfUAAAAJ
+Rem W. Collier,University College Dublin,https://people.ucd.ie/rem.collier,P6Qta-8AAAAJ
 Remco C. Veltkamp,Utrecht University,https://www.uu.nl/staff/RCVeltkamp,xGkWUqMAAAAJ
 Remco Chang,Tufts University,http://www.cs.tufts.edu/~remco,Q29WmWwAAAAJ
 Rémi Emonet,Université Jean Monnet,http://home.heeere.com,TOqZIGgAAAAJ

--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -1238,6 +1238,7 @@ Rui Zhang 0037,Pennsylvania State University,https://ryanzhumich.github.io,8GCLi
 Ruibang Luo,University of Hong Kong,http://www.bio8.cs.hku.hk,CwGy9jsAAAAJ
 Ruifeng Xu,Harbin Institute of Technology,http://www.hitsz.edu.cn/teacher/view/id-492.html,mObXnNIAAAAJ
 Ruigang Yang,University of Kentucky,http://www.vis.uky.edu/~ryang,yveq40QAAAAJ
+Ruihai Dong,University College Dublin,https://people.ucd.ie/ruihai.dong,icGRQ68AAAAJ
 Ruihong Huang,Texas A&M University,https://engineering.tamu.edu/cse/people/huang-ruihong,NU2aHWUAAAAJ
 Ruihua Song,Renmin University of China,http://ai.ruc.edu.cn/faculty/rsong,v5LctN8AAAAJ
 Ruihua Zhang,Shandong University,http://www.cs.sdu.edu.cn/info/1091/2352.htm,NOSCHOLARPAGE

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -777,6 +777,7 @@ Sheldon H. Jacobson,Univ. of Illinois at Urbana-Champaign,http://shj.cs.illinois
 Sheldon S. Williamson,Ontario Tech University,https://engineering.ontariotechu.ca/people/ecse/sheldon.williamson.php,I9aBAuQAAAAJ
 Sheldon X.-D. Tan,Univ. of California - Riverside,http://www.ee.ucr.edu/~stan,ugsbzTsAAAAJ
 Shen Furao,Nanjing University,https://cs.nju.edu.cn/rinc/student/qty/index.html,bjSi-dIAAAAJ
+Shen Wang,University College Dublin,https://people.ucd.ie/shen.wang,rPAOzIwAAAAJ
 Sheng Chen 0001,University of Southampton,https://www.ecs.soton.ac.uk/people/sqc,ZikGt_kAAAAJ
 Sheng Chen 0008,University of Louisiana - Lafayette,http://www.ucs.louisiana.edu/~sxc2311,NOSCHOLARPAGE
 Sheng Li 0001,University of Georgia,http://www.cs.uga.edu/~shengli,DEncVcYAAAAJ

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -1055,6 +1055,7 @@ Simina Brânzei,Purdue University,https://www.cs.purdue.edu/people/faculty/simin
 Simon A. Dobson,University of St Andrews,https://simondobson.org,AbJrH_EAAAAJ
 Simon Attfield,Middlesex University,http://www.cs.mdx.ac.uk/people/simon-attfield,Uh9q5_MAAAAJ
 Simon Bliudze,CRIStAL,https://www.cristal.univ-lille.fr/profil/sbliudze,P_D0LkkAAAAJ
+Simon Caton,University College Dublin,https://people.ucd.ie/simon.caton,yr8skEQAAAAJ
 Simon Colton,Queen Mary University of London,http://eecs.qmul.ac.uk/profiles/coltonsimon.html,L6GPVfcAAAAJ
 Simon D'Alfonso,University of Melbourne,https://findanexpert.unimelb.edu.au/profile/180658-simon-d%27alfonso,hXEZnsUAAAAJ
 Simon Delamare,Ecole Normale Superieure de Lyon,http://graal.ens-lyon.fr/~sdelamar,NOSCHOLARPAGE

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -439,6 +439,7 @@ Sean B. Maynard,University of Melbourne,http://people.eng.unimelb.edu.au/seanbm/
 Sean Bechhofer,University of Manchester,http://www.cs.man.ac.uk/~seanb,XRzaza0AAAAJ
 Sean C. Warnick,Brigham Young University,https://cs.byu.edu/faculty/sean,k7WBrxoAAAAJ
 Sean Chester,University of Victoria,https://sean-chester.github.io,ZxNF5OYAAAAJ
+Sean Edward Russell,University College Dublin,https://people.ucd.ie/sean.russell,SmKCcJQAAAAJ
 Seán F. McLoone,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=s.mcloone,lNHnKBAAAAAJ
 Sean Follmer,Stanford University,http://shape.stanford.edu,f3g5oeEAAAAJ
 Sean Hallgren,Pennsylvania State University,http://www.cse.psu.edu/~sjh26,NOSCHOLARPAGE

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -1261,6 +1261,7 @@ Soumya K. Ghosh,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ
 Soumya K. Ghosh 0001,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ
 Soumya Kanti Ghosh 0001,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ
 Soumya Ray,Case Western Reserve University,http://engr.case.edu/ray_soumya,T3Wxu_AAAAAJ
+Soumyabrata Dev,University College Dublin,https://people.ucd.ie/soumyabrata.dev,_akXw8IAAAAJ
 Soumyajit Dey,IIT Kharagpur,http://cse.iitkgp.ac.in/~soumya,XJI3nYIAAAAJ
 Sourabh Bhattacharya,Iowa State University,https://www.cs.iastate.edu/people/sourabh-bhattacharya,2nLY4NUAAAAJ
 Sourangshu Bhattacharya,IIT Kharagpur,http://cse.iitkgp.ac.in/~sourangshu,IixRsP0AAAAJ

--- a/csrankings-t.csv
+++ b/csrankings-t.csv
@@ -744,6 +744,7 @@ Tony Simons 0001,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/
 Tony Sloane,Macquarie University,https://researchers.mq.edu.au/en/persons/anthony-sloane,Rje58OMAAAAJ
 Tony Smith,University of Waikato,http://www.cms.waikato.ac.nz/people/tcs,mSp4V_4AAAAJ
 Tony Tan,National Taiwan University,https://www.csie.ntu.edu.tw/~tonytan,NOSCHOLARPAGE
+Tony Veale,University College Dublin,https://people.ucd.ie/tony.veale,i8nJh5YAAAAJ
 Tony Wauters,KU Leuven,https://people.cs.kuleuven.be/~tony.wauters,moTbWMUAAAAJ
 Tony White,Carleton University,https://carleton.ca/scs/people/tony-white,EkUL_2kAAAAJ
 Tony Wirth,University of Melbourne,http://people.eng.unimelb.edu.au/awirth,qVuN4MIAAAAJ

--- a/csrankings-v.csv
+++ b/csrankings-v.csv
@@ -351,6 +351,7 @@ Vittorio Zaccaria,Politecnico di Milano,http://home.deib.polimi.it/zaccaria,SUfl
 Vivek Chaturvedi,Nanyang Technological University,http://www.ntu.edu.sg/home/vchaturvedi,uLCnTDEAAAAJ
 Vivek K. Singh,Rutgers University,https://wp.comminfo.rutgers.edu/vsingh,Ef1hJ8IAAAAJ
 Vivek Kumar 0001,IIIT Delhi,https://www.iiitd.ac.in/vivekk,NOSCHOLARPAGE
+Vivek Nallur,University College Dublin,https://people.ucd.ie/vivek.nallur,TeqJsjcAAAAJ
 Vivek Sarin,Texas A&M University,http://faculty.cs.tamu.edu/sarin,4vLOo4wAAAAJ
 Vivek Sarkar,Georgia Institute of Technology,http://vsarkar.cc.gatech.edu,XjeIqxYAAAAJ
 Vivek Srikumar,University of Utah,http://svivek.com,TsTUfOIAAAAJ


### PR DESCRIPTION
The PR adds the entire University College Dublin School of Computer Science faculty in accordance with the guidelines.

- Added `country-info.csv` with `University College Dublin,europe,ie`
- Added each faculty member's DBLP name, home page, and Google Scholar entry to `csrankings-[0-9].csv` in individual commits
- Ensured Alphabetical Order