### PR TITLE
Adding Shuai Li to csrankings-s.csv

### DIFF
--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -963,6 +963,7 @@ Shu-Ching Chen,Florida International University,https://www.cs.fiu.edu/~chens,NO
 Shu-Mei Guo,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/depmember/teacherdetail/id/14,NOSCHOLARPAGE
 Shuai Cheng Li,City University of Hong Kong,https://www.cs.cityu.edu.hk/~shuaicli,HycDtOMAAAAJ
 Shuai Li 0001,Beihang University,http://scse.buaa.edu.cn/info/1024/3022.htm,NOSCHOLARPAGE
+Shuai Li 0010,Shanghai Jiao Tong University,https://shuaili8.github.io/,kMZgQxcAAAAJ
 Shuai Ma 0001,Beihang University,http://mashuai.buaa.edu.cn,vJUjFpQAAAAJ
 Shuai Mu,Stony Brook University,http://mpaxos.com,wcbyR5UAAAAJ
 Shuai Mu 0001,Stony Brook University,http://mpaxos.com,wcbyR5UAAAAJ


### PR DESCRIPTION
I am proposing to add Shuai Li (dblp Shuai Li 0010), an assistant professor at Shanghai Jiao Tong University), to csrankings-s.csv. Her research interest lies on multi-armed bandits, online learning, machine learning theory, reinforcement learning, and recommendation systems.

Thanks a lot!

# Contributing to CSrankings

Thanks for contributing to CSrankings! Here are some guidelines to getting your pull request accepted.

0. Use a reasonable title that explains what the PR corresponds to (as in, not "Update csrankings-x.csv"). **IF YOU DO NOT DO THIS, YOUR COMMIT WILL BE SUMMARILY REJECTED.**

1. _Do not use Excel to edit any .csv files; Excel incorrectly tries to
convert some Google Scholar entries to formulas, corrupting the
database. Use a text editor like emacs or NotePad instead._

2. _Insert new faculty **in alphabetical order**, not at the end of `csrankings-[a-z].csv`._ **Do not modify `csrankings.csv`, which is auto-generated.** **DO NOT MODIFY `csrankings-[0-9].csv`, WHICH ARE BEING DEPRECATED. USE `csrankings-[a-z].csv` INSTEAD.**

3. _Read and check **all** the boxes below by filling them in with an X._

**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track research
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department. Faculty should also have a 75%+ time appointment (check
`old/industry.csv` for faculty who are now more than 25% in industry).

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings-[a-z].csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings-[a-z].csv` (**the letters correspond to the first letter of the faculty members' names**; please **do not** use the numeric suffixes, which are being obsoleted); include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [x] If the institution you are adding is not in the US,
update `country-info.csv`.

**(Advanced) Quick contribution via a shallow clone** 

A full clone of the CSrankings repository is almost 2GB.  To contribute a change without creating a full local clone of the CSrankings repo, you can do a _shallow clone_.  To do so, follow these steps:

1. Fork the CSrankings repo.  If you have an existing fork, but it is not up to date with the main repository, this technique may not work.  If necessary, delete and re-create your fork to get it up to date.  (Do **not** delete your existing fork if it has unmerged changes you want to preserve!)
2. Do a shallow clone of your fork: `git clone --depth 1 https://github.com/yourusername/CSrankings`.  This will only download the most recent commit, not the full git history.
3. Make your changes on a branch, push them to your clone, and create a pull request on GitHub as usual.

If you want to do another contribution and some time has passed, perform steps 1-3 again, creating a fresh fork and shallow clone.


