### PR TITLE
Added Heidelberg University faculty member (Stefan Riezler)

### DIFF
--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -1459,6 +1459,7 @@ Stefan Nilsson,KTH Royal Institute of Technology,http://www.csc.kth.se/~snilsson
 Stefan Pickl,Bundeswehr University Munich,https://www.unibw.de/comtessa,NOSCHOLARPAGE
 Stefan Posch,University of Halle-Wittenberg,http://users.informatik.uni-halle.de/~posch,NOSCHOLARPAGE
 Stefan Resmerita,University of Salzburg,http://cs.uni-salzburg.at/~stefan.resmerita,NOSCHOLARPAGE
+Stefan Riezler,Heidelberg University,https://www.cl.uni-heidelberg.de/~riezler,nY9tQLYAAAAJ
 Stefan Roth 0001,TU Darmstadt,http://www.visinf.tu-darmstadt.de/team_members/sroth/sroth.en.jsp,0yDoR0AAAAAJ
 Stefan S. Dantchev,Durham University,https://www.dur.ac.uk/computer.science/staff/profile/?id=2378,NOSCHOLARPAGE
 Stefan Savage,Univ. of California - San Diego,http://cseweb.ucsd.edu/~savage,_JhgbioAAAAJ


### PR DESCRIPTION
Stefan Riezler is a full professor at the Department of Computational Linguistics and a member of the Interdisciplinary Center for Scientific Computing (IWR) at Heidelberg University. He is authorized to solely advise PhD students in Computer Science. 