### PR TITLE
add Valerio Terragni and Kelly Blincoe - University of Auckland

### DIFF
--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -389,6 +389,7 @@ Kejun Zhang,Zhejiang University,http://mypage.zju.edu.cn/en/zhangkejun,NOSCHOLAR
 Kelin Kuhn,Oregon State University,http://eecs.oregonstate.edu/people/kuhn-kelin,NOSCHOLARPAGE
 Kelly A. Lyons,University of Toronto,http://individual.utoronto.ca/klyons,PJsN8P0AAAAJ
 Kelly Androutsopoulos,Middlesex University,http://www.eis.mdx.ac.uk/staffpages/kellyandroutsopoulos,0VGY3MQAAAAJ
+Kelly Blincoe,University of Auckland,https://kblincoe.github.io/,lqL9DsoAAAAJ
 Kelly Caine,Clemson University,https://kellycaine.wordpress.com,nTMBPAIAAAAJ
 Kelly E. Caine,Clemson University,https://kellycaine.wordpress.com,nTMBPAIAAAAJ
 Kelly Garcés,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/kjgarces971/es/inicio,5p7oedgAAAAJ

--- a/csrankings-v.csv
+++ b/csrankings-v.csv
@@ -43,6 +43,7 @@ Valerie King,University of Victoria,http://webhome.cs.uvic.ca/~val,XS-XGGoAAAAJ
 Valerie Taylor 0001,Texas A&M University,https://engineering.tamu.edu/cse/people/vtaylor,UUWrt60AAAAJ
 Valerio Pascucci,University of Utah,http://www.pascucci.org,Wh-qjBsAAAAJ
 Valerio Selis,University of Liverpool,https://liverpool.ac.uk/electrical-engineering-and-electronics/staff/valerio-selis,PeaYlmIAAAAJ
+Valerio Terragni,University of Auckland,https://valerio-terragni.github.io,ifF-jLQAAAAJ
 Valeriu Breazu,University of Pennsylvania,http://www.cis.upenn.edu/~val,NOSCHOLARPAGE
 Valmir C. Barbosa,UFRJ,http://www.cos.ufrj.br/~valmir,NOSCHOLARPAGE
 Valmir Carneiro Barbosa,UFRJ,http://www.cos.ufrj.br/~valmir,NOSCHOLARPAGE


### PR DESCRIPTION
Kelly Blincoe and Valerio Terragni are faculty of the Department of Electrical, Computer, and Software Engineering at The University of Auckland

**They can advise PhD students in CS**

