### PR TITLE
Add missing faculty from Ruhr-University Bochum

### DIFF
--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -2057,6 +2057,7 @@ Asim Banerjee,DAIICT,http://www.daiict.ac.in/daiict/people/faculty.html,NOSCHOLA
 Asim Karim,LUMS,http://web.lums.edu.pk/~akarim,NXFekJ4AAAAJ
 Asim Zia,University of Vermont,http://www.uvm.edu/~azia,6pQUsD0AAAAJ
 Asish Mukhopadhyay,University of Windsor,http://www.uwindsor.ca/science/computerscience/1053/dr-asish-mukhopadhyay,Up_ZDaAAAAAJ
+Asja Fischer,Ruhr-University Bochum,https://www.ruhr-uni-bochum.de/lmi/fischer/,FyZbyIUAAAAJ
 Aske Mottelson,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/aske-mottelson(410df04c-bc1d-4cd3-9726-c35469ddab8c).html,TJ4FMD8AAAAJ
 Aslan Askarov,Aarhus University,http://askarov.net,VV78_dMAAAAJ
 Asma Adnane,Loughborough University,https://www.lboro.ac.uk/departments/compsci/staff/academic-teaching/asma-adnane,yNx6iUwAAAAJ

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -564,6 +564,7 @@ Aleksander Madry,Massachusetts Institute of Technology,https://people.csail.mit.
 Aleksandra Korolova,University of Southern California,http://informatics.usc.edu/people/aleksandra-korolova.htm,oK_XUmsAAAAJ
 Aleksy Schubert,University of Warsaw,http://www.mimuw.edu.pl/~alx,0vbRwBQAAAAJ
 Alena Denisova,City University of London,https://www.city.ac.uk/people/academics/alena-denisova,32v5DP4AAAAJ
+Alena Naiakshina,Ruhr-University Bochum,https://www.besec.uni-bonn.de/index.php/team/alena-naiakshina/,6HPZRskAAAAJ
 Ales Horák,Masaryk University,https://www.muni.cz/en/people/1648,lBJuYA8AAAAJ
 Ales Leonardis,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/leonardis-ales.aspx,BEFl4j0AAAAJ
 Alessandra Cavarra,University of Oxford,http://www.cs.ox.ac.uk/people/alessandra.cavarra,NOSCHOLARPAGE

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -643,6 +643,7 @@ Gregor Engels,Paderborn University,http://www.upb.de/cs/engels.html,3AV1TsAAAAAJ
 Gregor Kiczales,University of British Columbia,https://www.cs.ubc.ca/~gregor,Odh4GSYAAAAJ
 Gregor Leander,Ruhr-University Bochum,http://www.crypto.rub.de/staff/leander.html.en,qv21mtIAAAAJ
 Gregor Schiele,University of Duisburg-Essen,https://www.uni-due.de/es/en/en_gregor_schiele.php,jhSvu1wAAAAJ
+Gregor Schöner,Ruhr-University Bochum,https://www.ini.rub.de/the_institute/people/gregor-schoner/,SND5_8sAAAAJ
 Gregor Snelting,Karlsruhe Institute of Technology,https://pp.info.uni-karlsruhe.de/personhp/gregor_snelting.php,sprhcYcAAAAJ
 Gregor V. Bochmann,University of Ottawa,http://www.site.uottawa.ca/~bochmann,NOSCHOLARPAGE
 Gregor v. Bochmann,University of Ottawa,http://www.site.uottawa.ca/~bochmann,NOSCHOLARPAGE

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -392,6 +392,8 @@ Gevorg Grigoryan,Dartmouth College,http://dartmouth.edu/faculty-directory/gevorg
 Geyong Min,University of Exeter,http://emps.exeter.ac.uk/computer-science/staff/gm321,OKpejRIAAAAJ
 Ghadah Aldabbagh,King Abdulaziz University,http://www.kau.edu.sa/CVEn.aspx?Site_ID=0003149&Lng=EN,mZkyspYAAAAJ
 Ghassan Hamarneh,Simon Fraser University,http://www.cs.sfu.ca/~hamarneh,61DdlkAAAAAJ
+Ghassan Karame,Ruhr-University Bochum,http://www.ghassankarame.com/,C7StKesAAAAJ
+Ghassan O. Karame,Ruhr-University Bochum,http://www.ghassankarame.com/,C7StKesAAAAJ
 Ghazanfar Asadi,Sharif University of Technology,http://sharif.edu/~asadi,fgNWK9YAAAAJ
 Gheorghe Tecuci,George Mason University,http://lac.gmu.edu/members/tecuci.htm,OrhUjqEAAAAJ
 Gheorghita Ghinea,Brunel University London,https://www.brunel.ac.uk/people/george-ghinea,k-Q6RlEAAAAJ

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -500,6 +500,7 @@ Keting Jia,Tsinghua University,http://www.castu.tsinghua.edu.cn/publish/casen/12
 Keval Vora,Simon Fraser University,http://www.cs.sfu.ca/~keval,l40B-WYAAAAJ
 Kevin B. Korb,Monash University,http://monash.edu/research/explore/en/persons/kevin-korb(3170934f-4d80-435b-ad14-0af80566ad5a).html,RMtts8IAAAAJ
 Kevin Bierre,Rochester Institute of Technology,https://www.rit.edu/gccis/igm/kevin-bierre,NOSCHOLARPAGE
+Kevin Borgolte,Ruhr-University Bochum,https://kevin.borgolte.me,20bCZ_IAAAAJ
 Kevin Bryson,University College London,http://www0.cs.ucl.ac.uk/people/K.Bryson.html,m_OH6V8AAAAJ
 Kevin Buchin,TU Eindhoven,http://www.win.tue.nl/~kbuchin,sNa1oWcAAAAJ
 Kevin C. Almeroth,Univ. of California - Santa Barbara,http://www.cs.ucsb.edu/~almeroth,oXasn9EAAAAJ

--- a/csrankings-l.csv
+++ b/csrankings-l.csv
@@ -153,6 +153,7 @@ Laurent Michel,University of Connecticut,http://www.engr.uconn.edu/~ldm,njNdGR0A
 Laurent Noé,CRIStAL,https://www.cristal.univ-lille.fr/profil/noe,PtgUoRIAAAAJ
 Laurent Thévenoux,Ecole Normale Superieure de Lyon,http://www.ens-lyon.fr/annuaire/m-thevenoux-laurent-261284.kjsp?RH=ENS-LYON,NOSCHOLARPAGE
 Laurent Vanbever,ETH Zurich,https://nsg.ee.ethz.ch,uyCsSAEAAAAJ
+Laurenz Wiskott,Ruhr-University Bochum,https://www.ini.rub.de/PEOPLE/wiskott/,Uk8Le0YAAAAJ
 Lauri Malmi,Aalto University,http://www.cs.hut.fi/~lma,uKJ_WV4AAAAJ
 Lauri Savioja,Aalto University,https://mediatech.aalto.fi/~las,wTfO6z0AAAAJ
 Laurie A. Williams,North Carolina State University,http://collaboration.csc.ncsu.edu/laurie,Cln2viUAAAAJ

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -574,6 +574,8 @@ Marianne Graves Petersen,Aarhus University,http://au.dk/en/mgraves@cs,vgP6E1oAAA
 Marianne Sheelagh Therese Carpendale,Simon Fraser University,https://www.cs.sfu.ca/~sheelagh,43LLX2kAAAAJ
 Mariano Cabrero Canosa,University of A Coruña,https://pdi.udc.es/en/File/Pdi/LB4AF,uoekVL8AAAAJ
 Maríano Javier Cabrero Canosa,University of A Coruña,https://pdi.udc.es/en/File/Pdi/LB4AF,uoekVL8AAAAJ
+Maribel Acosta,Ruhr-Universty Bochum,https://www.ini.rub.de/the_institute/people/maribel-acosta/,druU9nsAAAAJ
+Maribel Acosta Deibe,Ruhr-Universty Bochum,https://www.ini.rub.de/the_institute/people/maribel-acosta/,druU9nsAAAAJ
 Maribel Fernández,King's College London,https://www.kcl.ac.uk/people/maribel-fernandez,dfag-lkAAAAJ
 Marie Durand,Ecole Normale Superieure de Lyon,http://www2.cnrs.fr/en/2621.htm,NOSCHOLARPAGE
 Marie Flavie Auclair-Fortier,Université de Sherbrooke,https://www.usherbrooke.ca/informatique/personnel/corps-professoral/professeurs/marie-flavie-auclair-fortier,NOSCHOLARPAGE

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -137,6 +137,8 @@ Mai ElSherief,Univ. of California - San Diego,https://mayelsherif.github.io/mels
 Mai Fadel,King Abdulaziz University,http://mfadel.kau.edu.sa/Default.aspx?Site_ID=0011432&Lng=EN,NOSCHOLARPAGE
 Maia L. Jacobs,Northwestern University,http://maiajacobs.com,014yACkAAAAJ
 Maic Masuch,University of Duisburg-Essen,https://www.ecg.uni-due.de/team/maic-masuch.html,NOSCHOLARPAGE
+Maike Buchin,Ruhr-University Bochum,https://www.ruhr-uni-bochum.de/lmi/buchin/,HvRX6I0AAAAJ
+Maike Walther,Ruhr-University Bochum,https://www.ruhr-uni-bochum.de/lmi/buchin/,HvRX6I0AAAAJ
 Mainack Mondal,IIT Kharagpur,https://cse.iitkgp.ac.in/~mainack,AUllGoAAAAAJ
 Mainak Chatterjee,University of Central Florida,http://www.cs.ucf.edu/~mainak,KpWOS14AAAAJ
 Mainak Chaudhuri,IIT Kanpur,https://www.cse.iitk.ac.in/users/mainakc,-0GC4ZMAAAAJ

--- a/csrankings-n.csv
+++ b/csrankings-n.csv
@@ -501,6 +501,7 @@ Niloy J. Mitra,University College London,http://www0.cs.ucl.ac.uk/staff/n.mitra,
 Nils Anders Danielsson,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/nad.aspx,NOSCHOLARPAGE
 Nils Aschenbruck,University of Osnabrück,http://sys.cs.uos.de/aschenbruck/index_en.shtml,NOSCHOLARPAGE
 Nils Bertschinger,Goethe University Frankfurt,https://www.fias.science/en/systemic-risk/research-groups/nils-bertschinger,iLErbK0AAAAJ
+Nils Fleischhacker,Ruhr-University Bochum,https://www.crypto.ruhr-uni-bochum.de/staff/fleischhacker.html.en,cJpkmxsAAAAJ
 Nils Gregor Leander,Ruhr-University Bochum,http://www.crypto.rub.de/staff/leander.html.en,qv21mtIAAAAJ
 Nils Jansen 0001,Radboud University,http://www.cs.ru.nl/personal/nilsjansen,zUavkyEAAAAJ
 Nils M. Kriege,University of Vienna,https://dm.cs.univie.ac.at/team/person/111520,wGT17PcAAAAJ

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -535,6 +535,7 @@ Sema F. Oktug,Istanbul Technical University,http://web.itu.edu.tr/oktug,3TRcRPkA
 Sema Fatma Oktug,Istanbul Technical University,http://web.itu.edu.tr/oktug,3TRcRPkAAAAJ
 Sema Oktug,Istanbul Technical University,http://web.itu.edu.tr/oktug,3TRcRPkAAAAJ
 Semih Salihoglu,University of Waterloo,https://cs.uwaterloo.ca/~ssalihog,XxQq8nsAAAAJ
+Sen Cheng,Ruhr-University Bochum,https://www.ini.rub.de/the_institute/people/sen-cheng/,_dzbEm4AAAAJ
 Sen Jia,Shenzhen University,http://csse.szu.edu.cn/cn/people?34040,UxbDMKoAAAAJ
 Sencun Zhu,Pennsylvania State University,http://www.cse.psu.edu/~sxz16,5qwfn20AAAAJ
 Senem Velipasalar,Syracuse University,http://eng-cs.syr.edu/our-departments/electrical-engineering-and-computer-science/people/faculty,HEAE9XsAAAAJ

--- a/csrankings-t.csv
+++ b/csrankings-t.csv
@@ -621,6 +621,7 @@ Tobias Andersen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Tobias Bollenbach,IST Austria,https://ist.ac.at/research/research-groups/bollenbach-group,NOSCHOLARPAGE
 Tobias Fischer 0001,Queensland University of Technology,https://research.qut.edu.au/qcr/people/tobias-fischer,eq46ylAAAAAJ
 Tobias Friedrich 0001,Hasso Plattner Institute,https://hpi.de/en/the-hpi/people/professors/prof-dr-tobias-friedrich.html,vxfzU6IAAAAJ
+Tobias Glasmachers,Ruhr-University Bochum,https://www.ini.rub.de/the_institute/people/tobias-glasmachers/,U8S86d4AAAAJ
 Tobias Höllerer,Univ. of California - Santa Barbara,http://www.cs.ucsb.edu/~holl,008lr2cAAAAJ
 Tobias Hossfeld,University of Würzburg,http://www.comnet.informatik.uni-wuerzburg.de/team/mitarbeiter/hossfeld,AdGp9e0AAAAJ
 Tobias Hoßfeld,University of Würzburg,http://www.comnet.informatik.uni-wuerzburg.de/team/mitarbeiter/hossfeld,AdGp9e0AAAAJ

--- a/csrankings-t.csv
+++ b/csrankings-t.csv
@@ -553,6 +553,7 @@ Tim Weninger,University of Notre Dame,https://www3.nd.edu/~tweninge,V1js0MUAAAAJ
 Tim Weyrich,University College London,http://www.cs.ucl.ac.uk/staff/t.weyrich,pUB0nnwhGVAC
 Tim Wilhelm Nattkemper,Bielefeld University,http://ekvv.uni-bielefeld.de/pers_publ/publ/PersonDetail.jsp?personId=11602,8SR1jMcAAAAJ
 Timo Gerkmann,University of Hamburg,https://www.inf.uni-hamburg.de/en/inst/ab/sp/people/gerkmann.html,X0WjZyMAAAAJ
+Timo Hönig,Ruhr-University Bochum,https://www4.cs.fau.de/~thoenig/,546Ya50AAAAJ
 Timo Kehrer,Humboldt University of Berlin,https://www.informatik.hu-berlin.de/de/forschung/gebiete/mse,WJw1SK0AAAAJ
 Timo Ropinski,University of Ulm,https://www.uni-ulm.de/in/mi/institut/mitarbeiter/tr,FuY-lbcAAAAJ
 Timothy A. Davis 0001,Texas A&M University,http://faculty.cse.tamu.edu/davis,v6zfjqMAAAAJ

--- a/csrankings-t.csv
+++ b/csrankings-t.csv
@@ -442,7 +442,7 @@ Thomas Young,University of Canterbury,https://www.cosc.canterbury.ac.nz/thomas.y
 Thomas Zinner,TU Berlin,https://www.inet.tu-berlin.de/menue/people/prof/zinner0/parameter/de,JWHwP_cAAAAJ
 Thore Husfeldt,IT University of Copenhagen,https://thorehusfeldt.com,wLSsxpAAAAAJ
 Thorsten Altenkirch,University of Nottingham,https://www.nottingham.ac.uk/computerscience/people/thorsten.altenkirch,EHksJkUAAAAJ
-Thorsten Berger,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/bergert.aspx,2-YjsDsAAAAJ
+Thorsten Berger,Ruhr-University Bochum,https://www.chalmers.se/en/staff/Pages/bergert.aspx,2-YjsDsAAAAJ
 Thorsten Grosch,TU Clausthal,https://www.in.tu-clausthal.de/en/abteilungen/cg/personen/prof-dr-thorsten-grosch,oiN-Nx4AAAAJ
 Thorsten Herfet,Saarland University,http://www.nt.uni-saarland.de/en/people/staff/thorsten-herfet,EE1ftG4AAAAJ
 Thorsten Holz,CISPA Helmholtz Center,http://syssec.rub.de/~tho,tv2HR38AAAAJ


### PR DESCRIPTION
Some faculty of the Faculty (Department) of Computer Science were missing from CSrankings. This pull requests adds all of the current faculty as listed on the website [informatik.rub.de](https://informatik.rub.de/en/faculty/professorships/).

# Contribution Checklist

> **Inclusion criteria**
> - [X] Make sure that any faculty you add meet the inclusion criteria. Eligible faculty include only full-time, tenure-track research faculty members on a given campus who can *solely* advise PhD students in Computer Science. Faculty not in a CS department or similar who can advise PhD students in CS can be included regardless of their home department. Faculty should also have a 75%+ time appointment (check `old/industry.csv` for faculty who are now more than 25% in industry).

All faculty are professors in the CS department at Ruhr-University Bochum.

> **Updating an affiliation or home page**
> - [X] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings-[a-z].csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

All professors have Google Scholar profiles.

> **Adding one or more faculty members (including an entire department)**
> - [X] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

Does not apply, the institution is listed already.

> - [X] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings-[a-z].csv` (**the letters correspond to the first letter of the faculty members' names**; please **do not** use the numeric suffixes, which are being obsoleted); include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

No faculty names are ambiguous.

> - [X] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

DBLP aliases exist only for two professors of this pull request, Ghassan Karame and Maribel Acosta. Both are already present in `dblp-aliases.csv`.

> - [X] If the institution you are adding is not in the US, update `country-info.csv`.

Does not apply, the institution is listed already.