### PR TITLE
Update Edmond Chow (Georgia Tech) Homepage

### DIFF
--- a/csrankings-e.csv
+++ b/csrankings-e.csv
@@ -42,7 +42,7 @@ Edith Hemaspaandra,Rochester Institute of Technology,https://www.cs.rit.edu/~eh,
 Edith L. M. Law,University of Waterloo,http://edithlaw.ca,dfKl1qQAAAAJ
 Edith Law,University of Waterloo,http://edithlaw.ca,dfKl1qQAAAAJ
 Edith Spaan,Rochester Institute of Technology,https://www.cs.rit.edu/~eh,Z9W_SPAAAAAJ
-Edmond Chow,Georgia Institute of Technology,http://www.edmondchow.com,NOSCHOLARPAGE
+Edmond Chow,Georgia Institute of Technology,http://www.cc.gatech.edu/~echow/,NOSCHOLARPAGE
 Edmund H. Durfee,University of Michigan,http://ai.eecs.umich.edu/people/durfee,NOSCHOLARPAGE
 Edmund S. Yu,Syracuse University,http://eng-cs.syr.edu/our-departments/electrical-engineering-and-computer-science/people,0uelS_AAAAAJ
 Edmund T. Rolls,University of Warwick,https://warwick.ac.uk/fac/sci/dcs/people/edmund_rolls,4tIgOKsAAAAJ


### PR DESCRIPTION
Dr. Chow does not currently own edmondchow.com, and the website is just an autogenerated one by the domain owners. I have updated the link to refer to his official georgia tech faculty webpage instead.