### PR TITLE
Update Dan Roth's Webpage

### DIFF
--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -118,7 +118,7 @@ Dan Page,University of Bristol,http://www.cs.bris.ac.uk/~page,z55uDZcAAAAJ
 Dan Pei,Tsinghua University,https://netman.cs.tsinghua.edu.cn/~peidan,i_zA1VsAAAAJ
 Dan R. Ghica,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/ghica-dan.aspx,nkaLcCAAAAAJ
 Dan Rockmore,Dartmouth College,http://www.cs.dartmouth.edu/~rockmore,NOSCHOLARPAGE
-Dan Roth,University of Pennsylvania,http://l2r.cs.uiuc.edu,WHOHV3AAAAAJ
+Dan Roth,University of Pennsylvania,http://www.cis.upenn.edu/~danroth/,WHOHV3AAAAAJ
 Dan Rubenstein,Columbia University,http://www.cs.columbia.edu/~danr,FM3vRPgAAAAJ
 Dan S. Wallach,Rice University,https://www.cs.rice.edu/~dwallach,oM25EQkAAAAJ
 Dan Schien,University of Bristol,http://www.bristol.ac.uk/engineering/departments/computerscience/people/daniel-schien,4C7fitQAAAAJ


### PR DESCRIPTION
Dan Roth is no longer at UIUC. This updates his webpage to be his UPenn link. 