### PR TITLE
add xingda wei's profile, an assistant professor at Shanghai JiaoTong University

### DIFF
--- a/csrankings-x.csv
+++ b/csrankings-x.csv
@@ -250,6 +250,7 @@ Xinfeng Ye,University of Auckland,https://unidirectory.auckland.ac.nz/profile/x-
 Xing Gao 0001,University of Delaware,http://xgao-work.github.io,Wkw_2-wAAAAJ
 Xing-Dong Yang,Dartmouth College,https://www.cs.dartmouth.edu/~xingdong,9WfDSNwAAAAJ
 Xingbo Wu,University of Illinois at Chicago,https://www.cs.uic.edu/~wuxb,PUXOLsoAAAAJ
+Xingda Wei,Shanghai Jiao Tong University,https://ipads.se.sjtu.edu.cn/pub/members/xingda_wei,gd-SO4oAAAAJ
 Xinggong Zhang,Peking University,http://www.icst.pku.edu.cn/vip/people-zhangxg_en.html,NOSCHOLARPAGE
 Xinghua Mindy Shi,Temple University,https://cis.temple.edu/~mindyshi,vSDPGjcAAAAJ
 Xinghua Shi,Temple University,https://cis.temple.edu/~mindyshi,vSDPGjcAAAAJ


### PR DESCRIPTION
Modified file:
- csrankings-x.csv

