### PR TITLE
Amin Coja-Oghlan moved to TU Dortmund

### DIFF
--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -1018,7 +1018,7 @@ Amihai Motro,George Mason University,http://cs.gmu.edu/~ami,YPhI-YsAAAAJ
 Amihood Amir,Bar-Ilan University,http://u.cs.biu.ac.il/~amir,otHomQ8AAAAJ
 Amin Alipour,University of Houston,http://alipourm.github.io,hwlkAZYAAAAJ
 Amin Beheshti,Macquarie University,https://researchers.mq.edu.au/en/persons/amin-beheshti,Uw1OLAgAAAAJ
-Amin Coja-Oghlan,Goethe University Frankfurt,https://www.uni-frankfurt.de/52107833,1SdgKVAAAAAJ
+Amin Coja-Oghlan,TU Dortmund,https://www.cs.tu-dortmund.de/nps/en/Home/Personen/C/Coja-Oghlan__Amin.html,1SdgKVAAAAAJ
 Amin Karbasi,Yale University,http://seas.yale.edu/faculty-research/faculty-directory/amin-karbasi,VusVB38AAAAJ
 Amin M. Abbosh,University of Queensland,http://researchers.uq.edu.au/researcher/1576,B3nuBzwAAAAJ
 Amin Sakzad,Monash University,https://research.monash.edu/en/persons/amin-sakzad,b8k6e8IAAAAJ


### PR DESCRIPTION
Amin Coja-Oghlan moved.


**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track research
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department. Faculty should also have a 75%+ time appointment (check
`old/industry.csv` for faculty who are now more than 25% in industry).

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings-[a-z].csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings-[a-z].csv` (**the letters correspond to the first letter of the faculty members' names**; please **do not** use the numeric suffixes, which are being obsoleted); include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [x] If the institution you are adding is not in the US,
update `country-info.csv`.
