### PR TITLE
Add profile for Dr. Timothy O'Donnell

### DIFF
--- a/csrankings-t.csv
+++ b/csrankings-t.csv
@@ -579,6 +579,7 @@ Timothy J. Ellis,Nova Southeastern University,https://cec.nova.edu/faculty/ellis
 Timothy J. Hickey,Brandeis University,http://www.cs.brandeis.edu/~tim,APFVA6sAAAAJ
 Timothy J. Norman,University of Southampton,https://www.ecs.soton.ac.uk/people/tjn1f15,8Rt0X9AAAAAJ
 Timothy L. Andersen,Boise State University,http://cs.boisestate.edu/~tim,mTErwxgAAAAJ
+Timothy J. O'Donnell,McGill University,https://mcqll.org/people/odonnell.timothy/,iYjXhYwAAAAJ
 Timothy Lethbridge,University of Ottawa,http://www.site.uottawa.ca/~tcl,PQ9tLbUAAAAJ
 Timothy M. Chan,Univ. of Illinois at Urbana-Champaign,http://tmc.web.engr.illinois.edu,NOSCHOLARPAGE
 Timothy M. Hospedales,University of Edinburgh,http://homepages.inf.ed.ac.uk/thospeda,nHhtvqkAAAAJ

--- a/dblp-aliases.csv
+++ b/dblp-aliases.csv
@@ -633,6 +633,7 @@ Gerson Flávio de Lima,Gerson Lima
 Gerson Flavio Mendes de Lima,Gerson Lima
 José Alberto Loera,José Loera
 Timothy J. W. Dawes,Timothy Dawes
+Timothy J. O'Donnell,Timothy O'Donnell
 Tim Dawes,Timothy Dawes
 Amin Kargarian,Amin Kargarian Marvasti
 Kyung-Jun Lee,Kyungjun Lee

--- a/dblp-aliases.csv
+++ b/dblp-aliases.csv
@@ -633,7 +633,6 @@ Gerson Flávio de Lima,Gerson Lima
 Gerson Flavio Mendes de Lima,Gerson Lima
 José Alberto Loera,José Loera
 Timothy J. W. Dawes,Timothy Dawes
-Timothy J. O'Donnell,Timothy O'Donnell
 Tim Dawes,Timothy Dawes
 Amin Kargarian,Amin Kargarian Marvasti
 Kyung-Jun Lee,Kyungjun Lee


### PR DESCRIPTION
Dr. Timothy J. O'Donnell is a full-time Assistant Professor at McGIll University. He is affiliated with the Department of Linguistics. However, he is active in the NLP area of research, having published over 6 papers in [NLP conferences like ACL/EMNLP](https://aclanthology.org/people/t/timothy-odonnell/) and also [NeurIPS](https://proceedings.neurips.cc/paper/2021/file/0a4dc6dae338c9cb08947c07581f77a2-Paper.pdf).

**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track research
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department. Faculty should also have a 75%+ time appointment (check
`old/industry.csv` for faculty who are now more than 25% in industry).

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings-[a-z].csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings-[a-z].csv` (**the letters correspond to the first letter of the faculty members' names**; please **do not** use the numeric suffixes, which are being obsoleted); include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [x] If the institution you are adding is not in the US,
update `country-info.csv`.
