### PR TITLE
Adding Jonathan K.Kummerfeld at the University of Sydney

### DIFF
--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -1695,6 +1695,7 @@ Jonathan F. Gemmell,DePaul University,http://www.cdm.depaul.edu/about/Pages/Peop
 Jonathan Gaudreault,Université Laval,https://www.ift.ulaval.ca/departement-et-professeurs/professeurs-et-personnel/professeurs-reguliers/fiche/show/gaudreault-jonathan,g7YxejsAAAAJ
 Jonathan Gemmell,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=494,RIhZrvIAAAAJ
 Jonathan I. Maletic,Kent State University,http://www.cs.kent.edu/~jmaletic,n9_W4kYAAAAJ
+Jonathan K. Kummerfeld,University of Sydney,https://www.jkk.name,OsoNG9AAAAAJ&hl
 Jonathan K. Lazar,University of Maryland - College Park,https://ischool.umd.edu/faculty-staff/jonathan-lazar,CDpfbBsAAAAJ
 Jonathan Katz,University of Maryland - College Park,https://www.cs.umd.edu/~jkatz,H4rKFc8AAAAJ
 Jonathan Lazar,University of Maryland - College Park,https://ischool.umd.edu/faculty-staff/jonathan-lazar,CDpfbBsAAAAJ


### PR DESCRIPTION
**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion criteria. Eligible faculty include only full-time, tenure-track research faculty members on a given campus who can *solely* advise PhD students in Computer Science. Faculty not in a CS department or similar who can advise PhD students in CS can be included regardless of their home department. Faculty should also have a 75%+ time appointment (check`old/industry.csv` for faculty who are now more than 25% in industry).

Note:
(1) My university page is here: <https://www.sydney.edu.au/engineering/about/our-people/academic-staff/jonathan-kummerfeld.html>
(2) My title is 'Senior Lecturer', which is the Australian equivalent of a tenure-track Assistant Professor. A Senior Lecturer has a 40-40-20 split of research-teaching-service.

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings-[a-z].csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put NOSCHOLARPAGE.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings-[a-z].csv` (**the letters correspond to the first letter of the faculty members' names**; please **do not** use the numeric suffixes, which are being obsoleted); include disambiguation suffixes like 0001 as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, all of them need to be listed. If an alias is not already present in `dblp-aliases.csv`, add it.

- [x] If the institution you are adding is not in the US,
update `country-info.csv`.

