### PR TITLE
add the missing quotation mark in csranking.ts

### DIFF
--- a/csrankings.ts
+++ b/csrankings.ts
@@ -1304,7 +1304,7 @@ class CSRankings {
                 }
                 p += `<span class="areaname">${this.areaString(name).toLowerCase()}</span>&nbsp;`;
 
-                p += `<a title="Click for author\'s home page." target="_blank" href="${homePage} `
+                p += `<a title="Click for author\'s home page." target="_blank" href="${homePage}" `
                     + `onclick="trackOutboundLink(\'${homePage}\', true); return false;"`
                     + '>'
                     + `<img alt=\"Home page\" src=\"${this.homepageImage}\"></a>&nbsp;`;


### PR DESCRIPTION
Due to lacking the quotation mark in the professor's home page link, clicking the icon of the author's home page will redirect to an error page (something like https://xxx.xxx.edu/xxx%20onclick=).