### PR TITLE
Update Google Scholar ID for Sorin Istrail

### DIFF
--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -1379,7 +1379,7 @@ Sören Auer,University of Hannover,https://vivo.tib.eu/fis/display/n0000-0002-06
 Sören Laue,Friedrich Schiller University Jena,https://theinf2.informatik.uni-jena.de/People/Soeren+Laue.html,XLOcv_sAAAAJ
 Sören Schwertfeger,ShanghaiTech University,https://robotics.shanghaitech.edu.cn/people/soeren,Y2olJ9kAAAAJ
 Sorin Draghici,Wayne State University,http://vortex.cs.wayne.edu/Sorin/index.htm,fbkIhRYAAAAJ
-Sorin Istrail,Brown University,http://www.brown.edu/Research/Istrail_Lab/sorin.php,NOSCHOLARPAGE
+Sorin Istrail,Brown University,http://www.brown.edu/Research/Istrail_Lab/sorin.php,HCEcMksAAAAJ
 Sorin Lerner,Univ. of California - San Diego,http://cseweb.ucsd.edu/~lerner,C6Pd5zoAAAAJ
 Soroush Vosoughi,Dartmouth College,https://web.cs.dartmouth.edu/people/soroush-vosoughi,45DAXkwAAAAJ
 Sos S. Agaian,CUNY,https://www.csi.cuny.edu/campus-directory/sos-agaian,FazfMZMAAAAJ


### PR DESCRIPTION
Updated Sorin Istrail's Google Scholar ID to "HCEcMksAAAAJ". Previously it was "NOSCHOLARPAGE". His Google Scholar page can be found here:
https://scholar.google.com/citations?user=HCEcMksAAAAJ&hl=en&oi=sra
