### PR TITLE
Added Mikhail Moshkov, removed Timothy Ravasi and Vladimir Bajic from KAUST.

### DIFF
--- a/csrankings-v.csv
+++ b/csrankings-v.csv
@@ -393,7 +393,6 @@ Vlad Kolesnikov,Georgia Institute of Technology,https://www.scs.gatech.edu/peopl
 Vlad Rusu,CRIStAL,https://www.cristal.univ-lille.fr/profil/rusu,uDBCQR8AAAAJ
 Vladik Kreinovich,University of Texas - El Paso,http://hb2504.utep.edu/vitas/vladik.pdf,iern2agAAAAJ
 Vladimir A. Kulyukin,Utah State University,https://cs.usu.edu/people/faculty/kulyukin-vladimir,NOSCHOLARPAGE
-Vladimir B. Bajic,KAUST,https://www.kaust.edu.sa/en/study/faculty/vladimir-bajic,uRmC0DQAAAAJ
 Vladimir Braverman,Rice University,https://profiles.rice.edu/faculty/vladimir-braverman,DTthB48AAAAJ
 Vladimir Filkov,Univ. of California - Davis,http://www.cs.ucdavis.edu/~filkov,rzwHnAcAAAAJ
 Vladimir I. Pavlovic,Rutgers University,http://www.business.rutgers.edu/faculty-research/directory/vladimir-pavlovic,bIiB7bUAAAAJ


### PR DESCRIPTION
Added Mikhail Moshkov, removed Timothy Ravasi and Vladimir Bajic from KAUST.
I followed all the guidelines for updating the csrankings database.