### PR TITLE
Modifications for Max Planck Society faculties

### DIFF
--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -2383,7 +2383,7 @@ Morgan Vigil-Hayes,Northern Arizona University,https://nau.edu/siccs/faculty,NOS
 Moris Behnam,Mälardalen University,http://www.es.mdh.se/staff/157-Moris_Behnam,zRqKryYAAAAJ
 Moritoshi Yasunaga,University of Tsukuba,http://www.islab.cs.tsukuba.ac.jp/~yasunaga/EnglishWebPage/index.html,NOSCHOLARPAGE
 Moritz Grosse-Wentrup,University of Vienna,https://cs.univie.ac.at/moritz.grosse-wentrup,15GNzKcAAAAJ
-Moritz Hardt,Max Planck Society,http://mrtz.org,adnTgaAAAAAJ
+Moritz Hardt [IS],Max Planck Society,http://mrtz.org,adnTgaAAAAAJ
 Morris Sloman,Imperial College London,http://wp.doc.ic.ac.uk/mss,ey299DUAAAAJ
 Morten Brøns,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Morten Fjeld,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/morten-fjeld.aspx,ZQhqxscAAAAJ

--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -618,6 +618,7 @@ Peter D. Bennett,University of Bristol,http://www.peteinfo.com,t_vvNfcAAAAJ
 Peter D. Grünwald,CWI,http://homepages.cwi.nl/~pdg,wItp6h8AAAAJ
 Peter Damaschke,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/ptr.aspx,NOSCHOLARPAGE
 Peter Danielis,University of Rostock,https://www.vhr.uni-rostock.de/team/vertretungsprofessur/dr-ing-habil-peter-danielis-vertretungsprofessur,XxRH9IoAAAAJ
+Peter Dayan,Max Planck Society,https://www.kyb.tuebingen.mpg.de/computational-neuroscience,_30hSU8AAAAJ
 Peter Desnoyers,Northeastern University,http://www.ccs.neu.edu/home/pjd,Zx2TxxsAAAAJ
 Peter Dittrich,Friedrich Schiller University Jena,http://www.informatik.uni-jena.de/csb,XCULQaAAAAAJ
 Peter Dolog,Aalborg University,https://peterdolog.wordpress.com,gCafUI0AAAAJ


### PR DESCRIPTION
This PR updates profiles of faculties belonging to the Max Planck Society:
* Peter Dayan's profile added
* IS note added to Moritz Hardt's existing profile
