### PR TITLE
Add new faculty at RIT

### DIFF
--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -2097,6 +2097,7 @@ Arrvindh Shriraman,Simon Fraser University,http://www.cs.sfu.ca/~ashriram,ZuBFPT
 Arshad Jhumka,University of Warwick,https://warwick.ac.uk/fac/sci/dcs/people/arshad_jhumka,TUVPGvYAAAAJ
 Arslan Munir,Kansas State University,http://people.cs.ksu.edu/~amunir,-P9waaQAAAAJ
 Arthorn Luangsodsai,Chulalongkorn University,http://pioneer.netserv.chula.ac.th/~larthorn,NOSCHOLARPAGE
+Arthur Azevedo de Amorim,Rochester Institute of Technology,http://arthuraa.net/,dZYdFBgAAAAJ
 Arthur Francisco Lorenzon,UFRGS,https://inf.ufrgs.br/~aflorenzon,ITN8AAAAJ
 Arthur G. Money,Brunel University London,https://www.brunel.ac.uk/people/arthur-money,dmzs-pIAAAAJ
 Arthur Gervais,Imperial College London,http://arthurgervais.com,jLr_xi4AAAAJ

--- a/csrankings-v.csv
+++ b/csrankings-v.csv
@@ -72,6 +72,7 @@ Vania Dimitrova,University of Leeds,https://eps.leeds.ac.uk/computing/staff/184/
 Vania G. Dimitrova,University of Leeds,https://eps.leeds.ac.uk/computing/staff/184/professor-vania-dimitrova,cDrHc2YAAAAJ
 Varmo Vene,University of Tartu,http://www.ut.ee/en/read-why-varmo-vene-running-dean,AR7YQTUAAAAJ
 Varsha Apte,IIT Bombay,https://www.cse.iitb.ac.in/~varsha,g2oLiH4AAAAJ
+Varsha Dhani,Rochester Institute of Technology,https://www.rit.edu/directory/vxdvcs-varsha-dani,qA3IkiwAAAAJ
 Varun Chandola,University at Buffalo,http://www.cse.buffalo.edu/~chandola,07Z4HAQAAAAJ
 Varun Dutt,IIT Mandi,https://faculty.iitmandi.ac.in/~varun,jly9u8AAAAAJ
 Varun Kanade,University of Oxford,http://www.cs.ox.ac.uk/people/varun.kanade,NOSCHOLARPAGE


### PR DESCRIPTION
**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track research
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department. Faculty should also have a 75%+ time appointment (check
`old/industry.csv` for faculty who are now more than 25% in industry).

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings-[a-z].csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put `NOSCHOLARPAGE`.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire CS faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings-[a-z].csv` (**the letters correspond to the first letter of the faculty members' names**); include disambiguation suffixes like `0001` as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, *all of them need to be listed*. Do not update `dblp-aliases.csv`.

- [x] If the institution you are adding is not in the US,
update `country-info.csv` and add *all* of the faculty in the CS department.