### PR TITLE
Adding the Universidad Carlos III de Madrid to country-info.csv and the

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -126,8 +126,8 @@ Karlsruhe Institute of Technology,europe,de
 Keio University,asia,jp
 King Abdulaziz University,asia,sa
 King's College London,europe,uk
-Korea University,asia,kr
 Koç University,europe,tr
+Korea University,asia,kr
 Kyoto University,asia,jp
 Kyung Hee University,asia,kr
 Kyungpook National University,asia,kr
@@ -141,6 +141,7 @@ Lund University,europe,se
 MBZUAI,asia,ae
 Maastricht University,europe,nl
 Macquarie University,australasia,au
+Mälardalen University,europe,se
 Masaryk University,europe,cz
 Masdar Institute,asia,ae
 Massey University,australasia,nz
@@ -151,7 +152,6 @@ Memorial University of Newfoundland,canada,ca
 Middle East Technical University,europe,tr
 Middlesex University,europe,uk
 Monash University,australasia,au
-Mälardalen University,europe,se
 NISER,asia,in
 NTNU,europe,no
 NTUA,europe,gr
@@ -170,6 +170,7 @@ Newcastle University,europe,uk
 Ontario Tech University,canada,ca
 Open University UK,europe,uk
 Osaka University,asia,jp
+Özyeğin University,europe,tr
 POSTECH,asia,kr
 PUC-RIO,southamerica,br
 PUC-RS,southamerica,br
@@ -181,9 +182,9 @@ Polytechnique Montreal,canada,ca
 Qatar Computing Research Institute,asia,qa
 Qatar University,asia,qa
 Queen Mary University of London,europe,uk
+Queen’s University,canada,ca
 Queen's University Belfast,europe,uk
 Queensland University of Technology,australasia,au
-Queen’s University,canada,ca
 RMIT University,australasia,au
 RWTH Aachen,europe,de
 Radboud University,europe,nl
@@ -255,6 +256,7 @@ UNSW,australasia,au
 USP,southamerica,br
 USP-ICMC,southamerica,br
 USTC,asia,cn
+Universidad Carlos III de Madrid,europe,es
 Universidad Nacional de Córdoba,southamerica,ar
 Universidad Rey Juan Carlos,europe,es
 Universidad de Chile,southamerica,cl
@@ -264,6 +266,13 @@ Universidade Federal de Viçosa,southamerica,br
 Universidade NOVA de Lisboa,europe,pt
 Universidade de Brasília,southamerica,br
 Universidade de Lisboa,europe,pt
+Università della Svizzera italiana,europe,ch
+Université Jean Monnet,europe,fr
+Université Laval,canada,ca
+Université Paris Dauphine,europe,fr
+Université de Sherbrooke,canada,ca
+Université du Québec à Montréal,canada,ca
+Université libre de Bruxelles,europe,be
 University College Dublin,europe,ie
 University College London,europe,uk
 University of A Coruña,europe,es
@@ -301,9 +310,9 @@ University of Essex,europe,uk
 University of Exeter,europe,uk
 University of Freiburg,europe,de
 University of Glasgow,europe,uk
+University of Göttingen,europe,de
 University of Groningen,europe,nl
 University of Guelph,canada,ca
-University of Göttingen,europe,de
 University of Haifa,europe,il
 University of Halle-Wittenberg,europe,de
 University of Hamburg,europe,de
@@ -324,8 +333,8 @@ University of L'Aquila,europe,it
 University of Leeds,europe,uk
 University of Leipzig,europe,de
 University of Liverpool,europe,uk
-University of Luxembourg,europe,lu
 University of Lübeck,europe,de
+University of Luxembourg,europe,lu
 University of Macau,asia,hk
 University of Magdeburg,europe,de
 University of Mainz,europe,de
@@ -338,8 +347,8 @@ University of Marburg,europe,de
 University of Melbourne,australasia,au
 University of Molise,europe,it
 University of Montreal,canada,ca
-University of Murcia,europe,es
 University of Münster,europe,de
+University of Murcia,europe,es
 University of New Brunswick,canada,ca
 University of Newcastle,australasia,au
 University of Nicosia,europe,cy
@@ -378,8 +387,8 @@ University of Toronto,canada,ca
 University of Trento,europe,it
 University of Trier,europe,de
 University of Tsukuba,asia,jp
-University of Twente,europe,nl
 University of Tübingen,europe,de
+University of Twente,europe,nl
 University of Ulm,europe,de
 University of Victoria,canada,ca
 University of Vienna,europe,at
@@ -394,13 +403,6 @@ University of Wuppertal,europe,de
 University of Würzburg,europe,de
 University of York,europe,uk
 University of Zurich,europe,ch
-Università della Svizzera italiana,europe,ch
-Université Jean Monnet,europe,fr
-Université Laval,canada,ca
-Université Paris Dauphine,europe,fr
-Université de Sherbrooke,canada,ca
-Université du Québec à Montréal,canada,ca
-Université libre de Bruxelles,europe,be
 Uppsala University,europe,se
 Utrecht University,europe,nl
 VISTEC,asia,th
@@ -414,8 +416,7 @@ Wuhan University,asia,cn
 Xi'an Jiaotong University,asia,cn
 Xiamen University,asia,cn
 Xidian University,asia,cn
+Yıldız Technical University,europe,tr
 Yonsei University,asia,kr
 York University,canada,ca
-Yıldız Technical University,europe,tr
 Zhejiang University,asia,cn
-Özyeğin University,europe,tr

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -113,8 +113,8 @@ Abdul Serwadda,Texas Tech University,http://www.depts.ttu.edu/CS/faculty/faculty
 Abdulaziz Ali,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/abdulla_alali.php,S42RixYAAAAJ
 Abdulhakim Qahtan,Utrecht University,https://www.uu.nl/staff/AAAQahtan,8eKzXa8AAAAJ
 Abdulla K. Al-Ali,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/abdulla_alali.php,s1LawbAAAAAJ
-Abdullah Al-Mamun 0001,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=AALMAMUN,PpBDA1cAAAAJ
 Abdullah Al Redwan Newaz,University of New Orleans,https://www.uno.edu/profile/faculty/abdullah-al_redwan-newaz,L_ctqf0AAAAJ
+Abdullah Al-Mamun 0001,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=AALMAMUN,PpBDA1cAAAAJ
 Abdullah Algarni,King Abdulaziz University,https://www.facebook.com/public/Abdullah-Algarni/school/King-Abdulaziz-University-103095679730320,fQldSpoAAAAJ
 Abdullah Basuhail,King Abdulaziz University,http://abasuhail.kau.edu.sa/Default.aspx?Site_ID=0012375&lng=EN,NOSCHOLARPAGE
 Abdullah Ercument Cicek,Bilkent University,http://ciceklab.cs.bilkent.edu.tr/ercumentcicek,n25sJzkAAAAJ
@@ -306,6 +306,7 @@ Adwait Jog,College of William and Mary,http://adwaitjog.github.io,9RgqL8gAAAAJ
 Adwait Nadkarni,College of William and Mary,https://www.adwaitnadkarni.com,Al2MvLoAAAAJ
 Afra Alishahi,Tilburg University,https://ilk.uvt.nl/~aalishah,IuAwLqUAAAAJ
 Afzel Noore,West Virginia University,https://www.statler.wvu.edu/faculty-staff/adjunct-faculty/afzel-noore,rEopbiMAAAAJ
+Agapito Ledezma,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-4495,OSGfSqwAAAAJ
 Agata Ciabattoni,TU Wien,https://www.logic.at/staff/agata,pAyqI0wAAAAJ
 Agathe Guilloux,MBZUAI,https://mbzuai.ac.ae/study/faculty/agathe-guilloux,kgTpYO8AAAAJ
 Agathoniki Trigoni,University of Oxford,https://www.cs.ox.ac.uk/niki.trigoni,185g9ckAAAAJ
@@ -338,9 +339,8 @@ Ahmad Sharieh,University of Jordan,http://eacademic.ju.edu.jo/sharieh,lXeTzzAAAA
 Ahmad-Reza Sadeghi,TU Darmstadt,https://www.trust.informatik.tu-darmstadt.de/people/ahmad-reza-sadeghi,p66Ie-YAAAAJ
 Ahmed Abdelali,Qatar Computing Research Institute,http://www.qcri.org/our-people/bio?pid=103&amp;par=acc&amp;name=AhmedAbdelali,ib1BYugAAAAJ
 Ahmed Abu-Hajar,Washington State University,https://school.eecs.wsu.edu/people/faculty/ahmed-abu-hajar,NOSCHOLARPAGE
-Ahmed F. Al-Eroud,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=AALEROUD,vW6NVIQAAAAJ
-Ahmed Aleroud,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=AALEROUD,vW6NVIQAAAAJ
 Ahmed AlEroud,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=AALEROUD,vW6NVIQAAAAJ
+Ahmed Aleroud,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=AALEROUD,vW6NVIQAAAAJ
 Ahmed Ali,Qatar Computing Research Institute,http://www.qcri.org/our-people/bio?pid=4&amp;par=acc&amp;name=AhmedAli,t0gYEjAAAAAJ
 Ahmed Ali-Eldin,Chalmers/GU,http://www.chalmers.se/en/Staff/Pages/ahmh.aspx,wwQ_TPYAAAAJ
 Ahmed Awad,University of Tartu,https://www.ut.ee/en/ahmed-mahmoud-hany-aly-awad,_Ty6jFcAAAAJ
@@ -349,11 +349,12 @@ Ahmed E. Hassan,Queen’s University,http://www.cs.queensu.ca/~ahmed,9hwXx34AAAA
 Ahmed El-Roby,Carleton University,https://people.scs.carleton.ca/~ahmedelroby,DA68vjUAAAAJ
 Ahmed Eldawy,Univ. of California - Riverside,http://www-users.cs.umn.edu/~eldawy,bshz1DEAAAAJ
 Ahmed Elgammal,Rutgers University,http://www.cs.rutgers.edu/~elgammal/Home.html,DxQiCiIAAAAJ
+Ahmed F. Al-Eroud,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=AALEROUD,vW6NVIQAAAAJ
 Ahmed Helmy,UNC - Charlotte,http://www.cise.ufl.edu/~helmy,QcO9p8AAAAAJ
+Ahmed Hussain Qureshi,Purdue University,https://www.cs.purdue.edu/people/faculty/qureshi7.html,Lkrx2SkAAAAJ
 Ahmed K. Elmagarmid,Purdue University,https://www.cs.purdue.edu/homes/ake,Cb9BDJkAAAAJ
 Ahmed Karmouch,University of Ottawa,http://www.site.uottawa.ca/~karmouch,kQpPzdgAAAAJ
 Ahmed M. Elgammal,Rutgers University,http://www.cs.rutgers.edu/~elgammal/Home.html,DxQiCiIAAAAJ
-Ahmed Hussain Qureshi,Purdue University,https://www.cs.purdue.edu/people/faculty/qureshi7.html,Lkrx2SkAAAAJ
 Ahmed Rafea,American University in Cairo,https://www.aucegypt.edu/fac/ahmedrafea,szDaQLYAAAAJ
 Ahmed Sabbir Arif,Univ. of California - Merced,http://www.asarif.com,l9kbH78AAAAJ
 Ahmed Saeed 0001,Georgia Institute of Technology,https://www.cc.gatech.edu/~amsmti3,nuiUbpsAAAAJ
@@ -417,8 +418,8 @@ Akihiko Takano,University of Tokyo,http://www.nii.ac.jp/en/faculty/digital_conte
 Akihiro Sato,Kyoto University,http://ssuopt.amp.i.kyoto-u.ac.jp/akihiro/wiki_eng,NOSCHOLARPAGE
 Akihiro Sugimoto,National Institute of Informatics,http://www.dgcv.nii.ac.jp/,r7ZaWDUAAAAJ
 Akihiro Yamamoto,Kyoto University,http://www.iip.ist.i.kyoto-u.ac.jp/member/akihiro/index-e.html,NOSCHOLARPAGE
-Akihito Soeda,National Institute of Informatics,https://www.nii.ac.jp/en/faculty/informatics/soeda_akihito/,NOSCHOLARPAGE
 Akihisa Ohya,University of Tsukuba,http://www.cs.tsukuba.ac.jp/~ohya/index_eng.html,FcWCsSgAAAAJ
+Akihito Soeda,National Institute of Informatics,https://www.nii.ac.jp/en/faculty/informatics/soeda_akihito/,NOSCHOLARPAGE
 Akiko Aizawa,National Institute of Informatics,http://www-al.nii.ac.jp/ja/,JQy5hPoAAAAJ
 Akiko N. Aizawa,National Institute of Informatics,http://www-al.nii.ac.jp/ja/,JQy5hPoAAAAJ
 Akiko Nakahara,University of Tokyo,http://research.nii.ac.jp/~akiko/index_e.html,NOSCHOLARPAGE
@@ -505,8 +506,8 @@ Alastair F. Donaldson,Imperial College London,http://multicore.doc.ic.ac.uk,ZIUu
 Alastair R. Beresford,University of Cambridge,https://www.cl.cam.ac.uk/~arb33,KJmh8GAAAAAJ
 Alba C. M. A. Melo,Universidade de Brasília,http://cic.unb.br/~alba/alba.html,vM_I8f4AAAAJ
 Alba Cristina Magalhaes Alves de Melo,Universidade de Brasília,http://cic.unb.br/~alba/alba.html,vM_I8f4AAAAJ
-Alba Garcia Seco de Herrera,University of Essex,https://www.essex.ac.uk/people/garci58409/alba-garcia-seco-de-herrera,80OVgTwAAAAJ
 Alba García Seco de Herrera,University of Essex,https://www.essex.ac.uk/people/garci58409/alba-garcia-seco-de-herrera,80OVgTwAAAAJ
+Alba Garcia Seco de Herrera,University of Essex,https://www.essex.ac.uk/people/garci58409/alba-garcia-seco-de-herrera,80OVgTwAAAAJ
 Alba de Melo,Universidade de Brasília,http://cic.unb.br/~alba/alba.html,vM_I8f4AAAAJ
 Alban Grastien,Australian National University,https://cs.anu.edu.au/people/alban-grastien,87u0x6UAAAAJ
 Alban Ponse,VU Amsterdam,https://staff.fnwi.uva.nl/a.ponse,v709bGQAAAAJ
@@ -574,6 +575,7 @@ Aldo A. Faisal,Imperial College London,https://www.imperial.ac.uk/people/a.faisa
 Aldo Faisal,Imperial College London,https://www.imperial.ac.uk/people/a.faisal,WjHjbrwAAAAJ
 Alec Jacobson,University of Toronto,http://www.cs.toronto.edu/~jacobson,lSJavJUAAAAJ
 Alejandra Beghelli,Goldsmiths University of London,https://www.gold.ac.uk/computing/people/beghelli-alejandra,kP8pBuEAAAAJ
+Alejandro Calderón 0001,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-4000,3_0UdX8AAAAJ
 Alejandro F. Frangi,University of Leeds,https://eps.leeds.ac.uk/computing/staff/1535/professor-alejandro-f-frangi,9fGrB0sAAAAJ
 Alejandro Federico Frangi,University of Leeds,https://eps.leeds.ac.uk/computing/staff/1535/professor-alejandro-f-frangi,9fGrB0sAAAAJ
 Alejandro Frangi,University of Leeds,https://eps.leeds.ac.uk/computing/staff/1535/professor-alejandro-f-frangi,9fGrB0sAAAAJ
@@ -668,8 +670,8 @@ Alex Liu,Michigan State University,http://www.cse.msu.edu/~alexliu,qRjO51UAAAAJ
 Alex Lopez-Lorca,University of Melbourne,http://people.eng.unimelb.edu.au/tmiller,NOSCHOLARPAGE
 Alex M. Bronstein,Technion,http://www.cs.technion.ac.il/~bron,lafKN0sAAAAJ
 Alex Mariakakis,University of Toronto,https://www.cs.toronto.edu/~mariakakis/,YeGQtewAAAAJ
-Alex Mihailidis,University of Toronto,http://www.iatsl.org/people/amihailidis.htm,FgKrtn0AAAAJ
 Alex Mariakakis,University of Toronto,https://mariakakis.github.io/,YeGQtewAAAAJ
+Alex Mihailidis,University of Toronto,http://www.iatsl.org/people/amihailidis.htm,FgKrtn0AAAAJ
 Alex Nicolau,Univ. of California - Irvine,http://www.ics.uci.edu/~nicolau,NOSCHOLARPAGE
 Alex Orailoglu,Univ. of California - San Diego,http://cseweb.ucsd.edu/~alex,RJhla18AAAAJ
 Alex Pang,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~pang,wYggXHoAAAAJ
@@ -688,6 +690,8 @@ Alex Volfovsky,Duke University,https://volfovsky.github.io/,9qHFzDoAAAAJ
 Alex Wong 0002,Yale University,https://seas.yale.edu/faculty-research/faculty-directory/alex-wong,9_XuM8AAAAJ
 Alex Zelikovsky,Georgia State University,http://cs.gsu.edu/profile/alex-zelikovsky,UzCRNJwAAAAJ
 Alexander A. Razborov,University of Chicago,https://people.cs.uchicago.edu/~razborov,NOSCHOLARPAGE
+Alexander A. Schvartsman,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=ASCHWARZMANN,gQo0AHYAAAAJ
+Alexander A. Schwarzmann,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=ASCHWARZMANN,gQo0AHYAAAAJ
 Alexander A. Sherstov,Univ. of California - Los Angeles,http://www.cs.ucla.edu/~sherstov,JinbAIQAAAAJ
 Alexander Afanasyev,Florida International University,https://users.cs.fiu.edu/~afanasyev,goyNhdoAAAAJ
 Alexander Aiken,Stanford University,https://theory.stanford.edu/~aiken,3vKjkoQAAAAJ
@@ -753,8 +757,6 @@ Alexander S. Kotov,Wayne State University,http://www.cs.wayne.edu/kotov,83gsCFsA
 Alexander Schill,TU Dresden,http://www.rn.inf.tu-dresden.de,TABb2iQAAAAJ
 Alexander Schlaefer,Hamburg University of Technology,https://mtec.et8.tuhh.de/staff/alexander-schlaefer.html,NOSCHOLARPAGE
 Alexander Schliep,Chalmers/GU,https://schlieplab.org,NOSCHOLARPAGE
-Alexander A. Schwarzmann,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=ASCHWARZMANN,gQo0AHYAAAAJ
-Alexander A. Schvartsman,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=ASCHWARZMANN,gQo0AHYAAAAJ
 Alexander Serebrenik,TU Eindhoven,http://www.win.tue.nl/~aserebre,Mcn2e18AAAAJ
 Alexander T. Ihler,Univ. of California - Irvine,http://www.ics.uci.edu/~ihler,ffdt7gMAAAAJ
 Alexander Tiskin,University of Warwick,https://warwick.ac.uk/fac/sci/dcs/people/alexander_tiskin,P9lIbS0AAAAJ
@@ -848,8 +850,8 @@ Alexey V. Onufriev,Virginia Tech,http://people.cs.vt.edu/onufriev,b7TXx40AAAAJ
 Alexia Briasouli,Maastricht University,https://sites.google.com/view/alexiab,t7KC74oAAAAJ
 Alexia Briassouli,Maastricht University,https://sites.google.com/view/alexiab,t7KC74oAAAAJ
 Alexia Zoumpoulaki,Cardiff University,https://www.cardiff.ac.uk/people/view/978549-zoumpoulaki-alexia,HVvcecAAAAAJ
-Alexis J. Battle,Johns Hopkins University,http://battlelab.jhu.edu,yPOT9K0AAAAJ
 Alexis Hiniker,University of Washington,http://alexishiniker.com,tY-tZTkAAAAJ
+Alexis J. Battle,Johns Hopkins University,http://battlelab.jhu.edu,yPOT9K0AAAAJ
 Alexis Tsoukiàs,Université Paris Dauphine,https://www.lamsade.dauphine.fr/~tsoukias/,dD54LqIAAAAJ
 Alf Inge Wang,NTNU,http://www.idi.ntnu.no/~alfw,EObDw_AAAAAJ
 Alf Weaver,University of Virginia,https://engineering.virginia.edu/faculty/alfred-c-weaver,0skgDnMAAAAJ
@@ -1013,12 +1015,12 @@ Alois Knoll,TU Munich,http://www6.in.tum.de/Main/Knoll,NOSCHOLARPAGE
 Alois Zoitl,JKU Linz,https://www.jku.at/linz-institute-of-technology/forschung/research-labs/cyber-physical-systems-lab/team/univ-prof-di-dr-alois-zoitl,OG52DQ8AAAAJ
 Alok N. Choudhary,Northwestern University,http://www.eecs.northwestern.edu/~choudhar,q0nuNrEAAAAJ
 Alon Cohen,Tel Aviv University,https://english.tau.ac.il/profile/alonco,shoYR_AAAAAJ
-Aloni Cohen,University of Chicago,https://aloni.net/,g7Op2tgAAAAJ
 Alon Efrat,University of Arizona,http://www.cs.arizona.edu/people/alon,QH90248AAAAJ
 Alon Keinan,Cornell University,http://keinanlab.cb.bscb.cornell.edu,rS0EX5EAAAAJ
 Alon Orlitsky,Univ. of California - San Diego,http://jacobsdev.ucsd.edu/faculty/faculty_bios/index.sfe?fmp_recid=54,NOSCHOLARPAGE
 Alon Rosen,Bocconi University,https://www.alonrosen.net,lfJmfM0AAAAJ
 Alona Fyshe,University of Alberta,http://webdocs.cs.ualberta.ca/~alona,Vw8z7qwAAAAJ
+Aloni Cohen,University of Chicago,https://aloni.net/,g7Op2tgAAAAJ
 Alonzo Kelly,Carnegie Mellon University,http://www.frc.ri.cmu.edu/users/alonzo,W7yeGUoAAAAJ
 Aloysius K. Mok,University of Texas at Austin,https://www.cs.utexas.edu/users/mok,M6urChQAAAAJ
 Aloysius Ka-Lau Mok,University of Texas at Austin,https://www.cs.utexas.edu/users/mok,M6urChQAAAAJ
@@ -1214,21 +1216,23 @@ Ana Cavalcanti 0001,University of York,https://www-users.cs.york.ac.uk/~alcc,fu6
 Ana Claudia Arias,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/acarias.html,LbYsy_QAAAAJ
 Ana Cristina Bicharra Garcia,UFF,http://www.addlabs.uff.br/bicharra,qN-wg74AAAAJ
 Ana Cristina Vieira de Melo,USP,http://www.ime.usp.br/~acvm,NOSCHOLARPAGE
+Ana García Armada,Universidad Carlos III de Madrid,https://agarcia.webs.tsc.uc3m.es/,PYPKZJ8AAAAJ
 Ana Gualdina Almeida Matos,Universidade de Lisboa,http://web.ist.utl.pt/~ist24690,D6nVmPQAAAAJ
+Ana I. González-Tablas,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-2512,c4eSKuMAAAAJ
+Ana Iglesias,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-3190,HmSUxOoAAAAJ
 Ana Klimovic,ETH Zurich,https://anakli.inf.ethz.ch,i7jievkAAAAJ
 Ana L. C. Bazzan,UFRGS,http://www.inf.ufrgs.br/~bazzan,NOSCHOLARPAGE
+Ana L. Milanova,Rensselaer Polytechnic Institute,http://www.cs.rpi.edu/~milanova,PsGxHG0AAAAJ
 Ana Lúcia C. Bazzan,UFRGS,http://www.inf.ufrgs.br/~bazzan,NOSCHOLARPAGE
 Ana Lúcia Cetertich Bazzan,UFRGS,http://www.inf.ufrgs.br/~bazzan,NOSCHOLARPAGE
+Ana Lucia Varbanescu,University of Amsterdam,https://www.uva.nl/en/profile/v/a/a.l.varbanescu/a.l.varbanescu.html,UypyD2wAAAAJ
 Ana M. D. Moreira,Universidade NOVA de Lisboa,http://nova-lincs.di.fct.unl.pt/person/12,uB4MBw4AAAAJ
 Ana Marasovic,University of Utah,https://www.anamarasovic.com/,3W6OnfAAAAAJ
 Ana Maria Dinis Moreira,Universidade NOVA de Lisboa,http://nova-lincs.di.fct.unl.pt/person/12,uB4MBw4AAAAJ
 Ana Maria Paiva,Universidade de Lisboa,http://gaips.inesc-id.pt/~apaiva/Ana_Paiva_Site_2/Home.html,dTG0kWAAAAAJ
 Ana Matran-Fernandez,University of Essex,https://www.essex.ac.uk/people/matra32701/ana-matran-fernandez,_g01zM4AAAAJ
-Ana L. Milanova,Rensselaer Polytechnic Institute,http://www.cs.rpi.edu/~milanova,PsGxHG0AAAAJ
-Ana Lucia Varbanescu,University of Amsterdam,https://www.uva.nl/en/profile/v/a/a.l.varbanescu/a.l.varbanescu.html,UypyD2wAAAAJ
 Ana Moreira 0001,Universidade NOVA de Lisboa,http://nova-lincs.di.fct.unl.pt/person/12,uB4MBw4AAAAJ
 Ana Oprescu,University of Amsterdam,https://cci-research.nl/author/ana-oprescu/,cWSfzoUAAAAJ
-Ana-Maria Oprescu,University of Amsterdam,https://cci-research.nl/author/ana-oprescu/,cWSfzoUAAAAJ
 Ana Paiva,Universidade de Lisboa,http://gaips.inesc-id.pt/~apaiva/Ana_Paiva_Site_2/Home.html,dTG0kWAAAAAJ
 Ana Paiva 0001,Universidade de Lisboa,http://gaips.inesc-id.pt/~apaiva/Ana_Paiva_Site_2/Home.html,dTG0kWAAAAAJ
 Ana Paula Cláudio,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/apclaudio,q8mWLdoAAAAJ
@@ -1240,8 +1244,11 @@ Ana Salagean,Loughborough University,https://www.lboro.ac.uk/departments/compsci
 Ana Serrano,Universidad de Zaragoza,http://webdiis.unizar.es/~aserrano,-tzn_AsAAAAJ
 Ana Sokolova,University of Salzburg,http://cs.uni-salzburg.at/~anas,TqOx714AAAAJ
 Ana T. Freitas,Universidade de Lisboa,http://web.tecnico.ulisboa.pt/ana.freitas,INpn7mMAAAAJ
+Ana Tajadura-Jiménez,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-250253,eG4m4Y8AAAAJ
 Ana Teresa Freitas,Universidade de Lisboa,http://web.tecnico.ulisboa.pt/ana.freitas,INpn7mMAAAAJ
 Ana Vladan Stankovic,Cleveland State University,https://academic.csuohio.edu/stankovica,Tz7AVLMAAAAJ
+Ana-Maria Oprescu,University of Amsterdam,https://cci-research.nl/author/ana-oprescu/,cWSfzoUAAAAJ
+Anabel Fraga,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-1565,dEdhy2YAAAAJ
 Anamika Dubey,Washington State University,https://school.eecs.wsu.edu/people/faculty/anamika-dubey,y-3RPK0AAAAJ
 Anand Bhojan,National University of Singapore,http://www.comp.nus.edu.sg/~bhojan,FDxsgEgAAAAJ
 Anand Louis,IISc Bangalore,http://www.csa.iisc.ac.in/~anand,PedG3PYAAAAJ
@@ -1287,9 +1294,9 @@ Anders Hast,Uppsala University,https://andershast.com,Jffvy8AAAAAJ
 Anders Møller,Aarhus University,https://cs.au.dk/~amoeller,Wx0bdN0AAAAJ
 Anders Nymark Christensen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Anders Robertsson,Lund University,http://www.control.lth.se/Staff/AndersRobertsson.html,YZNvXjAAAAAJ
+Anders Søgaard,University of Copenhagen,http://www.diku.dk/Ansatte/?pure=da/persons/221553,x3I4CrYAAAAJ
 Anders Stockmarr,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Anders Sundnes Løvlie,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/anders-sundnes-loevlie(22ec9269-2fff-4dbf-a9c7-5037559a15ee).html,UhP1dScAAAAJ
-Anders Søgaard,University of Copenhagen,http://www.diku.dk/Ansatte/?pure=da/persons/221553,x3I4CrYAAAAJ
 Anders Tychsen,University of York,https://www.cs.york.ac.uk/people/?group=Academic%20and%20Teaching%20Staff&username=adrachen,rOcL0NgAAAAJ
 Anders Vastberg,KTH Royal Institute of Technology,https://www.kth.se/profile/vastberg,8FRcZh4AAAAJ
 Anders Västberg,KTH Royal Institute of Technology,https://www.kth.se/profile/vastberg,8FRcZh4AAAAJ
@@ -1316,8 +1323,8 @@ André Filipe Torres Martins,Universidade de Lisboa,https://andre-martins.github
 André Fujita,USP,http://www.ime.usp.br/~fujita,R2gGcVYAAAAJ
 André G. Santos 0001,Universidade Federal de Viçosa,http://www2.dpi.ufv.br/?page_id=556,NOSCHOLARPAGE
 André Grahl Pereira,UFRGS,http://www.inf.ufrgs.br/~agpereira,uVd5njYAAAAJ
-Andre Gregio,UFPR,https://sites.google.com/view/andregregio,aUQ9ARUAAAAJ
 André Grégio,UFPR,https://sites.google.com/view/andregregio,aUQ9ARUAAAAJ
+Andre Gregio,UFPR,https://sites.google.com/view/andregregio,aUQ9ARUAAAAJ
 André Gustavo dos Santos,Universidade Federal de Viçosa,http://www2.dpi.ufv.br/?page_id=556,NOSCHOLARPAGE
 André Inácio Reis,UFRGS,http://www.inf.ufrgs.br/~andreis,Cajbmi8AAAAJ
 André J. A. Unger,University of Waterloo,https://uwaterloo.ca/earth-environmental-sciences/people-profiles/andre-unger,D0ix3KsAAAAJ
@@ -1335,6 +1342,7 @@ Andre Scedrov,University of Pennsylvania,https://www.cis.upenn.edu/~scedrov,F-kv
 André Vasconcelos,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist10876/doutoramentos,mSzH4DQAAAAJ
 Andre Wibisono,Yale University,http://www.cs.yale.edu/homes/wibisono,Py_StfUAAAAJ
 André van der Hoek,Univ. of California - Irvine,http://www.ics.uci.edu/~andre,h3L7zkoAAAAJ
+Andrea Bellucci,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-80518,iCS-XDYAAAAJ
 Andrea Bianchi,KAIST,http://alsoplantsfly.com,wVDtZB0AAAAJ
 Andrea Bonarini,Politecnico di Milano,http://home.deib.polimi.it/bonarini,WgxMfwMAAAAJ
 Andrea Bunt,University of Manitoba,https://www.cs.umanitoba.ca/~bunt,NoBlw7EAAAAJ
@@ -1478,9 +1486,9 @@ Andrew Cobley,University of Dundee,https://www.computing.dundee.ac.uk/about/staf
 Andrew Coles,King's College London,https://www.kcl.ac.uk/people/andrew-coles,EMiUE40AAAAJ
 Andrew Colin Rice,University of Cambridge,https://www.cl.cam.ac.uk/~acr31,bxvOPw8AAAAJ
 Andrew Crabtree,University of Nottingham,https://www.nottingham.ac.uk/computerscience/people/andy.crabtree,LX_P5GYAAAAJ
-Andrew D. Miller 0001,IUPUI,https://soic.iupui.edu/people/andrew-miller,U5QeuUcAAAAJ
 Andrew D. Calway,University of Bristol,http://people.cs.bris.ac.uk/~andrew/,jtlbdOoAAAAJ
 Andrew D. Ker,University of Oxford,http://www.cs.ox.ac.uk/andrew.ker/home.html,9fTPyU0AAAAJ
+Andrew D. Miller 0001,IUPUI,https://soic.iupui.edu/people/andrew-miller,U5QeuUcAAAAJ
 Andrew D. Richardson,Northern Arizona University,https://nau.edu/siccs/faculty,GlGy7vgAAAAJ
 Andrew David Ker,University of Oxford,http://www.cs.ox.ac.uk/andrew.ker/home.html,9fTPyU0AAAAJ
 Andrew Dekker,University of Queensland,http://researchers.uq.edu.au/researcher/15139,JKSGdVIAAAAJ
@@ -1600,6 +1608,9 @@ Andy van Dam,Brown University,http://cs.brown.edu/~avd,NOSCHOLARPAGE
 Anelis Kaiser,University of Freiburg,http://gmint.informatik.uni-freiburg.de/kaiser,NOSCHOLARPAGE
 Anfu Zhou,BUPT,https://scs.bupt.edu.cn/info/1100/2285.htm,NOSCHOLARPAGE
 Ang Chen,Rice University,https://www.cs.rice.edu/~angchen,8Y4dDxkAAAAJ
+Angel García Olaya,Universidad Carlos III de Madrid,http://www.plg.inf.uc3m.es/~agolaya/,4R_owNoAAAAJ
+Ángel García-Crespo,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-3241,9Yvx70cAAAAJ
+Ángel Navia-Vázquez,Universidad Carlos III de Madrid,https://www.tsc.uc3m.es/profile.php?uid=navia,7E7LibYAAAAJ
 Ángel Viña,University of A Coruña,https://pdi.udc.es/es/File/Pdi/FK7AF,NOSCHOLARPAGE
 Ángel Viña Castiñeiras,University of A Coruña,https://pdi.udc.es/es/File/Pdi/FK7AF,NOSCHOLARPAGE
 Angel X. Chang,Simon Fraser University,http://www.sfu.ca/computing/people/faculty/angelchang11111111.html,8gfs8XIAAAAJ
@@ -1614,8 +1625,8 @@ Angela K. Demke,University of Toronto,http://www.cs.toronto.edu/~demke,xicy8QcAA
 Angela M. Sasse,Ruhr-University Bochum,https://www.ei.ruhr-uni-bochum.de/fakultaet/personen/sasse,9H_eJqAAAAAJ
 Angela Schwering,University of Münster,https://www.uni-muenster.de/Geoinformatics/institute/staff/index.php/109/Angela_Schwering,NwGtPmsAAAAJ
 Angela Yao,National University of Singapore,https://www.comp.nus.edu.sg/~ayao/,-LJCZMMAAAAJ
-Angeles Saavedra,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=5,IYkBYzQAAAAJ
 Ángeles Saavedra,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=5,IYkBYzQAAAAJ
+Angeles Saavedra,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=5,IYkBYzQAAAAJ
 Ángeles Saavedra Places,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=5,IYkBYzQAAAAJ
 Angelika Kimmig,Cardiff University,https://www.cardiff.ac.uk/people/view/634329-kimmig-angelika,_H5OzrgAAAAJ
 Angelika Steger,ETH Zurich,http://www.as.inf.ethz.ch/people/prof,Kzeoyq8AAAAJ
@@ -1641,6 +1652,7 @@ Anh Tuan Luu,Nanyang Technological University,https://tuanluu.github.io,d6ixOGYA
 Anhong Guo,University of Michigan,https://guoanhong.com,xSZXqZQAAAAJ
 Ani Calinescu,University of Oxford,http://www.cs.ox.ac.uk/people/ani.calinescu,aCljaCYAAAAJ
 Ani Nenkova,University of Pennsylvania,http://www.cis.upenn.edu/~nenkova,vXQdb5kAAAAJ
+Aníbal R. Figueiras-Vidal,Universidad Carlos III de Madrid,https://www.tsc.uc3m.es/~anibal/en/,NOSCHOLARPAGE
 Aniello Cimitile,University of Sannio,https://www.ding.unisannio.it/persone/docenti/cimitile,NOSCHOLARPAGE
 Aniket Bera,Purdue University,https://www.cs.purdue.edu/~ab,q3UdHk4AAAAJ
 Aniket Kate,Purdue University,https://www.cs.purdue.edu/homes/akate,dmhWxJgAAAAJ
@@ -1772,8 +1784,8 @@ Anneliese Amschler Andrews,University of Denver,http://www.cs.du.edu/~andrews,NO
 Anneliese Andrews,University of Denver,http://www.cs.du.edu/~andrews,NOSCHOLARPAGE
 Anneliese von Mayrhauser,University of Denver,http://www.cs.du.edu/~andrews,NOSCHOLARPAGE
 Annette Bieniusa,TU Kaiserslautern,https://softech.informatik.uni-kl.de/team/annettebieniusa,ncuwZ2cAAAAJ
-Annette Middelkoop-Bieniusa,TU Kaiserslautern,https://softech.informatik.uni-kl.de/team/annettebieniusa,ncuwZ2cAAAAJ
 Annette M. Payne,Brunel University London,https://www.brunel.ac.uk/people/annette-payne,bLTTMDgAAAAJ
+Annette Middelkoop-Bieniusa,TU Kaiserslautern,https://softech.informatik.uni-kl.de/team/annettebieniusa,ncuwZ2cAAAAJ
 Annette R. von Jouanne,Oregon State University,http://eecs.oregonstate.edu/people/von-jouanne-annette,NOSCHOLARPAGE
 Annette ten Teije,VU Amsterdam,http://www.few.vu.nl/~annette,2fDYEcgAAAAJ
 Annibale Panichella,TU Delft,https://apanichella.github.io,xPQ72u4AAAAJ
@@ -1864,9 +1876,11 @@ Antonina Kolokolova,Memorial University of Newfoundland,https://www.mun.ca/compu
 Antonino Santos,University of A Coruña,https://pdi.udc.es/en/File/Pdi/ZD99E,ksY1gFgAAAAJ
 Antonio A. F. Loureiro,UFMG,http://homepages.dcc.ufmg.br/~loureiro,GOGlTIMAAAAJ
 Antonio Alfredo Ferreira Loureiro,UFMG,http://homepages.dcc.ufmg.br/~loureiro,GOGlTIMAAAAJ
+Antonio Artés-Rodríguez,Universidad Carlos III de Madrid,https://www.tsc.uc3m.es/~antonio/antonio_artes/Home.html,3aFFX5oAAAAJ
 Antonio Augusto de Aragão Rocha,UFF,http://www2.ic.uff.br/~arocha,C_3SJ4oAAAAJ
 Antonio Badia,University of Louisville,http://louisville.edu/speed/people/faculty/badiaAntonio,LlBDyJcAAAAJ
 Antonio Barbalace,University of Edinburgh,http://www.barbalace.it/antonio,uQWP8_0AAAAJ
+Antonio Berlanga,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-2712,pFcm2TwAAAAJ
 Antonio Bianchi,Purdue University,https://antoniobianchi.me,RMm4j1AAAAAJ
 Antonio Blanca,Pennsylvania State University,http://www.cse.psu.edu/~azb1015,tl6ib-MAAAAJ
 António Branco,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/ambranco,JeBor2UAAAAJ
@@ -1888,8 +1902,8 @@ Antonio Fernández 0001,IMDEA Networks Institute,http://people.networks.imdea.or
 Antonio Fernández Anta,IMDEA Networks Institute,http://people.networks.imdea.org/~antonio_fernandez,kh4x8goAAAAJ
 Antonio Filieri,Imperial College London,http://www.antonio.filieri.name,MdbPRwMAAAAJ
 Antonio Frangioni,University of Pisa,http://www.di.unipi.it/~frangio,W3pkToYAAAAJ
-Antonio G. Marques,Universidad Rey Juan Carlos,http://www.tsc.urjc.es/~amarques,d05JMMkAAAAJ
 Antonio G. Marqués,Universidad Rey Juan Carlos,http://www.tsc.urjc.es/~amarques,d05JMMkAAAAJ
+Antonio G. Marques,Universidad Rey Juan Carlos,http://www.tsc.urjc.es/~amarques,d05JMMkAAAAJ
 Antonio Garcia Marques,Universidad Rey Juan Carlos,http://www.tsc.urjc.es/~amarques,d05JMMkAAAAJ
 Antonio González 0001,Polytechnic University of Catalonia,http://people.ac.upc.es/antonio,WegaFkUAAAAJ
 António Grilo,Universidade de Lisboa,http://www.demi.fct.unl.pt/en/pessoas/docentes/antonio-carlos-barbara-grilo,G6nldpYAAAAJ
@@ -1913,6 +1927,7 @@ Antonio Ruiz-Martínez,University of Murcia,http://webs.um.es/arm,x-whC_gAAAAJ
 Antonio Toral,University of Groningen,http://antoniotor.al,YcdNfhcAAAAJ
 Antonio Toral Ruiz,University of Groningen,http://antoniotor.al,YcdNfhcAAAAJ
 Antonio Torralba 0001,Massachusetts Institute of Technology,http://web.mit.edu/torralba/www,8cxDHS4AAAAJ
+Antonio de Amescua Seco,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169378/idu-1931,UXJnoikAAAAJ
 António dos Anjos,Aberystwyth University,https://www.aber.ac.uk/en/cs/staff-profiles/listing/profile/ara11,vmlD9VYAAAAJ
 Antonios A. Savidis,University of Crete,https://www.ics.forth.gr/hci/index_main.php?l=g&c=517,m0b5D28AAAAJ
 Antonios Anastasopoulos,George Mason University,https://cs.gmu.edu/directory/detail/100,g_G_SNAAAAAJ
@@ -1980,6 +1995,7 @@ Apurva Mudgal,IIT Ropar,http://www.iitrpr.ac.in/cse/apurva,NOSCHOLARPAGE
 Aqueasha Martin-Hammond,IUPUI,https://soic.iupui.edu/people/aqueasha-martin-hammond,ldnCWNQAAAAJ
 Aquinas Hobor,National University of Singapore,https://www.comp.nus.edu.sg/~hobor,NOSCHOLARPAGE
 Arabella Sinclair,University of Aberdeen,https://www.abdn.ac.uk/people/arabella.sinclair,PSOtEH4AAAAJ
+Araceli Sanchis,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169378/idu-2718,6oWnSecAAAAJ
 Aram Ter-Sarkisov,City University of London,https://www.city.ac.uk/people/academics/alex-aram-ter-sarkisov,E_buu40AAAAJ
 Arani Bhattacharya,IIIT Delhi,https://www.iiitd.ac.in/arani,YjiIDkjozUcC
 Arash Eshghi,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/arash-eshghi.htm,yCku-o8AAAAJ
@@ -2158,6 +2174,7 @@ Asaf Cidon,Columbia University,https://www.asafcidon.com,yKzSdygAAAAJ
 Asaf Levin,Technion,https://web.iem.technion.ac.il/en/people/userprofile/levinas.html,cRDZAZoAAAAJ
 Asaf Shabtai,Ben-Gurion University of the Negev,http://www.ise.bgu.ac.il/engineering/PersonalWebSite1main.aspx?id=VrjseMur,k-J7GfgAAAAJ
 Asanobu Kitamoto,National Institute of Informatics,http://agora.ex.nii.ac.jp/~kitamoto/,TZG-qp0AAAAJ
+Ascensión Gallardo-Antolín,Universidad Carlos III de Madrid,https://gpm.webs.tsc.uc3m.es/people/faculty/ascension-gallardo-antolin/,VKwQAcYAAAAJ
 Ashikur Rahman,BUET,http://ashikur.buet.ac.bd,obaBwx4AAAAJ
 Ashique Rupam Mahmood,University of Alberta,https://armahmood.github.io,YwB8XM4AAAAJ
 Ashiqur R. KhudaBukhsh,Rochester Institute of Technology,https://www.rit.edu/directory/axkvse-ashique-khudabukhsh,mWyMp38AAAAJ
@@ -2275,8 +2292,8 @@ Austin J. Brockmeier,University of Delaware,https://www.cis.udel.edu/people/facu
 Austin Melton,Kent State University,https://www.kent.edu/node/austin-melton,NOSCHOLARPAGE
 Austin R. Benson,Cornell University,https://www.cs.cornell.edu/~arb,BzOqNoQAAAAJ
 Austin Tate,University of Edinburgh,http://www.aiai.ed.ac.uk/~bat,CWYxFcQAAAAJ
-Autran Macedo,UFU,http://www.facom.ufu.br/~autran,4dU3acUAAAAJ
 Autran Macêdo,UFU,http://www.facom.ufu.br/~autran,4dU3acUAAAAJ
+Autran Macedo,UFU,http://www.facom.ufu.br/~autran,4dU3acUAAAAJ
 Avah Banerjee,Missouri S&T,https://www.avahbanerjee.com,dLDW7UQAAAAJ
 Avani Wildani,Emory University,https://cs.emory.edu/~avani/index.html,08UkfMsAAAAJ
 Aveek Dutta,University of Kansas,http://www.ittc.ku.edu/~aveekd,NOSCHOLARPAGE
@@ -2333,8 +2350,8 @@ Ayse Tosun Misirli,Istanbul Technical University,http://web.itu.edu.tr/tosunay,K
 Ayse Yilmazer,Istanbul Technical University,https://web.itu.edu.tr/yilmazerayse,PSsiqbYAAAAJ
 Ayse Yilmazer-Metin,Istanbul Technical University,https://web.itu.edu.tr/yilmazerayse,PSsiqbYAAAAJ
 Aysegul Dundar,Bilkent University,http://www.cs.bilkent.edu.tr/~adundar,pvu770UAAAAJ
-Aysenur Akyuz Birturk,Middle East Technical University,http://user.ceng.metu.edu.tr/~birturk,hyJqGeMAAAAJ
 Aysenur Akyuz Birtürk,Middle East Technical University,http://user.ceng.metu.edu.tr/~birturk,hyJqGeMAAAAJ
+Aysenur Akyuz Birturk,Middle East Technical University,http://user.ceng.metu.edu.tr/~birturk,hyJqGeMAAAAJ
 Aysenur Birturk,Middle East Technical University,http://user.ceng.metu.edu.tr/~birturk,hyJqGeMAAAAJ
 Aysenur Birtürk,Middle East Technical University,http://user.ceng.metu.edu.tr/~birturk,hyJqGeMAAAAJ
 Ayumi Igarashi,National Institute of Informatics,https://www.nii.ac.jp/en/faculty/informatics/igarashi_ayumi/,wpHvNtYAAAAJ

--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -175,6 +175,7 @@ Béchir Ktari,Université Laval,http://www2.ift.ulaval.ca/~ktari,NOSCHOLARPAGE
 Beddhu Murali,University of Southern Mississippi,https://www.usm.edu/computing/faculty/beddhu-murali,NOSCHOLARPAGE
 Bedrich Benes,Purdue University,http://hpcg.purdue.edu/bbenes,2VvQrz0AAAAJ
 Beena Ahmed,Texas A&M at Qatar,https://www.qatar.tamu.edu/programs/ecen/faculty-and-staff/dr.-beena-ahmed,giTayZwAAAAJ
+Beenish Moalla Chaudhry,University of Louisiana - Lafayette,https://people.cmix.louisiana.edu/chaudhry/,fQ92dqkAAAAJ
 Begüm Demir,TU Berlin,https://www.rsim.tu-berlin.de/menue/team/prof_dr_beguem_demir,zq4kgCAAAAAJ
 Behnam Malakooti,Case Western Reserve University,http://engineering.case.edu/eecs/faculty-staff,ICngR3sAAAAJ
 Behnaz Ghoraani,Florida Atlantic University,http://www.eng.fau.edu/directory/faculty/ghoraani,ssLvFH8AAAAJ
@@ -196,8 +197,9 @@ Beki Grinter,Georgia Institute of Technology,http://www.cc.gatech.edu/~beki/Beki
 Bela Gipp,University of Göttingen,https://gipplab.org,No2ot2YAAAAJ
 Béla Gipp,University of Göttingen,https://gipplab.org,No2ot2YAAAAJ
 Belén Masiá,Universidad de Zaragoza,http://webdiis.unizar.es/~bmasia,d10sXc8AAAAJ
-Belgin Ergenc,Izmir Institute of Technology,http://ceng.iyte.edu.tr/people/belgin-ergenc,e00LSrIAAAAJ
+Belén Ruíz-Mezcua,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169378/idu-2075,6CtArLEAAAAJ
 Belgin Ergenç,Izmir Institute of Technology,http://ceng.iyte.edu.tr/people/belgin-ergenc,e00LSrIAAAAJ
+Belgin Ergenc,Izmir Institute of Technology,http://ceng.iyte.edu.tr/people/belgin-ergenc,e00LSrIAAAAJ
 Belgin Ergenç Bostanoglu,Izmir Institute of Technology,http://ceng.iyte.edu.tr/people/belgin-ergenc,e00LSrIAAAAJ
 Belgin Ozakar,Izmir Institute of Technology,http://ceng.iyte.edu.tr/people/belgin-ergenc,e00LSrIAAAAJ
 Bella Bose,Oregon State University,http://eecs.oregonstate.edu/people/bose-bella,NOSCHOLARPAGE
@@ -233,7 +235,6 @@ Beng Chin Ooi,National University of Singapore,http://www.comp.nus.edu.sg/~ooibc
 Bengt Carlsson,Uppsala University,http://www.it.uu.se/katalog/bc,WY1FerUAAAAJ
 Bengt Jonsson,Uppsala University,http://user.it.uu.se/~bengt,idIfuU4AAAAJ
 Bengt L. Sandblad,Uppsala University,http://user.it.uu.se/~bengts,NOSCHOLARPAGE
-Beenish Moalla Chaudhry,University of Louisiana - Lafayette,https://people.cmix.louisiana.edu/chaudhry/,fQ92dqkAAAAJ
 Benjamin A. Carterette,University of Delaware,http://ir.cis.udel.edu/~carteret,2Y4R04EAAAAJ
 Benjamin Adam Raichel,University of Texas at Dallas,http://www.utdallas.edu/~bar150630,6Qyzi1cAAAAJ
 Benjamin Allen Watson,North Carolina State University,https://www.csc.ncsu.edu/people/bwatson,yfYYAMQAAAAJ
@@ -572,12 +573,12 @@ Björn Lisper,Mälardalen University,http://www.idt.mdh.se/~blr01/,sk_3rz0AAAAJ
 Björn M. Eskofier,University of Erlangen–Nuremberg,https://www.mad.tf.fau.de/person/bjoern-eskofier,7ems5nYAAAAJ
 Björn Ommer,LMU Munich,https://ommer-lab.com/people/ommer/,zWbvIUcAAAAJ
 Björn Regnell,Lund University,http://cs.lth.se/bjorn-regnell,W37CtAwAAAAJ
+Bjørn Sand Jensen,University of Glasgow,https://www.gla.ac.uk/schools/computing/staff/bjornjensen,sa4OOmUAAAAJ
 Björn Scheuermann 0001,Humboldt University of Berlin,http://www.ti.informatik.hu-berlin.de,NOSCHOLARPAGE
+Björn Þór Jónsson 0001,IT University of Copenhagen,http://www.itu.dk/people/bjth,syXaq1IAAAAJ
 Björn Victor,Uppsala University,http://www.it.uu.se/katalog/victor,ipxE33cAAAAJ
 Björn W. Schuller,Imperial College London,https://www.doc.ic.ac.uk/~bschulle,TxKNCSoAAAAJ
 Björn Waske,University of Osnabrück,https://www.uni-osnabrueck.de/universitaet/personensuche/personendetails.html?module=TemplatePersondetails&target=15852&source=14776&config_id=182d4abe417c9851aacad4acd6e0df1b&range_id=studip&username=bwaske,dWjh5LEAAAAJ
-Björn Þór Jónsson 0001,IT University of Copenhagen,http://www.itu.dk/people/bjth,syXaq1IAAAAJ
-Bjørn Sand Jensen,University of Glasgow,https://www.gla.ac.uk/schools/computing/staff/bjornjensen,sa4OOmUAAAAJ
 Blaine A. Price,Open University UK,http://stem.open.ac.uk/people/bp5,txHHqGQAAAAJ
 Blair D. Sullivan,University of Utah,https://www.cs.utah.edu/~sullivan/#!/about,oZBtvZMAAAAJ
 Blair Nonnecke,University of Guelph,https://www.uoguelph.ca/computing/people/blair-nonnecke,73-woeEAAAAJ
@@ -603,8 +604,8 @@ Bo Mao,Xiamen University,https://informatics.xmu.edu.cn/info/1019/15289.htm,XHT9
 Bo Ou,Hunan University,http://csee.hnu.edu.cn/people/oubo,o81gbSQAAAAJ
 Bo Sheng,University of Massachusetts Boston,http://www.cs.umb.edu/~shengbo,Dt5oPoMAAAAJ
 Bo Tang 0016,SUSTech,https://faculty.sustech.edu.cn/tangb3,og0Jsq4AAAAJ
-Bo Wang 0044,University of Toronto,https://wanglab.ml/people.html,37FDILIAAAAJ
 Bo Waggoner,University of Colorado Boulder,https://www.bowaggoner.com,Y_Ieu7EAAAAJ
+Bo Wang 0044,University of Toronto,https://wanglab.ml/people.html,37FDILIAAAAJ
 Bo Wu 0002,Colorado School of Mines,https://inside.mines.edu/~bwu,E-2t4EQAAAAJ
 Bo Yan 0001,Fudan University,http://homepage.fudan.edu.cn/boyan,NOSCHOLARPAGE
 Bo Yang 0011,UESTC,https://www.en.scse.uestc.edu.cn/info/1085/1772.htm,H2Oo_MkAAAAJ
@@ -636,9 +637,9 @@ Bodhisatwa Mazumdar,IIT Indore,http://cse.iiti.ac.in/faculty.html,ea-e9TwAAAAJ
 Bodo Rosenhahn,University of Hannover,http://www.tnt.uni-hannover.de/staff/rosenhahn,qq3TxtcAAAAJ
 Bodo Urban,University of Rostock,https://www.igd.fraunhofer.de/institut/ueber-uns/alumni/bodo-urban,NOSCHOLARPAGE
 Bogdan Carbunar,Florida International University,https://users.cs.fiu.edu/~carbunar,B7BCFdoAAAAJ
-Bogdan S. Chlebus,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=BCHLEBUS,_JWhZSAAAAAJ
 Bogdan Dit,Boise State University,http://cs.boisestate.edu/~bdit,txY2NHUAAAAJ
 Bogdan Korel,Illinois Institute of Technology,https://science.iit.edu/people/faculty/bogdan-korel,NOSCHOLARPAGE
+Bogdan S. Chlebus,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=BCHLEBUS,_JWhZSAAAAAJ
 Bogdan Savchynskyy,Heidelberg University,https://hci.iwr.uni-heidelberg.de/vislearn/people/bogdan,nvycljAAAAAJ
 Bogdan Simion,University of Toronto,http://www.cs.toronto.edu/~bogdan,NOSCHOLARPAGE
 Bogdan Vasilescu,Carnegie Mellon University,http://bvasiles.github.io,bcXjlqYAAAAJ
@@ -697,7 +698,7 @@ Boudewijn P. F. Lelieveldt,TU Delft,https://www.tudelft.nl/ewi/over-de-faculteit
 Boulbaba Ben Amor,CRIStAL,https://sites.google.com/site/bbenamorshomepage1,8kGJcCIAAAAJ
 Boxin Shi,Peking University,http://www.shiboxin.com,K1LjZxcAAAAJ
 Boyana Norris,University of Oregon,https://ix.cs.uoregon.edu/~norris,prJFPwUAAAAJ
-Boyang "Albert" Li,Nanyang Technological University,http://boyangli.org,QwL4z2UAAAAJ
+"Boyang ""Albert"" Li",Nanyang Technological University,http://boyangli.org,QwL4z2UAAAAJ
 Boyang Li 0001,Nanyang Technological University,http://boyangli.org,QwL4z2UAAAAJ
 Bracha Shapira,Ben-Gurion University of the Negev,http://www.ise.bgu.ac.il/bws/home,1biUWpIAAAAJ
 Brad A. Myers,Carnegie Mellon University,http://www.cs.cmu.edu/~bam,E1cp_aYAAAAJ
@@ -780,7 +781,6 @@ Brian Kocoloski,Washington University in St. Louis,https://www.cse.wustl.edu/~br
 Brian Kulis,Boston University,http://people.bu.edu/bkulis,okcbLqoAAAAJ
 Brian L. Curless,University of Washington,http://homes.cs.washington.edu/~curless,tlh8i7gAAAAJ
 Brian Logan 0001,University of Aberdeen,https://www.abdn.ac.uk/people/brian.logan,tnSWU68AAAAJ
-Brian S. Logan 0001,University of Aberdeen,https://www.abdn.ac.uk/people/brian.logan,tnSWU68AAAAJ
 Brian M. Tomaszewski,Rochester Institute of Technology,https://people.rit.edu/bmtski,hcIpln4AAAAJ
 Brian Mac Namee,University College Dublin,https://people.ucd.ie/brian.macnamee,rZ3_vb0AAAAJ
 Brian MacNamee,University College Dublin,https://people.ucd.ie/brian.macnamee,rZ3_vb0AAAAJ
@@ -791,6 +791,7 @@ Brian Nielsen,Aalborg University,http://people.cs.aau.dk/~bnielsen,iAgWGgwAAAAJ
 Brian Noble,University of Michigan,http://www.engin.umich.edu/college/about/people/profiles/k-to-o/brian-noble,U0Ps_DwAAAAJ
 Brian P. Bailey,Univ. of Illinois at Urbana-Champaign,https://cs.illinois.edu/directory/profile/bpbailey,eiqD0hoAAAAJ
 Brian Ricks,University of Nebraska - Omaha,https://www.unomaha.edu/college-of-information-science-and-technology/about/faculty-staff/brian-ricks.php,S-C6lf0AAAAJ
+Brian S. Logan 0001,University of Aberdeen,https://www.abdn.ac.uk/people/brian.logan,tnSWU68AAAAJ
 Brian Scassellati,Yale University,http://www.cs.yale.edu/~scaz,0jSdqoEAAAAJ
 Brian Summa,Tulane University,http://www.cs.tulane.edu/~bsumma,QKJVjcIAAAAJ
 Brian V. Funt,Simon Fraser University,http://www.cs.sfu.ca/~funt,tXuVUYMAAAAJ
@@ -865,6 +866,7 @@ Bruno Salvy,Ecole Normale Superieure de Lyon,http://www.ens-lyon.fr/annuaire/m-s
 Bruno Sinopoli,Carnegie Mellon University,https://users.ece.cmu.edu/~brunos,zZO9qG4AAAAJ
 Bruno Yun,University of Aberdeen,https://www.abdn.ac.uk/people/bruno.yun,QrOqsP4AAAAJ
 Bryan A. Plummer,Boston University,https://bryanplummer.com,Rv8E-_cAAAAJ
+Bryan C. Ward,Vanderbilt University,https://engineering.vanderbilt.edu/bio/bryan-ward,20aP08UAAAAJ
 Bryan David Minor,Washington State University,https://school.eecs.wsu.edu/people/faculty/bryan-minor,0g7f1_YAAAAJ
 Bryan Ford,EPFL,http://www.brynosaurus.com,TwyzQP4AAAAJ
 Bryan Hooi,National University of Singapore,https://www.comp.nus.edu.sg/~bhooi,ErEL3bgAAAAJ
@@ -876,13 +878,12 @@ Bryan S. Kim,Syracuse University,https://sites.google.com/view/bryansjkim,axFOJt
 Bryan S. Morse,Brigham Young University,http://morse.cs.byu.edu,yOyREHoAAAAJ
 Bryan Suk Joon Kim,Syracuse University,https://sites.google.com/view/bryansjkim,axFOJtEAAAAJ
 Bryan Suk Kim,Syracuse University,https://sites.google.com/view/bryansjkim,axFOJtEAAAAJ
-Bryan C. Ward,Vanderbilt University,https://engineering.vanderbilt.edu/bio/bryan-ward,20aP08UAAAAJ
 Brygg Ullmer,Louisiana State University,https://www.lsu.edu/eng/cse/people/faculty/ullmer.php,JxG7a6sAAAAJ
 Bu-Sung Lee,Nanyang Technological University,http://research.ntu.edu.sg/expertise/academicprofile/Pages/StaffProfile.aspx?ST_EMAILID=ebslee,TyytTfQAAAAJ
 Bud Mishra,New York University,https://cs.nyu.edu/mishra,kXVBr20AAAAJ
 Budi Arief,University of Kent,https://www.cs.kent.ac.uk/people/staff/ba284,bSZk250AAAAJ
-Bui Quang Minh,Australian National University,https://cecs.anu.edu.au/people/minh-bui,UI0xN_QAAAAJ
 Bugra Caskurlu,TOBB ETÜ,http://bugracaskurlu.etu.edu.tr,yLgnAu0AAAAJ
+Bui Quang Minh,Australian National University,https://cecs.anu.edu.au/people/minh-bui,UI0xN_QAAAAJ
 Bulusu Uma Shankar,ISI Kolkata,https://www.isical.ac.in/~uma/,qE04IkQAAAAJ
 Bundit Laekhanukit,SUFE,http://cs.mcgill.ca/~blaekh,vmemchMAAAAJ
 Buntarou Shizuki,University of Tsukuba,https://www.iplab.cs.tsukuba.ac.jp/~shizuki/index-e.html,lXG_jWEAAAAJ

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -120,6 +120,7 @@ Carlos Alberto de Jesus Martinhon,UFF,http://www2.ic.uff.br/~mart,343VizIAAAAJ
 Carlos Alvarez-Martinez,Polytechnic University of Catalonia,https://www.ac.upc.edu/en/content/calvarez,7c0avmcAAAAJ
 Carlos Areces,Universidad Nacional de Córdoba,https://cs.famaf.unc.edu.ar/~careces,Ku5jaRkAAAAJ
 Carlos Beltrán Almeida,Universidade de Lisboa,http://www.fd.ulisboa.pt/professores/corpo-docente,eeHc8KYAAAAJ
+Carlos Bousoño-Calzón,Universidad Carlos III de Madrid,https://www.tsc.uc3m.es/profile.php?uid=cbousono,EXBFfSMAAAAJ
 Carlos Caleiro,Universidade de Lisboa,http://sqig.math.ist.utl.pt/ccal,YnVAMh4AAAAJ
 Carlos Camarão,UFMG,http://homepages.dcc.ufmg.br/~camarao,2LRi77IAAAAJ
 Carlos Cid,Royal Holloway University of London,https://pure.royalholloway.ac.uk/portal/en/persons/carlos-cid(a447674c-2c08-47a2-b318-57e3acc2bb66).html,NOSCHOLARPAGE
@@ -139,6 +140,7 @@ Carlos Hitoshi Morimoto,USP,http://www.ime.usp.br/~hitoshi,ylIa7EoAAAAJ
 Carlos J. P. Lucena,PUC-RIO,http://www.inf.puc-rio.br/blog/professor/@carlos-jose-pereira-de-lucena,BCW5XGIAAAAJ
 Carlos Jensen,Univ. of California - San Diego,https://www.linkedin.com/in/carlos-jensen-356145,v7fzzssAAAAJ
 Carlos José Pereira de Lucena,PUC-RIO,http://www.inf.puc-rio.br/blog/professor/@carlos-jose-pereira-de-lucena,BCW5XGIAAAAJ
+Carlos Linares López,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-4036,IDOjxNoAAAAJ
 Carlos López Pombo,University of Buenos Aires,https://www.dc.uba.ar/~clpombo,DGmfF8QAAAAJ
 Carlos Lucena,PUC-RIO,http://www.inf.puc-rio.br/blog/professor/@carlos-jose-pereira-de-lucena,BCW5XGIAAAAJ
 Carlos M. Duarte,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/caduarte,I7hcyJgAAAAJ
@@ -166,6 +168,7 @@ Carmel Domshlak,Technion,https://ie.technion.ac.il/~dcarmel,Wj7GFosAAAAJ
 Carmela Troncoso,EPFL,http://carmelatroncoso.com,sMkt3SgAAAAJ
 Carmem S. Hara,UFPR,https://www.inf.ufpr.br/carmem,NrgcBX8AAAAJ
 Carmem Satie Hara,UFPR,https://www.inf.ufpr.br/carmem,NrgcBX8AAAAJ
+Carmen Peláez-Moreno,Universidad Carlos III de Madrid,https://gpm.webs.tsc.uc3m.es/people/faculty/carmen-pelaez-moreno/,PXEKOr8AAAAJ
 Carmine Gravino,University of Salerno,http://www.unisa.it/docenti/carminegravino/english/index,fGpVbKwAAAAJ
 Carmine Ventre,King's College London,https://www.kcl.ac.uk/people/carmine-ventre,kx8cKycAAAAJ
 Carol J. Fung,Virginia Commonwealth University,http://www.people.vcu.edu/~cfung,lIYpkGYAAAAJ
@@ -178,8 +181,8 @@ Carole Twining,University of Manchester,http://personalpages.manchester.ac.uk/st
 Carole-Jean Wu,Arizona State University,http://faculty.engineering.asu.edu/carolewu,S1szbyAAAAAJ
 Carolina Cruz-Neira,University of Central Florida,https://www.cs.ucf.edu/person/carolina-cruz-neira,7oDeTpkAAAAJ
 Carolina Fuentes,Cardiff University,https://www.cardiff.ac.uk/people/view/1764542-fuentes-carolina,HMu_pZ0AAAAJ
-Carolina Scarton,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/carolina-scarton,e6YOuiQAAAAJ
 Carolina Ruiz,Worcester Polytechnic Institute,http://www.cs.wpi.edu/~ruiz,xuOJUqsAAAAJ
+Carolina Scarton,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/carolina-scarton,e6YOuiQAAAAJ
 Carolina Wählby,Uppsala University,http://user.it.uu.se/~cli05194/index.html,eRR9pK4AAAAJ
 Caroline C. Friedel,LMU Munich,https://www.bio.ifi.lmu.de/mitarbeiter/caroline-friedel/index.html,FcW0DAUAAAAJ
 Caroline Christina Friedel,LMU Munich,https://www.bio.ifi.lmu.de/mitarbeiter/caroline-friedel/index.html,FcW0DAUAAAAJ
@@ -257,10 +260,10 @@ Cecilia R. Aragon,University of Washington,http://faculty.washington.edu/aragon,
 Cecilia Testart,Georgia Institute of Technology,https://www.cc.gatech.edu/people/cecilia-testart,p2fibvQAAAAJ
 Cédric Dumoulin,CRIStAL,http://cristal.univ-lille.fr/~dumoulin,mmKnPuMAAAAJ
 Cédric Lhoussaine,CRIStAL,https://www.cristal.univ-lille.fr/profil/lhoussai,NOSCHOLARPAGE
-Cees de Laat,University of Amsterdam,https://delaat.net,woax8kAAAAJ
-Cees T. A. M. de Laat,University of Amsterdam,https://delaat.net,woax8kAAAAJ
 Cees G. M. Snoek,University of Amsterdam,http://www.ceessnoek.info,0uKdbscAAAAJ
 Cees Snoek,University of Amsterdam,http://www.ceessnoek.info,0uKdbscAAAAJ
+Cees T. A. M. de Laat,University of Amsterdam,https://delaat.net,woax8kAAAAJ
+Cees de Laat,University of Amsterdam,https://delaat.net,woax8kAAAAJ
 Célia A. Z. Barcelos,UFU,http://www.ppgco.facom.ufu.br/en/pessoas/celia-aparecida-zorzo-barcelos,f9fPNbsAAAAJ
 Célia A. Zorzo Barcelos,UFU,http://www.ppgco.facom.ufu.br/en/pessoas/celia-aparecida-zorzo-barcelos,f9fPNbsAAAAJ
 Célia G. Ralha,Universidade de Brasília,http://cic.unb.br/~ghedini,c6JLbaUAAAAJ
@@ -473,8 +476,8 @@ Chen Greif,University of British Columbia,https://www.cs.ubc.ca/~greif,NOSCHOLAR
 Chen Hajaj,Ariel University,https://www.ariel.ac.il/wp/chen-hajaj,Zy2cIskAAAAJ
 Chen Li 0001,Univ. of California - Irvine,https://chenli.ics.uci.edu,NOSCHOLARPAGE
 Chen Lin 0001,Xiamen University,https://xmudm.github.io/,z1l2JSMAAAAJ
-Chen Ma 0001,City University of Hong Kong,https://allenjack.github.io,sSy7nvsAAAAJ
 Chen Liu 0027,City University of Hong Kong,https://liuchen1993.cn/HomePage/index.html,48PsswEAAAAJ
+Chen Ma 0001,City University of Hong Kong,https://allenjack.github.io,sSy7nvsAAAAJ
 Chen Qian 0001,Univ. of California - Santa Cruz,https://www.soe.ucsc.edu/people/qian,QRxf7EUAAAAJ
 Chen Sun 0002,Brown University,https://chensun.me,vQa7heEAAAAJ
 Chen Tian 0001,Nanjing University,https://cs.nju.edu.cn/tianchen,OYNQpFYAAAAJ
@@ -654,6 +657,7 @@ Chris Crispin-Bailey,University of York,https://www-users.cs.york.ac.uk/~chrisb,
 Chris De Sa,Cornell University,http://www.cs.cornell.edu/~cdesa,v7EjGHkAAAAJ
 Chris Ding,CUHK (SZ),https://sds.cuhk.edu.cn/teacher/197,q7FfnjgAAAAJ
 Chris Doughty,Northern Arizona University,https://nau.edu/siccs/faculty/chris-doughty,5I08jB8AAAAJ
+Chris E. Weaver,University of Oklahoma,http://cs.ou.edu/~weaver/academic,SrIEIUgAAAAJ
 Chris Evans,University College London,https://uclic.ucl.ac.uk/people/chris-evans,EViLL-IAAAAJ
 Chris Fermüller,TU Wien,https://www.logic.at/staffpages/chrisf,-6IV5oIAAAAJ
 Chris Fietkiewicz,Case Western Reserve University,http://engineering.case.edu/eecs/faculty-staff,r7veCY0AAAAJ
@@ -700,7 +704,6 @@ Chris Umans,California Institute of Technology,http://www.cs.caltech.edu/~umans,
 Chris Verhoef,VU Amsterdam,http://www.cs.vu.nl/~x,ziKj-v0AAAAJ
 Chris W. Johnson 0001,University of Glasgow,http://www.dcs.gla.ac.uk/~johnson,pU6c2PQAAAAJ
 Chris Watkins,Royal Holloway University of London,https://pure.royalholloway.ac.uk/portal/en/persons/chris-watkins_09225e27-7a15-4edc-a087-69efb68c65c0.html,v8QhiOwAAAAJ
-Chris E. Weaver,University of Oklahoma,http://cs.ou.edu/~weaver/academic,SrIEIUgAAAAJ
 Chris Wilcox,Colorado State University,http://www.cs.colostate.edu/~wilcox,V-o9ZkIAAAAJ
 Chris Wilson,University of Oregon,http://ix.cs.uoregon.edu/~cwilson,NOSCHOLARPAGE
 Chris Wojtan,IST Austria,http://pub.ist.ac.at/group_wojtan,OGdXlpcAAAAJ
@@ -764,6 +767,8 @@ Christian N. S. Pedersen,Aarhus University,https://birc.au.dk/~cstorm/,RHtkRKwAA
 Christian Napoli,Sapienza University of Rome,https://sites.google.com/diag.uniroma1.it/napoli,NS1JOAUAAAAJ
 Christian Nørgaard Storm Pedersen,Aarhus University,https://birc.au.dk/~cstorm/,RHtkRKwAAAAJ
 Christian O'Reilly,University of South Carolina,https://sc.edu/study/colleges_schools/engineering_and_computing/faculty-staff/oreilly_christian.php,NllRAkwAAAAJ
+Christian Ø. Madsen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/christian-oestergaard-madsen(74a08deb-18e1-48d0-a86e-ed6675da92ab).html,k2LJs3YAAAAJ
+Christian Østergaard Madsen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/christian-oestergaard-madsen(74a08deb-18e1-48d0-a86e-ed6675da92ab).html,k2LJs3YAAAAJ
 Christian Pérez,Ecole Normale Superieure de Lyon,http://www.ens-lyon.fr/annuaire/m-perez-christian-144203.kjsp?RH=ENS-LYON,PHpSuswAAAAJ
 Christian Plessl,Paderborn University,https://cs.uni-paderborn.de/hit/team/plessl,hP5-OnsAAAAJ
 Christian Poellabauer,Florida International University,https://users.cs.fiu.edu/~cpoellab/,7anf7aEAAAAJ
@@ -794,8 +799,6 @@ Christian Wagner 0002,University of Nottingham,https://www.nottingham.ac.uk/comp
 Christian Wallraven,Korea University,http://cogsys.korea.ac.kr/Cognitive_Systems.html,VJuuzLwAAAAJ
 Christian Wressnegger,Karlsruhe Institute of Technology,https://intellisec.de/chris,GTiPndkAAAAJ
 Christian Wulff-Nilsen,University of Copenhagen,http://www.diku.dk/~koolooz,y5cX8ekAAAAJ
-Christian Ø. Madsen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/christian-oestergaard-madsen(74a08deb-18e1-48d0-a86e-ed6675da92ab).html,k2LJs3YAAAAJ
-Christian Østergaard Madsen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/christian-oestergaard-madsen(74a08deb-18e1-48d0-a86e-ed6675da92ab).html,k2LJs3YAAAAJ
 Christiane Neme Campos,UNICAMP,http://www.ic.unicamp.br/~campos,t6j8h7UAAAAJ
 Christiano Braga,UFF,http://www2.ic.uff.br/~cbraga,zYumbMwAAAAJ
 Christiano de O. Braga,UFF,http://www2.ic.uff.br/~cbraga,zYumbMwAAAAJ
@@ -818,10 +821,10 @@ Christine L. Lisetti,Florida International University,http://www.cis.fiu.edu/~li
 Christine L. Mumford,Cardiff University,https://www.cardiff.ac.uk/people/view/118148-mumford-christine,4z8juZ0AAAAJ
 Christine L. Mumford-Valenzuela,Cardiff University,https://www.cardiff.ac.uk/people/view/118148-mumford-christine,4z8juZ0AAAAJ
 Christine L. Valenzuela,Cardiff University,https://www.cardiff.ac.uk/people/view/118148-mumford-christine,4z8juZ0AAAAJ
+Christine Lætitia Lisetti,Florida International University,http://www.cis.fiu.edu/~lisetti,NOSCHOLARPAGE
 Christine Largeron,Université Jean Monnet,http://perso.univ-st-etienne.fr/largeron,YgSSCaIAAAAJ
 Christine Largeron-Leténo,Université Jean Monnet,http://perso.univ-st-etienne.fr/largeron,YgSSCaIAAAAJ
 Christine Lv,University of Colorado Boulder,https://www.cs.colorado.edu/~lv,dTkWR0MAAAAJ
-Christine Lætitia Lisetti,Florida International University,http://www.cis.fiu.edu/~lisetti,NOSCHOLARPAGE
 Christine Rizkallah,UNSW,http://www.cse.unsw.edu.au/~crizkallah,rTEeEsYAAAAJ
 Christine Zarges,Aberystwyth University,https://www.aber.ac.uk/en/cs/staff-profiles/listing/profile/chz8,lDm_Kf4AAAAJ
 Christo Wilson,Northeastern University,http://www.ccs.neu.edu/home/cbw,KzmHyt8AAAAJ
@@ -1144,8 +1147,8 @@ Claudia Linnhoff,LMU Munich,http://www.mobile.ifi.lmu.de/team/claudia-linnhoff-p
 Claudia Linnhoff-Popien,LMU Munich,http://www.mobile.ifi.lmu.de/team/claudia-linnhoff-popien,bJBAUu8AAAAJ
 Claudia Lucía Jiménez-Guarín,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/cjimenez/es/inicio,EAFoxGQAAAAJ
 Cláudia Maria Lima Werner,UFRJ,http://www.cos.ufrj.br/index.php/pt-BR/pessoas/details/18/1005-werner,Ejog01AAAAAJ
-Claudia Müller-Birn,Freie Universitaet Berlin,https://www.mi.fu-berlin.de/en/inf/groups/hcc/members/professor/mueller-birn.html,NOSCHOLARPAGE
 Claudia Müller 0001,Freie Universitaet Berlin,https://www.mi.fu-berlin.de/en/inf/groups/hcc/members/professor/mueller-birn.html,NOSCHOLARPAGE
+Claudia Müller-Birn,Freie Universitaet Berlin,https://www.mi.fu-berlin.de/en/inf/groups/hcc/members/professor/mueller-birn.html,NOSCHOLARPAGE
 Claudia Neuhauser,University of Minnesota,http://cbs.umn.edu/contacts/claudia-neuhauser,_3qZty0AAAAJ
 Claudia Plant,University of Vienna,https://cs.univie.ac.at/claudia.plant,QSYzTd0AAAAJ
 Claudia Popien,LMU Munich,http://www.mobile.ifi.lmu.de/team/claudia-linnhoff-popien,bJBAUu8AAAAJ
@@ -1189,9 +1192,9 @@ Clemens Grelck,University of Amsterdam,https://staff.fnwi.uva.nl/c.u.grelck/,hw9
 Clemens H. Cap,University of Rostock,https://iuk.uni-rostock.de/mitarbeiter/prof-dr-rernat-clemens-h-cap,fAf_fA4AAAAJ
 Clemens Kupke,University of Strathclyde,https://pureportal.strath.ac.uk/en/persons/clemens-kupke/publications,NOSCHOLARPAGE
 Clemens Nylandsted Klokmose,Aarhus University,https://cs.au.dk/~clemens,ugdQqIcAAAAJ
-Clement H. C. Leung,CUHK (SZ),https://sse.cuhk.edu.cn/en/faculty/clementleung,U_YmUb4AAAAJ
 Clément Aubert,Augusta University,https://spots.augusta.edu/caubert,mV9zWOoAAAAJ
 Clément Ballabriga,CRIStAL,https://www.cristal.univ-lille.fr/profil/ballabri,NOSCHOLARPAGE
+Clement H. C. Leung,CUHK (SZ),https://sse.cuhk.edu.cn/en/faculty/clementleung,U_YmUb4AAAAJ
 Clément L. Canonne,University of Sydney,https://www.sydney.edu.au/engineering/about/our-people/academic-staff/clement-canonne.html,gjLr_FgAAAAJ
 Clément Louis Canonne,University of Sydney,https://www.sydney.edu.au/engineering/about/our-people/academic-staff/clement-canonne.html,gjLr_FgAAAAJ
 Clément Pernet,Ecole Normale Superieure de Lyon,http://lig-membres.imag.fr/pernet,ldovqf4AAAAJ

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -34,8 +34,8 @@ Daeyoung Kim 0001,KAIST,http://www.resl.kaist.ac.kr,encxuNcAAAAJ
 Dafna Shahaf,Hebrew University of Jerusalem,http://www.cs.huji.ac.il/~dshahaf,AgyW_90AAAAJ
 Dag Haugland,University of Bergen,http://www.ii.uib.no/~dag,NOSCHOLARPAGE
 Dag Svanaes,NTNU,https://www.ntnu.edu/employees/dag.svanes,rrAsOFsAAAAJ
-Dag Svanes,NTNU,https://www.ntnu.edu/employees/dag.svanes,rrAsOFsAAAAJ
 Dag Svanæs,NTNU,https://www.ntnu.edu/employees/dag.svanes,rrAsOFsAAAAJ
+Dag Svanes,NTNU,https://www.ntnu.edu/employees/dag.svanes,rrAsOFsAAAAJ
 Dag Wedelin,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/dag.aspx,5TbkPtwAAAAJ
 Dagan Feng,University of Sydney,http://sydney.edu.au/engineering/it/about/people/staff/feng.shtml,89py58oAAAAJ
 Dagan Feng 0003,University of Sydney,http://sydney.edu.au/engineering/it/about/people/staff/feng.shtml,89py58oAAAAJ
@@ -194,7 +194,7 @@ Daniel Beimborn,University of Bamberg,https://www.uni-bamberg.de/ism/team/prof-d
 Daniel Bodemer,University of Duisburg-Essen,https://www.uni-due.de/psychologische-forschungsmethoden/bodemer.php,Lsyx1fkAAAAJ
 Daniel Bogaard,Rochester Institute of Technology,https://people.rit.edu/dsbics,NOSCHOLARPAGE
 Daniel Boley,University of Minnesota,http://www-users.cs.umn.edu/~boley,QeRUVr0AAAAJ
-Daniel S. Brown,University of Utah,https://www.cs.utah.edu/~dsbrown/index.html,A3wg18wAAAAJ  
+Daniel Borrajo,Universidad Carlos III de Madrid,http://www.plg.inf.uc3m.es/~dborrajo/,gWi0D8IAAAAJ
 Daniel C. Alexander,University College London,http://cmic.cs.ucl.ac.uk/staff/daniel_alexander,mH-ZOQEAAAAJ
 Daniel C. M. de Oliveira,UFF,http://www2.ic.uff.br/~danielcmo,T_YePXEAAAAJ
 Daniel Cardoso Moraes de Oliveira,UFF,http://www2.ic.uff.br/~danielcmo,T_YePXEAAAAJ
@@ -227,11 +227,11 @@ Daniel Gardham,University of Surrey,https://www.surrey.ac.uk/people/daniel-gardh
 Daniel Genkin,Georgia Institute of Technology,https://faculty.cc.gatech.edu/~genkin/,BqkyhDEAAAAJ
 Daniel Gildea,University of Rochester,https://www.cs.rochester.edu/u/gildea,NOSCHOLARPAGE
 Daniel Gillis,University of Guelph,https://www.uoguelph.ca/computing/people/daniel-gillis,mcKPf6gAAAAJ
+Daniel Goehring,Freie Universitaet Berlin,https://www.mi.fu-berlin.de/inf/groups/ag-ki/members/Professoren/Daniel_G__hring1.html,-yZse64AAAAJ
+Daniel Göhring,Freie Universitaet Berlin,https://www.mi.fu-berlin.de/inf/groups/ag-ki/members/Professoren/Daniel_G__hring1.html,-yZse64AAAAJ
 Daniel Gonçalves 0002,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist13898,_D1cFMkAAAAJ
 Daniel Gooch,Open University UK,http://stem.open.ac.uk/people/dg7692,pqnBZVYAAAAJ
 Daniel Gottesman,University of Maryland - College Park,https://www.cs.umd.edu/article/2020/07/new-professors-join-computer-science-faculty,6eJtRigAAAAJ
-Daniel Göhring,Freie Universitaet Berlin,https://www.mi.fu-berlin.de/inf/groups/ag-ki/members/Professoren/Daniel_G__hring1.html,-yZse64AAAAJ
-Daniel Goehring,Freie Universitaet Berlin,https://www.mi.fu-berlin.de/inf/groups/ag-ki/members/Professoren/Daniel_G__hring1.html,-yZse64AAAAJ
 Daniel Gregory Brown,University of Waterloo,https://cs.uwaterloo.ca/~browndg,cD37cXcAAAAJ
 Daniel Grosu,Wayne State University,http://www.cs.wayne.edu/~dgrosu,LhsomaUAAAAJ
 Daniel Gruss,Graz University of Technology,https://gruss.cc,JmCg4uQAAAAJ
@@ -245,8 +245,8 @@ Daniel Hughes,KU Leuven,https://distrinet.cs.kuleuven.be/people/dannyh,PhAY-GwAA
 Daniel Hughes 0001,KU Leuven,https://distrinet.cs.kuleuven.be/people/dannyh,PhAY-GwAAAAJ
 Daniel J. Abadi,University of Maryland - College Park,https://www.cs.umd.edu/people/abadi,zxeEF2gAAAAJ
 Daniel J. Dougherty,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/djd.html,6dDd-M4AAAAJ
-Daniel J. Fremont,Univ. of California - Santa Cruz,https://engineering.ucsc.edu/people/dfremont,ceJJNbMAAAAJ
 Daniel J. Finnegan,Cardiff University,https://www.cardiff.ac.uk/people/view/1496260-finnegan-daniel,YxCvjCoAAAAJ
+Daniel J. Fremont,Univ. of California - Santa Cruz,https://engineering.ucsc.edu/people/dfremont,ceJJNbMAAAAJ
 Daniel J. Hsu,Columbia University,http://www.cs.columbia.edu/~djhsu,jj0Evx0AAAAJ
 Daniel J. Lizotte,Western University,http://www.csd.uwo.ca/~dlizotte,35zn-2cAAAAJ
 Daniel J. McQuillan,Goldsmiths University of London,https://www.gold.ac.uk/computing/staff/d-mcquillan,7e1W_LcAAAAJ
@@ -322,6 +322,7 @@ Daniel Rochowiak,University of Alabama - Huntsville,https://www.uah.edu/science/
 Daniel Rough,University of Dundee,https://discovery.dundee.ac.uk/en/persons/daniel-rough,RCkETH8AAAAJ
 Daniel Rueckert,Imperial College London,http://wp.doc.ic.ac.uk/dr,H0O0WnQAAAAJ
 Daniel Russo,Aalborg University,https://danielrusso.org,BQ6QbwkAAAAJ
+Daniel S. Brown,University of Utah,https://www.cs.utah.edu/~dsbrown/index.html,A3wg18wAAAAJ  
 Daniel S. Hirschberg,Univ. of California - Irvine,http://www.ics.uci.edu/~dan,6-Kbf7AAAAAJ
 Daniel S. Lopes,Universidade de Lisboa,http://web.tecnico.ulisboa.pt/daniel.s.lopes,ocGMkV8AAAAJ
 Daniel S. Wallach,Rice University,https://www.cs.rice.edu/~dwallach,oM25EQkAAAAJ
@@ -411,16 +412,16 @@ Daochuan Hung,NJIT,http://cs.njit.edu/people/hung.php,NOSCHOLARPAGE
 Daojing He,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/hedaojing,Ps1Zbd4AAAAJ
 Daoshun Wang,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101224173511625489538/20101224173511625489538_.html,NOSCHOLARPAGE
 Daoxu Chen,Nanjing University,https://cs.nju.edu.cn/58/29/c2639a153641/page.htm,NOSCHOLARPAGE
-Dapeng Wu 0001,City University of Hong Kong,https://www.cs.cityu.edu.hk/~dapengwu/,sDRLr8gAAAAJ
 Dapeng Oliver Wu,City University of Hong Kong,https://www.cs.cityu.edu.hk/~dapengwu/,sDRLr8gAAAAJ
+Dapeng Wu 0001,City University of Hong Kong,https://www.cs.cityu.edu.hk/~dapengwu/,sDRLr8gAAAAJ
 Daphna Weinshall,Hebrew University of Jerusalem,http://www.cs.huji.ac.il/~daphna,kwZTvH4AAAAJ
 Daqing He,University of Pittsburgh,http://www.pitt.edu/~dah44,FpyCxD4AAAAJ
 Daqing Zhang 0001,Peking University,http://www.sei.pku.edu.cn/people/dqzhang,qn8CqEYAAAAJ
 Dar-Jen Chang,University of Louisville,http://louisville.edu/speed/people/faculty/changDarJen,NOSCHOLARPAGE
 Darek Kowalski,University of Liverpool,https://www.liverpool.ac.uk/computer-science/staff/dariusz-kowalski,HbzofJcAAAAJ
 Daria Siekhaus,IST Austria,https://ist.ac.at/research/research-groups/siekhaus-group,NOSCHOLARPAGE
-Darío Correal,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/dcorreal/es/inicio,Bo4lXDAtq9QC
 Dario Colazzo,Université Paris Dauphine,https://www.lamsade.dauphine.fr/~colazzo/,mdE4fyoAAAAJ
+Darío Correal,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/dcorreal/es/inicio,Bo4lXDAtq9QC
 Dario D. Salvucci,Drexel University,http://www.mcs.drexel.edu/~salvucci,i1VJMhgAAAAJ
 Darío Ernesto Correal Torres,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/dcorreal/es/inicio,Bo4lXDAtq9QC
 Dario Fiore 0001,IMDEA Software Institute,http://www.dariofiore.it,RiIDoKQAAAAJ
@@ -544,6 +545,7 @@ David E. Irwin 0001,University of Massachusetts Amherst,http://www.ecs.umass.edu
 David E. Keyes,KAUST,https://www.kaust.edu.sa/en/study/faculty/david-keyes,Ps73fz8AAAAJ
 David E. Kieras,University of Michigan,http://web.eecs.umich.edu/~kieras,dnbSFbUAAAAJ
 David E. Millard,University of Southampton,https://www.ecs.soton.ac.uk/people/dem,mzlPYbAAAAAJ
+David E. Singh,Universidad Carlos III de Madrid,https://www.arcos.inf.uc3m.es/dexposito/,zfORWjgAAAAJ
 David Ebert,University of Oklahoma,https://www.ou.edu/coe/cs/people/ebert,LB2Ji0sAAAAJ
 David Edward Millard,University of Southampton,https://www.ecs.soton.ac.uk/people/dem,mzlPYbAAAAAJ
 David Edwin Carlson,Duke University,http://carlson.pratt.duke.edu,R9FqK9cAAAAJ
@@ -631,8 +633,8 @@ David Kaeli,Northeastern University,http://www.ece.neu.edu/faculty/kaeli.html,Mk
 David Kay,University of Oxford,http://www.cs.ox.ac.uk/people/david.kay,qwRn6J8AAAAJ
 David Kempe 0001,University of Southern California,http://www-bcf.usc.edu/~dkempe,jUNqQpgAAAAJ
 David Klappholz,Stevens Institute of Technology,http://web.stevens.edu/facultyprofile/?id=826,NOSCHOLARPAGE
-David Koslicki,Pennsylvania State University,https://koslickilab.github.io/Koslicki-lab-PSU/,Oz90sQsAAAAJ
 David Kohlbrenner,University of Washington,https://homes.cs.washington.edu/~dkohlbre/,uQdC9agAAAAJ
+David Koslicki,Pennsylvania State University,https://koslickilab.github.io/Koslicki-lab-PSU/,Oz90sQsAAAAJ
 David Kotz,Dartmouth College,http://www.cs.dartmouth.edu/~dfk,w_Q7iBoAAAAJ
 David Kristjanson Duvenaud,University of Toronto,http://www.cs.toronto.edu/~duvenaud,ZLpO3XQAAAAJ
 David Kung,University of Texas at Arlington,http://ranger.uta.edu/~kung/kung.html,cgO5XwcAAAAJ
@@ -691,14 +693,15 @@ David Orville Johnson,University of Kansas,https://eecs.ku.edu/david-johnson,LyE
 David P. Helmbold,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~dph,NOSCHOLARPAGE
 David P. Williamson,Cornell University,http://www.orie.cornell.edu/people/profile.cfm?netid=dw36,pOd2M64AAAAJ
 David P. Woodruff,Carnegie Mellon University,http://www.cs.cmu.edu/~dwoodruf,kMmxbbIAAAAJ
-David Page,Duke University,https://scholars.duke.edu/person/david.page,z-P08tgAAAAJ
 David Page,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~dpage,aNh0te8AAAAJ
+David Page,Duke University,https://scholars.duke.edu/person/david.page,z-P08tgAAAAJ
 David Parker 0001,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/academic-staff/parker-david.aspx,nEKbXSMAAAAJ
 David Pearce 0005,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/DavidPearce,x2QxevkAAAAJ
 David Peleg,Weizmann Institute of Science,https://www.weizmann.ac.il/pages/search/people?language=english&single=1&person_id=1883,wBVagosAAAAJ
 David Pichardie,Ecole Normale Superieure de Rennes,http://people.irisa.fr/David.Pichardie,pFAWVGIAAAAJ
 David Pointcheval,Ecole Normale Superieure,http://www.di.ens.fr/~pointche,GzBaxPMAAAAJ
 David Poole 0001,University of British Columbia,https://www.cs.ubc.ca/~poole,CeWswygAAAAJ
+David Quintana,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-3000,NOSCHOLARPAGE
 David R. Bull,University of Bristol,https://david-bull.github.io,WraDXlkAAAAJ
 David R. Cheriton,Stanford University,http://web.stanford.edu/~cheriton,NOSCHOLARPAGE
 David R. Choffnes,Northeastern University,http://david.choffnes.com,OG2QONwAAAAJ
@@ -708,6 +711,7 @@ David R. Kaeli,Northeastern University,http://www.ece.neu.edu/faculty/kaeli.html
 David R. Karger,Massachusetts Institute of Technology,http://people.csail.mit.edu/karger,2vQRGrYAAAAJ
 David R. O'Hallaron,Carnegie Mellon University,https://www.cs.cmu.edu/~droh,738WppcAAAAJ
 David Rajaratnam,UNSW,https://www.engineering.unsw.edu.au/computer-science-engineering/staff/david-rajaratnam,NOSCHOLARPAGE
+David Ramírez 0001,Universidad Carlos III de Madrid,https://ramirezgd.github.io/,OiCtUT0AAAAJ
 David Rappaport,Queen’s University,http://www.cs.queensu.ca/home/daver,NOSCHOLARPAGE
 David Richerby,University of Essex,https://www.essex.ac.uk/people/riche29705/david-richerby,G1KQAusAAAAJ
 David Roger Gilbert,Brunel University London,https://www.brunel.ac.uk/people/david-gilbert,DS-hZXgAAAAJ
@@ -717,8 +721,8 @@ David S. Bowers,Open University UK,http://stem.open.ac.uk/people/dsb69,RG_i8q4AA
 David S. Doermann,University at Buffalo,https://cse.buffalo.edu/~doermann,RoGOW9AAAAAJ
 David S. Rosenblum,George Mason University,https://cs.gmu.edu/~dsr/index.html,FyUQvCoAAAAJ
 David S. Wishart,University of Alberta,http://www.wishartlab.com,NOSCHOLARPAGE
-David Saldana,Lehigh University,http://davidsaldana.co,VU1s_Z8AAAAJ
 David Saldaña,Lehigh University,http://davidsaldana.co,VU1s_Z8AAAAJ
+David Saldana,Lehigh University,http://davidsaldana.co,VU1s_Z8AAAAJ
 David Sands 0001,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/dave.aspx,NOSCHOLARPAGE
 David Sarne,Bar-Ilan University,http://u.cs.biu.ac.il/~sarned,SnvLcLEAAAAJ
 David Schlangen,University of Potsdam,https://www.ling.uni-potsdam.de/~das,QoDgwZYAAAAJ
@@ -806,6 +810,7 @@ Dean Knudson,North Dakota State University,http://www.cs.ndsu.nodak.edu/~deaknud
 Dean M. Tullsen,Univ. of California - San Diego,https://cseweb.ucsd.edu/~tullsen,BEEuinQAAAAJ
 Dean Mohamedally,University College London,http://www0.cs.ucl.ac.uk/staff/D.Mohamedally,NOSCHOLARPAGE
 Dean Pemberton,Victoria University of Wellington,https://ecs.victoria.ac.nz/Main/DeanPemberton,rnQ432kAAAAJ
+Deba Prasad Mandal,ISI Kolkata,https://www.isical.ac.in/deba-prasad-mandal,NOSCHOLARPAGE
 Debabrata Das,IIIT Bangalore,http://www.iiitb.ac.in/faculty_page.php?name=DebabrataDas,gU6HKm4AAAAJ
 Debajyoti Bera,IIIT Delhi,https://www.iiitd.edu.in/~dbera,kv2a54oAAAAJ
 Debajyoti Mondal,University of Saskatchewan,https://www.cs.usask.ca/faculty/dmondal/index.html,DYu56mwAAAAJ
@@ -817,7 +822,6 @@ Debashis Sahoo,Univ. of California - San Diego,https://sites.google.com/view/deb
 Debasis Mitra,Florida Institute of Technology,https://cs.fit.edu/~dmitra,NhlPH-8AAAAJ
 Debasis Samanta,IIT Kharagpur,https://cse.iitkgp.ac.in/~dsamanta,RctLVqcAAAAJ
 Debdeep Mukhopadhyay,IIT Kharagpur,http://cse.iitkgp.ac.in/~debdeep,2ELnl9IAAAAJ
-Deba Prasad Mandal,ISI Kolkata,https://www.isical.ac.in/deba-prasad-mandal,NOSCHOLARPAGE
 Debi Prosad Dogra,IIT Bhubaneswar,http://www.iitbbs.ac.in/profile.php/dpdogra,e7AbmE8AAAAJ
 Debin Gao,Singapore Management University,http://flyer.sis.smu.edu.sg,ufQVl6UAAAAJ
 Debin Zhao,Harbin Institute of Technology,http://homepage.hit.edu.cn/zhaodebin,QXyj0hkAAAAJ
@@ -1012,7 +1016,6 @@ Diana Francisca Adamatti,Federal University of Rio Grande,http://www.diana.c3.fu
 Diana Franklin,University of Chicago,http://people.cs.uchicago.edu/~dmfranklin,gG5PRvgAAAAJ
 Diana Inkpen,University of Ottawa,http://www.site.uottawa.ca/~diana,66pwIBcAAAAJ
 Diana Keen,University of Chicago,http://people.cs.uchicago.edu/~dmfranklin,gG5PRvgAAAAJ
-Diane M. Rasmussen Pennington,University of Strathclyde,https://pureportal.strath.ac.uk/en/persons/diane-pennington/publications,ndW6HpAAAAAJ
 Diana Marculescu,Carnegie Mellon University,https://users.ece.cmu.edu/~dianam,MRHzTAIAAAAJ
 Diana S. Bental,Heriot-Watt University,https://researchportal.hw.ac.uk/en/persons/diana-bental,NOSCHOLARPAGE
 Diana Wilson,Trinity College Dublin,https://www.tcd.ie/research/profiles/?profile=diwilson,NOSCHOLARPAGE
@@ -1024,6 +1027,7 @@ Diane J. Litman,University of Pittsburgh,https://www.cs.pitt.edu/~litman,8MFFVgE
 Diane Joyce Cook,Washington State University,http://www.eecs.wsu.edu/~cook,VpfWvTUAAAAJ
 Diane Kelly 0002,Royal Military College of Canada,https://www.rmc-cmr.ca/en/mathematics-and-computer-science/dr-diane-kelly,NOSCHOLARPAGE
 Diane L. Souvaine,Tufts University,http://provost.tufts.edu/about/about-the-office/diane-souvaine,QTRDjTUAAAAJ
+Diane M. Rasmussen Pennington,University of Strathclyde,https://pureportal.strath.ac.uk/en/persons/diane-pennington/publications,ndW6HpAAAAAJ
 Dianfu Ma,Beihang University,http://scse.buaa.edu.cn/info/1078/2638.htm,NOSCHOLARPAGE
 Dianne Foreback,Kent State University,https://www.kent.edu/ehhs/hs/profile/dr-dianne-kerr,KLexhgsAAAAJ
 Dianne P. O'Leary,University of Maryland - College Park,https://www.cs.umd.edu/people/oleary,5mXaSbgAAAAJ
@@ -1111,6 +1115,7 @@ Dimitrios Koutsonikolas,University at Buffalo,http://www.cse.buffalo.edu/faculty
 Dimitrios Letsios,King's College London,https://www.kcl.ac.uk/people/dimitrios-letsios,2vpL9fUAAAAJ
 Dimitrios Makrakis,University of Ottawa,http://www.site.uottawa.ca/~dimitris,wsKoAKcAAAAJ
 Dimitrios P. Pezaros,University of Glasgow,http://www.dcs.gla.ac.uk/~dp,7_7cAlgAAAAJ
+Dimitrios Papadopoulos 0001,HKUST,https://www.cse.ust.hk/~dipapado,9Q8DH5sAAAAJ
 Dimitrios Pezaros,University of Glasgow,http://www.dcs.gla.ac.uk/~dp,7_7cAlgAAAAJ
 Dimitrios Rafailidis,Maastricht University,http://www.drafail.eu,0aMmyHgAAAAJ
 Dimitrios S. Kolovos,University of York,https://www-users.cs.york.ac.uk/~dkolovos,aRd1i6UAAAAJ
@@ -1140,7 +1145,6 @@ Dimitris Samaras,Stony Brook University,http://www3.cs.stonybrook.edu/~samaras,B
 Dimitris Syvridis,University of Athens,http://www.photonics.di.uoa.gr/index.php/prof-dimitris-syvridis,NOSCHOLARPAGE
 Dimitris Varoutas,University of Athens,http://cgi.di.uoa.gr/~arkas,mc8en0AAAAAJ
 Dimity Miller,Queensland University of Technology,https://research.qut.edu.au/qcr/people/dimity-miller/,MRrgOrgAAAAJ
-Dimitrios Papadopoulos 0001,HKUST,https://www.cse.ust.hk/~dipapado,9Q8DH5sAAAAJ
 Dimosthenis Kyriazis,University of Piraeus,https://www.ds.unipi.gr/en/faculty/dimos-en,bYjcoDQAAAAJ
 Dina Duhovny,Hebrew University of Jerusalem,http://www.huji.ac.il/dataj/controller/ihoker/MOP-STAFF_LINK?sno=70741876&Save_t=,NOSCHOLARPAGE
 Dina Katabi,Massachusetts Institute of Technology,http://people.csail.mit.edu/dina,nst5fHgAAAAJ
@@ -1358,8 +1362,8 @@ Donna K. Slonim,Tufts University,http://www.cs.tufts.edu/~slonim,i3pEsbgAAAAJ
 Donna M. Kaminski,Western Michigan University,https://scholarworks.wmich.edu/masters_theses/2470,NOSCHOLARPAGE
 Donna M. Rizzo,University of Vermont,http://www.uvm.edu/~drizzo,NOSCHOLARPAGE
 Donna S. Reese,Mississippi State University,http://web.cse.msstate.edu/~dreese,NOSCHOLARPAGE
-Doowon Kim,University of Tennessee,https://www.eecs.utk.edu/people/doowon-kim,5lMlCeIAAAAJ
 Doo­Hwan Bae,KAIST,http://se.kaist.ac.kr/professor,NOSCHOLARPAGE
+Doowon Kim,University of Tennessee,https://www.eecs.utk.edu/people/doowon-kim,5lMlCeIAAAAJ
 Dora Varvarigou,NTUA,https://www.ece.ntua.gr/en/staff/60,kueSeb4AAAAJ
 Dorgival O. Guedes,UFMG,http://www.dcc.ufmg.br/~dorgival,NOSCHOLARPAGE
 Dorgival Olavo Guedes Neto,UFMG,http://www.dcc.ufmg.br/~dorgival,NOSCHOLARPAGE

--- a/csrankings-e.csv
+++ b/csrankings-e.csv
@@ -8,8 +8,8 @@ E. N. Elnozahy,KAUST,https://www.kaust.edu.sa/en/study/faculty/mootaz-elnozahy,3
 E.M.J. Huis in 't Veld,Tilburg University,https://www.tilburguniversity.edu/webwijs/show/e.m.j.huisintveld.htm,NOSCHOLARPAGE
 Eakta Jain,University of Florida,http://www.cise.ufl.edu/~ejain,5ouAiisAAAAJ
 Eamonn J. Keogh,Univ. of California - Riverside,http://www.cs.ucr.edu/~eamonn,slVcOQIAAAAJ
-Eamonn O. Nuallain,Trinity College Dublin,https://www.tcd.ie/research/profiles/?profile=ONUALLAE,NOSCHOLARPAGE
 Eamonn O'Neill,University of Bath,http://www.bath.ac.uk/comp-sci/contacts/academics/eamonn_oneill,1m173DEAAAAJ
+Eamonn O. Nuallain,Trinity College Dublin,https://www.tcd.ie/research/profiles/?profile=ONUALLAE,NOSCHOLARPAGE
 Earl T. Barr,University College London,http://earlbarr.com,lSvqKPkAAAAJ
 Earlence Fernandes,Univ. of California - San Diego,http://earlence.com,OSPeHGAAAAAJ
 Eatai Roth,Indiana University,http://www.eatairoth.com,Wf_rspwAAAAJ
@@ -17,8 +17,8 @@ Eberhard Zehendner,Friedrich Schiller University Jena,http://www2.informatik.uni
 Ebroul Izquierdo,Queen Mary University of London,http://mmv.eecs.qmul.ac.uk/Ebroul,cyiYJhMAAAAJ
 Ebru Akcapinar Sezer,Hacettepe University,http://yunus.hacettepe.edu.tr/~ebru,0xMgS9AAAAAJ
 Ebru Akçapinar Sezer,Hacettepe University,http://yunus.hacettepe.edu.tr/~ebru,0xMgS9AAAAAJ
-Ebru Aydin Gol,Middle East Technical University,http://user.ceng.metu.edu.tr/~ebru/wordpress,iO5JVYIAAAAJ
 Ebru Aydin Göl,Middle East Technical University,http://user.ceng.metu.edu.tr/~ebru/wordpress,iO5JVYIAAAAJ
+Ebru Aydin Gol,Middle East Technical University,http://user.ceng.metu.edu.tr/~ebru/wordpress,iO5JVYIAAAAJ
 Ebru Gökalp,Hacettepe University,http://web.cs.hacettepe.edu.tr/~ebrugokalp,iDmoPK8AAAAJ
 Ebubekir Avci,Massey University,https://www.massey.ac.nz/massey/learning/colleges/college-of-sciences/staff-list.cfm?stref=288350,Q1gDTVgAAAAJ
 Eck Doerry,Northern Arizona University,https://www.cefns.nau.edu/~edo,NOSCHOLARPAGE
@@ -53,9 +53,9 @@ Edmundo R. M. Madeira,UNICAMP,http://www.ic.unicamp.br/~edmundo,NOSCHOLARPAGE
 Edmundo Roberto Mauro Madeira,UNICAMP,http://www.ic.unicamp.br/~edmundo,NOSCHOLARPAGE
 Edmundo de Souza e Silva,UFRJ,http://www.land.ufrj.br/~edmundo,r9ngIuMAAAAJ
 Edoardo Biagioni,University of Hawaii at Manoa,http://www2.hawaii.edu/~esb,Ls94lsAAAAAJ
-Edoardo S. Biagioni,University of Hawaii at Manoa,http://www2.hawaii.edu/~esb,Ls94lsAAAAAJ
-Edoardo Maria Ponti,University of Edinburgh,https://ducdauge.github.io/,tklL2q0AAAAJ
 Edoardo M. Ponti,University of Edinburgh,https://ducdauge.github.io/,tklL2q0AAAAJ
+Edoardo Maria Ponti,University of Edinburgh,https://ducdauge.github.io/,tklL2q0AAAAJ
+Edoardo S. Biagioni,University of Hawaii at Manoa,http://www2.hawaii.edu/~esb,Ls94lsAAAAAJ
 Edoardo Serra,Boise State University,https://sites.google.com/site/serraedoardo,9FRe3hcAAAAJ
 Edouard Amouroux,RMIT University,https://scholar.google.com/citations?user=XfUV3XAAAAAJ,XfUV3XAAAAAJ
 Edouard Bugnion,EPFL,https://people.epfl.ch/edouard.bugnion,8ztj2yEAAAAJ
@@ -362,6 +362,7 @@ Emiliano De Cristofaro,University College London,http://www.cs.ucl.ac.uk/people/
 Emiliano Garcia-Palacios,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=e.garcia,NOSCHOLARPAGE
 Emilie Kaufmann,CRIStAL,http://chercheurs.lille.inria.fr/ekaufman,9GE1vx4AAAAJ
 Emilie Morvant,Université Jean Monnet,http://perso.univ-st-etienne.fr/me63854h,4dzYdBsAAAAJ
+Emilio Parrado-Hernández,Universidad Carlos III de Madrid,https://www.tsc.uc3m.es/~emipar/EmiparTSC/Welcome.html,hJr9QBwAAAAJ
 Emily Hand,University of Nevada,http://www.cse.unr.edu/~ehand,5oWxowoAAAAJ
 Emily M. Hand,University of Nevada,http://www.cse.unr.edu/~ehand,5oWxowoAAAAJ
 Emily Morgan Hand,University of Nevada,http://www.cse.unr.edu/~ehand,5oWxowoAAAAJ
@@ -485,8 +486,8 @@ Eric Fosler,Ohio State University,http://web.cse.ohio-state.edu/~fosler,AlsMV98A
 Eric Fosler-Lussier,Ohio State University,http://web.cse.ohio-state.edu/~fosler,AlsMV98AAAAJ
 Eric G. Mercer,Brigham Young University,https://cs.byu.edu/faculty/egm,FbUhdYYAAAAJ
 Eric Gilbert,University of Michigan,http://eegilbert.org,71OktocAAAAJ
-Eric Granger,ETS Montreal,https://etsmtl.ca/Professeurs/egranger/Accueil?lang=en-CA,TmfbdagAAAAJ
 Éric Granger,ETS Montreal,https://etsmtl.ca/Professeurs/egranger/Accueil?lang=en-CA,TmfbdagAAAAJ
+Eric Granger,ETS Montreal,https://etsmtl.ca/Professeurs/egranger/Accueil?lang=en-CA,TmfbdagAAAAJ
 Eric Harley,Toronto Metropolitan University,https://www.scs.torontomu.ca/~eharley,NOSCHOLARPAGE
 Eric J. Pauwels,CWI,https://www.cwi.nl/people/1302,NOSCHOLARPAGE
 Eric J. Schwabe,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=728,NOSCHOLARPAGE
@@ -519,8 +520,8 @@ Eric Rogers,University of Southampton,https://www.ecs.soton.ac.uk/people/er,NOSC
 Eric Rotenberg,North Carolina State University,https://people.engr.ncsu.edu/ericro,L0Lz4t0AAAAJ
 Eric Rozner,University of Colorado Boulder,http://www.ericrozner.com,z0KD3z4AAAAJ
 Eric Ruppert,York University,http://www.cs.yorku.ca/~ruppert,ficDn98AAAAJ
-Eric Samperton,Purdue University,https://www.cs.purdue.edu/people/faculty/esampert.html,NOSCHOLARPAGE
 Eric S. K. Yu,University of Toronto,http://www.cs.toronto.edu/~eric,c36OREEAAAAJ
+Eric Samperton,Purdue University,https://www.cs.purdue.edu/people/faculty/esampert.html,NOSCHOLARPAGE
 Éric Schost,University of Waterloo,https://cs.uwaterloo.ca/~eschost/,qWXMDWkAAAAJ
 Eric Sedgwick,DePaul University,https://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=121,pKWxgxUAAAAJ
 Eric Steegmans,KU Leuven,https://distrinet.cs.kuleuven.be/people/eric,Iv6jkGcAAAAJ
@@ -701,8 +702,10 @@ Eva Heinrich,Massey University,http://www.massey.ac.nz/massey/learning/colleges/
 Eva Hladká,Masaryk University,https://www.muni.cz/en/people/2053,8cg5zgYAAAAJ
 Eva Hornecker,Bauhaus University Weimar,https://www.uni-weimar.de/en/media/institutes/digital-bauhaus-lab/people/prof-dr-eva-hornecker,D-F9a1AAAAAJ
 Eva Kalyvianaki,University of Cambridge,https://www.cl.cam.ac.uk/~ek264,8nhT3JAAAAAJ
+Eva Kühn,TU Wien,http://www.complang.tuwien.ac.at/eva,NOSCHOLARPAGE
 Eva M. Navarro-Lopez,University of Manchester,http://www.cs.man.ac.uk/~navarroe,1IDSDUwAAAAJ
 Eva Maria Kuehn,TU Wien,http://www.complang.tuwien.ac.at/eva,NOSCHOLARPAGE
+Eva Maria Kühn,TU Wien,http://www.complang.tuwien.ac.at/eva,NOSCHOLARPAGE
 Eva Marín-Tordera,Polytechnic University of Catalonia,https://craax.upc.edu/eva,NOSCHOLARPAGE
 Eva Rodriguez,Polytechnic University of Catalonia,http://www.crcsi.com.au/about/our-people/eva-rodriguez-rodriguez,6-ZbUAoAAAAJ
 Eva Rotenberg,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
@@ -744,8 +747,8 @@ Ewan D. Tempero,University of Auckland,https://www.cs.auckland.ac.nz/~ewan,ciAtQ
 Ewan Klein,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Ewan_Klein.html,Sh28erYAAAAJ
 Ewert Bengtsson,Uppsala University,http://www.cb.uu.se/~ewert,3rdSJSgAAAAJ
 Eyal Kushilevitz,Technion,http://www.cs.technion.ac.il/~eyalk,gUGK3TYAAAAJ
-Eyal de Lara,University of Toronto,http://www.cs.toronto.edu/~delara,KfGfDvcAAAAJ
 Eyal Ronen,Tel Aviv University,https://eyalro.net/,jDyCADyMIQgC
+Eyal de Lara,University of Toronto,http://www.cs.toronto.edu/~delara,KfGfDvcAAAAJ
 Eyke Hüllermeier,LMU Munich,https://www.kiml.ifi.lmu.de,usVJeNN3xFAC
 Eylon Yogev,Bar-Ilan University,https://www.eylonyogev.com/,5BrpQ74AAAAJ
 Eynollah Khanjari,IUST,http://www.iust.ac.ir/content/22145/Dr.Khanjari,7o0YDzkAAAAJ
@@ -755,5 +758,3 @@ Eytan Adar,University of Michigan,http://www.cond.org,4tMapHYAAAAJ
 Eytan Ruppin,University of Maryland - College Park,https://www.cs.umd.edu/people/ruppinumiacsumdedu,L3KXa3cAAAAJ
 Eyuphan Bulut,Virginia Commonwealth University,http://www.people.vcu.edu/~ebulut,wvvIyOwAAAAJ
 Ezio Bartocci,TU Wien,http://www.eziobartocci.com,EeK43rAAAAAJ
-Eva Kühn,TU Wien,http://www.complang.tuwien.ac.at/eva,NOSCHOLARPAGE
-Eva Maria Kühn,TU Wien,http://www.complang.tuwien.ac.at/eva,NOSCHOLARPAGE

--- a/csrankings-f.csv
+++ b/csrankings-f.csv
@@ -113,6 +113,7 @@ Fang Liu 0001,Xidian University,https://web.xidian.edu.cn/fliu/,qrQkfxYAAAAJ
 Fang Liu 0002,Hunan University,http://design.hnu.edu.cn/info/1023/5787.htm,PXo2aVUAAAAJ
 Fang Song 0001,Portland State University,https://fangsong.info,A6C3geAAAAAJ
 Fang Zhao 0003,BUPT,https://scs.bupt.edu.cn/info/1277/2497.htm,NOSCHOLARPAGE
+Fang-Yi Yu,George Mason University,http://www-personal.umich.edu/~fayu/index.html,LhLBzWEAAAAJ
 Fangchu Yang,BUPT,https://int.bupt.edu.cn/content/content.php?p=6_16_94,NOSCHOLARPAGE
 Fangju Wang,University of Guelph,https://www.uoguelph.ca/computing/people/fangju-wang,NOSCHOLARPAGE
 Fangmin Song,Nanjing University,http://www.easychair.org/smart-program/VSL2014/person4653.html,NOSCHOLARPAGE
@@ -122,7 +123,6 @@ Fangxiang Feng,BUPT,https://teacher.bupt.edu.cn/fengfangxiang1/en/index.htm,W0O_
 Fangxin Wang 0001,CUHK (SZ),https://mypage.cuhk.edu.cn/academics/wangfangxin/,HX4VSZ0AAAAJ
 Fangxing Li,University of Tennessee,http://web.eecs.utk.edu/~fli6,Xlzr3HMAAAAJ
 Fangzhen Lin,HKUST,http://www.cs.ust.hk/~flin,klFoxpYAAAAJ
-Fang-Yi Yu,George Mason University,http://www-personal.umich.edu/~fayu/index.html,LhLBzWEAAAAJ
 Fanhua Shang,Xidian University,https://web.xidian.edu.cn/fhshang/,rk_HZTkAAAAJ
 Fanny Chevalier,University of Toronto,http://www.cs.toronto.edu/~fchevali/fannydotnet/index.html,qc6jW8sAAAAJ
 Fanxin Kong,Syracuse University,https://sites.google.com/site/fanxink,XeDepwwAAAAJ
@@ -212,6 +212,7 @@ Felix Brandt 0001,TU Munich,http://dss.in.tum.de/staff/brandt,fVnXdaQAAAAJ
 Felix C. Freiling,University of Erlangen–Nuremberg,https://www.cs1.tf.fau.de/person/felix-freiling,NOSCHOLARPAGE
 Felix C. Gärtner,University of Erlangen–Nuremberg,https://www.cs1.tf.fau.de/person/felix-freiling,NOSCHOLARPAGE
 Felix Freitag,Polytechnic University of Catalonia,http://people.ac.upc.edu/felix,6wJ4ZdQAAAAJ
+Félix García Carballeira,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169378/idu-3167,NOSCHOLARPAGE
 Félix Gómez Mármol,University of Murcia,http://webs.um.es/felixgm,YFwhSEcAAAAJ
 Felix Heide,Princeton University,https://www.cs.princeton.edu/~fheide/,gRqzSHsAAAAJ
 Félix J. García,University of Murcia,http://webs.um.es/fgarcia/miwiki/doku.php,WaQfrJ0AAAAJ
@@ -278,8 +279,10 @@ Fernando A. Kuipers,TU Delft,https://www.fernandokuipers.nl,W9BWce4AAAAJ
 Fernando Castor,UFPE,http://www.cin.ufpe.br/~fjclf,c_egjh0AAAAJ
 Fernando Castor Filho,UFPE,http://www.cin.ufpe.br/~fjclf,c_egjh0AAAAJ
 Fernando De la Rosa,Universidad de los Andes,https://sistemasacademico.uniandes.edu.co/~fde,UB6e9ywAAAAJ
+Fernando Díaz-de-María,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/UC3MInstitucional/en/Detalle/Organismo_C/1371264218797/1371264218750/Fernando_Diaz_de_Maria,Vn8KJc8AAAAJ
 Fernando E. B. Otero,University of Kent,https://www.cs.kent.ac.uk/people/staff/febo,pEa-vucAAAAJ
 Fernando Esteban Barril Otero,University of Kent,https://www.cs.kent.ac.uk/people/staff/febo,pEa-vucAAAAJ
+Fernando Fernández 0001,Universidad Carlos III de Madrid,https://www.cs.cmu.edu/~fernando/,XRDnkTMAAAAJ
 Fernando G. S. L. Brandão,California Institute of Technology,http://fernandobrandao.org,zmDJrh0AAAAJ
 Fernando Gehm Moraes,PUC-RS,http://www.inf.pucrs.br/moraes,XNjum_8AAAAJ
 Fernando Jiménez,University of Murcia,http://webs.um.es/fernan/miwiki/doku.php?id=english,CWgxQY8AAAAJ
@@ -445,6 +448,8 @@ Francisco Gomes,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/gomesf.aspx,N
 Francisco J. Mitropoulos,Nova Southeastern University,https://cec.nova.edu/faculty/mitropoulos.html,NOSCHOLARPAGE
 Francisco J. Soulignac,University of Buenos Aires,http://www-2.dc.uba.ar/profesores/lin/docs/cv/cv_oscar.htm,NOSCHOLARPAGE
 Francisco J. Valero Cuevas,University of Southern California,http://bbdl.usc.edu/Francisco.php,nq85o3QAAAAJ
+Francisco Javier García Blas,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-1370,89aVrHIAAAAJ
+Francisco Javier González-Serrano,Universidad Carlos III de Madrid,https://www.tsc.uc3m.es/profile.php?uid=fran,NOSCHOLARPAGE
 Francisco Javier Nóvoa,University of A Coruña,https://pdi.udc.es/en/File/Pdi/HB9HJ,YZbHA_EAAAAJ
 Francisco Jordan Fernandez,Polytechnic University of Catalonia,http://directori.upc.edu/directori/dadesPersona.jsp?id=1000062,NOSCHOLARPAGE
 Francisco José Monaco,USP-ICMC,http://icmc.usp.br/pessoas?id=1678183,EXey2yQAAAAJ
@@ -467,8 +472,8 @@ François Bernard Lauze,University of Copenhagen,http://image.diku.dk/francois,n
 François Boulier,CRIStAL,http://cristal.univ-lille.fr/~boulier/pmwiki/pmwiki.php,pzwDiKgAAAAJ
 François Bry,LMU Munich,https://www.pms.ifi.lmu.de/mitarbeiter/derzeitige/francois-bry,uERnzWQAAAAJ
 François Bry-Haußer,LMU Munich,https://www.pms.ifi.lmu.de/mitarbeiter/derzeitige/francois-bry,uERnzWQAAAAJ
-François Dupressoir,University of Bristol,https://fdupress.net,gxFJ_bYAAAAJ
 François Chadebecq,Middlesex University,https://www.mdx.ac.uk/about-us/our-people/staff-directory/profile/chadebecq-francois,peUbh44AAAAJ
+François Dupressoir,University of Bristol,https://fdupress.net,gxFJ_bYAAAAJ
 François Fleuret,EPFL,https://people.epfl.ch/francois.fleuret,Bj1tRlsAAAAJ
 François Guimbretière,Cornell University,https://www.cs.cornell.edu/~francois,PxZT1sgAAAAJ
 François Gygi,Univ. of California - Davis,http://faculty.engineering.ucdavis.edu/gygi,NOSCHOLARPAGE
@@ -575,10 +580,10 @@ Fred R. M. Barnes,University of Kent,https://www.cs.kent.ac.uk/~frmb,ajvbY_0AAAA
 Fred S. Annexstein,University of Cincinnati,http://www.ece.uc.edu/~annexste/UC_Pages/Dr._Fred_Annexsteins_Computer_Science_Department_Homepage_____.html,pOKCwi4AAAAJ
 Fred Sala 0001,University of Wisconsin - Madison,https://pages.cs.wisc.edu/~fredsala,9KhIkNkAAAAJ
 Freddy Bruckstein,Technion,http://www.cs.technion.ac.il/~freddy,P1OaUP8AAAAJ
-Frédéric Blanqui,Ecole Normale Superieure de Cachan,http://www.lsv.ens-cachan.fr/People,PHpAzZ8AAAAJ
 Frederic Andres,National Institute of Informatics,https://www.nii.ac.jp/en/faculty/digital_content/andres_frederic/,K3vTs8sAAAAJ
-Frederic Desprez,Ecole Normale Superieure de Lyon,http://www.inria.fr/institut/organisation/adjoints-au-directeur-scientifique/frederic-desprez,9KkV5HAAAAAJ
+Frédéric Blanqui,Ecole Normale Superieure de Cachan,http://www.lsv.ens-cachan.fr/People,PHpAzZ8AAAAJ
 Frédéric Desprez,Ecole Normale Superieure de Lyon,http://www.inria.fr/institut/organisation/adjoints-au-directeur-scientifique/frederic-desprez,9KkV5HAAAAAJ
+Frederic Desprez,Ecole Normale Superieure de Lyon,http://www.inria.fr/institut/organisation/adjoints-au-directeur-scientifique/frederic-desprez,9KkV5HAAAAAJ
 Frederic F. Leymarie,Goldsmiths University of London,https://www.gold.ac.uk/computing/staff/f-folleymarie,Lahlh-cAAAAJ
 Frederic Fol Leymarie,Goldsmiths University of London,https://www.gold.ac.uk/computing/staff/f-folleymarie,Lahlh-cAAAAJ
 Frédéric Gibou,Univ. of California - Santa Barbara,https://engineering.ucsb.edu/~fgibou,KKUAx0sAAAAJ
@@ -628,6 +633,7 @@ Fuat Akal,Hacettepe University,http://yunus.hacettepe.edu.tr/~akal,rnq1_mIAAAAJ
 Fuchun J. Lin,National Chiao Tung University,http://www.cs.nctu.edu.tw/~fuchun_lin,Pei7LGcAAAAJ
 Fuchun Joseph Lin,National Chiao Tung University,http://www.cs.nctu.edu.tw/~fuchun_lin,Pei7LGcAAAAJ
 Fuchun Sun 0001,Tsinghua University,http://www.tsinghua.edu.cn/publish/csen/4623/2010/20101224193039440369874/20101224193039440369874_.html,DbviELoAAAAJ
+Fuensanta Medina-Domínguez,Universidad Carlos III de Madrid,https://sites.google.com/site/fuensantamedinadominguez/dr-fuensanta-medina-dominguez?authuser=0,zLI3VqoAAAAJ
 Fuhua (Frank) Cheng,University of Kentucky,http://www.cs.uky.edu/~cheng,NOSCHOLARPAGE
 Fuhua Cheng,University of Kentucky,http://www.cs.uky.edu/~cheng,NOSCHOLARPAGE
 Fumihide Tanaka,University of Tsukuba,http://fumihide-tanaka.org/lab/en/members.html,NOSCHOLARPAGE

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -495,9 +495,9 @@ Giorgos Christodoulou,University of Liverpool,https://cgi.csc.liv.ac.uk/~gchrist
 Giorgos Christodoulou 0001,University of Liverpool,https://cgi.csc.liv.ac.uk/~gchristo,QRIaADsAAAAJ
 Giorgos Stamou,NTUA,http://www.image.ntua.gr/~gstam,R3y5dxMAAAAJ
 Giorgos Tolias,Czech Technical University,http://cmp.felk.cvut.cz/~toliageo,e765N80AAAAJ
-Giovanna Rosone,University of Pisa,http://pages.di.unipi.it/rosone,gx_HzA0AAAAJ
 Giovane C. M. Moura,TU Delft,http://giovane-moura.nl/,DuJtdjUAAAAJ
 Giovane Cesar Moreira Moura,TU Delft,http://giovane-moura.nl/,DuJtdjUAAAAJ
+Giovanna Rosone,University of Pisa,http://pages.di.unipi.it/rosone,gx_HzA0AAAAJ
 Giovanni Agosta,Politecnico di Milano,http://home.deib.polimi.it/agosta,eLxnBysAAAAJ
 Giovanni Comarela,Universidade Federal de Viçosa,http://www.dpi.ufv.br/~gcom,onfmt40AAAAJ
 Giovanni Da San Martino,University of Padova,https://www.unipd.it/en/contatti/rubrica/?detail=Y&ruolo=1&checkout=cerca&persona=DA%20SAN%20MARTINO&key=92B9FC5AFB76ECA91B1FFDE427C41AF5,URABLy0AAAAJ
@@ -535,7 +535,6 @@ Giuseppe A. Di Lucca,University of Sannio,https://www.ding.unisannio.it/persone/
 Giuseppe Antonio Di Lucca,University of Sannio,https://www.ding.unisannio.it/persone/docenti/di-lucca,pHMonFwAAAAJ
 Giuseppe Ateniese,George Mason University,https://ateniese.github.io,EyZJ08MAAAAJ
 Giuseppe Attardi,University of Pisa,https://www.di.unipi.it/~attardi,p86Ewsi7jXwJ
-Giuseppe M. J. Barca,Australian National University,https://comp.anu.edu.au/people/giuseppe-barca/,bdx0QCoAAAAJ
 Giuseppe Caire,TU Berlin,https://www.commit.tu-berlin.de/menue/mitarbeiter/fachgebietsleiter,g66ErTcAAAAJ
 Giuseppe Carenini,University of British Columbia,https://www.cs.ubc.ca/~carenini,HNNL22kAAAAJ
 Giuseppe Cattaneo,University of Salerno,http://www.di.unisa.it/~roscigno,PKs7M0gAAAAJ
@@ -543,6 +542,7 @@ Giuseppe De Giacomo,Sapienza University of Rome,http://www.diag.uniroma1.it/degi
 Giuseppe Destefanis,Brunel University London,https://www.brunel.ac.uk/people/giuseppe-destefanis,o2KkJXIAAAAJ
 Giuseppe Fenza,University of Salerno,https://docenti.unisa.it/021699/home,0C3IjEIAAAAJ
 Giuseppe Lipari,CRIStAL,http://cristal.univ-lille.fr/~lipari,rnBRPpQAAAAJ
+Giuseppe M. J. Barca,Australian National University,https://comp.anu.edu.au/people/giuseppe-barca/,bdx0QCoAAAAJ
 Giuseppe Pelagatti,Politecnico di Milano,http://home.deib.polimi.it/pelagatt,NOSCHOLARPAGE
 Giuseppe Persiano,University of Salerno,http://www.di.unisa.it/~giuper,wbQQcfQAAAAJ
 Giuseppe Pirrò,Sapienza University of Rome,http://wwwusers.di.uniroma1.it/~pirro,3zY1VlIAAAAJ
@@ -584,6 +584,8 @@ Gonçalo Nuno Gomes Tavares,Universidade de Lisboa,https://fenix.tecnico.ulisboa
 Gonçalo Tavares,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist13269,mRRctaMAAAAJ
 Gong Cheng 0001,Nanjing University,http://ws.nju.edu.cn/~gcheng,_ncKAiwAAAAJ
 Gong Gu,University of Tennessee,http://web.eecs.utk.edu/~ggu1,A2-AVVcAAAAJ
+Gonzalo Génova,Universidad Carlos III de Madrid,http://www.ie.inf.uc3m.es/ggenova/,kILuKYEAAAAJ
+Gonzalo Vazquez-Vilar,Universidad Carlos III de Madrid,https://www.tsc.uc3m.es/~gvazquez/,XdPkhaEAAAAJ
 Gopal Gupta 0001,University of Texas at Dallas,http://www.utdallas.edu/~gupta,NOSCHOLARPAGE
 Gopal Pandurangan,University of Houston,http://www.uh.edu/nsm/computer-science/news-events/stories/2014/0711-pandurangan.php,xJyMo0MAAAAJ
 Gopalakrishnan Srinivasaraghavan,IIIT Bangalore,http://www.iiitb.ac.in/faculty_page.php?name=GSrinivasaraghavan,NOSCHOLARPAGE
@@ -639,12 +641,12 @@ Graham E. Farr,Monash University,http://www.csse.monash.edu.au/~gfarr,NOSCHOLARP
 Graham Farr,Monash University,http://www.csse.monash.edu.au/~gfarr,NOSCHOLARPAGE
 Graham Horton,University of Magdeburg,http://www.sim.ovgu.de,m_vBaEkAAAAJ
 Graham Hutton,University of Nottingham,https://www.nottingham.ac.uk/computerscience/people/graham.hutton,6wDy-sMAAAAJ
+Graham J. Williams,Australian National University,https://comp.anu.edu.au/people/graham-williams/,08HEV_kAAAAJ
 Graham Kemp,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/kemp.aspx,9Olx8xYAAAAJ
 Graham Kirby,University of St Andrews,https://graham.host.cs.st-andrews.ac.uk,_pn1_vgAAAAJ
 Graham Knight,University College London,http://www.cs.ucl.ac.uk/staff/graham_knight,HdunwTkAAAAJ
 Graham Neubig,Carnegie Mellon University,http://www.phontron.com,wlosgkoAAAAJ
 Graham Roberts,University College London,http://www0.cs.ucl.ac.uk/staff/G.Roberts,NOSCHOLARPAGE
-Graham J. Williams,Australian National University,https://comp.anu.edu.au/people/graham-williams/,08HEV_kAAAAJ
 Graham W. Taylor,University of Guelph,https://www.gwtaylor.ca,PUeKU8kAAAAJ
 Grant E. Weddell,University of Waterloo,https://cs.uwaterloo.ca/faculty-staff/contacts/grant-weddell,NOSCHOLARPAGE
 Grant Ho,University of Chicago,https://cs.uchicago.edu/people/grant-ho/,EASHOTUAAAAJ
@@ -725,7 +727,6 @@ Grzegorz W. Wasilkowski,University of Kentucky,https://www.cs.uky.edu/~greg,NOSC
 Gu Ming 0001,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2010/20101219102622467554674/20101219102622467554674_.html,NOSCHOLARPAGE
 Guanbin Li,Sun Yat-sen University,http://guanbinli.com,2A2Bx2UAAAAJ
 Guanfeng Liu 0001,Macquarie University,http://web.science.mq.edu.au/~gliu,6P6EnQkAAAAJ
-Guansong Pang,Singapore Management University,https://scis.smu.edu.sg/faculty/profile/6271/guansong-pang,1ZO7pHkAAAAJ
 Guang Song,Iowa State University,http://www.cs.iastate.edu/people/guang-song,wB7NTEcAAAAJ
 Guang Wang,Florida State University,https://guangwang.me/,DfHyVboAAAAJ
 Guang-Yu Sun 0003,Peking University,http://ceca.pku.edu.cn/en/team.php?action=show&member_id=15,m3f70oYAAAAJ
@@ -751,6 +752,7 @@ Guangzhong Sun,USTC,http://staff.ustc.edu.cn/~gzsun,sm_uYE8AAAAJ
 Guanhua Yan,Binghamton University,https://www.binghamton.edu/cs/people/ghyan.html,6rPWxsgAAAAJ
 Guanjie Zheng,Shanghai Jiao Tong University,https://jhc.sjtu.edu.cn/~gjzheng/,jJpqDQIAAAAJ
 Guanpeng Li,University of Iowa,http://homepage.cs.uiowa.edu/~guanpli,hIoeKKkAAAAJ
+Guansong Pang,Singapore Management University,https://scis.smu.edu.sg/faculty/profile/6271/guansong-pang,1ZO7pHkAAAAJ
 Guanying Chen,CUHK (SZ),https://guanyingc.github.io/,Z2Kv_SsAAAAJ
 Gudmund Skovbjerg Frandsen,Aarhus University,http://cs.au.dk/~gudmund,bHvSLToAAAAJ
 Gudula Rünger,TU Chemnitz,https://www.tu-chemnitz.de/informatik/PI/professur/inhaber/index.php,NOSCHOLARPAGE
@@ -761,8 +763,8 @@ Guevara Noubir,Northeastern University,http://www.ccs.neu.edu/home/noubir,pUaHHj
 Gugan Thoppe,IISc Bangalore,https://www.csa.iisc.ac.in/people/gugan-thoppe,X5zV3s8AAAAJ
 Guha Balakrishnan,Rice University,https://profiles.rice.edu/faculty/guha-balakrishnan,CsEOFL8AAAAJ
 Guido A. Maier,Politecnico di Milano,http://home.deib.polimi.it/maier,PLEkIaAAAAAJ
-Guido Araujo,UNICAMP,https://guidoaraujo.wordpress.com/guido-araujo-homepage,xjuoV4QAAAAJ
 Guido Araújo,UNICAMP,https://guidoaraujo.wordpress.com/guido-araujo-homepage,xjuoV4QAAAAJ
+Guido Araujo,UNICAMP,https://guidoaraujo.wordpress.com/guido-araujo-homepage,xjuoV4QAAAAJ
 Guido Brunnett,TU Chemnitz,https://www.tu-chemnitz.de/informatik/HomePages/GDV/professurinhaber.php,NOSCHOLARPAGE
 Guido Gerig,New York University,http://engineering.nyu.edu/people/guido-gerig,P5CovF0AAAAJ
 Guido Germano 0001,University College London,http://www0.cs.ucl.ac.uk/people/G.Germano.html,8zCKUmoAAAAJ
@@ -784,8 +786,8 @@ Guiling Wang,NJIT,https://web.njit.edu/~gwang,PJOGQc4AAAAJ
 Guillaume Hanrot,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/guillaume.hanrot,NOSCHOLARPAGE
 Guillaume Lajoie,University of Montreal,https://www.guillaumelajoie.com,ifu_7_0AAAAJ
 Guillaume Rabusseau,University of Montreal,https://www.iro.umontreal.ca/~grabus,t2i4V4EAAAAJ
-Guillermo Gallego Bonet,TU Berlin,https://www.eecs.tu-berlin.de/menue/einrichtungen/professuren/professorinnen/gallego/parameter/en/,v0_XxF0AAAAJ
 Guillermo Gallego 0002,TU Berlin,https://www.eecs.tu-berlin.de/menue/einrichtungen/professuren/professorinnen/gallego/parameter/en/,v0_XxF0AAAAJ
+Guillermo Gallego Bonet,TU Berlin,https://www.eecs.tu-berlin.de/menue/einrichtungen/professuren/professorinnen/gallego/parameter/en/,v0_XxF0AAAAJ
 Guillermo Payá Vayá,TU Braunschweig,https://www.tu-braunschweig.de/eis/paya-vaya,uJLGjFUAAAAJ
 Guillermo Sapiro,Duke University,https://ece.duke.edu/faculty/guillermo-sapiro,ISRNX3gAAAAJ
 Guillermo Suarez-Tangil,IMDEA Networks Institute,https://networks.imdea.org/team/imdea-networks-team/people/guillermo-suarez-tangil,182ZkIgAAAAJ
@@ -869,9 +871,9 @@ Guozhu Meng,Chinese Academy of Sciences,https://impillar.github.io,fpE34K0AAAAJ
 Guri Sohi,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~sohi,NOSCHOLARPAGE
 Gurindar S. Sohi,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~sohi,NOSCHOLARPAGE
 Gurminder Singh,Naval Postgraduate School,http://faculty.nps.edu/gsingh,VP5CMagAAAAJ
-Gursimran Walia,Augusta University,http://www.gursimransinghwalia.com,X2qEWo0AAAAJ
 Gurpur M. Prabhu,Iowa State University,http://www.cs.iastate.edu/~prabhu,NOSCHOLARPAGE
 Gursimran Singh Walia,Augusta University,http://www.gursimransinghwalia.com,X2qEWo0AAAAJ
+Gursimran Walia,Augusta University,http://www.gursimransinghwalia.com,X2qEWo0AAAAJ
 Gushu Li,University of Pennsylvania,https://sites.google.com/view/gushuli,Po0BT08AAAAJ
 Gustavo Alonso,ETH Zurich,https://people.inf.ethz.ch/alonso,fkNjVcIAAAAJ
 Gustavo Carneiro,University of Adelaide,http://cs.adelaide.edu.au/~carneiro,E0TtOWAAAAAJ

--- a/csrankings-i.csv
+++ b/csrankings-i.csv
@@ -7,6 +7,7 @@ I-Ting Angelina Lee,Washington University in St. Louis,http://www.cse.wustl.edu/
 I. Emre Telatar,EPFL,https://people.epfl.ch/emre.telatar,8fiH7UkAAAAJ
 I. J. Bate,University of York,https://www-users.cs.york.ac.uk/~ijb,dE_ooMIAAAAJ
 I. V. Ramakrishnan,Stony Brook University,https://www.cs.stonybrook.edu/people/faculty/IVRamakrishnan,FgfwY_UAAAAJ
+IL-Chul Moon,KAIST,https://aai.kaist.ac.kr,23AxIc0AAAAJ
 Iacopo Masi,Sapienza University of Rome,http://iacopomasi.github.io,t4zrDEAAAAAJ
 Iadh Ounis,University of Glasgow,http://www.dcs.gla.ac.uk/~ounis,rKQMXOEAAAAJ
 Iain A. Stewart,Durham University,https://www.dur.ac.uk/computer.science/staff/profile/?id=1151,pYwb1nMAAAAJ
@@ -104,14 +105,15 @@ Ifat Yasin,University College London,http://www.cs.ucl.ac.uk/cs_people/I.Yasin.h
 Ifeoma Nwogu,University at Buffalo,https://cubs.buffalo.edu/~inwogu,pCOmTY0AAAAJ
 Iftach Haitner,Tel Aviv University,http://www.cs.tau.ac.il/~iftachh,EdV8gVgAAAAJ
 Iftekhar Ahmed 0001,Univ. of California - Irvine,https://www.ics.uci.edu/~iftekha,_TdMD7sAAAAJ
+Ignacio Aedo,Universidad Carlos III de Madrid,https://nachoaedo.me/,4itHck4AAAAJ
 Ignacio Cascudo,IMDEA Software Institute,http://software.imdea.org/~ignacio.cascudo,rOOEx5cAAAAJ
 Ignacio Cascudo Pueyo,IMDEA Software Institute,http://software.imdea.org/~ignacio.cascudo,rOOEx5cAAAAJ
 Ignaz Rutter,TU Eindhoven,http://i11www.iti.uni-karlsruhe.de/members/ignaz_rutter,BXLsurkAAAAJ
 Igor A. Semaev,University of Bergen,https://www.uib.no/en/persons/Igor.A..Semaev,NOSCHOLARPAGE
 Igor Carboni Oliveira,University of Warwick,https://warwick.ac.uk/fac/sci/dcs/people/igor_carboni_oliveira,aaGW2qwAAAAJ
 Igor Fabio Steinmacher,Northern Arizona University,http://www.igor.pro.br,I8o8rfoAAAAJ
-Igor Goryanin,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Igor_Goryanin.html,E-duT6oAAAAJ
 Igor Gilitschenski,University of Toronto,https://www.gilitschenski.org/igor/,Nuw1Y4oAAAAJ
+Igor Goryanin,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Igor_Goryanin.html,E-duT6oAAAAJ
 Igor L. Markov,University of Michigan,http://web.eecs.umich.edu/~imarkov,CHIZtZAAAAAJ
 Igor M. Moraes,UFF,http://www2.ic.uff.br/~igor,zFaRYScAAAAJ
 Igor Melatti,Sapienza University of Rome,http://wwwusers.di.uniroma1.it/~melatti,mehmJloAAAAJ
@@ -128,7 +130,6 @@ Ihsan Ayyub Qazi,LUMS,http://web.lums.edu.pk/~ihsan,lVzlcmUAAAAJ
 Ikkaku Kawaguchi,University of Tsukuba,https://sites.google.com/view/ikkakukawaguchi/e-home,NOSCHOLARPAGE
 Ikushi Yoda,University of Tsukuba,https://staff.aist.go.jp/i-yoda,NOSCHOLARPAGE
 Il Kon Kim,Kyungpook National University,http://www.ihis.or.kr,aCgpEqcAAAAJ
-IL-Chul Moon,KAIST,https://aai.kaist.ac.kr,23AxIc0AAAAJ
 Ilan Komargodski,Hebrew University of Jerusalem,https://www.cs.huji.ac.il/~ilank,WYTugmIAAAAJ
 Ilan Newman,University of Haifa,http://cs.haifa.ac.il/~ilan,dxWoV3UAAAAJ
 Ilario Filippini,Politecnico di Milano,http://home.deib.polimi.it/filippini,spXlyVwAAAAJ
@@ -187,6 +188,7 @@ Indranil Sengupta 0001,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~isg,1IIL5HU
 Indre Zliobaite,University of Helsinki,https://www.zliobaite.com,yyXBot4AAAAJ
 Indrė Žliobaitė,University of Helsinki,https://www.zliobaite.com,yyXBot4AAAAJ
 Inês Lynce,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist14029,uvgyhBMAAAAJ
+Inés María Galván,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169378/idu-3929,shgFBjgAAAAJ
 Ing-Chao Lin,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/depmember/teacherdetail/id/31,NOSCHOLARPAGE
 Ing-Ray Chen,Virginia Tech,http://people.cs.vt.edu/~irchen,UdangLEAAAAJ
 Inge Jonassen,University of Bergen,http://www.ii.uib.no/~inge,NOSCHOLARPAGE
@@ -196,10 +198,10 @@ Ingemar J. Cox,University College London,http://mediafutures.cs.ucl.ac.uk/people
 Ingemar Johansson Cox,University College London,http://mediafutures.cs.ucl.ac.uk/people/IngemarCox,b88nUpYAAAAJ
 Ingmar Weber,Saarland University,https://ingmarweber.de/,3YDUbP0AAAAJ
 Ingo J. Timm,University of Trier,https://www.uni-trier.de/index.php?id=35358,Ui6-EXQAAAAJ
+Ingo M. Weber,TU Berlin,https://www.sbe.tu-berlin.de/menue/team/prof_dr_ingo_weber/parameter/en/,uZP6cXwAAAAJ
 Ingo Schmitt,Brandenburg University of Technology,https://www.b-tu.de/fg-dbis/team/professor,NOSCHOLARPAGE
 Ingo Scholtes,University of Würzburg,https://www.informatik.uni-wuerzburg.de/ml4nets/team/prof-dr-ingo-scholtes,pouriVsAAAAJ
 Ingo Steinwart,University of Stuttgart,https://www.isa.uni-stuttgart.de/institut/team/Steinwart-00002,zFuwHeAAAAAJ
-Ingo M. Weber,TU Berlin,https://www.sbe.tu-berlin.de/menue/team/prof_dr_ingo_weber/parameter/en/,uZP6cXwAAAAJ
 Ingo Weber,TU Berlin,https://www.sbe.tu-berlin.de/menue/team/prof_dr_ingo_weber/parameter/en/,uZP6cXwAAAAJ
 Ingolf H. Krüger,Univ. of California - San Diego,http://jacobsschool.ucsd.edu/faculty/faculty_bios/index.sfe?fmp_recid=199,NOSCHOLARPAGE
 Ingolf Krueger,Univ. of California - San Diego,http://jacobsschool.ucsd.edu/faculty/faculty_bios/index.sfe?fmp_recid=199,NOSCHOLARPAGE
@@ -296,8 +298,8 @@ Irina Rish,University of Montreal,https://sites.google.com/site/irinarish,Avse5g
 Irina Shklovski,University of Copenhagen,http://miswritings.org,ufIlFCIAAAAJ
 Irina V. Biktasheva,University of Liverpool,https://www.csc.liv.ac.uk/~ivb,LE5QNgYAAAAJ
 Irina Voiculescu,University of Oxford,http://www.cs.ox.ac.uk/people/irina.voiculescu,NOSCHOLARPAGE
-Iris Groher,JKU Linz,https://www.se.jku.at/iris-groher,7I1zR48AAAAJ
 Iris Bahar,Colorado School of Mines,https://people.mines.edu/ribahar,kfIj9oYAAAAJ
+Iris Groher,JKU Linz,https://www.se.jku.at/iris-groher,7I1zR48AAAAJ
 Irwin King,Chinese University of Hong Kong,https://www.cse.cuhk.edu.hk/irwin.king,MXvC7tkAAAAJ
 Iryna Gurevych,TU Darmstadt,https://www.ukp.tu-darmstadt.de/people/group-heads/prof-dr-iryna-gurevych,t3A39e8AAAAJ
 Isaac Balbin,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/b/balbin-associate-professor-isaac,YCMaqMYAAAAJ
@@ -313,6 +315,7 @@ Isabel Maria Cacho Teixeira,Universidade de Lisboa,https://ciencias.ulisboa.pt/e
 Isabel Méndez-Díaz,University of Buenos Aires,https://www.dc.uba.ar/rrhh/profesores/mendezdiaz,NOSCHOLARPAGE
 Isabel Nunes,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/minunes,CLnZIEQAAAAJ
 Isabel Rosseti,UFF,http://www2.ic.uff.br/~rosseti,PEyGjwsAAAAJ
+Isabel Segura-Bedmar,Universidad Carlos III de Madrid,https://hulat.inf.uc3m.es/nosotros/miembros/isegura,ZpbtnaUAAAAJ
 Isabel Trancoso,Universidade de Lisboa,https://www.l2f.inesc-id.pt/wiki/index.php/Isabel_Trancoso,Auzu_DcAAAAJ
 Isabel Valera,Saarland University,https://ivaleram.github.io,cpdQqpsAAAAJ
 Isabella Peters,University of Kiel,https://www.ws.informatik.uni-kiel.de/de/team/prof.-dr.-isabella-peters,VRJcHbQAAAAJ
@@ -347,6 +350,7 @@ Isolde Adler,University of Leeds,https://eps.leeds.ac.uk/computing/staff/810/dr-
 Israat Haque,Dalhousie University,https://www.dal.ca/faculty/computerscience/news-events/events/2017/05/01/cs_seminar__israat_haque___software_defined_architectures_and_protocols_for_emerging_wireless_networks.html,ZBhZBwoAAAAJ
 Israat Tanzeena Haque,Dalhousie University,https://www.dal.ca/faculty/computerscience/faculty-staff/israat-haque.html,ZBhZBwoAAAAJ
 Israel Cidon,Technion,http://cidon.eew.technion.ac.il,azcMaLoAAAAJ
+Israel González-Carrasco,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-3423,iYoS6zcAAAAJ
 Issa Batarseh,University of Central Florida,http://www.cecs.ucf.edu/faculty/issa-batarseh,xl0jn_IAAAAJ
 Issei Fujishiro,Keio University,https://www.st.keio.ac.jp/en/tprofile/ics/fujishiro.html,0bnysWMAAAAJ
 Issei Sato,University of Tokyo,http://www.ms.k.u-tokyo.ac.jp/sato,NOSCHOLARPAGE
@@ -366,6 +370,7 @@ Ivan Damgård,Aarhus University,https://cs.au.dk/~ivan/,-UhqXIEAAAAJ
 Ivan De Oliveira Nunes,Rochester Institute of Technology,https://www.rit.edu/directory/ixdics-ivan-de-oliveira-nunes,2ITEX20AAAAJ
 Ivan Flechais,University of Oxford,https://www.cs.ox.ac.uk/people/ivan.flechais,w6PR9pkAAAAJ
 Ivan Garibay,University of Central Florida,https://www.cs.ucf.edu/~garibay,rPuLfoMAAAAJ
+Iván González-Díaz 0001,Universidad Carlos III de Madrid,https://www.tsc.uc3m.es/~igonzalez/,fPGStlcAAAAJ
 Ivan Hal Sudborough,University of Texas at Dallas,https://explorer.utdallas.edu/editprofile.php?pid=13187,NOSCHOLARPAGE
 Ivan Herman,CWI,http://homepages.cwi.nl/~ivan,ofRrImEAAAAJ
 Iván Herman,CWI,http://homepages.cwi.nl/~ivan,ofRrImEAAAAJ

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -346,16 +346,16 @@ Jamie Payton,Temple University,https://cis.temple.edu/~payton,dIbeva0AAAAJ
 Jamie Sikora,Virginia Tech,https://www.perimeterinstitute.ca/people/jamie-sikora,EBxyd5gAAAAJ
 Jamie Twycross,University of Nottingham,https://www.nottingham.ac.uk/computerscience/people/jamie.twycross,I9Tsqf8AAAAJ
 Jamie Vicary,University of Cambridge,https://www.cl.cam.ac.uk/~jv258,9LG1IeMAAAAJ
-Jan "Matt" Pedersen,University of Nevada Las Vegas,http://www.egr.unlv.edu/~matt,Oh3z3nEAAAAJ
+"Jan ""Matt"" Pedersen",University of Nevada Las Vegas,http://www.egr.unlv.edu/~matt,Oh3z3nEAAAAJ
 Jan Allebach,Purdue University,https://engineering.purdue.edu/ECE/People/ptProfile?resource_id=3043,NOSCHOLARPAGE
 Jan Arne Telle,University of Bergen,http://www.ii.uib.no/~telle,NOSCHOLARPAGE
 Jan B. Pedersen,University of Nevada Las Vegas,http://www.egr.unlv.edu/~matt,Oh3z3nEAAAAJ
 Jan B. Pedersen 0001,University of Nevada Las Vegas,http://www.egr.unlv.edu/~matt,Oh3z3nEAAAAJ
+Jan Bækgaard Pedersen,University of Nevada Las Vegas,http://www.egr.unlv.edu/~matt,Oh3z3nEAAAAJ
 Jan Bender,RWTH Aachen,https://www.animation.rwth-aachen.de,POEoFagAAAAJ
 Jan Beutel,University of Innsbruck,https://www.uibk.ac.at/informatik/forschung/professorinnen.html.de,LRkwAAAAJ
 Jan Bosch,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/jan-bosch.aspx,Wr6oSWIAAAAJ
 Jan Bouda,Masaryk University,https://www.muni.cz/en/people/3717,To23LQMAAAAJ
-Jan Bækgaard Pedersen,University of Nevada Las Vegas,http://www.egr.unlv.edu/~matt,Oh3z3nEAAAAJ
 Jan C. van Gemert,TU Delft,https://www.tudelft.nl/ewi/over-de-faculteit/afdelingen/intelligent-systems/pattern-recognition-bioinformatics/computer-vision-lab/people/jan-van-gemert,JUdMRGcAAAAJ
 Jan Carlo Barca,Monash University,http://monash.edu/research/explore/en/persons/jan-barca(b809a264-a966-4c49-b3b3-1425a47f97ee).html,bZQ0r6YAAAAJ
 Jan Carlson,Mälardalen University,http://www.es.mdh.se/staff/40-Jan_Carlson,gH5Au04AAAAJ
@@ -419,10 +419,10 @@ Jan Strejcek,Masaryk University,https://www.muni.cz/en/people/3366,2Bdz-iAAAAAJ
 Jan Tretmans,Radboud University,http://www.cs.ru.nl/~tretmans,J_y4V0UAAAAJ
 Jan Treur,VU Amsterdam,http://www.cs.vu.nl/~treur,2NzjnkYAAAAJ
 Jan Vahrenhold,University of Münster,https://www.uni-muenster.de/Informatik.AGVahrenhold/personen/prof.dr.janvahrenhold/index.html,NOSCHOLARPAGE
+Jan Vitek,Northeastern University,https://www.khoury.northeastern.edu/people/jan-vitek/,Ws0GjboAAAAJ
 Jan van Eijck,CWI,http://homepages.cwi.nl/~jve,ptYHch4AAAAJ
 Jan van Gemert,TU Delft,https://www.tudelft.nl/ewi/over-de-faculteit/afdelingen/intelligent-systems/pattern-recognition-bioinformatics/computer-vision-lab/people/jan-van-gemert,JUdMRGcAAAAJ
 Jan van Leeuwen,Utrecht University,https://www.uu.nl/staff/JvanLeeuwen1,7s_pSa4AAAAJ
-Jan Vitek,Northeastern University,https://www.khoury.northeastern.edu/people/jan-vitek/,Ws0GjboAAAAJ
 Jan-J. Rückmann,University of Bergen,https://www.uib.no/en/persons/Jan-Joachim.R%C3%BCckmann,NOSCHOLARPAGE
 Jan-Philipp Steghöfer,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/jan-philipp-steghofer.aspx,NOSCHOLARPAGE
 Jan-Willem van de Meent,University of Amsterdam,https://www.ccs.neu.edu/home/jwvdm,CX9Lu38AAAAJ
@@ -492,8 +492,8 @@ Jarred Ligatti,University of South Florida,http://www.cse.usf.edu/~ligatti,xmQRE
 Jarrod Knibbe,University of Melbourne,https://findanexpert.unimelb.edu.au/profile/860467-jarrod-knibbe,FOsmPdoAAAAJ
 Jaruloj Eamsiri Chongstitvatana,Chulalongkorn University,http://65.54.113.26/Author/3358202/jaruloj-eamsiri-chongstitvatana,NOSCHOLARPAGE
 Jasleen Kaur 0001,University of North Carolina,http://www.cs.unc.edu/~jasleen,K9_NT-MAAAAJ
-Jasmijn Baaijens,TU Delft,https://www.tudelft.nl/en/ewi/over-de-faculteit/afdelingen/intelligent-systems/pattern-recognition-bioinformatics/the-delft-bioinformatics-lab/people/jasmijn-baaijens,Wf6FjvIAAAAJ
 Jasmijn A. Baaijens,TU Delft,https://www.tudelft.nl/en/ewi/over-de-faculteit/afdelingen/intelligent-systems/pattern-recognition-bioinformatics/the-delft-bioinformatics-lab/people/jasmijn-baaijens,Wf6FjvIAAAAJ
+Jasmijn Baaijens,TU Delft,https://www.tudelft.nl/en/ewi/over-de-faculteit/afdelingen/intelligent-systems/pattern-recognition-bioinformatics/the-delft-bioinformatics-lab/people/jasmijn-baaijens,Wf6FjvIAAAAJ
 Jasmin Blanchette,VU Amsterdam,https://people.mpi-inf.mpg.de/~jblanche,OpuTG3IAAAAJ
 Jasmin Christian Blanchette,VU Amsterdam,https://people.mpi-inf.mpg.de/~jblanche,OpuTG3IAAAAJ
 Jason A. D. Atkin,University of Nottingham,https://www.nottingham.ac.uk/computerscience/people/jason.atkin,Dor8JVYAAAAJ
@@ -551,7 +551,10 @@ Javier Cámara,University of York,http://www.javicamara.com,iMMncw8AAAAJ
 Javier Cámara Moreno,University of York,http://www.javicamara.com,iMMncw8AAAAJ
 Javier Cuenca,University of Murcia,http://ditec.um.es/%7Ejaviercm/index_english.html,VfJyirIAAAAJ
 Javier Esparza,TU Munich,https://www7.in.tum.de/people/detail/index.php?id=people.detail&arg=33,c9qgPSYAAAAJ
+Javier Fernández 0001,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-182,YiTgEHUAAAAJ
+Javier García Guzmán,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-959,cNP6EGEAAAAJ
 Javier Guerrero,Washington State University,https://foundation.wsu.edu/2013/04/12/solar-car-donation-accelerates-renewables-education,ntHlYjcAAAAJ
+Javier Ignacio Carbó Rubiera,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-2595,4v09bcsAAAAJ
 Javier L. Marenco,University of Buenos Aires,https://www.dc.uba.ar/rrhh/profesores/marenco,NOSCHOLARPAGE
 Javier Marenco,University of Buenos Aires,https://www.dc.uba.ar/rrhh/profesores/marenco,NOSCHOLARPAGE
 Javier Navaridas,University of Manchester,https://personalpages.manchester.ac.uk/staff/javier.navaridas,A6LgSWkAAAAJ
@@ -747,8 +750,8 @@ Jennifer Tour Chayes,Univ. of California - Berkeley,http://jenniferchayes.com,YA
 Jennifer Waycott,University of Melbourne,http://findanexpert.unimelb.edu.au/display/person52243,kc5Fr-0AAAAJ
 Jennifer Widom,Stanford University,http://infolab.stanford.edu/~widom,zdKmnYwAAAAJ
 Jenny Coady,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/jenny-coady.htm,NOSCHOLARPAGE
-Jennyfer Lawrence Taylor,Australian National University,https://comp.anu.edu.au/people/jennyfer-taylor/,YojqErAAAAAJ
 Jenny Waycott,University of Melbourne,http://findanexpert.unimelb.edu.au/display/person52243,kc5Fr-0AAAAJ
+Jennyfer Lawrence Taylor,Australian National University,https://comp.anu.edu.au/people/jennyfer-taylor/,YojqErAAAAAJ
 Jenq Kuen Lee,National Tsing Hua University,http://pllab.cs.nthu.edu.tw/~jklee,cIxlQU4AAAAJ
 Jenq-Kuen Lee,National Tsing Hua University,http://pllab.cs.nthu.edu.tw/~jklee,cIxlQU4AAAAJ
 Jens B. Schmitt,TU Kaiserslautern,https://disco.cs.uni-kl.de/index.php/people/jens-schmitt,lmEldBwAAAAJ
@@ -819,6 +822,7 @@ Jerome Harri,EURECOM,http://www.eurecom.fr/~haerri,QSAclH8AAAAJ
 Jerome Knopp,University of Missouri - Kansas City,https://sce.umkc.edu/about/directory/name/jerome-knopp-ph-d,NOSCHOLARPAGE
 Jérôme Lang,Université Paris Dauphine,https://www.lamsade.dauphine.fr/~lang/,cNgZXNcAAAAJ
 Jérôme Waldispühl,McGill University,http://www.cs.mcgill.ca/~jeromew,IVZp2gQAAAAJ
+Jerónimo Arenas-García,Universidad Carlos III de Madrid,https://www.tsc.uc3m.es/~jarenas/,40AV6F0AAAAJ
 Jerónimo Castrillón,TU Dresden,https://cfaed.tu-dresden.de/ccc-about,Vez2G1kAAAAJ
 Jerónimo Castrillón Mazo,TU Dresden,https://cfaed.tu-dresden.de/ccc-about,Vez2G1kAAAAJ
 Jerry Alan Fails,Boise State University,http://cs.boisestate.edu/~jfails,eO71_M8AAAAJ
@@ -861,8 +865,11 @@ Jessica R. Hullman,Northwestern University,http://faculty.washington.edu/jhullma
 Jessie Hui Wang,Tsinghua University,https://jessiehuiwang.github.io/index.html,fcLOhBoAAAAJ
 Jesualdo Tomás Fernández-Breis,University of Murcia,http://webs.um.es/jfernand/miwiki/doku.php,KaEwPLIAAAAJ
 Jesus Ángel Velázquez-Iturbide,Universidad Rey Juan Carlos,http:/www.lite.etsii.urjc.es/angel.velazquez,JfWXVVgAAAAJ
+Jesús Carretero 0001,Universidad Carlos III de Madrid,https://www.arcos.inf.uc3m.es/jcarretero/,kSQoV-sAAAAJ
+Jesús Cid-Sueiro,Universidad Carlos III de Madrid,https://www.tsc.uc3m.es/~jcid/,O9fo-w8AAAAJ
 Jesus Dario Landa-Silva,University of Nottingham,https://www.nottingham.ac.uk/computerscience/people/dario.landasilva,T8jdVWwAAAAJ
 Jesus De Loera,Univ. of California - Davis,https://www.math.ucdavis.edu/~deloera,1S0o7WwAAAAJ
+Jesús García 0001,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169378/idu-2747,0H3WqAsAAAAJ
 Jesus García Molina,University of Murcia,http://dis.um.es/~jmolina,GU8Kf8UAAAAJ
 Jesús Labarta,Polytechnic University of Catalonia,https://www.bsc.es/labarta-mancho-jesus,6vj6TdsAAAAJ
 Jesús M. González-Barahona,Universidad Rey Juan Carlos,https://gsyc.urjc.es/jgb,vYIPWB0AAAAJ
@@ -887,7 +894,6 @@ Jia Di,University of Arkansas,https://sites.uark.edu/jdi,NOSCHOLARPAGE
 Jia Hu,University of Exeter,http://emps.exeter.ac.uk/computer-science/staff/jh815,n1Q5NG4AAAAJ
 Jia Jia 0001,Tsinghua University,http://hcsi.cs.tsinghua.edu.cn,NOSCHOLARPAGE
 Jia Li 0003,Beihang University,http://arts.buaa.edu.cn/staff/jiali/index.htm,BfWMlE4AAAAJ
-Jiajia Li 0001,North Carolina State University,http://jiajiali.org,A8TTuWMAAAAJ
 Jia Liu 0002,Ohio State University,https://kevinliu-osu-ece.github.io,NOSCHOLARPAGE
 Jia Liu 0008,Nanjing University,https://cs.nju.edu.cn/liujia,Q583YzMAAAAJ
 Jia Liu 0015,Nanjing University,http://www.iselab.cn/faculty/JiaLiu,5c8-XCAAAAJ
@@ -915,6 +921,7 @@ Jiaguang Sun 0001,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/so
 Jiahai Yang,Tsinghua University,http://nmgroup.tsinghua.edu.cn/yang/index_en.htm,NOSCHOLARPAGE
 Jiaheng Lu,University of Helsinki,https://www.cs.helsinki.fi/u/jilu,EVNolAkAAAAJ
 Jiahua Jiang,ShanghaiTech University,https://sist.shanghaitech.edu.cn/sist_en/2020/0707/c7582a58299/page.htm,ZHLDtbsAAAAJ
+Jiajia Li 0001,North Carolina State University,http://jiajiali.org,A8TTuWMAAAAJ
 Jiajie Xu 0001,Soochow University,http://jwsy.suda.edu.cn/69/bf/c9398a223679/page.htm,HYURJ-0AAAAJ
 Jiajun Bu,Zhejiang University,http://mypage.zju.edu.cn/bjj,OgZP2okAAAAJ
 Jiajun Chen,Nanjing University,https://cs.nju.edu.cn/chenjiajun/index_en.htm,WIF7VaoAAAAJ
@@ -960,8 +967,8 @@ Jian-qiang Li 0001,Shenzhen University,http://csse.szu.edu.cn/staff/lijq,-oVMPBw
 Jianbin Huang,Xidian University,https://web.xidian.edu.cn/jbhuang,s60vEVYAAAAJ
 Jianbin Qin,Shenzhen University,http://csse.szu.edu.cn/en/peoplec4be.html?222367,2ZmhZpgAAAAJ
 Jianbing Shen,University of Macau,https://www.fst.um.edu.mo/people/jianbingshen/,_Q3NTToAAAAJ
-Jianbo Shi,University of Pennsylvania,https://www.cis.upenn.edu/~jshi,Sm14jYIAAAAJ
 Jianbo Jiao,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/academic-staff/jiao-jianbo.aspx,HkEiMMwAAAAJ
+Jianbo Shi,University of Pennsylvania,https://www.cis.upenn.edu/~jshi,Sm14jYIAAAAJ
 Jianchao Luo,UESTC,https://www.en.scse.uestc.edu.cn/info/1085/1918.htm,NOSCHOLARPAGE
 Jianer Chen,Texas A&M University,http://faculty.cs.tamu.edu/chen,0zVOVQ0AAAAJ
 Jianfei Cai 0001,Nanyang Technological University,http://www.ntu.edu.sg/home/asjfcai,N6czCoUAAAAJ
@@ -1021,8 +1028,8 @@ Jianping Wang 0001,City University of Hong Kong,https://www.cs.cityu.edu.hk/~jia
 Jianping Wu,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101224194435414856631/20101224194435414856631_.html,Y-nqSYgAAAAJ
 Jianping Zeng 0002,Fudan University,http://homepage.fudan.edu.cn/zengjp,A-I4mjgAAAAJ
 Jianqiang Li 0001,Shenzhen University,http://csse.szu.edu.cn/staff/lijq,-oVMPBwAAAAJ
-Jianshe Wu,Xidian University,https://web.xidian.edu.cn/jshwu/,y2GUW9UAAAAJ
 Jianqin Yin,BUPT,https://teacher.bupt.edu.cn/yinjianqin/en/index.htm,NOSCHOLARPAGE
+Jianshe Wu,Xidian University,https://web.xidian.edu.cn/jshwu/,y2GUW9UAAAAJ
 Jiantao Jiao,Univ. of California - Berkeley,https://people.eecs.berkeley.edu/~jiantao,aO8KpGcAAAAJ
 Jiantao Zhou 0001,University of Macau,https://www.fst.um.edu.mo/people/jtzhou/,mcROAxAAAAAJ
 Jianting Zhang,CUNY,http://www-cs.ccny.cuny.edu/~jzhang,UKjJKUIAAAAJ
@@ -1295,10 +1302,10 @@ Jirí Fiala 0001,Charles University,https://kam.mff.cuni.cz/~fiala,UD7oqQoAAAAJ
 Jiri Friml,IST Austria,https://ist.ac.at/research/research-groups/friml-group,NOSCHOLARPAGE
 Jirí Kléma,Czech Technical University,https://ida.fel.cvut.cz/klema,zuwJZmEAAAAJ
 Jiri Matas,Czech Technical University,http://cmp.felk.cvut.cz/~matas,EJCNY6QAAAAJ
-Jiri Sgall,Charles University,https://iuuk.mff.cuni.cz/~sgall,5XzFcZoAAAAJ
 Jirí Sgall,Charles University,https://iuuk.mff.cuni.cz/~sgall,5XzFcZoAAAAJ
-Jiri Sochor,Masaryk University,https://www.muni.cz/en/people/2446,kd3m5-4AAAAJ
+Jiri Sgall,Charles University,https://iuuk.mff.cuni.cz/~sgall,5XzFcZoAAAAJ
 Jirí Sochor,Masaryk University,https://www.muni.cz/en/people/2446,kd3m5-4AAAAJ
+Jiri Sochor,Masaryk University,https://www.muni.cz/en/people/2446,kd3m5-4AAAAJ
 Jirí Srba,Aalborg University,http://people.cs.aau.dk/~srba,PYmuJQoAAAAJ
 Jirí Vokrínek,Czech Technical University,http://cs.fel.cvut.cz/en/people/xvokrine,-FihvIMAAAAJ
 Jiri Zara,Czech Technical University,https://dcgi.fel.cvut.cz/people/zara,V2QQklIAAAAJ
@@ -1313,8 +1320,8 @@ Jitender S. Deogun,University of Nebraska,http://cse.unl.edu/~deogun,QpLZdfoAAAA
 Jitendra Malik,Univ. of California - Berkeley,https://people.eecs.berkeley.edu/~malik,oY9R5YQAAAAJ
 Jiun-Long Huang,National Chiao Tung University,http://www.cs.nctu.edu.tw/~jlhuang,NOSCHOLARPAGE
 Jiwon Seo,Hanyang University,http://bdsl.hanyang.ac.kr/members/jiwonseo,O1WC6TAAAAAJ
-Jiwu Shu,Tsinghua University,http://storage.cs.tsinghua.edu.cn/~jiwu-shu,VccUDSgAAAAJ
 Jiwu Shu,Xiamen University,https://informatics.xmu.edu.cn/info/1018/15693.htm,VccUDSgAAAAJ
+Jiwu Shu,Tsinghua University,http://storage.cs.tsinghua.edu.cn/~jiwu-shu,VccUDSgAAAAJ
 Jiyan Wu,Shenzhen University,https://sites.google.com/site/wujiyanweb,3aTNQsgAAAAJ
 Jiyao An,Hunan University,http://csee.hnu.edu.cn/people/anjiyao,BeWWwfsAAAAJ
 Jiying Zhao,University of Ottawa,http://www.site.uottawa.ca/~jyzhao,zHFUSYMAAAAJ
@@ -1348,8 +1355,8 @@ Joan Feigenbaum,Yale University,http://www.cs.yale.edu/~jf,IAeKTGsAAAAJ
 Joan-Manuel Parcerisa,Polytechnic University of Catalonia,http://personals.ac.upc.edu/jmanel,S6AXVlAAAAAJ
 Joana Gonçalves,TU Delft,http://joanagoncalves.org,NcQxaAsAAAAJ
 Joanna Bergström,University of Copenhagen,https://di.ku.dk/english/staff/vip/?pure=en/persons/540723,NL1Q89sAAAAJ
-Joanna Bergstrom-Lehtovirta,University of Copenhagen,https://di.ku.dk/english/staff/vip/?pure=en/persons/540723,NL1Q89sAAAAJ
 Joanna Bergström-Lehtovirta,University of Copenhagen,https://di.ku.dk/english/staff/vip/?pure=en/persons/540723,NL1Q89sAAAAJ
+Joanna Bergstrom-Lehtovirta,University of Copenhagen,https://di.ku.dk/english/staff/vip/?pure=en/persons/540723,NL1Q89sAAAAJ
 Joanna Bryson,University of Bath,http://www.cs.bath.ac.uk/~jjb,QOU1RTUAAAAJ
 Joanna C. S. Santos,University of Notre Dame,https://cse.nd.edu/faculty/joanna-cecilia-da-silva-santos,mkGmYyAAAAAJ
 Joanna Cecilia da Silva Santos,University of Notre Dame,https://cse.nd.edu/faculty/joanna-cecilia-da-silva-santos,mkGmYyAAAAAJ
@@ -1412,6 +1419,7 @@ João Silva 0004,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/jrsil
 João do E. S. Batista Neto,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/jbatista,NOSCHOLARPAGE
 Joaquim A. Jorge,Universidade de Lisboa,http://web.tecnico.ulisboa.pt/jorgej,RgiMdpAAAAAJ
 Joaquim Armando Pires Jorge,Universidade de Lisboa,http://web.tecnico.ulisboa.pt/jorgej,RgiMdpAAAAAJ
+Joaquín Míguez,Universidad Carlos III de Madrid,https://jmiguez.webs.tsc.uc3m.es/,laif78oAAAAJ
 Joaquin Vaschoren,TU Eindhoven,http://www.win.tue.nl/~jvanscho,NOSCHOLARPAGE
 Jocelyn Simmonds,Universidad de Chile,http://www.dcc.uchile.cl/~jsimmond,QTdKy5gAAAAJ
 Jocelynn Cu,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742661694&command=GETPROFILE,vHVPmkgAAAAJ
@@ -1455,8 +1463,8 @@ Joel H. Spencer,New York University,http://cs.nyu.edu/spencer,AmmWYgEAAAAJ
 Joel I. Seiferas,University of Rochester,https://www.cs.rochester.edu/~joel,NOSCHOLARPAGE
 Joel Ilao,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742738160&command=GETPROFILE,gd8W9ecAAAAJ
 Joël Lefebvre,Université du Québec à Montréal,https://joel-lefebvre.uqam.ca/,vPnYJ34AAAAJ
-Joel Luis Carbonera,UFRGS,https://www.inf.ufrgs.br/site/docente/joel-luis-carbonera,oMtHaoQAAAAJ
 Joel Luís Carbonera,UFRGS,https://www.inf.ufrgs.br/site/docente/joel-luis-carbonera,oMtHaoQAAAAJ
+Joel Luis Carbonera,UFRGS,https://www.inf.ufrgs.br/site/docente/joel-luis-carbonera,oMtHaoQAAAAJ
 Joël M. H. Karel,Maastricht University,https://dke.maastrichtuniversity.nl/joel.karel,QDYgJMEAAAAJ
 Joel Moses,Massachusetts Institute of Technology,https://esd.mit.edu/Faculty_Pages/moses/moses.htm,NOSCHOLARPAGE
 Joël Ouaknine [SWS],Max Planck Society,https://people.mpi-sws.org/~joel,ZfE4iQ4AAAAJ
@@ -1751,8 +1759,8 @@ Jonathan Gemmell,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/
 Jonathan I. Maletic,Kent State University,http://www.cs.kent.edu/~jmaletic,n9_W4kYAAAAJ
 Jonathan K. Kummerfeld,University of Sydney,https://www.jkk.name,OsoNG9AAAAAJ&hl
 Jonathan K. Lazar,University of Maryland - College Park,https://ischool.umd.edu/faculty-staff/jonathan-lazar,CDpfbBsAAAAJ
-Jonathan Kelly,University of Toronto,https://starslab.ca/,KtSR8_0AAAAJ
 Jonathan Katz,University of Maryland - College Park,https://www.cs.umd.edu/~jkatz,H4rKFc8AAAAJ
+Jonathan Kelly,University of Toronto,https://starslab.ca/,KtSR8_0AAAAJ
 Jonathan Lazar,University of Maryland - College Park,https://ischool.umd.edu/faculty-staff/jonathan-lazar,CDpfbBsAAAAJ
 Jonathan Lee 0001,National Taiwan University,https://www.csie.ntu.edu.tw/~jlee,iYNIPS8AAAAJ
 Jonathan Lewis,University of St Andrews,https://jonl.host.cs.st-andrews.ac.uk,NOSCHOLARPAGE
@@ -1857,8 +1865,10 @@ Jorge S. Marques,Universidade de Lisboa,http://users.isr.ist.utl.pt/~jsm,8Vwg-7s
 Jorge Sánchez,Universidad Nacional de Córdoba,https://www.famaf.unc.edu.ar/~jsanchez,XV4_wlwAAAAJ
 Jorge Stolfi,UNICAMP,https://twitter.com/jorgestolfi?lang=en,mLo7gCEAAAAJ
 Jorge Villalobos,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/jvillalo/es/inicio,6pj6oSUAAAAJ
+Jørgen P. Bansler,University of Copenhagen,http://diku.dk/Ansatte/beskrivelse/?id=160232,YuHIy0IAAAAJ
 Jorgen P. Bansler,University of Copenhagen,http://diku.dk/Ansatte/beskrivelse/?id=160232,YuHIy0IAAAAJ
 Jorgen Peddersen,UNSW,https://www.engineering.unsw.edu.au/computer-science-engineering/staff/jorgen-peddersen,NOSCHOLARPAGE
+Jørgen Villadsen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Joris M. Mooij,University of Amsterdam,https://staff.fnwi.uva.nl/j.m.mooij,Td3_kIwAAAAJ
 Jörn Diedrichsen,Western University,http://www.diedrichsenlab.org,mF72dYoAAAAJ
 Jörn Janneck,Lund University,http://www.lunduniversity.lu.se/lucat/user/6d94f235ba6e4b38f5fbc1a7b0ed0c00,acaDIH8AAAAJ
@@ -1879,6 +1889,7 @@ José Alberto Rodrigues Pereira Sardinha,Universidade de Lisboa,http://web.ist.u
 José Antonio Becerra,University of A Coruña,https://pdi.udc.es/es/File/Pdi/EU69E,QTPUBioAAAAJ
 José Antonio Becerra Permuy,University of A Coruña,https://pdi.udc.es/es/File/Pdi/EU69E,QTPUBioAAAAJ
 José António Beltran Gerald,Universidade de Lisboa,http://ieeexplore.ieee.org/document/7845358,NOSCHOLARPAGE
+José Antonio Iglesias,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-713,aDPfBOwAAAAJ
 José Augusto Suruagy Monteiro,UFPE,http://www.di.ufpe.br/~suruagy,xCIQf-QAAAAJ
 José Bento 0001,Boston College,http://www.jbento.net,8K6Z0lEAAAAJ
 José Bento Ayres Pereira,Boston College,http://www.jbento.net,8K6Z0lEAAAAJ
@@ -1886,10 +1897,11 @@ José C. Monteiro,Universidade de Lisboa,http://algos.inesc-id.pt/~jcm,tkeh3OAAA
 José Camacho-Collados,Cardiff University,https://www.cardiff.ac.uk/people/view/1178085-camacho-collados-jose,NP4KdQQAAAAJ
 José Carlos Alves Pereira Monteiro,Universidade de Lisboa,http://algos.inesc-id.pt/~jcm,tkeh3OAAAAAJ
 José Carlos Dafonte Vázquez,University of A Coruña,https://pdi.udc.es/en/File/Pdi/9K9AF,plU2iAkAAAAJ
-Jose Dolz,ETS Montreal,https://www.etsmtl.ca/Professeurs/jdolz,yHQIFFMAAAAJ
+José Daniel García,Universidad Carlos III de Madrid,https://www.arcos.inf.uc3m.es/jdgarcia/,ioPm6ooAAAAJ
 José Dolz,ETS Montreal,https://www.etsmtl.ca/Professeurs/jdolz,yHQIFFMAAAAJ
-José Elias C. Arroyo,Universidade Federal de Viçosa,http://www.dpi.ufv.br/~jarroyo,4Z4noW4AAAAJ
+Jose Dolz,ETS Montreal,https://www.etsmtl.ca/Professeurs/jdolz,yHQIFFMAAAAJ
 José Elías C. Arroyo,Universidade Federal de Viçosa,http://www.dpi.ufv.br/~jarroyo,4Z4noW4AAAAJ
+José Elias C. Arroyo,Universidade Federal de Viçosa,http://www.dpi.ufv.br/~jarroyo,4Z4noW4AAAAJ
 José Elias Claudio Arroyo,Universidade Federal de Viçosa,http://www.dpi.ufv.br/~jarroyo,4Z4noW4AAAAJ
 José F. Martínez,Cornell University,http://www.csl.cornell.edu/~martinez,f1CZknQAAAAJ
 José F. Morales,IMDEA Software Institute,http://software.imdea.org/people/josef.morales,DZOdfUIAAAAJ
@@ -1909,6 +1921,7 @@ José Legatheaux Martins,Universidade NOVA de Lisboa,http://legatheaux.eu,jWrKqa
 José Losada,University of A Coruña,https://pdi.udc.es/en/File/Pdi/DJ5HF,NOSCHOLARPAGE
 José Luis Borbinha,Universidade de Lisboa,http://joslusborbinha.cgpublisher.com/product/pub.222/prod.27,NOSCHOLARPAGE
 José Luis Brinquete Borbinha,Universidade de Lisboa,http://joslusborbinha.cgpublisher.com/product/pub.222/prod.27,NOSCHOLARPAGE
+José Luis López Cuadrado,Universidad Carlos III de Madrid,https://hulat.inf.uc3m.es/nosotros/miembros/jlcuad,MVabAjsAAAAJ
 José Luis Rojo-Álvarez,Universidad Rey Juan Carlos,https://gestion2.urjc.es/pdi/ver/joseluis.rojo,KaBeaJwAAAAJ
 José M. Barceló,Polytechnic University of Catalonia,http://compnet.ac.upc.edu/intranet/?q=node/169,NOSCHOLARPAGE
 José M. Barceló-Ordinas,Polytechnic University of Catalonia,http://compnet.ac.upc.edu/intranet/?q=node/169,NOSCHOLARPAGE
@@ -1917,6 +1930,7 @@ José M. Cela,Polytechnic University of Catalonia,https://www.bsc.es/about-bsc/s
 José M. García 0001,University of Murcia,http://webs.um.es/jmgarcia/miwiki/doku.php,QzRE5OIAAAAJ
 José M. Juarez,University of Murcia,http://webs.um.es/jmjuarez,cCDpQu4AAAAJ
 José M. Llabería,Polytechnic University of Catalonia,https://www.ac.upc.edu/en/content/llaberia,NOSCHOLARPAGE
+José M. Molina López,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169378/idu-3749,GyT7dN0AAAAJ
 Jose M. Such,King's College London,https://www.kcl.ac.uk/people/jose-such,xNr_IMUAAAAJ
 José M. Tribolet,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist10876,dzslQ5MAAAAJ
 José M. Vidal,University of South Carolina,http://jmvidal.cse.sc.edu,pKs-384AAAAJ
@@ -1925,10 +1939,13 @@ José Manuel García Carrasco,University of Murcia,http://webs.um.es/jmgarcia/mi
 José Manuel Vázquez-Naya,University of A Coruña,https://pdi.udc.es/es/File/Pdi/HE9JF,4RFnlZ0AAAAJ
 José Marcos S. Nogueira,UFMG,http://homepages.dcc.ufmg.br/~jmarcos,SmuqzcYAAAAJ
 José Marcos Silva Nogueira,UFMG,http://homepages.dcc.ufmg.br/~jmarcos,SmuqzcYAAAAJ
+Jose María Álvarez Rodríguez,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-212557,DWKdLBYAAAAJ
 José Maria Barceló-Ordinas,Polytechnic University of Catalonia,http://compnet.ac.upc.edu/intranet/?q=node/169,NOSCHOLARPAGE
 José María Cela,Polytechnic University of Catalonia,https://www.bsc.es/about-bsc/staff-directory/cela-espin-jose-maria,QJWbGSEAAAAJ
 Jose María Cela-Espín,Polytechnic University of Catalonia,https://www.bsc.es/about-bsc/staff-directory/cela-espin-jose-maria,QJWbGSEAAAAJ
 José María Llabería,Polytechnic University of Catalonia,https://www.ac.upc.edu/en/content/llaberia,NOSCHOLARPAGE
+José María Valls,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-3871,NOSCHOLARPAGE
+José María de Fuentes,Universidad Carlos III de Madrid,https://cosec.inf.uc3m.es/people/jose-maria-de-fuentes/,eBt__HMAAAAJ
 José Mennesson,CRIStAL,https://www.cristal.univ-lille.fr/profil/mennesso,GZUxAm4AAAAJ
 José Meseguer,Univ. of Illinois at Urbana-Champaign,http://formal.cs.illinois.edu/meseguer,KZFo7ZkAAAAJ
 José Miguel Hernández-Lobato,University of Cambridge,http://jmhl.org,BEBccCQAAAAJ
@@ -2094,14 +2111,17 @@ Juan J. Navarro,Polytechnic University of Catalonia,https://www.dama.upc.edu/en/
 Juan J. Romero Cardalda,University of A Coruña,https://pdi.udc.es/en/File/Pdi/9D9AF,NOSCHOLARPAGE
 Juan Jesús Romero Cardalda,University of A Coruña,https://pdi.udc.es/en/File/Pdi/9D9AF,NOSCHOLARPAGE
 Juan L. Aragón,University of Murcia,http://ditec.um.es/~jlaragon,iRoda2IAAAAJ
+Juan Llorens Morillo,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169378/idu-8,nkzbbg4AAAAJ
 Juan Luo,Hunan University,http://csee.hnu.edu.cn/people/luojuan,NOSCHOLARPAGE
 Juan M. Banda,Georgia State University,http://www.jmbanda.com,lCgSjYAAAAAJ
+Juan Miguel Gómez 0001,Universidad Carlos III de Madrid,http://www.berbis.io/,a2T86e0AAAAJ
 Juan P. Galeotti,University of Buenos Aires,http://lafhis.dc.uba.ar/en/~jgaleotti,xeL-QIoAAAAJ
 Juan Pablo Galeotti,University of Buenos Aires,http://lafhis.dc.uba.ar/en/~jgaleotti,xeL-QIoAAAAJ
 Juan Pablo Hourcade,University of Iowa,https://www.cs.uiowa.edu/~hourcade,HLv0dl0AAAAJ
 Juan R. Rabuñal,University of A Coruña,https://pdi.udc.es/en/File/Pdi/9299E,JoKdcZwAAAAJ
 Juan Ramón Rabuñal,University of A Coruña,https://pdi.udc.es/en/File/Pdi/9299E,JoKdcZwAAAAJ
 Juan Raposo,University of A Coruña,https://pdi.udc.es/es/File/Pdi/S429E,NOSCHOLARPAGE
+Juan Tapiador,Universidad Carlos III de Madrid,https://0xjet.github.io/,HtKFCtMAAAAJ
 Juan Ye,University of St Andrews,https://sites.google.com/site/juanyeresearch,g2K5ofYAAAAJ
 Juan-Ramón López,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=14,SashQSIAAAAJ
 Juan-Zi Li,Tsinghua University,http://keg.cs.tsinghua.edu.cn/persons/ljz,NOSCHOLARPAGE
@@ -2324,6 +2344,7 @@ Juntao Li,Soochow University,https://lijuntaopku.github.io,sZSygsYAAAAJ
 Junting Chen,CUHK (SZ),http://chenjunting.org/,hsPzukQAAAAJ
 Junwei Han,NWPU,http://www.escience.cn/people/JunweiHan/index.html,xrqsoesAAAAJ
 Junya Honda,University of Tokyo,http://www.it.k.u-tokyo.ac.jp/~honda/index_e.html,NOSCHOLARPAGE
+Junyang Chen,Shenzhen University,https://csse.szu.edu.cn/pages/user/index?id=1101,Q0u3dRQAAAAJ
 Junyong Noh,KAIST,https://ct.kaist.ac.kr/people/sub01.php,NOSCHOLARPAGE
 Junyu Niu,Fudan University,http://www.cs.fudan.edu.cn/?page_id=2132,NOSCHOLARPAGE
 Junyu Xuan,University of Technology Sydney,https://www.uts.edu.au/staff/junyu.xuan,POQ_yJUAAAAJ
@@ -2394,6 +2415,3 @@ Jyrki Katajainen,University of Copenhagen,http://www.diku.dk/~jyrki,91jGnMUAAAAJ
 Jyrki Kivinen,University of Helsinki,https://www.cs.helsinki.fi/u/jkivinen,ZKq0Us0AAAAJ
 Jyrki Nummenmaa,Tampere University,https://www.tuni.fi/en/jyrki-nummenmaa,NOSCHOLARPAGE
 Jyuo-Min Shyu,National Tsing Hua University,http://web-en.cs.nthu.edu.tw/files/13-1044-5696.php,NOSCHOLARPAGE
-Jørgen P. Bansler,University of Copenhagen,http://diku.dk/Ansatte/beskrivelse/?id=160232,YuHIy0IAAAAJ
-Jørgen Villadsen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
-Junyang Chen,Shenzhen University,https://csse.szu.edu.cn/pages/user/index?id=1101,Q0u3dRQAAAAJ

--- a/csrankings-l.csv
+++ b/csrankings-l.csv
@@ -76,8 +76,8 @@ Lars Hedrich,Goethe University Frankfurt,http://www.em.cs.uni-frankfurt.de/index
 Lars J. Svensson,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/lars-svensson.aspx,NOSCHOLARPAGE
 Lars Kai Hansen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Lars Kulik,University of Melbourne,http://www.findanexpert.unimelb.edu.au/display/person97563,3kVu88AAAAAJ
-Lars Linsen,University of Münster,https://www.uni-muenster.de/VISIX/linsen.shtml,3YRfrpsAAAAJ
 Lars Lindemann,University of Southern California,https://sites.google.com/view/larslindemann,AkVKyzkAAAAJ
+Lars Linsen,University of Münster,https://www.uni-muenster.de/VISIX/linsen.shtml,3YRfrpsAAAAJ
 Lars Mikelsons,University of Augsburg,https://www.informatik.uni-augsburg.de/lehrstuehle/imech/Team,NOSCHOLARPAGE
 Lars Nagel 0001,Loughborough University,https://www.lboro.ac.uk/departments/compsci/staff/academic-teaching/lars-nagel,9z7L6NQAAAAJ
 Lars Oestreicher,Uppsala University,https://katalog.uu.se/empinfo/?id=XX3662,PBwBAzQAAAAJ
@@ -245,8 +245,8 @@ Lei Xie 0006,CUNY,http://compsci.hunter.cuny.edu/~leixie,CujCxdYAAAAJ
 Lei Xu 0001,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/~lxu,rN2ny9kAAAAJ
 Lei Xu 0003,Nanjing University,http://cs.nju.edu.cn/xulei,NOSCHOLARPAGE
 Lei Yang 0001,University of Nevada,http://www.unr.edu/cse/people/faculty/yang,uztxAqsAAAAJ
-Lei Yang 0025,The Hong Kong Polytechnic University,https://www4.comp.polyu.edu.hk/~csyanglei/#/pages/profile/about,rvlURhkAAAAJ
 Lei Yang 0018,George Mason University,https://leiyang0416.github.io,UTTE_wEAAAAJ
+Lei Yang 0025,The Hong Kong Polytechnic University,https://www4.comp.polyu.edu.hk/~csyanglei/#/pages/profile/about,rvlURhkAAAAJ
 Lei Zhang 0006,The Hong Kong Polytechnic University,https://www4.comp.polyu.edu.hk/~cslzhang,tAK5l1IAAAAJ
 Lei Zhang 0009,East China Normal University,https://faculty.ecnu.edu.cn/_s43/zl2_en/main.psp,Y0Mf58wAAAAJ
 Lei Zhang 0066,Shenzhen University,https://leizhang19.github.io,aKgV8B8AAAAJ
@@ -473,6 +473,7 @@ Limin Wang 0002,Nanjing University,http://wanglimin.github.io,HEuN8PcAAAAJ
 Limin Xiao,Beihang University,http://scse.buaa.edu.cn/info/1078/2653.htm,NOSCHOLARPAGE
 Liming Cai,University of Georgia,http://cobweb.cs.uga.edu/~cai,xj8uYUUAAAAJ
 Limsoon Wong,National University of Singapore,https://www.comp.nus.edu.sg/~wongls,Inqu8SkAAAAJ
+Lin Chen 0009,Texas Tech University,https://www.depts.ttu.edu/cs/faculty/lin_chen,a0DapS0AAAAJ
 Lin Chen 0015,Nanjing University,https://cs.nju.edu.cn/chenlin,kuWNhAoAAAAJ
 Lin Feng 0001,Nanyang Technological University,http://research.ntu.edu.sg/expertise/academicprofile/Pages/StaffProfile.aspx?ST_EMAILID=ASFLIN,vasvExMAAAAJ
 Lin Gao 0004,Chinese Academy of Sciences,http://www.geometrylearning.com/lin,_RIupXUAAAAJ
@@ -644,6 +645,7 @@ Loren G. Terveen,University of Minnesota,http://www-users.cs.umn.edu/~terveen,r6
 Loren Gilbert Terveen,University of Minnesota,http://www-users.cs.umn.edu/~terveen,r6cAovIAAAAJ
 Loren Schwiebert,Wayne State University,http://www.cs.wayne.edu/~loren,mP7h9LcAAAAJ
 Loren Terveen,University of Minnesota,http://www-users.cs.umn.edu/~terveen,r6cAovIAAAAJ
+Lorena González-Manzano,Universidad Carlos III de Madrid,https://lgmanzan.github.io/,HUrjDlgAAAAJ
 Lorenz Hilty,University of Zurich,http://www.ifi.uzh.ch/isr/people/hilty.html,nRTZV54AAAAJ
 Lorenzo Alvisi,Cornell University,http://www.cs.utexas.edu/~lorenzo,K_-KJi8AAAAJ
 Lorenzo Bruzzone,University of Trento,https://rslab.disi.unitn.it,ff9-TK4AAAAJ
@@ -685,6 +687,7 @@ Louise Knight,Cardiff University,https://www.cardiff.ac.uk/people/view/1235342-k
 Louise Laforest,Université du Québec à Montréal,https://professeurs.uqam.ca/professeur/Y%252bVnHzE%252bja4_/,NOSCHOLARPAGE
 Loukas Georgiadis,University of Ioannina,https://cs.uoi.gr/~loukas,y5vDB7sAAAAJ
 Lourdes Agapito,University College London,http://www0.cs.ucl.ac.uk/people/L.Agapito.html,IRMX4-4AAAAJ
+Lourdes Moreno 0001,Universidad Carlos III de Madrid,https://hulat.inf.uc3m.es/nosotros/miembros/lmoreno,aYCDUYEAAAAJ
 Lourdes Peña Castillo,Memorial University of Newfoundland,https://www.mun.ca/computerscience/people/lourdes.php,4MmWOFMAAAAJ
 Lourdes de Agapito,University College London,http://www0.cs.ucl.ac.uk/people/L.Agapito.html,IRMX4-4AAAAJ
 Louwe B. Kuijer,University of Liverpool,https://www.liverpool.ac.uk/computer-science/staff/louwe-kuijer,iF9PsigAAAAJ
@@ -787,6 +790,7 @@ Luigi Vincenzo Mancini,Sapienza University of Rome,https://sites.google.com/di.u
 Luigia Aiello,Sapienza University of Rome,http://www.diag.uniroma1.it/users/luigia%20carlucci-aiello,NOSCHOLARPAGE
 Luigia Carlucci Aiello,Sapienza University of Rome,http://www.diag.uniroma1.it/users/luigia%20carlucci-aiello,NOSCHOLARPAGE
 Luis A. F. M. Ferreira,Universidade de Lisboa,http://ciisa.fmv.ulisboa.pt/en/research-labs/research-lab-10/pessoas/item/64-luis-ferreira,7eEExREAAAAJ
+Luis Antonio Azpicueta-Ruiz,Universidad Carlos III de Madrid,https://researchportal.uc3m.es/display/inv37250,TkF0gA8AAAAJ
 Luis Antonio Brasil Kowada,UFF,http://www.professores.uff.br/kowada,8DN4mmEAAAAJ
 Luís C. Lamb,UFRGS,http://www.inf.ufrgs.br/~lamb,NOSCHOLARPAGE
 Luís Caires,Universidade NOVA de Lisboa,http://ctp.di.fct.unl.pt/~lcaires,mzi8n0QAAAAJ
@@ -794,11 +798,12 @@ Luís Caldas de Oliveira,Universidade de Lisboa,https://www.l2f.inesc-id.pt/wiki
 Luís Carlos Erpen De Bona,UFPR,https://web.inf.ufpr.br/bona,YJL1PhUAAAAJ
 Luís Carriço,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/lmcarrico,MLg1ZJMAAAAJ
 Luis Ceze,University of Washington,https://www.cs.washington.edu/people/faculty/luisceze,KzESVKwAAAAJ
-Luis Cruz 0002,TU Delft,https://luiscruz.github.io/,O13oaH0AAAAJ
 Luís Cruz 0002,TU Delft,https://luiscruz.github.io/,O13oaH0AAAAJ
+Luis Cruz 0002,TU Delft,https://luiscruz.github.io/,O13oaH0AAAAJ
 Luís D. Pedrosa,Universidade de Lisboa,https://pedrosa.2y.net,Rue7JwcAAAAJ
 Luís E. T. Rodrigues,Universidade de Lisboa,http://www.gsd.inesc-id.pt/~ler,iSVcwh8AAAAJ
 Luis Eduardo Teixeira Rodrigues,Universidade de Lisboa,http://www.gsd.inesc-id.pt/~ler,iSVcwh8AAAAJ
+Luis Enrique García-Muñoz,Universidad Carlos III de Madrid,https://grema.webs.tsc.uc3m.es/luis-enrique-garcia-munoz/,NOSCHOLARPAGE
 Luis Espinosa Anke,Cardiff University,https://www.cardiff.ac.uk/people/view/1063569-anke-luis,elA4WqkAAAAJ
 Luís F. M. de Moraes,UFRJ,http://www.cos.ufrj.br/~moraes,NOSCHOLARPAGE
 Luis Felipe Gonzalez,Queensland University of Technology,https://research.qut.edu.au/qcr/people/felipe-gonzalez,c_5ewxYAAAAJ
@@ -806,6 +811,7 @@ Luís Felipe M. de Moraes,UFRJ,http://www.cos.ufrj.br/~moraes,NOSCHOLARPAGE
 Luís G. Rueda,University of Windsor,http://www.uwindsor.ca/science/computerscience/1033/dr-luis-rueda,2OPjLFkAAAAJ
 Luis Gravano,Columbia University,http://www.cs.columbia.edu/~gravano,Ff6era8AAAAJ
 Luís Guerra e Silva,Universidade de Lisboa,http://algos.inesc-id.pt/~lgs,4HUmvlUAAAAJ
+Luis Inclán-Sánchez,Universidad Carlos III de Madrid,https://gea.webs.tsc.uc3m.es/luis-inclan-sanchez/,NOSCHOLARPAGE
 Luís M. Correia,Universidade de Lisboa,http://www.di.fc.ul.pt/~lcorreia,a0tgRXcAAAAJ
 Luís M. S. Russo,Universidade de Lisboa,http://web.tecnico.ulisboa.pt/luis.russo,O-PD_hsAAAAJ
 Luís Manuel Jesus Sousa Correia,Universidade de Lisboa,http://www.di.fc.ul.pt/~lcorreia,a0tgRXcAAAAJ
@@ -889,4 +895,3 @@ Lynne Baillie,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/lynne-ba
 Lynne Blair,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/people/lynne-blair,h8gpGz0AAAAJ
 Lynne E. Parker,University of Tennessee,http://web.eecs.utk.edu/~leparker,XxGyUpAAAAAJ
 Lynne Parker,University of Tennessee,http://web.eecs.utk.edu/~leparker,XxGyUpAAAAAJ
-Lin Chen 0009,Texas Tech University,https://www.depts.ttu.edu/cs/faculty/lin_chen,a0DapS0AAAAJ

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -1,7 +1,7 @@
 name,affiliation,homepage,scholarid
 M. Amaç Güvensan,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/amacg?lang=en,YPbvk4gAAAAJ
-M. Ani Hsieh,University of Pennsylvania,https://www.grasp.upenn.edu/people/ani-hsieh/,Bh8bGCYAAAAJ
 M. Angela Sasse,Ruhr-University Bochum,https://www.ei.ruhr-uni-bochum.de/fakultaet/personen/sasse,9H_eJqAAAAAJ
+M. Ani Hsieh,University of Pennsylvania,https://www.grasp.upenn.edu/people/ani-hsieh/,Bh8bGCYAAAAJ
 M. Anton Ertl,TU Wien,http://www.complang.tuwien.ac.at/anton,NOSCHOLARPAGE
 M. B. Do Coutto Filho,UFF,http://www.ic.uff.br/index.php/en-GB/people/317-faculty-ic?docente=53,C7WY29gAAAAJ
 M. B. Thuraisingham,University of Texas at Dallas,http://www.utdallas.edu/~bhavani.thuraisingham,o_xUNWkAAAAJ
@@ -24,6 +24,7 @@ M. Gopi,Univ. of California - Irvine,http://www.ics.uci.edu/~gopi,DI8bU-0AAAAJ
 M. Gopi 0001,Univ. of California - Irvine,http://www.ics.uci.edu/~gopi,DI8bU-0AAAAJ
 M. H. Samadzadeh,Oklahoma State University,http://cs.okstate.edu/faculty.html,NOSCHOLARPAGE
 M. Hassan Najafi,University of Louisiana - Lafayette,https://sites.google.com/view/mhassannajafi/,vIc-83QAAAAJ
+M. Julia Fernández-Getino García,Universidad Carlos III de Madrid,https://mjulia.webs.tsc.uc3m.es/,RW4jAysAAAAJ
 M. Kaykobad,BUET,http://kaykobad.buet.ac.bd,3rYfNBIAAAAJ
 M. Kemal Sönmez,OHSU,http://www.ohsu.edu/xd/education/schools/school-of-medicine/departments/basic-science-departments/csee/csee-people/sonmez.cfm,NOSCHOLARPAGE
 M. L. Chaudhry,Royal Military College of Canada,https://www.rmc-cmr.ca/en/mathematics-and-computer-science/dr-mohan-chaudhry,NOSCHOLARPAGE
@@ -57,8 +58,8 @@ Maarit Käpylä,Aalto University,https://research.aalto.fi/en/persons/maarit-k%C
 Maarten Jansen,Université libre de Bruxelles,http://homepages.ulb.ac.be/~majansen,ynC74rsAAAAJ
 Maarten Löffler,Utrecht University,http://www.staff.science.uu.nl/~loffl001/research.html,u-pn2g0AAAAJ
 Maarten Marx,University of Amsterdam,http://www.uva.nl/profiel/m/a/m.j.marx/m.j.marx.html,H54oRlIAAAAJ
-Maarten de Rijke,University of Amsterdam,https://staff.fnwi.uva.nl/m.derijke,AVDkgFIAAAAJ
 Maarten Sap,Carnegie Mellon University,https://maartensap.com/,gFN4QUYAAAAJ
+Maarten de Rijke,University of Amsterdam,https://staff.fnwi.uva.nl/m.derijke,AVDkgFIAAAAJ
 Maarten van Steen,VU Amsterdam,http://www.distributed-systems.net,1mFRcc0AAAAJ
 Maarten van Walstijn,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=m.vanwalstijn,p-fDhmsAAAAJ
 Maartje M. A. de Graaf,Utrecht University,https://robonarratives.wordpress.com,nqcBWMwAAAAJ
@@ -94,6 +95,7 @@ Maen M. Al Assaf,University of Jordan,http://link.springer.com/article/10.1007/s
 Magda Balazinska,University of Washington,http://www.cs.washington.edu/people/faculty/magda,DDxFvcIAAAAJ
 Magda El Zarki,Univ. of California - Irvine,http://www.ics.uci.edu/~magda,NOSCHOLARPAGE
 Magdalena Balazinska,University of Washington,http://www.cs.washington.edu/people/faculty/magda,DDxFvcIAAAAJ
+Magdalena Salazar Palma,Universidad Carlos III de Madrid,https://grema.webs.tsc.uc3m.es/magdalena-salazar-palma/,xD5iWiUAAAAJ
 Magdy A. Bayoumi,University of Louisiana - Lafayette,https://cacs.louisiana.edu/~mab,NOSCHOLARPAGE
 Magdy Bayoumi,University of Louisiana - Lafayette,https://cacs.louisiana.edu/~mab,NOSCHOLARPAGE
 Maggie Makar,University of Michigan,https://mymakar.github.io/,bmlgkM4AAAAJ
@@ -255,12 +257,12 @@ Manoj M. Prabhakaran,IIT Bombay,http://mmp.cs.illinois.edu,FANRIhwAAAAJ
 Manoj Mishra,NISER,https://www.niser.ac.in/users/manojmishra,NOSCHOLARPAGE
 Manoj Misra,IIT Roorkee,http://www.iitr.ac.in/departments/CSE/pages/People+Faculty+manojfec.html,EwxWd40AAAAJ
 Manoj Prabhakaran,IIT Bombay,http://mmp.cs.illinois.edu,FANRIhwAAAAJ
+Manolis C. Tsakiris,ShanghaiTech University,https://sites.google.com/site/manolisctsakiris,NOSCHOLARPAGE
 Manolis G. H. Katevenis,University of Crete,http://users.ics.forth.gr/~kateveni,E2-GshsAAAAJ
 Manolis Katevenis,University of Crete,http://users.ics.forth.gr/~kateveni,E2-GshsAAAAJ
 Manolis Kellis,Massachusetts Institute of Technology,http://mit.edu/manoli,lsYXBx8AAAAJ
 Manolis Koubarakis,University of Athens,http://cgi.di.uoa.gr/~koubarak,FKy2868AAAAJ
 Manolis Savva,Simon Fraser University,https://msavva.github.io,4D2vsdYAAAAJ
-Manolis C. Tsakiris,ShanghaiTech University,https://sites.google.com/site/manolisctsakiris,NOSCHOLARPAGE
 Manos Antonakakis,Georgia Institute of Technology,https://sites.google.com/site/antonakakis,P6VJcVIAAAAJ
 Manos Athanassoulis,Boston University,https://cs-people.bu.edu/mathan,RyXHY68AAAAJ
 Manos Kapritsos,University of Michigan,http://web.eecs.umich.edu/~manosk,65VCOs0AAAAJ
@@ -274,6 +276,7 @@ Mantis Cheng,University of Victoria,http://www.csc.uvic.ca/~mcheng,NOSCHOLARPAGE
 Manton M. Matthews,University of South Carolina,https://cse.sc.edu/~matthews,NOSCHOLARPAGE
 Manu Kaul,IIT Hyderabad,http://www.iith.ac.in/~mkaul,jNroyK4AAAAJ
 Manu Sridharan,Univ. of California - Riverside,https://manu.sridharan.net,iNtk_EQAAAAJ
+Manuel A. Vázquez,Universidad Carlos III de Madrid,https://researchportal.uc3m.es/display/inv40320,vfBBVcAAAAAJ
 Manuel Alejandro Pajuelo Gonzalez,Polytechnic University of Catalonia,https://www.bsc.es/cv-mateo/8-theses,NOSCHOLARPAGE
 Manuel Álvarez Díaz,University of A Coruña,https://pdi.udc.es/es/File/Pdi/WJ6AF,aqGNCqIAAAAJ
 Manuel Blum 0001,Carnegie Mellon University,https://www.cs.cmu.edu/~mblum,7S-LSKoAAAAJ
@@ -303,6 +306,7 @@ Manuel Menezes de Oliveira Neto,UFRGS,http://inf.ufrgs.br/~oliveira,f2UrnmAAAAAJ
 Manuel Rigger,National University of Singapore,https://www.comp.nus.edu.sg/~rigger/,yRsLClYAAAAJ
 Manuel Roveri,Politecnico di Milano,http://home.deib.polimi.it/roveri,j2NbakMAAAAJ
 Manuel V. Hermenegildo,IMDEA Software Institute,http://software.imdea.org/people/manuel.hermenegildo,VXQGJD0AAAAJ
+Manuel Velasco,Universidad Carlos III de Madrid,https://hulat.inf.uc3m.es/taxonomy/term/309,NOSCHOLARPAGE
 Manuel Wimmer,JKU Linz,https://www.se.jku.at/manuel-wimmer,YZDY1psAAAAJ
 Manya Ghobadi,Massachusetts Institute of Technology,http://people.csail.mit.edu/ghobadi,M78g4SAAAAAJ
 Mao Ye 0001,UESTC,https://www.scse.uestc.edu.cn/info/1081/10957.htm,UUbEzBYAAAAJ
@@ -365,6 +369,7 @@ Marcela Hernández Hoyos,Universidad de los Andes,http://profesores.virtual.unia
 Marcela M. Gomez,University of Pittsburgh,http://www.sci.pitt.edu/faculty-and-research/faculty-directory/marcela-gomez,UZtn6wUAAAAJ
 Marcelino B. Santos,Universidade de Lisboa,http://orcid.org/0000-0002-2091-1165,ZlmBiE4AAAAJ
 Marcelino Bicho Dos Santos,Universidade de Lisboa,http://orcid.org/0000-0002-2091-1165,ZlmBiE4AAAAJ
+Marcelino Lázaro,Universidad Carlos III de Madrid,https://www.tsc.uc3m.es/~mlazaro/,UtD9PNIAAAAJ
 Marcella Anselmo,University of Salerno,http://www.di.unisa.it/professori/anselmo,NOSCHOLARPAGE
 Marcello La Rossa,University of Melbourne,https://findanexpert.unimelb.edu.au/profile/806849-marcello-la-rosa,RTrK8csAAAAJ
 Marcello Restelli,Politecnico di Milano,http://home.deib.polimi.it/restelli,xdgxRiEAAAAJ
@@ -470,8 +475,8 @@ Marco Túlio Valente,UFMG,http://homepages.dcc.ufmg.br/~mtov,0vFkqMIAAAAJ
 Marco Túlio de Oliveira Valente,UFMG,http://homepages.dcc.ufmg.br/~mtov,0vFkqMIAAAAJ
 Marco Valtorta,University of South Carolina,http://www.cse.sc.edu/~mgv,IXWSOxcAAAAJ
 Marco Wiering,University of Groningen,http://www.ai.rug.nl/~mwiering,880vFIgAAAAJ
-Marco Zuniga,TU Delft,http://www.st.ewi.tudelft.nl/~marco,xWdb5R8AAAAJ
 Marco Zúñiga,TU Delft,http://www.st.ewi.tudelft.nl/~marco,xWdb5R8AAAAJ
+Marco Zuniga,TU Delft,http://www.st.ewi.tudelft.nl/~marco,xWdb5R8AAAAJ
 Marcos A. Castilho,UFPR,https://www.inf.ufpr.br/marcos,WL0Bf30AAAAJ
 Marcos A. M. Vieira,UFMG,http://homepages.dcc.ufmg.br/~mmvieira,2pp8xosAAAAJ
 Marcos Alexandre Castilho,UFPR,https://www.inf.ufpr.br/marcos,WL0Bf30AAAAJ
@@ -570,6 +575,7 @@ Maria Halkidi,University of Piraeus,https://www.ds.unipi.gr/en/faculty/mhalk-en,
 Maria Hybinette,University of Georgia,http://cobweb.cs.uga.edu/~maria,d6gfNpIAAAAJ
 Maria Indrawan,Monash University,http://monash.edu/research/explore/en/persons/maria-indrawansantiago(f6075934-9dab-4cc5-82ef-d26d20d5b294).html,xzE1AkgAAAAJ
 Maria Indrawan-Santiago,Monash University,http://monash.edu/research/explore/en/persons/maria-indrawansantiago(f6075934-9dab-4cc5-82ef-d26d20d5b294).html,xzE1AkgAAAAJ
+María Isabel Sánchez Segura,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169378/idu-168,BijBdesAAAAJ
 Maria Isabel Valera Martinez,Saarland University,https://ivaleram.github.io,cpdQqpsAAAAJ
 Maria J. García de la Banda,Monash University,http://www.csse.monash.edu.au/~mbanda,mkm8ZlQAAAAJ
 Maria K. Virvou,University of Piraeus,https://www.unipi.gr/unipi/en/mvirvou.html,Ce6s_FoAAAAJ
@@ -1135,6 +1141,7 @@ Mathieu Nancel,CRIStAL,http://mathieu.nancel.net,-Lm0OKsAAAAJ
 Mathijs Michiel de Weerdt,TU Delft,http://www.alg.ewi.tudelft.nl/weerdt,9GJ8AvgAAAAJ
 Mathijs de Weerdt,TU Delft,http://www.alg.ewi.tudelft.nl/weerdt,9GJ8AvgAAAAJ
 Matias David Lee,Ecole Normale Superieure de Lyon,https://angel.co/matias-david-lee,eWYixqsAAAAJ
+Matilde Sánchez Fernández,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/UC3MInstitucional/es/Detalle/Organismo_C/1371206550633/1371206550723/Matilde_Pilar_Sanchez_Fernandez,MKQ1szgAAAAJ
 Matluba Khodjaeva,CUNY,https://www.jjay.cuny.edu/faculty/matluba-khodjaeva,-E8t9pwAAAAJ
 Mats Björkman,Mälardalen University,http://www.es.mdh.se/staff/55-Mats_Bj__rkman,UrhfOq0AAAAJ
 Mats Brorsson,KTH Royal Institute of Technology,https://www.kth.se/profile/matsbror,BaZm_X8AAAAJ
@@ -1194,8 +1201,8 @@ Matthew Guzdial,University of Alberta,http://guzdial.com,jKqmTbIAAAAJ
 Matthew Hague,Royal Holloway University of London,https://pure.royalholloway.ac.uk/portal/en/persons/matthew-hague(c4baa4a0-192e-49c8-a699-feda6a04a583).html,s37BfYAAAAAJ
 Matthew Hicks,Virginia Tech,http://www.impedimenttoprogress.com,_rJCgzIAAAAJ
 Matthew Hole,Australian National University,https://comp.anu.edu.au/people/matthew-hole/,BoPimVUAAAAJ
-Matthew J. Hole,Australian National University,https://comp.anu.edu.au/people/matthew-hole/,BoPimVUAAAAJ
 Matthew J. Guzdial,University of Alberta,http://guzdial.com,jKqmTbIAAAAJ
+Matthew J. Hole,Australian National University,https://comp.anu.edu.au/people/matthew-hole/,BoPimVUAAAAJ
 Matthew J. Luckie,University of Waikato,http://www.cms.waikato.ac.nz/people/mluckie,y_BSpQYAAAAJ
 Matthew J. Patitz,University of Arkansas,http://self-assembly.net/mpatitz,fv8RSFgAAAAJ
 Matthew J. Thazhuthaveetil,IISc Bangalore,http://www.csa.iisc.ac.in/~mjt,NOSCHOLARPAGE
@@ -1305,8 +1312,8 @@ Maurice Pagnucco,UNSW,https://www.cse.unsw.edu.au/~morri,lqjmockAAAAJ
 Mauricio A. Álvarez,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/mauricio-alvarez,vrb4a_wAAAAJ
 Maurício Aniche,TU Delft,http://www.mauricioaniche.com,AyX0Ou0AAAAJ
 Mauricio Ayala-Rincón,Universidade de Brasília,http://cic.unb.br/~ayala,hd3UcpsAAAAJ
-Mauricio Finavaro Aniche,TU Delft,http://www.mauricioaniche.com,AyX0Ou0AAAAJ
 Maurício Finavaro Aniche,TU Delft,http://www.mauricioaniche.com,AyX0Ou0AAAAJ
+Mauricio Finavaro Aniche,TU Delft,http://www.mauricioaniche.com,AyX0Ou0AAAAJ
 Mauricio Kischinhevsky,UFF,http://www2.ic.uff.br/~kisch,U5qX4hsAAAAJ
 Mauricio Papa,University of Tulsa,https://faculty.utulsa.edu/~/mauricio-papa,NOSCHOLARPAGE
 Maurits R. R. de Planque,University of Southampton,https://www.ecs.soton.ac.uk/people/mrdp1x07,mGK_vD0AAAAJ
@@ -1363,8 +1370,8 @@ Mayank Singh 0001,IIT Gandhinagar,http://www.iitgn.ac.in/faculty/comp/mayank.htm
 Mayank Varia,Boston University,https://www.bu.edu/cds-faculty/profile/mayank-varia/,lneZSfIAAAAJ
 Mayank Vatsa,IIT Jodhpur,http://home.iitj.ac.in/~mvatsa,-DAxp-cAAAAJ
 Mays F. Al-Naday,University of Essex,https://www.essex.ac.uk/people/alned81405/mays-al-naday,aOlKyJ0AAAAJ
-Mayur Naik,University of Pennsylvania,http://www.cis.upenn.edu/~mhnaik,fmsV6nEAAAAJ
 Mayumi Bono,National Institute of Informatics,http://research.nii.ac.jp/~bono/ja/,NOSCHOLARPAGE
+Mayur Naik,University of Pennsylvania,http://www.cis.upenn.edu/~mhnaik,fmsV6nEAAAAJ
 Maziar Goudarzi,Sharif University of Technology,http://sharif.edu/~goudarzi,qAJqk9IAAAAJ
 Md. Endadul Hoque,Syracuse University,https://users.cs.fiu.edu/~ehoque,dSLXaKUAAAAJ
 Md. Khaled Khan,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/khaled_khan.php,SpQmNnoAAAAJ
@@ -1556,7 +1563,6 @@ Michael C. Yip,Univ. of California - San Diego,https://yip.eng.ucsd.edu,gSYxbCYA
 Michael Carbin,Massachusetts Institute of Technology,http://people.csail.mit.edu/mcarbin,mtejbKYAAAAJ
 Michael Cashmore,University of Strathclyde,https://pureportal.strath.ac.uk/en/persons/michael-cashmore/publications,AapWF-kAAAAJ
 Michael Chertkov,University of Arizona,https://sites.google.com/site/mchertkov,k4UNBd4AAAAJ
-Michael J. Coblenz,Univ. of California - San Diego,https://cseweb.ucsd.edu/~mcoblenz/,sKuY6fIAAAAJ
 Michael Collins 0001,Columbia University,http://www.cs.columbia.edu/~mcollins,DxoenfgAAAAJ
 Michael Crabb,University of Dundee,https://discovery.dundee.ac.uk/en/persons/michael-crabb,9FznG1oAAAAJ
 Michael Curtis Mozer,University of Colorado Boulder,http://www.cs.colorado.edu/~mozer,lmjR_qMAAAAJ
@@ -1642,8 +1648,9 @@ Michael J. Black [IS],Max Planck Society,https://ps.is.tuebingen.mpg.de/person/b
 Michael J. Brooks,University of Adelaide,http://www.adelaide.edu.au/directory/michael.brooks,IRsRrroAAAAJ
 Michael J. Butler,University of Southampton,https://www.ecs.soton.ac.uk/people/mbutler,c0BzzQwAAAAJ
 Michael J. Carey 0001,Univ. of California - Irvine,http://www.ics.uci.edu/~mjcarey,qqiZTS8AAAAJ
-Michael J. Coblenz,Univ. of California - San Diego,https://www.cs.umd.edu/~mcoblenz/,sKuY6fIAAAAJ
 Michael J. Chantler,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/mike-chantler.htm,oBixg1wAAAAJ
+Michael J. Coblenz,Univ. of California - San Diego,https://www.cs.umd.edu/~mcoblenz/,sKuY6fIAAAAJ
+Michael J. Coblenz,Univ. of California - San Diego,https://cseweb.ucsd.edu/~mcoblenz/,sKuY6fIAAAAJ
 Michael J. Dinneen,University of Auckland,https://www.cs.auckland.ac.nz/~mjd,NspX1ZIAAAAJ
 Michael J. Donahoo,Baylor University,http://cs.baylor.edu/~donahoo/,NOSCHOLARPAGE
 Michael J. Feeley,University of British Columbia,https://www.cs.ubc.ca/people/mike-feeley,g93mhb4AAAAJ
@@ -1898,6 +1905,7 @@ Miguel A. Alonso 0001,University of A Coruña,http://www.grupolys.org/~alonso,Kt
 Miguel Á. Carreira-Perpiñán,Univ. of California - Merced,https://faculty.ucmerced.edu/mcarreira-perpinan,SYdYhxgAAAAJ
 Miguel A. Nacenta,University of Victoria,https://nacenta.com,M_Ne0psAAAAJ
 Miguel A. Otaduy,Universidad Rey Juan Carlos,http://mslab.es/otaduy,PhHt3mIAAAAJ
+Miguel A. Patricio,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-2140,JsdiiHYAAAAJ
 Miguel Angel Alonso Pardo,University of A Coruña,http://www.grupolys.org/~alonso,KtuaRUAAAAAJ
 Miguel Angel Otaduy,Universidad Rey Juan Carlos,http://mslab.es/otaduy,PhHt3mIAAAAJ
 Miguel Ángel Otaduy,Universidad Rey Juan Carlos,http://mslab.es/otaduy,PhHt3mIAAAAJ
@@ -1995,8 +2003,8 @@ Mikko Kivelä,Aalto University,https://people.aalto.fi/new/mikko.kivela,Z3913I0A
 Mikko Koivisto,University of Helsinki,https://www.cs.helsinki.fi/u/mkhkoivi,ENv3yqoAAAAJ
 Miklós Bartha,Memorial University of Newfoundland,https://www.mun.ca/computerscience/people/bartha.php,NOSCHOLARPAGE
 Miklós Csürös,University of Montreal,http://www.iro.umontreal.ca/~csuros,NOSCHOLARPAGE
-Miklos Maroti,University of Szeged,https://www.math.u-szeged.hu/~mmaroti,NAPEgBUAAAAJ
 Miklós Maróti,University of Szeged,https://www.math.u-szeged.hu/~mmaroti,NAPEgBUAAAAJ
+Miklos Maroti,University of Szeged,https://www.math.u-szeged.hu/~mmaroti,NAPEgBUAAAAJ
 Mikolaj Bojanczyk,University of Warsaw,http://www.mimuw.edu.pl/~bojan,Rv0YwPAAAAAJ
 Mikolas Janota,Universidade de Lisboa,https://ciencias.ulisboa.pt/pt/perfil/mjanota,SFg4raQAAAAJ
 Mikolás Janota,Universidade de Lisboa,https://ciencias.ulisboa.pt/pt/perfil/mjanota,SFg4raQAAAAJ
@@ -2024,10 +2032,11 @@ Milos Nikolic 0001,University of Edinburgh,http://homepages.inf.ed.ac.uk/mnikoli
 Milos Prvulovic,Georgia Institute of Technology,http://www.cc.gatech.edu/~milos,A_j_baAAAAAJ
 Milos Zefran,University of Illinois at Chicago,https://www.ece.uic.edu/~mzefran,2kwHHWMAAAAJ
 Miltiades E. Anagnostou,NTUA,http://mcwt.cn.ntua.gr/?q=el/content/miltiades-anagnostou,pvThzK0AAAAJ
+Mimi Xie,University of Texas at San Antonio,https://cs.utsa.edu/people/faculty/xie-mimi-936,Za4_qhkAAAAJ
 Mimi Zhang,Trinity College Dublin,https://www.tcd.ie/research/profiles/?profile=zhangm3,6NC-XagAAAAJ
 Mimmo Parente,University of Salerno,http://www.di.unisa.it/~parente,45LUzAwAAAAJ
-Mimi Xie,University of Texas at San Antonio,https://cs.utsa.edu/people/faculty/xie-mimi-936,Za4_qhkAAAAJ
 Min C. Shin,UNC - Charlotte,https://sites.google.com/a/uncc.edu/mcshin/,BVPAmrwAAAAJ
+Min C. Shin,UNC - Charlotte,https://viscenter.uncc.edu/min-shin,T50sdQ8AAAAJ
 Min Cao,Soochow University,http://web.suda.edu.cn/cm,nhMWtZsAAAAJ
 Min Chi,North Carolina State University,https://www.csc.ncsu.edu/people/mchi,gJmbChYAAAAJ
 Min Chih Lin,University of Buenos Aires,http://www.ic.fcen.uba.ar/~mlin/homepage.html,NOSCHOLARPAGE
@@ -2035,8 +2044,6 @@ Min H. Kim 0001,KAIST,http://vclab.kaist.ac.kr/minhkim,pMT5lrwAAAAJ
 Min Hun Lee,Singapore Management University,https://scis.smu.edu.sg/faculty/profile/6256/lee-min,quDiEBkAAAA
 Min Long,Boise State University,http://flash.uchicago.edu/~long,Ex_raoQAAAAJ
 Min Lu 0002,Shenzhen University,http://deardeer.github.io,xFAU798AAAAJ
-Minmei Wang,University of Connecticut,https://archer-w.github.io,d_yUM3QAAAAJ
-Min C. Shin,UNC - Charlotte,https://viscenter.uncc.edu/min-shin,T50sdQ8AAAAJ
 Min Song 0002,Michigan Technological University,https://www.mtu.edu/cs/department/faculty-staff/adjunct-research/song,NOSCHOLARPAGE
 Min Suk Kang,KAIST,https://netsp.kaist.ac.kr/people,R6KDuS8AAAAJ
 Min Tang 0001,Zhejiang University,http://give.zju.edu.cn/memberHomepage/TangMin.html,E1RM9OUAAAAJ
@@ -2129,6 +2136,7 @@ Minjie Cai,Hunan University,https://cai-mj.github.io,lmUOLU8AAAAJ
 Minjoon Seo,KAIST,https://seominjoon.github.io,zYze5fIAAAAJ
 Minlan Yu,Harvard University,http://www-bcf.usc.edu/~minlanyu,K1cZ7SsAAAAJ
 Minlie Huang,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101225162940345843104/20101225162940345843104_.html,mWS1pY4AAAAJ
+Minmei Wang,University of Connecticut,https://archer-w.github.io,d_yUM3QAAAAJ
 Minming Li,City University of Hong Kong,https://www.cs.cityu.edu.hk/~minmli,7XT5sH4AAAAJ
 Minnan Luo,Xi'an Jiaotong University,http://gr.xjtu.edu.cn/web/minnluo,C3ujEF0AAAAJ
 Minseok Kwon,Rochester Institute of Technology,https://www.cs.rit.edu/~jmk,d0SpJbIAAAAJ
@@ -2143,8 +2151,8 @@ Minyi Li,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic
 Minyou Wu,Shanghai Jiao Tong University,http://wirelesslab.sjtu.edu.cn/~wu,Sz5Y7RsAAAAJ
 Miodrag Bolic,University of Ottawa,http://www.site.uottawa.ca/~mbolic,1HJ-KYMAAAAJ
 Miodrag Potkonjak,Univ. of California - Los Angeles,http://www.cs.ucla.edu/~miodrag,NOSCHOLARPAGE
-Miquel Pericas,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/miquelp.aspx,2NRoXHMAAAAJ
 Miqing Li,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/academic-staff/li-miqing.aspx,h8UksmEAAAAJ
+Miquel Pericas,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/miquelp.aspx,2NRoXHMAAAAJ
 Mira Gonen,Ariel University,http://www.ariel.ac.il/Projects/TRP/GeneralInformation.asp?numRec=433&numtafrit=1&id_lang=1&d=,pILEObcAAAAJ
 Mira Kajko-Mattsson,KTH Royal Institute of Technology,https://www.kth.se/profile/mekm2,jt0To6MAAAAJ
 Mira Mezini,TU Darmstadt,http://www.stg.tu-darmstadt.de/staff/mira_mezini,ESQUnJEAAAAJ
@@ -2298,6 +2306,7 @@ Mohammad-Reza Siadat,Oakland University,https://oakland.edu/secs/directory/siada
 Mohammad-Taghi Manzuri Shalmani,Sharif University of Technology,http://sharif.edu/~manzuri,NOSCHOLARPAGE
 MohammadReza Jahed-Motlagh,IUST,http://ce.iust.ac.ir/content/1049/Dr.-Jahed-Motlagh,i5G246QAAAAJ
 MohammadTaghi Hajiaghayi,University of Maryland - College Park,http://www.cs.umd.edu/~hajiagha,SQ1eGN4AAAAJ
+Mohammadkazem Taram,Purdue University,https://www.cs.purdue.edu/people/faculty/mtaram.html,DX4p3bQAAAAJ
 Mohammadkazem Taram,Purdue University,https://www.cs.purdue.edu/homes/mtaram,DX4p3bQAAAAJ
 Mohammadreza Kangavari,IUST,http://www.iust.ac.ir/content/1064/Dr.Kangavari,PJa-dVMAAAAJ
 Mohammed (Ehsan) Hoque 0001,University of Rochester,http://web.media.mit.edu/~mehoque,ZJrR0KQAAAAJ
@@ -2318,7 +2327,6 @@ Mohammed N. Moustafa 0001,American University in Cairo,https://www.aucegypt.edu/
 Mohammed Qatawneh,University of Jordan,http://computer.ju.edu.jo/Lists/FacultyAcademicStaff/Attachments/16/Mohammed%20Shriedeh.doc,V6iTZ-4AAAAJ
 Mohammed Samaka,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/mohamed_samaka.php,iqiEX78AAAAJ
 Mohammed Seyam,Virginia Tech,https://sites.google.com/vt.edu/mohammedseyam/home,OYautn0AAAAJ
-Mohammadkazem Taram,Purdue University,https://www.cs.purdue.edu/people/faculty/mtaram.html,DX4p3bQAAAAJ
 Mohan Kumar,Rochester Institute of Technology,https://www.cs.rit.edu/~mjk,FoRBkdsAAAAJ
 Mohan L. Chaudhry,Royal Military College of Canada,https://www.rmc-cmr.ca/en/mathematics-and-computer-science/dr-mohan-chaudhry,NOSCHOLARPAGE
 Mohan S. Kankanhalli,National University of Singapore,http://www.comp.nus.edu.sg/~mohan,6Lx_eowAAAAJ
@@ -2350,8 +2358,8 @@ Momotaz Begum,University of New Hampshire,http://www.cs.unh.edu/~mbegum,YP9KtBQA
 Mona Singh 0001,Princeton University,https://www.cs.princeton.edu/~mona,JpAehzgAAAAJ
 Moncef Gabbouj,Tampere University,https://www.tuni.fi/en/moncef-gabbouj,cHukfSUAAAAJ
 Mong-Li Lee,National University of Singapore,https://www.comp.nus.edu.sg/~leeml,_xFTK8wAAAAJ
-Mongi A. Abidi,University of Tennessee,http://www.eecs.utk.edu/people/faculty/abidi,p6w_qmoAAAAJ
 Mong-ying Ani Hsieh,University of Pennsylvania,https://www.grasp.upenn.edu/people/ani-hsieh/,Bh8bGCYAAAAJ
+Mongi A. Abidi,University of Tennessee,http://www.eecs.utk.edu/people/faculty/abidi,p6w_qmoAAAAJ
 Moni Naor,Weizmann Institute of Science,https://www.weizmann.ac.il/pages/search/people?language=english&single=1&person_id=2337,stSUaHAAAAAJ
 Monia Ghobadi,Massachusetts Institute of Technology,http://people.csail.mit.edu/ghobadi,M78g4SAAAAAJ
 Monica Anderson,The University of Alabama,http://robotics.cs.ua.edu,NOSCHOLARPAGE
@@ -2425,6 +2433,7 @@ Mu Zhang 0001,University of Utah,https://www.cs.utah.edu/~muzhang,UFiuFf8AAAAJ
 Muath Obaidat,CUNY,https://www.jjay.cuny.edu/faculty/muath-obaidat,XLYQ1ukAAAAJ
 Mubarak Shah,University of Central Florida,https://www.crcv.ucf.edu/person/mubarak-shah,p8gsO3gAAAAJ
 Mubbasir Kapadia,Rutgers University,http://www.cs.rutgers.edu/~mk1353,xhkzmycAAAAJ
+Mücahid Kutlu,TOBB ETÜ,https://www.etu.edu.tr/en/bolum/computer-engineering/akademik-kadro?l=1#mucahid-kutlu,9pxldM0AAAAJ
 Muffy Calder,University of Glasgow,http://www.dcs.gla.ac.uk/~muffy,HvAfVsAAAAAJ
 Muffy Thomas,University of Glasgow,http://www.dcs.gla.ac.uk/~muffy,HvAfVsAAAAAJ
 Muhammad Abdullah Adnan,BUET,https://sites.google.com/site/abdullahadnan,T5QF918AAAAJ
@@ -2503,7 +2512,6 @@ Musti Narasimha Murty,IISc Bangalore,http://www.csa.iisc.ac.in/~mnm,VQZTmpcAAAAJ
 Muthucumaru Maheswaran,McGill University,http://www.cs.mcgill.ca/~maheswar,1qbLa7YAAAAJ
 Muthuramakrishnan Venkitasubramaniam,University of Rochester,https://www.cs.rochester.edu/u/muthuv,VYBH2BsAAAAJ
 Muyun Yang,Harbin Institute of Technology,http://mitlab.hit.edu.cn/2018/0608/c9183a210161/page.htm,-eepG9kAAAAJ
-Mücahid Kutlu,TOBB ETÜ,https://www.etu.edu.tr/en/bolum/computer-engineering/akademik-kadro?l=1#mucahid-kutlu,9pxldM0AAAAJ
 My T. Thai,University of Florida,http://www.cise.ufl.edu/~mythai,zLLJimcAAAAJ
 My Tra Thai,University of Florida,http://www.cise.ufl.edu/~mythai,zLLJimcAAAAJ
 Myeongjae Jeon,UNIST,https://sites.google.com/site/myeongjae,q942rJgAAAAJ

--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -34,6 +34,7 @@ Pablo Cesar,TU Delft,https://www.pablocesar.me,guRMl5IAAAAJ
 Pablo E. Paredes,University of Maryland - College Park,https://www.umiacs.umd.edu/people/pparedes,DL7MtjMAAAAJ
 Pablo Figueroa,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/pfiguero/es/inicio,1pVmx_4AAAAJ
 Pablo G. Turjanski,University of Buenos Aires,https://www.dc.uba.ar/inv/lsc/PTurjanski,NOSCHOLARPAGE
+Pablo M. Olmos,Universidad Carlos III de Madrid,https://www.tsc.uc3m.es/~olmos/,pdcdDVoAAAAJ
 Pablo Moscato,University of Newcastle,https://www.newcastle.edu.au/profile/pablo-moscato,cc3Ym4gAAAAJ
 Pablo Paredes,University of Maryland - College Park,https://www.umiacs.umd.edu/people/pparedes,DL7MtjMAAAAJ
 Pablo Rivas,Baylor University,https://www.rivas.ai/,kYfaCFMAAAAJ
@@ -46,8 +47,8 @@ Padmanabhan Rajan,IIT Mandi,https://faculty.iitmandi.ac.in/~padman,3sZ-nzAAAAAJ
 Padmini Srinivasan,University of Iowa,https://cs.uiowa.edu/people/padmini-srinivasan,NOSCHOLARPAGE
 Padraic Edgington,University of Connecticut,http://www.cse.uconn.edu/people/faculty,eivODg0AAAAJ
 Padraig Corcoran,Cardiff University,https://www.cardiff.ac.uk/people/view/155896-corcoran-padraig,eoqE1OEAAAAJ
-Padraig Cunningham,University College Dublin,https://people.ucd.ie/padraig.cunningham,HqGgUVAAAAAJ
 Pádraig Cunningham,University College Dublin,https://people.ucd.ie/padraig.cunningham,HqGgUVAAAAAJ
+Padraig Cunningham,University College Dublin,https://people.ucd.ie/padraig.cunningham,HqGgUVAAAAAJ
 Pai H. Chou,National Tsing Hua University,http://epl.tw/people/phchou,r7I9N5cAAAAJ
 Paige Rodeghero,Clemson University,http://paigerodeghero.com,vTZVpdqxruwC
 Pak Ching Li,University of Manitoba,http://www.cs.umanitoba.ca/~lipakc,NOSCHOLARPAGE
@@ -59,6 +60,8 @@ Pallab Dasgupta,IIT Kharagpur,http://cse.iitkgp.ac.in/~pallab,Pw4jS9sAAAAJ
 Pallavi Dhagat,Oregon State University,http://eecs.oregonstate.edu/people/dhagat-pallavi,mHQxTHEAAAAJ
 Pallavi Jain 0001,IIT Jodhpur,https://pallavijain.weebly.com,Z6Gkk6UAAAAJ
 Palle Dahlstedt,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/palle-dahlstedt.aspx,NOSCHOLARPAGE
+Paloma Díaz 0001,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169378/Detalle_Personal_Departamento/idu-4113,8rG_hYgAAAAJ
+Paloma Martínez,Universidad Carlos III de Madrid,https://hulat.inf.uc3m.es/nosotros/miembros/pmf,xmF4rlgAAAAJ
 Pamela J. Wisniewski,Vanderbilt University,https://stirlab.org,3JZB10QAAAAJ
 Pamela Karr,Vanderbilt University,https://stirlab.org,3JZB10QAAAAJ
 Pamela Karr Wisniewski,Vanderbilt University,https://stirlab.org,3JZB10QAAAAJ
@@ -384,6 +387,7 @@ Paula Herber,University of Münster,https://www.uni-muenster.de/EmbSys/team/herb
 Paula Montoto,University of A Coruña,https://pdi.udc.es/en/File/Pdi/YD8AF,NOSCHOLARPAGE
 Paula Roberts,Trinity College Dublin,https://www.scss.tcd.ie/personnel/robertsp,NOSCHOLARPAGE
 Paula Zabala,University of Buenos Aires,https://www.dc.uba.ar/materias/aed3/2013/2c/docentes/zabala,Zxmyb4MAAAAJ
+Paula de Toledo,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-166,4nsrLPwAAAAJ
 Pauline C Haddow,NTNU,https://www.ntnu.edu/employees/pauline,HIHxCNAAAAAJ
 Paulo A. Pagliosa,UFMS,https://www.facom.ufms.br/~pagliosa,lNUJYtwAAAAJ
 Paulo A. S. Veloso,UFRJ,http://www.cos.ufrj.br/index.php/pt-BR/pessoas/details/18/1043-veloso,NOSCHOLARPAGE
@@ -473,6 +477,7 @@ Pedro F. Felzenszwalb,Brown University,http://cs.brown.edu/~pff,k1hJzF0AAAAJ
 Pedro Felipe Felzenszwalb,Brown University,http://cs.brown.edu/~pff,k1hJzF0AAAAJ
 Pedro Fonseca 0001,Purdue University,https://www.cs.purdue.edu/homes/pfonseca,xTvNYN8AAAAJ
 Pedro Frosi Rosa,UFU,http://www.facom.ufu.br/~frosi,iRbluD4AAAAJ
+Pedro Isasi Viñuela,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169378/idu-4069,BHf4l7wAAAAJ
 Pedro J. de Rezende,UNICAMP,http://www.ic.unicamp.br/~rezende,NOSCHOLARPAGE
 Pedro José Sousa da Fonseca,Purdue University,https://www.cs.purdue.edu/homes/pfonseca,xTvNYN8AAAAJ
 Pedro Jussieu de Rezende,UNICAMP,http://www.ic.unicamp.br/~rezende,NOSCHOLARPAGE
@@ -490,6 +495,7 @@ Pedro Moreno-Sanchez,IMDEA Software Institute,https://software.imdea.org/people/
 Pedro Morgado 0001,University of Wisconsin - Madison,https://pedro-morgado.github.io/,Yy4gO-QAAAAJ
 Pedro O. S. Vaz de Melo,UFMG,http://homepages.dcc.ufmg.br/~olmo,WjS15esAAAAJ
 Pedro Olmo Stancioli Vaz de Melo,UFMG,http://homepages.dcc.ufmg.br/~olmo,WjS15esAAAAJ
+Pedro Peris-Lopez,Universidad Carlos III de Madrid,https://cosec.inf.uc3m.es/people/pedro-peris/,pTN1gA8AAAAJ
 Pedro Petersen Moura Trancoso,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/ppedro.aspx,NOSCHOLARPAGE
 Pedro R. D'Argenio,Universidad Nacional de Córdoba,https://cs.famaf.unc.edu.ar/~dargenio,Z7i2nckAAAAJ
 Pedro Sánchez Terraf,Universidad Nacional de Córdoba,https://cs.famaf.unc.edu.ar/~pedro,pgrAV_MAAAAJ
@@ -519,8 +525,8 @@ Pekka Marttinen,Aalto University,https://research.aalto.fi/en/persons/pekka-mart
 Pekka Orponen,Aalto University,https://users.ics.aalto.fi/orponen,vxczc7gAAAAJ
 Pekka Parviainen,University of Bergen,http://www.ii.uib.no/~pekkap,NOSCHOLARPAGE
 Pelin Angin,Middle East Technical University,http://user.ceng.metu.edu.tr/~pangin,PgwZYeoAAAAJ
-Penelope Sweetser,Australian National University,https://cs.anu.edu.au/people/penny-kyburz,mrvBuvsAAAAJ
 Pen-Chung Yew,University of Minnesota,http://www-users.cs.umn.edu/~yew,NOSCHOLARPAGE
+Penelope Sweetser,Australian National University,https://cs.anu.edu.au/people/penny-kyburz,mrvBuvsAAAAJ
 Peng Cui 0001,Tsinghua University,http://pengcui.thumedialab.com,G8x97ZgAAAAJ
 Peng Di,UNSW,http://www.cse.unsw.edu.au/~pengd,PVGQdJIAAAAJ
 Peng Gao 0008,Virginia Tech,https://people.cs.vt.edu/penggao,lJJpxssAAAAJ
@@ -538,27 +544,27 @@ Peng Yang 0008,SUSTech,http://cse.sustech.edu.cn/faculty/~yangp,5T9jy2MAAAAJ
 Peng Zhang 0011,Xi'an Jiaotong University,https://nskeylab.xjtu.edu.cn/people/pzhang,AdvgGYgAAAAJ
 Peng Zhao 0001,Xi'an Jiaotong University,http://gr.xjtu.edu.cn/web/p.zhao,NOSCHOLARPAGE
 Peng Zou,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/zoupeng1,NOSCHOLARPAGE
-Pengbo Bo,Harbin Institute of Technology,http://homepage.hit.edu.cn/bopengbo,1rfwxSUAAAAJ
-Pengjie Ren,Shandong University,https://pengjieren.github.io,4OdmSOcAAAAJ
 Peng-Jun Wan,Illinois Institute of Technology,https://science.iit.edu/people/faculty/peng-jun-wan,TXUhDokAAAAJ
+Pengbo Bo,Harbin Institute of Technology,http://homepage.hit.edu.cn/bopengbo,1rfwxSUAAAAJ
 Pengcheng Shi,Rochester Institute of Technology,https://www.rit.edu/gccis/pengcheng-shi,JiVaZf8AAAAJ
 Pengdi Huang,Shenzhen University,http://vcc.szu.edu.cn/~pengdi,MKjgy_UAAAAJ
 Pengfei Su 0001,Univ. of California - Merced,https://pengfei-su.github.io,LAttsHIAAAAJ
 Pengfei Xu 0002,Shenzhen University,http://pengfeixu.com,bmC8UcoAAAAJ
 Penghui Yao,Nanjing University,http://penghuiyao.info,iFxJ6XIAAAAJ
+Pengjie Ren,Shandong University,https://pengjieren.github.io,4OdmSOcAAAAJ
 Pengpeng Zhao,Soochow University,http://web.suda.edu.cn/ppzhao/index.html,JyX1YfUAAAAJ
 Pengtao Xie,Univ. of California - San Diego,https://sites.google.com/site/pengtaoxie2008,cnncomYAAAAJ
 Pengyang Wang,University of Macau,https://www.fst.um.edu.mo/people/pywang/,o26vQZwAAAAJ
 Pengyu Hong,Brandeis University,http://www.cs.brandeis.edu/~hong,pvDa8pcAAAAJ
 Penny Kyburz,Australian National University,https://cs.anu.edu.au/people/penny-kyburz,mrvBuvsAAAAJ
 Penny Rheingans,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~rheingan,1k0rojcAAAAJ
-Penny Sweetser,Australian National University,https://cs.anu.edu.au/people/penny-kyburz,mrvBuvsAAAAJ
 Penny Sanderson,University of Queensland,https://www.psy.uq.edu.au/people/personal.html?id=533,eMywJ4sAAAAJ
+Penny Sweetser,Australian National University,https://cs.anu.edu.au/people/penny-kyburz,mrvBuvsAAAAJ
 Per Andersson,Lund University,http://www.svet.lu.se/en/per-andersson,38DogacAAAAJ
 Per Austrin,KTH Royal Institute of Technology,http://www.nada.kth.se/~austrin,ttQM0ocAAAAJ
 Per B. Brockhoff,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
-Per Baekgaard,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Per Bækgaard,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
+Per Baekgaard,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Per Christian Hansen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Per Gunningberg,Uppsala University,http://user.it.uu.se/~perg,NOSCHOLARPAGE
 Per Kristian Lehre,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/academic-staff/lehre-kristian-per.aspx,HTszQ5gAAAAJ
@@ -637,16 +643,16 @@ Peter G. Jeavons,University of Oxford,http://www.cs.ox.ac.uk/peter.jeavons,xEE8Q
 Péter Gács,Boston University,http://www.cs.bu.edu/~gacs,vNCcKo0AAAAJ
 Peter Garraghan,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/people/peter-garraghan,lkP_Zd8AAAAJ
 Peter Graham,University of Manitoba,http://www.cs.umanitoba.ca/~pgraham,5suVxUYAAAAJ
-Peter Grunwald,CWI,http://homepages.cwi.nl/~pdg,wItp6h8AAAAJ
 Peter Grünwald,CWI,http://homepages.cwi.nl/~pdg,wItp6h8AAAAJ
+Peter Grunwald,CWI,http://homepages.cwi.nl/~pdg,wItp6h8AAAAJ
 Peter H. Welch,University of Kent,https://www.cs.kent.ac.uk/~phw,hd1j2w0AAAAJ
 Peter Hall 0001,University of Bath,http://www.cs.bath.ac.uk/~pmh/start/home.html,Tgz4GT8AAAAJ
 Peter Hastings,DePaul University,http://reed.cs.depaul.edu/peterh,r-U50JwAAAAJ
 Peter Hertling,Bundeswehr University Munich,https://www.unibw.de/timor/mitarbeiter/hertling/univ-prof-dr-peter-hertling,NOSCHOLARPAGE
 Peter Höfner,Australian National University,https://cs.anu.edu.au/people/peter-hoefner,JbCZr9sAAAAJ
+Peter Høyer,University of Calgary,http://www.cpsc.ucalgary.ca/~hoyer,NOSCHOLARPAGE
 Peter Hubwieser,TU Munich,http://www.professoren.tum.de/en/hubwieser-peter,YuvySKkAAAAJ
 Peter Husar,TU Ilmenau,https://www.tu-ilmenau.de/bmti/fachgebiete/biosignalverarbeitung/prof-dr-ing-habil-peter-husar,NOSCHOLARPAGE
-Peter Høyer,University of Calgary,http://www.cpsc.ucalgary.ca/~hoyer,NOSCHOLARPAGE
 Peter I. Corke,Queensland University of Technology,https://research.qut.edu.au/qcr/people/peter-corke,wnePPc4AAAAJ
 Peter I. Cowling,University of York,https://www-users.cs.york.ac.uk/~pic,xQ7IpL8AAAAJ
 Peter J. Bentley,University College London,http://www0.cs.ucl.ac.uk/staff/p.bentley,9DHkQbYAAAAJ
@@ -722,10 +728,10 @@ Peter Robinson 0001,University of Cambridge,https://www.cl.cam.ac.uk/~pr10,91Nxd
 Peter Robinson 0002,Augusta University,https://pwrobinson.github.io,DsPjnMQAAAAJ
 Peter Rodgers,University of Kent,https://www.cs.kent.ac.uk/people/staff/pjr,wu6mHBsAAAAJ
 Peter Rodgers 0001,University of Kent,https://www.cs.kent.ac.uk/people/staff/pjr,wu6mHBsAAAAJ
+Peter Røgen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Peter Rohde,University of Technology Sydney,https://www.uts.edu.au/staff/peter.rohde,9FnYa84AAAAJ
 Peter Rossmanith,RWTH Aachen,http://tcs.rwth-aachen.de/~rossmani,NOSCHOLARPAGE
 Peter Ryan,University of Luxembourg,http://wwwen.uni.lu/snt/research/apsia/prof_peter_ryan,NOSCHOLARPAGE
-Peter Røgen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Peter Sanders 0001,Karlsruhe Institute of Technology,http://algo2.iti.kit.edu/sanders.php,0xWltyAAAAAJ
 Peter Schachte,University of Melbourne,http://people.eng.unimelb.edu.au/schachte,ZL83PpwAAAAJ
 Peter Schartner,University of Klagenfurt,https://www.syssec.at/de/team/schartner,MRKBB1UAAAAJ
@@ -935,9 +941,9 @@ Pietro Perona,California Institute of Technology,https://www.vision.caltech.edu/
 Pietro S. Oliveto,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/pietro-oliveto,dGRqOi0AAAAJ
 Pietro Simone Oliveto,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/pietro-oliveto,dGRqOi0AAAAJ
 Pin Tao,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101224173206168406028/20101224173206168406028_.html,NOSCHOLARPAGE
-Pinakpani Pal,ISI Kolkata,https://www.isical.ac.in/~pinak,J26Wmf0AAAAJ
 Pinaki Mazumder,University of Michigan,http://web.eecs.umich.edu/~mazum,8knozEkAAAAJ
 Pinaki Mitra,IIT Guwahati,http://www.iitg.ernet.in/pinaki,ZVxC1rB3vXEC
+Pinakpani Pal,ISI Kolkata,https://www.isical.ac.in/~pinak,J26Wmf0AAAAJ
 Pinar Duygulu,Hacettepe University,https://web.cs.hacettepe.edu.tr/~pinar,1KEMrHkAAAAJ
 Pinar Duygulu Sahin,Hacettepe University,https://web.cs.hacettepe.edu.tr/~pinar,1KEMrHkAAAAJ
 Pinar Heggernes,University of Bergen,http://www.ii.uib.no/~pinar,NOSCHOLARPAGE
@@ -1106,10 +1112,10 @@ Prosenjit Bose,Carleton University,http://jitbose.ca,1jR53ZQAAAAJ
 Prosenjit K. Bose,Carleton University,http://jitbose.ca,1jR53ZQAAAAJ
 Prudence W. H. Wong,University of Liverpool,https://www.liverpool.ac.uk/computer-science/staff/prudence-wong,vjIXDW4AAAAJ
 Przemyslaw Musialski,NJIT,https://web.njit.edu/~przem,GG5256IAAAAJ
+Przemysław Pawełczak,TU Delft,http://www.pawelczak.net,NzykFrsAAAAJ
 Przemyslaw Pawelczak,TU Delft,http://www.pawelczak.net,NzykFrsAAAAJ
 Przemyslaw Pochec,University of New Brunswick,https://www.cs.unb.ca/people/pochec,NOSCHOLARPAGE
 Przemyslaw Prusinkiewicz,University of Calgary,http://algorithmicbotany.org,pjH7e8IAAAAJ
-Przemysław Pawełczak,TU Delft,http://www.pawelczak.net,NzykFrsAAAAJ
 Pu Wang 0001,UNC - Charlotte,https://webpages.uncc.edu/pwang13/,0buJlAUAAAAJ
 Pu-Jen Cheng,National Taiwan University,https://www.csie.ntu.edu.tw/~pjcheng,uYdM_rwAAAAJ
 Puneet Goyal,IIT Ropar,http://www.iitrpr.ac.in/cse/puneet,J_MIa1oAAAAJ

--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -3,7 +3,6 @@ R. A. Bodnar,University of Southampton,https://www.ecs.soton.ac.uk/people/rab1e1
 R. B. Mishra,IIT (BHU) Varanasi,http://www.iitbhu.ac.in/cse/index.php/people/faculty/24.html,5ujlOtgAAAAJ
 R. Benjamin Shapiro,University of Colorado Boulder,http://benshapi.ro,BjX6lbwAAAAJ
 R. Chandrasekaran,University of Texas at Dallas,https://www.utdallas.edu/~chandra,NOSCHOLARPAGE
-Rumi Chunara,New York University,http://rumichunara.github.io,7NhhkR8AAAAJ
 R. Clint Whaley,Indiana University,http://homes.sice.indiana.edu/rcwhaley,NOSCHOLARPAGE
 R. Clinton Whaley,Indiana University,http://homes.sice.indiana.edu/rcwhaley,NOSCHOLARPAGE
 R. E. Ellis,Queen’s University,http://www.cs.queensu.ca/~ellis,u97Fg9IAAAAJ
@@ -172,9 +171,9 @@ Rajagopalan Jayakumar,Concordia University,http://www.concordia.ca/faculty/rajag
 Rajalakshmi Nandakumar [Tech],Cornell University,https://tech.cornell.edu/people/rajalakshmi-nandakumar,CO4txjAAAAAJ
 Rajalida Lipikorn,Chulalongkorn University,http://www.math.sc.chula.ac.th/en/profile/rajalida.l,NOSCHOLARPAGE
 Rajasekhar Inkulu,IIT Guwahati,http://www.iitg.ernet.in/rinkulu,NOSCHOLARPAGE
+Rajat Kumar De,ISI Kolkata,https://www.isical.ac.in/~rajat,gM9LAI0AAAAJ
 Rajat Mittal 0001,IIT Kanpur,http://www.cse.iitk.ac.in/users/rmittal,gK5DF9QAAAAJ
 Rajat Moona,IIT Kanpur,http://www.cse.iitk.ac.in/users/moona,NOSCHOLARPAGE
-Rajat Kumar De,ISI Kolkata,https://www.isical.ac.in/~rajat,gM9LAI0AAAAJ
 Rajat Subhra Chakraborty,IIT Kharagpur,https://sites.google.com/site/rschakraborty,ITIg9kkAAAAJ
 Rajdeep Niyogi,IIT Roorkee,http://www.iitr.ac.in/departments/CSE/pages/People+Faculty+rajdpfec.html,NOSCHOLARPAGE
 Rajeev Alur,University of Pennsylvania,https://www.cis.upenn.edu/~alur,kWnv_YkAAAAJ
@@ -412,10 +411,10 @@ Ravishankar K. Iyer,Univ. of Illinois at Urbana-Champaign,https://www.ece.illino
 Ravishankar Krishnan Iyer,Univ. of Illinois at Urbana-Champaign,https://www.ece.illinois.edu/directory/profile/rkiyer,NOSCHOLARPAGE
 Raviv Raich,Oregon State University,http://web.engr.oregonstate.edu/~raich,NOSCHOLARPAGE
 Ray-I Chang,National Taiwan University,http://homepage.ntu.edu.tw/~rayichang,YiqWyHkAAAAJ
-Raymond A. Yeh,Purdue University,https://www.cs.purdue.edu/people/faculty/rayyeh.html,7HDE1ZwAAAAJ
 Rayford B. Vaughn,University of Alabama - Huntsville,https://www.uah.edu/images/research/ovpr/cvs/vaughn.pdf,UK-AZvMAAAAJ
 Rayford B. Vaughn Jr.,University of Alabama - Huntsville,https://www.uah.edu/images/research/ovpr/cvs/vaughn.pdf,UK-AZvMAAAAJ
 Rayid Ghani,Carnegie Mellon University,http://www.rayidghani.com,_ufWH4IAAAAJ
+Raymond A. Yeh,Purdue University,https://www.cs.purdue.edu/people/faculty/rayyeh.html,7HDE1ZwAAAAJ
 Raymond Bisdorff,University of Luxembourg,http://wwwen.uni.lu/studies/doctoral_education/contact/raymond_bisdorff,Vz4YXfcAAAAJ
 Raymond Chi-Wing Wong,HKUST,http://www.cse.ust.hk/~raywong,IKgiD0AAAAAJ
 Raymond D. Gumb,University of Massachusetts Lowell,http://www.cs.uml.edu/~gumb,NOSCHOLARPAGE
@@ -489,8 +488,8 @@ Reis Burak Arslan,Galatasaray University,https://avesis.gsu.edu.tr/buarslan,msee
 Rem W. Collier,University College Dublin,https://people.ucd.ie/rem.collier,P6Qta-8AAAAJ
 Remco C. Veltkamp,Utrecht University,https://www.uu.nl/staff/RCVeltkamp,xGkWUqMAAAAJ
 Remco Chang,Tufts University,http://www.cs.tufts.edu/~remco,Q29WmWwAAAAJ
-Remi A. Chou,Wichita State University,https://www.wichita.edu/profiles/academics/engineering/SoC/Chou-Remi.php,1yJ_XP8AAAAJ
 Rémi A. Chou,Wichita State University,https://www.wichita.edu/profiles/academics/engineering/SoC/Chou-Remi.php,1yJ_XP8AAAAJ
+Remi A. Chou,Wichita State University,https://www.wichita.edu/profiles/academics/engineering/SoC/Chou-Remi.php,1yJ_XP8AAAAJ
 Rémi Emonet,Université Jean Monnet,http://home.heeere.com,TOqZIGgAAAAJ
 Rémi Gilleron,CRIStAL,https://sites.google.com/view/remi-gilleron,dKliE7IAAAAJ
 Remo Pareschi,University of Molise,http://docenti.unimol.it/index.php?u=remo.pareschi&id=8,4LGMlCEAAAAJ
@@ -589,6 +588,7 @@ Riad Jabri,University of Jordan,http://eacademic.ju.edu.jo/jabri,6OS8WIIAAAAJ
 Riaz Ahmed Shaikh,King Abdulaziz University,http://www.kau.edu.sa/Content.aspx?Site_ID=61117&lng=EN&cid=60829,aKvhKTAAAAAJ
 Ribana Roscher,University of Osnabrück,https://www.informatik.uni-osnabrueck.de/institut/personen.html,37m2U7QAAAAJ
 Ricardo A. L. Reis,UFRGS,http://inf.ufrgs.br/~reis,Iw4qTucAAAAJ
+Ricardo Aler,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-66,WTFavwQAAAAJ
 Ricardo Augusto da Luz Reis,UFRGS,http://inf.ufrgs.br/~reis,Iw4qTucAAAAJ
 Ricardo C. Farias,UFRJ,http://www.cos.ufrj.br/~rfarias,tmOKSCgAAAAJ
 Ricardo Chaves,Universidade de Lisboa,http://sips.inesc-id.pt/~rjfc/mypublications.php,fCwoC5gAAAAJ
@@ -735,9 +735,9 @@ Rico Sennrich,University of Zurich,https://www.cl.uzh.ch/en/people/team/sennrich
 Rida A. Bazzi,Arizona State University,http://bazzi.faculty.asu.edu,FrMOlk8AAAAJ
 Rida Laraki,University of Liverpool,https://sites.google.com/site/ridalaraki,zwkQWEgAAAAJ
 Ridha Khedri,McMaster University,http://www.cas.mcmaster.ca/~khedri,NOSCHOLARPAGE
-Rihan Hai,TU Delft,https://www.wis.ewi.tudelft.nl/hai,vD8M9R0AAAAJ
 Rie Yamaguchi,University of Tokyo,http://www.yamagula.ic.i.u-tokyo.ac.jp/index_e.html,NOSCHOLARPAGE
 Rifat Shahriyar,BUET,http://rifatshahriyar.github.io,p-w4hOUAAAAJ
+Rihan Hai,TU Delft,https://www.wis.ewi.tudelft.nl/hai,vD8M9R0AAAAJ
 Rijurekha Sen,IIT Delhi,http://www.cse.iitd.ernet.in/~rijurekha,yTPVlzgAAAAJ
 Rik Sarkar,University of Edinburgh,http://homepages.inf.ed.ac.uk/rsarkar,rmMWizEAAAAJ
 Rikky Muller,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/rikky.html,4bgii4oAAAAJ
@@ -751,8 +751,8 @@ Rio Yokota,Tokyo Institute of Technology,http://www.rio.gsic.titech.ac.jp/jp/ind
 Ripon Patgiri,National Institute of Technology Silchar,http://cs.nits.ac.in/rp,UqnzylwAAAAJ
 Risat Mahmud Pathan,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/risat.aspx,NOSCHOLARPAGE
 Risat Pathan,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/risat.aspx,NOSCHOLARPAGE
-Rishab Nithyanand,University of Iowa,https://cs.uiowa.edu/people/rishab-nithyanand,iFjAUN8AAAAJ
 Rishab Goyal,University of Wisconsin - Madison,https://sites.google.com/prod/utexas.edu/rigoy,YsOdB70AAAAJ
+Rishab Nithyanand,University of Iowa,https://cs.uiowa.edu/people/rishab-nithyanand,iFjAUN8AAAAJ
 Rishabh K. Iyer,University of Texas at Dallas,https://cs.utdallas.edu/people/faculty/iyer-rishabh,XxJ1kAAAAJ
 Rishiraj Bhattacharyya,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/academic-staff/bhattacharyya-rishiraj.aspx,NOSCHOLARPAGE
 Risi Kondor,University of Chicago,http://people.cs.uchicago.edu/~risi,v12-jLUAAAAJ
@@ -798,8 +798,8 @@ Robert A. van de Geijn,University of Texas at Austin,http://cs.utexas.edu/~rvdg,
 Robert Akl,University of North Texas,http://www.cse.unt.edu/~rakl/index.html,NOSCHOLARPAGE
 Robert Alexander,University of York,https://www-users.cs.york.ac.uk/~rda,DFdBpC0AAAAJ
 Robert Allison,York University,http://www.cse.yorku.ca/~allison,1LbWyf4AAAAJ
-Robert Atkey,University of Strathclyde,https://pureportal.strath.ac.uk/en/persons/bob-atkey/publications,0bo89OQAAAAJ
 Robert Amor,University of Auckland,https://www.cs.auckland.ac.nz/~trebor,WqqlB5oAAAAJ
+Robert Atkey,University of Strathclyde,https://pureportal.strath.ac.uk/en/persons/bob-atkey/publications,0bo89OQAAAAJ
 Robert B. Fisher,University of Edinburgh,http://homepages.inf.ed.ac.uk/rbf,LigYduEAAAAJ
 Robert B. Heckendorn,University of Idaho,http://marvin.cs.uidaho.edu/~heckendo,Hd0x1I4AAAAJ
 Robert B. Schnabel,University of Colorado Boulder,https://www.colorado.edu/cs/bobby-schnabel,NOSCHOLARPAGE
@@ -1060,7 +1060,6 @@ Roel Vertegaal,Queen’s University,http://www.hml.queensu.ca/people/roelvertega
 Roeland C. H. J. van Ham,TU Delft,https://www.tudelft.nl/ewi/over-de-faculteit/afdelingen/intelligent-systems/pattern-recognition-bioinformatics/the-delft-bioinformatics-lab/people/roeland-van-ham,2bJ-DgsAAAAJ
 Roeland M. H. Merks,CWI,https://www.cwi.nl/people/2230,rLcMoaUAAAAJ
 Roeland Merks,CWI,https://www.cwi.nl/people/2230,rLcMoaUAAAAJ
-Roghayeh Barmaki,University of Delaware,https://www.cis.udel.edu/people/faculty-profile/?id=263,vS0MhokAAAAJ
 Rogelio Cardona-Rivera,University of Utah,http://rogel.io,04bZH_kAAAAJ
 Rogelio E. Cardona-Rivera,University of Utah,http://rogel.io,04bZH_kAAAAJ
 Rogelio Enrique Cardona-Rivera,University of Utah,http://rogel.io,04bZH_kAAAAJ
@@ -1089,6 +1088,7 @@ Roger Wattenhofer,ETH Zurich,https://disco.ethz.ch,EG3VPm4AAAAJ
 Roger Zimmermann,National University of Singapore,https://www.comp.nus.edu.sg/~rogerz/roger.html,IDREwXEAAAAJ
 Rogério de Lemos,University of Kent,https://www.cs.kent.ac.uk/people/staff/rdl,gq9hIiAAAAAJ
 Rogers Mathew,IIT Hyderabad,https://iith.ac.in/~rogers,-euQnQYAAAAJ
+Roghayeh Barmaki,University of Delaware,https://www.cis.udel.edu/people/faculty-profile/?id=263,vS0MhokAAAAJ
 Rohan Padhye,Carnegie Mellon University,https://rohan.padhye.org,XI03UxYAAAAJ
 Rohini K. Srihari,University at Buffalo,http://www.cse.buffalo.edu/people/?u=rohini,Uttu9kkAAAAJ
 Rohit Babbar,Aalto University,https://research.aalto.fi/en/persons/rohit-babbar,QsqvuGsAAAAJ
@@ -1352,6 +1352,7 @@ Ruizhe Ma,University of Massachusetts Lowell,https://www.uml.edu/Sciences/comput
 Ruizhen Hu,Shenzhen University,http://csse.szu.edu.cn/staff/ruizhenhu,MloRITsAAAAJ
 Rujia Wang,Illinois Institute of Technology,https://rujiawang.github.io,IbOb-M4AAAAJ
 Rumi Chunara,New York University,https://rumichunara.github.io,7NhhkR8AAAAJ
+Rumi Chunara,New York University,http://rumichunara.github.io,7NhhkR8AAAAJ
 Rumyana Neykova,Brunel University London,https://www.brunel.ac.uk/people/rumyana-neykova,AN2wqD0AAAAJ
 Rune Kristian Lundedal Nielsen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/rune-kristian-lundedal-nielsen(80784458-06f6-4eff-b0c8-df982ffa9835).html,xS-DSmQAAAAJ
 Rune Møller Jensen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/rune-moeller-jensen(4d7fda5a-3cf4-4d39-9daf-1ae192b0e0e7).html,NOSCHOLARPAGE

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -138,8 +138,8 @@ Sam Tobin-Hochstadt,Indiana University,http://www.ccs.neu.edu/home/samth,vMSSQbA
 Sam Toueg,University of Toronto,http://www.cs.toronto.edu/theory/People.html,NOSCHOLARPAGE
 Sam Wiseman,Duke University,https://swiseman.github.io/,SDavuPAAAAAJ
 Saman A. Zonouz,Georgia Institute of Technology,https://sites.google.com/site/samanzonouz4n6/,kgFnNewAAAAJ
-Saman P. Amarasinghe,Massachusetts Institute of Technology,http://people.csail.mit.edu/saman,cF6i_goAAAAJ
 Saman A. Zonouz,Georgia Institute of Technology,https://sites.google.com/site/samanzonouz4n6/saman-zonouz,kgFnNewAAAAJ
+Saman P. Amarasinghe,Massachusetts Institute of Technology,http://people.csail.mit.edu/saman,cF6i_goAAAAJ
 Samantha Kleinberg,Stevens Institute of Technology,http://www.skleinberg.org,WIRLT4UAAAAJ
 Samantha M. W. Wood,Indiana University,https://luddy.indiana.edu/contact/profile/index.html?Samantha_Wood,LduPsQ4AAAAJ
 Samar Agnihotri,IIT Mandi,http://faculty.iitmandi.ac.in/~samar,qZkww5oAAAAJ
@@ -212,8 +212,8 @@ Sandeep Neema,Vanderbilt University,https://engineering.vanderbilt.edu/bio/sande
 Sandeep Sen,IIT Delhi,http://www.cse.iitd.ac.in/~ssen,GK7JUpkAAAAJ
 Sander Bakkes,Utrecht University,http://sander.landofsand.com,R4OXfi4AAAAJ
 Sander C. J. Bakkes,Utrecht University,http://sander.landofsand.com,R4OXfi4AAAAJ
-Sander M. Bohte,CWI,http://homepages.cwi.nl/~sbohte,zHlebkUAAAAJ
 Sander M. Bohté,CWI,http://homepages.cwi.nl/~sbohte,zHlebkUAAAAJ
+Sander M. Bohte,CWI,http://homepages.cwi.nl/~sbohte,zHlebkUAAAAJ
 Sandhya Dwarkadas,University of Virginia,https://engineering.virginia.edu/faculty/sandhya-dwarkadas,L1pb8GUAAAAJ
 Sandhya Saisubramanian,Oregon State University,https://www.sandhyasai.com,pUWf24gAAAAJ
 Sandip Chakraborty,IIT Kharagpur,http://cse.iitkgp.ac.in/~sandipc,dEpbTokAAAAJ
@@ -441,12 +441,12 @@ Saurabh Joshi 0001,IIT Hyderabad,http://www.iith.ac.in/~sbjoshi,MvHEGbYAAAAJ
 Saurabh Sinha,Univ. of Illinois at Urbana-Champaign,http://www.sinhalab.net/sinha-s-home,7BM1uyYAAAAJ
 Saurabh Tiwari,DAIICT,http://www.daiict.ac.in/daiict/people/faculty.html,rjyRdosAAAAJ
 Savas Kaya,Ohio University,http://savaskaya.net,k8A7YxcAAAAJ
+Sayako Shimizu,National Institute of Informatics,https://www.nii.ac.jp/en/faculty/architecture/sayako_shimizu/,NOSCHOLARPAGE
 Sayan Bhattacharya,University of Warwick,https://www.dcs.warwick.ac.uk/~u1671158,ca-urkIAAAAJ
 Sayan Mitra,Univ. of Illinois at Urbana-Champaign,http://mitras.ece.illinois.edu,dXUl8ewAAAAJ
 Sayan Mukherjee 0001,Duke University,https://sayanmuk.github.io/,R94cBVgAAAAJ
 Sayan Ranu,IIT Delhi,http://www.cse.iitd.ac.in/~sayan,K4w5qYUAAAAJ
 Sayan Sarcar,University of Tsukuba,https://sayansarcar.github.io/index.html,bIkNGO4AAAAJ
-Sayako Shimizu,National Institute of Informatics,https://www.nii.ac.jp/en/faculty/architecture/sayako_shimizu/,NOSCHOLARPAGE
 Sayed Vahid Azhari,IUST,http://ce.iust.ac.ir/content/7755/Dr.-Azhari,-mM5PJAAAAAJ
 Sayeef S. Salahuddin,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/salahuddin.html,Ay4FZFUAAAAJ
 Sazzadur Rahaman,University of Arizona,https://www.sazzadur.com/,JBbGF1gAAAAJ
@@ -653,6 +653,7 @@ Sergio Lucia,TU Berlin,https://www.iot.tu-berlin.de/menue/team/sergio_lucia,cp0s
 Sergio Maffeis,Imperial College London,https://www.doc.ic.ac.uk/~maffeis,ODKP7a0AAAAJ
 Sergio Miguel Fernandes,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist14264,VR4qbCIAAAAJ
 Sergio Montenegro 0001,University of Würzburg,http://www8.informatik.uni-wuerzburg.de/mitarbeiter/montenegro,NOSCHOLARPAGE
+Sergio Pastrana,Universidad Carlos III de Madrid,https://cosec.inf.uc3m.es/people/sergio-pastrana/,I2r0r-MAAAAJ
 Sergio Salinas 0001,Wichita State University,https://www.wichita.edu/profiles/academics/engineering/SoC/Salinas-Sergio.php,2Gh-ZdAAAAAJ
 Sérgio Soares,UFPE,http://www.cin.ufpe.br/~scbs,Jqll4wwAAAAJ
 Sérgio Vale Aguiar Campos,UFMG,http://homepages.dcc.ufmg.br/~scampos,NOSCHOLARPAGE
@@ -714,10 +715,10 @@ Seyed-Hassan Mirian-Hosseinabadi,Sharif University of Technology,http://ce.shari
 Seyed-Mehdi-Reza Beheshti,UNSW,http://www.cse.unsw.edu.au/~sbeheshti,Uw1OLAgAAAAJ
 Seyede Fatemeh Ghoreishi,Northeastern University,https://ghoreishi.sites.northeastern.edu/#_ga=2.121167816.151196753.1645503161-368177100.1593803560,BS8sZXgAAAAJ
 Seymour E. Goodman,Georgia Institute of Technology,http://www.iac.gatech.edu/people/faculty/goodman,NOSCHOLARPAGE
-Seyran Khademi,TU Delft,https://www.tudelft.nl/en/ewi/over-de-faculteit/afdelingen/intelligent-systems/pattern-recognition-bioinformatics/computer-vision-lab/people/seyran-khademi,5xfMpw0AAAAJ
 Seyoung Kim,Carnegie Mellon University,http://www.cs.cmu.edu/~sssykim,G99KBM8AAAAJ
 Seyoung Park,Kyungpook National University,http://nlp.knu.ac.kr,TPBJpLQAAAAJ
 Seyoung Yun,KAIST,https://fbsqkd.github.io,X_IAjb8AAAAJ
+Seyran Khademi,TU Delft,https://www.tudelft.nl/en/ewi/over-de-faculteit/afdelingen/intelligent-systems/pattern-recognition-bioinformatics/computer-vision-lab/people/seyran-khademi,5xfMpw0AAAAJ
 Shaahin Hessabi,Sharif University of Technology,http://sharif.edu/~hessabi,upXLWZEAAAAJ
 Shabnam Kasra Kermanshahi,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/k/kasra-kermanshahi-dr-shabnam,IX9BVTIAAAAJ
 Shachar Lovett,Univ. of California - San Diego,http://cseweb.ucsd.edu/~slovett,f6JF7BkAAAAJ
@@ -840,9 +841,9 @@ Sharon Mason,Rochester Institute of Technology,http://ist.rit.edu/~spm,_03eTDYAA
 Sharon Shoham,Tel Aviv University,http://www.tau.ac.il/~sharonshoham,SCP6RcEAAAAJ
 Sharon Weiss,Vanderbilt University,http://eecs.vanderbilt.edu/people/sharonweiss,fSYvY7sAAAAJ
 Sharon Wood,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/2974,NOSCHOLARPAGE
-Sharon Xiaolei Huang,Pennsylvania State University,https://faculty.ist.psu.edu/suh972,iTtzc1UAAAAJ
 Sharon X. Huang,Pennsylvania State University,https://faculty.ist.psu.edu/suh972,iTtzc1UAAAAJ
 Sharon Xianghua Ding,Fudan University,http://www.xianghuading.com,B9M48i8AAAAJ
+Sharon Xiaolei Huang,Pennsylvania State University,https://faculty.ist.psu.edu/suh972,iTtzc1UAAAAJ
 Shasha Mao,Xidian University,https://web.xidian.edu.cn/ssmao/,QLCqaOwAAAAJ
 Shashank K. Mehta,IIT Kanpur,http://www.iitk.ac.in/new/dr-shashank-k-mehta,77K1J3cAAAAJ
 Shashank Srivastava,University of North Carolina,https://www.ssriva.com,-vKI5s0AAAAJ
@@ -1087,8 +1088,8 @@ Shubham Jain,Stony Brook University,https://www3.cs.stonybrook.edu/~jain,P9Z011Y
 Shubham Tulsiani,Carnegie Mellon University,https://shubhtuls.github.io,06rffEkAAAAJ
 Shubhangi K. Gawali,BITS Pilani-Goa,http://www.bits-pilani.ac.in/goa/shubhangi/profile,2hDkzdgAAAAJ
 Shubhangi Saraf,University of Toronto,https://www.math.toronto.edu/ssaraf,NiRqwkcAAAAJ
-Shubhra Kanti Karmaker Santu,Auburn University,https://karmake2.github.io,y6pZKT4AAAAJ
 Shubhra (Santu) K. Karmaker,Auburn University,https://karmake2.github.io,y6pZKT4AAAAJ
+Shubhra Kanti Karmaker Santu,Auburn University,https://karmake2.github.io,y6pZKT4AAAAJ
 Shubhra Sankar Ray,ISI Kolkata,https://www.isical.ac.in/~shubhra,or5TH2oAAAAJ
 Shucheng Yu,University of Arkansas - Little Rock,https://ualr.edu/faculty-7wazt/yu,jYW_WCwAAAAJ
 Shuchi Chawla 0001,University of Texas at Austin,http://pages.cs.wisc.edu/~shuchi,Znp3UkEAAAAJ
@@ -1260,8 +1261,8 @@ Simon Peter,University of Washington,https://homes.cs.washington.edu/~simpeter,N
 Simon R. Arridge,University College London,http://cmic.cs.ucl.ac.uk/staff/simon_arridge,UKy9ejwAAAAJ
 Simon Robert Arridge,University College London,http://cmic.cs.ucl.ac.uk/staff/simon_arridge,UKy9ejwAAAAJ
 Simon Rogers,University of Glasgow,http://www.dcs.gla.ac.uk/~srogers,5EiC_wEAAAAJ
-Simon S. Lam,University of Texas at Austin,https://www.cs.utexas.edu/users/lam,0XV1sFsAAAAJ
 Simon S. Du,University of Washington,https://www.cs.washington.edu/people/faculty/ssdu,OttawxUAAAAJ
+Simon S. Lam,University of Texas at Austin,https://www.cs.utexas.edu/users/lam,0XV1sFsAAAAJ
 Simon Shaolei Du,University of Washington,https://www.cs.washington.edu/people/faculty/ssdu,OttawxUAAAAJ
 Simon Sin-Sing Lam,University of Texas at Austin,https://www.cs.utexas.edu/users/lam,0XV1sFsAAAAJ
 Simon T. Perrault,SUTD,http://istd.sutd.edu.sg/people/faculty/simon-perrault,pfKzDx8AAAAJ
@@ -1321,8 +1322,8 @@ Siwei Feng,Soochow University,http://web.suda.edu.cn/fsw,_7xkHz8AAAAJ
 Siwei Lyu,University at Buffalo,http://www.cse.buffalo.edu/~siweilyu,wefAEM4AAAAJ
 Siwei Ma,Peking University,http://idm.pku.edu.cn/staff/masiwei/masiwei.htm,y3YqlaUAAAAJ
 Siyao Guo,NYU Shanghai,https://sites.google.com/site/siyaoguo,nscLxl4AAAAJ
-Siyuan Ji,University of York,https://www.cs.york.ac.uk/people/?group=Academic%20and%20Teaching%20Staff&username=ji,oZdrNNwAAAAJ
 Siyu Tang 0001,ETH Zurich,https://vlg.inf.ethz.ch/people/person-detail.siyutang.html,BUDh_4wAAAAJ
+Siyuan Ji,University of York,https://www.cs.york.ac.uk/people/?group=Academic%20and%20Teaching%20Staff&username=ji,oZdrNNwAAAAJ
 Sjaak Smetsers,Radboud University,http://www.cs.ru.nl/S.Smetsers,acnD_MEAAAAJ
 Sjouke Mauw,University of Luxembourg,http://satoss.uni.lu/members/sjouke,NDXZhwcAAAAJ
 Sjur Didrik Flåm,University of Bergen,https://www.uib.no/en/persons/Sjur.Didrik.Fl%C3%A5m,NOSCHOLARPAGE
@@ -1390,9 +1391,9 @@ Song Liu 0003,ShanghaiTech University,https://sist.shanghaitech.edu.cn/sist_en/2
 Song Min Kim,KAIST,https://sites.google.com/view/smilelab,lBJc3B8AAAAJ
 Song Wang 0002,University of South Carolina,http://www.cse.sc.edu/~songwang,eycXl_QAAAAJ
 Song Wang 0009,York University,https://www.eecs.yorku.ca/~wangsong,gzyZhcgAAAAJ
-Songbai Liu,Shenzhen University,https://www.researchgate.net/profile/Songbai-Liu-2,jXTQ1TwAAAAJ
 Song-Chun Zhu,Peking University,http://www.stat.ucla.edu/~sczhu,Al8dyb4AAAAJ
 Song-Hai Zhang,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101225165936235350290/20101225165936235350290_.html,AWtV-EQAAAAJ
+Songbai Liu,Shenzhen University,https://www.researchgate.net/profile/Songbai-Liu-2,jXTQ1TwAAAAJ
 Songhwai Oh,Seoul National University,http://rllab.snu.ac.kr,VEzNY_oAAAAJ
 Songqing Chen,George Mason University,https://cs.gmu.edu/~sqchen,T7IRM8EAAAAJ
 Songul Albayrak,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/songul?lang=en,LF5HfgEAAAAJ
@@ -1431,7 +1432,14 @@ Soraia Raupp Musse,PUC-RS,http://www.inf.pucrs.br/~smusse,MyKLYVMAAAAJ
 Sorav Bansal,IIT Delhi,http://www.cse.iitd.ernet.in/~sbansal,TqGZtpoAAAAJ
 Soraya Kouadri Mostéfaoui,Open University UK,http://stem.open.ac.uk/people/skm234,NOSCHOLARPAGE
 Sören Auer,University of Hannover,https://vivo.tib.eu/fis/display/n0000-0002-0698-2864,2cpal78AAAAJ
+Søren Debois,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/soeren-debois(d3b41838-e2bf-4735-b1cd-03f60b49c7e5).html,okin7NMAAAAJ
+Søren Hauberg,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
+Søren I. Olsen,University of Copenhagen,http://diku.dk/english/staff/?pure=en/persons/5264,NOSCHOLARPAGE
+Søren Ingvor Olsen,University of Copenhagen,http://diku.dk/english/staff/?pure=en/persons/5264,NOSCHOLARPAGE
+Søren Kimmer Schou Gregersen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
+Søren Knudsen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/soeren-knudsen(2575c800-642d-4984-9c56-41601cf07a26).html,DT6JUdcAAAAJ
 Sören Laue,TU Kaiserslautern,https://laue.ai,XLOcv_sAAAAJ
+Søren Lauesen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/soeren-lauesen(ea6d10cf-6bb5-4414-8966-f1ed2591f794).html,NOSCHOLARPAGE
 Sören Schwertfeger,ShanghaiTech University,https://robotics.shanghaitech.edu.cn/people/soeren,Y2olJ9kAAAAJ
 Sorin Draghici,Wayne State University,http://vortex.cs.wayne.edu/Sorin/index.htm,fbkIhRYAAAAJ
 Sorin Istrail,Brown University,http://www.brown.edu/Research/Istrail_Lab/sorin.php,HCEcMksAAAAJ
@@ -1468,8 +1476,8 @@ Souren Paul,Nova Southeastern University,https://cec.nova.edu/faculty/paul.html,
 Sourish Dasgupta,DAIICT,http://www.daiict.ac.in/daiict/people/faculty.html,dK0_8CcAAAAJ
 Souti Chattopadhyay,University of Southern California,https://soutirini.com/,kfFmB4MAAAAJ
 Sowmya Somanath,University of Victoria,https://celab.cs.uvic.ca,R9ar1NkAAAAJ
-Spencer Smith,McMaster University,http://www.cas.mcmaster.ca/~smiths,Z0WEv1oAAAAJ
 Spencer Bryngelson,Georgia Institute of Technology,https://comp-physics.group/,dM-nHdMAAAAJ
+Spencer Smith,McMaster University,http://www.cas.mcmaster.ca/~smiths,Z0WEv1oAAAAJ
 Spiridon Bakiras,CUNY,http://www.gc.cuny.edu/Page-Elements/Academics-Research-Centers-Initiatives/Doctoral-Programs/Computer-Science/Faculty-Bios/Spiridon-Bakiras,rpzKBjQAAAAJ
 Spiros E. Papadimitriou,Rutgers University,https://www.business.rutgers.edu/faculty/spiros-papadimitriou,WUrGGDgAAAAJ
 Spiros Mancoridis,Drexel University,http://drexel.edu/cci/contact/Faculty/Mancoridis-Spiros,bKGwUrQAAAAJ
@@ -1685,6 +1693,7 @@ Steffen Zschaler,King's College London,https://www.kcl.ac.uk/people/steffen-zsch
 Steffen van Bakel,Imperial College London,http://www.doc.ic.ac.uk/~svb,wSUVpA0AAAAJ
 Stelian Coros,ETH Zurich,http://crl.ethz.ch/coros.html,DFQNrvUAAAAJ
 Stelios Asteriadis,Maastricht University,https://dke.maastrichtuniversity.nl/stelios.asteriadis,MzZME8sAAAAJ
+Stelios Kapetanakis,Middlesex University,https://www.mdx.ac.uk/about-us/our-people/staff-directory/profile/kapetanakis-stylianos,NOSCHOLARPAGE
 Stelios Sotiriadis,Birkbeck University of London,https://www.dcs.bbk.ac.uk/about/people/academic-staff/sotiriadis-stelios,hLqLr1IAAAAJ
 Stella X. Yu,University of Michigan,https://web.eecs.umich.edu/~stellayu/,uqWkLzMAAAAJ
 Stephan Chalup,University of Newcastle,https://www.newcastle.edu.au/profile/stephan-chalup,61q7GXYAAAAJ
@@ -1757,7 +1766,6 @@ Stephen H. Edwards,Virginia Tech,http://people.cs.vt.edu/~edwards,5pV6DQ4AAAAJ
 Stephen H. Muggleton,Imperial College London,http://wp.doc.ic.ac.uk/shm,WxJXT2MAAAAJ
 Stephen Hailes,University College London,http://www0.cs.ucl.ac.uk/staff/S.Hailes,LJD3OxkAAAAJ
 Stephen Herwig,College of William and Mary,http://www.cs.wm.edu/~smherwig,SPZRj5kAAAAJ
-Steve Hanneke,Purdue University,https://www.cs.purdue.edu/people/faculty/hanneke.html,fEhNO7YAAAAJ
 Stephen Huang,University of Houston,http://www2.cs.uh.edu/shuang,hPY6T7gAAAAJ
 Stephen Hutt,University of Denver,https://ritchieschool.du.edu/about/people/stephen-hutt,ZYXjuGMAAAAJ
 Stephen J. Counsell,Brunel University London,https://www.brunel.ac.uk/people/steve-counsell,It_Dl_UAAAAJ
@@ -1812,7 +1820,6 @@ Steve Benford,University of Nottingham,https://www.nottingham.ac.uk/computerscie
 Steve Blackburn,Australian National University,http://users.cecs.anu.edu.au/~steveb,HgSTO7oAAAAJ
 Steve C. Maddock,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/steve-maddock,NbHpc-UAAAAJ
 Steve Carr 0001,Western Michigan University,https://wmich.edu/cs/directory/carr,NOSCHOLARPAGE
-Steven Carr 0001,Western Michigan University,https://wmich.edu/cs/directory/carr,NOSCHOLARPAGE
 Steve Cassidy,Macquarie University,http://web.science.mq.edu.au/~cassidy,Td8IE6cAAAAJ
 Steve Chapin,Syracuse University,http://www.hpdc.syr.edu/~chapin,NOSCHOLARPAGE
 Steve Counsell,Brunel University London,https://www.brunel.ac.uk/people/steve-counsell,It_Dl_UAAAAJ
@@ -1826,13 +1833,13 @@ Steve Gregory,University of Bristol,http://www.bris.ac.uk/engineering/people/ste
 Steve H. Harrison,Virginia Tech,http://people.cs.vt.edu/srh,r6k-SS4AAAAJ
 Steve Hailes,University College London,http://www0.cs.ucl.ac.uk/staff/S.Hailes,LJD3OxkAAAAJ
 Steve Hall,University of Liverpool,https://liverpool.ac.uk/electrical-engineering-and-electronics/staff/stephen-hall,NOSCHOLARPAGE
+Steve Hanneke,Purdue University,https://www.cs.purdue.edu/people/faculty/hanneke.html,fEhNO7YAAAAJ
 Steve Harrison,Virginia Tech,http://people.cs.vt.edu/srh,r6k-SS4AAAAJ
 Steve Homer,Boston University,http://www.cs.bu.edu/~homer,y1n8bZAAAAAJ
 Steve J. Maybank,Birkbeck University of London,https://www.dcs.bbk.ac.uk/about/people/academic-staff/sjmaybank,gpyHJmcAAAAJ
 Steve King 0001,University of York,https://www-users.cs.york.ac.uk/~king,Q75-BIgAAAAJ
 Steve Kroon,Stellenbosch University,http://www.cs.sun.ac.za/~kroon,-M2yWHQAAAAJ
 Steve Linton,University of St Andrews,https://sal.host.cs.st-andrews.ac.uk,DtnwP5MAAAAJ
-Steven M. Carr 0001,Western Michigan University,https://wmich.edu/cs/directory/carr,NOSCHOLARPAGE
 Steve M. Easterbrook,University of Toronto,http://www.cs.toronto.edu/~sme,bD8DWiEAAAAJ
 Steve Maddock,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/steve-maddock,NbHpc-UAAAAJ
 Steve Marschner,Cornell University,http://www.cs.cornell.edu/~srm,llo3F3QAAAAJ
@@ -1860,6 +1867,7 @@ Steven Bedrick,OHSU,http://www.ohsu.edu/xd/education/schools/school-of-medicine/
 Steven Bethard,University of Arizona,http://bethard.faculty.arizona.edu,sXM8J5EAAAAJ
 Steven Bradley,Durham University,https://www.dur.ac.uk/computer.science/staff/profile/?id=106,cia3XYoAAAAJ
 Steven C. H. Hoi,Singapore Management University,https://www.smu.edu.sg/faculty/profile/110831/Steven-HOI,JoLjflYAAAAJ
+Steven Carr 0001,Western Michigan University,https://wmich.edu/cs/directory/carr,NOSCHOLARPAGE
 Steven Castellucci,York University,http://www.eecs.yorku.ca/~stevenc,KNonqogAAAAJ
 Steven Chu-Hong Hoi,Singapore Management University,https://www.smu.edu.sg/faculty/profile/110831/Steven-HOI,JoLjflYAAAAJ
 Steven Costiou,CRIStAL,https://www.cristal.univ-lille.fr/profil/scostiou,KLPmm0gAAAAJ
@@ -1886,6 +1894,7 @@ Steven L. Lytinen,DePaul University,http://condor.depaul.edu/slytinen/papers/WS5
 Steven L. Tanimoto,University of Washington,http://www.cs.washington.edu/people/faculty/tanimoto,NOSCHOLARPAGE
 Steven Lumetta,Univ. of Illinois at Urbana-Champaign,https://www.ece.illinois.edu/directory/profile/lumetta,NOSCHOLARPAGE
 Steven M. Bellovin,Columbia University,https://www.cs.columbia.edu/~smb,9RlvgLEAAAAJ
+Steven M. Carr 0001,Western Michigan University,https://wmich.edu/cs/directory/carr,NOSCHOLARPAGE
 Steven M. Conolly,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/sconolly.html,DVnrB-4AAAAJ
 Steven M. Kelk,Maastricht University,http://skelk.sdf-eu.org,Eoays_KFyQsC
 Steven M. LaValle,Univ. of Illinois at Urbana-Champaign,http://oulu.cs.illinois.edu,72e5VYEAAAAJ
@@ -1933,10 +1942,8 @@ Stuart Thomason,University of Liverpool,https://www.liverpool.ac.uk/computer-sci
 Stuart Walker 0001,University of Essex,https://www.essex.ac.uk/people/walke72201/stuart-walker,etJByJ8AAAAJ
 Stylianos Asteriadis,Maastricht University,https://dke.maastrichtuniversity.nl/stelios.asteriadis,MzZME8sAAAAJ
 Stylianos D. Assimonis,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=s.assimonis,VM41-X0AAAAJ
-Stelios Kapetanakis,Middlesex University,https://www.mdx.ac.uk/about-us/our-people/staff-directory/profile/kapetanakis-stylianos,NOSCHOLARPAGE
 Su White,University of Southampton,https://www.ecs.soton.ac.uk/people/su,fh2HSVcAAAAJ
 Su Yang,Fudan University,http://homepage.fudan.edu.cn/suyang,NOSCHOLARPAGE
-Suhaib A. Fahmy,KAUST,https://cemse.kaust.edu.sa/accl/people/person/suhaib-fahmy,88wtbPwAAAAJ
 Su-In Lee,University of Washington,http://suinlee.cs.washington.edu,3ifikJ0AAAAJ
 SuKyoung Lee,Yonsei University,http://winet.yonsei.ac.kr/home/professor,NOSCHOLARPAGE
 Suat Ozdemir,Hacettepe University,https://web.cs.hacettepe.edu.tr/~ozdemir,2x5qoTkAAAAJ
@@ -1952,8 +1959,8 @@ Subhamoy Maitra,ISI Kolkata,https://www.isical.ac.in/~subho,PEDk2XQAAAAJ
 Subhankar Mishra,NISER,https://www.niser.ac.in/~smishra/,FICz_ukAAAAJ
 Subhanshu Gupta,Washington State University,https://sites.google.com/site/researcheecswsusubhanshu/home,GNhTWHoAAAAJ
 Subhas C. Mukhopadhyay,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=265530,fsu2yL8AAAAJ
-Subhas Chandra Mukhopadhyay,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=265530,fsu2yL8AAAAJ
 Subhas C. Nandy,ISI Kolkata,https://www.isical.ac.in/~nandysc,8v3wjowAAAAJ
+Subhas Chandra Mukhopadhyay,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=265530,fsu2yL8AAAAJ
 Subhas Mukhopadhyay,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=265530,fsu2yL8AAAAJ
 Subhash Khot,New York University,http://www.cs.nyu.edu/~khot,NOSCHOLARPAGE
 Subhash Suri,Univ. of California - Santa Barbara,https://www.cs.ucsb.edu/~suri,VgrH9A8AAAAJ
@@ -2008,6 +2015,7 @@ Suganya Devi K,National Institute of Technology Silchar,http://cs.nits.ac.in/sug
 Sugata Gangopadhyay,IIT Roorkee,http://www.iitr.ac.in/departments/CSE/pages/Home+Departments_and_Centres+Mathematics+People+Faculty+Gangopadhyay_Sugata.html,J7_k8JEAAAAJ
 Sugih Jamin,University of Michigan,http://web.eecs.umich.edu/~sugih,NOSCHOLARPAGE
 Suha Kwak,POSTECH,http://cvlab.postech.ac.kr/~suhakwak,-gscDIEAAAAJ
+Suhaib A. Fahmy,KAUST,https://cemse.kaust.edu.sa/accl/people/person/suhaib-fahmy,88wtbPwAAAAJ
 Suhang Wang,Pennsylvania State University,https://faculty.ist.psu.edu/szw494,cdT_WMMAAAAJ
 Sui-Tung Mak,University of Southampton,https://www.ecs.soton.ac.uk/people/tsm3g15,TdSU6G8AAAAJ
 Suining He,University of Connecticut,http://hesuining.weebly.com,3OlOXn4AAAAJ
@@ -2162,9 +2170,9 @@ Susanna Pelagatti,University of Pisa,http://www.di.unipi.it/~susanna,NOSCHOLARPA
 Susanne Albers,TU Munich,http://www14.in.tum.de/personen/albers,apxmY1gAAAAJ
 Susanne Biundo,University of Ulm,https://www.uni-ulm.de/in/ki/inst/staff/susanne-biundo,H_f_vikAAAAJ
 Susanne Biundo-Stephan,University of Ulm,https://www.uni-ulm.de/in/ki/inst/staff/susanne-biundo,H_f_vikAAAAJ
+Susanne Bødker,Aarhus University,http://pure.au.dk/portal/en/persons/id(87d4fbb6-b38c-449e-b87d-59f693b7d6f0).html,tO-dGhkAAAAJ
 Susanne Boll,University of Oldenburg,https://uol.de/en/susanne-boll,1vsF_kYAAAAJ
 Susanne Boll-Westermann,University of Oldenburg,https://uol.de/en/susanne-boll,1vsF_kYAAAAJ
-Susanne Bødker,Aarhus University,http://pure.au.dk/portal/en/persons/id(87d4fbb6-b38c-449e-b87d-59f693b7d6f0).html,tO-dGhkAAAAJ
 Susanne C. J. Boll,University of Oldenburg,https://uol.de/en/susanne-boll,1vsF_kYAAAAJ
 Susanne E. Hambrusch,Purdue University,https://www.cs.purdue.edu/people/seh,NOSCHOLARPAGE
 Susanne Krömker,Heidelberg University,https://vngg.iwr.uni-heidelberg.de/People/kroemker,ScUVMiQAAAAJ
@@ -2176,15 +2184,15 @@ Sushil J. Louis,University of Nevada,https://www.cse.unr.edu/~sushil,aHOOYsAAAAA
 Sushil K. Prasad,Georgia State University,http://cs.gsu.edu/profile/sushil-prasad,WdZpkD0AAAAJ
 Sushmita Mitra,ISI Kolkata,https://www.isical.ac.in/~sushmita,PrUB1fAAAAAJ
 Sushmita Roy,University of Wisconsin - Madison,http://wid.wisc.edu/profile/sushmita-roy,vzmzPSIAAAAJ
-Susmita Sur-Kolay,ISI Kolkata,https://www.isical.ac.in/~ssk,KjdkL_8AAAAJ
 Susmit Sarkar,University of St Andrews,https://ss265.host.cs.st-andrews.ac.uk,j4LMPLwAAAAJ
+Susmita Sur-Kolay,ISI Kolkata,https://www.isical.ac.in/~ssk,KjdkL_8AAAAJ
 Susu Xu,Stony Brook University,https://www.cs.stonybrook.edu/people/faculty/SusuXu,MSCQE-YAAAAJ
 Sutanu Chakraborti,IIT Madras,http://www.cse.iitm.ac.in/~sutanuc,HYCDDuoAAAAJ
 Suyash P. Awate,IIT Bombay,https://www.cse.iitb.ac.in/~suyash,xVs3dPgAAAAJ
 Suyun Zhao,Renmin University of China,http://info.ruc.edu.cn/academic_professor.php?teacher_id=37,Nbvw280AAAAJ
 Suzan Arslanturk,Wayne State University,http://suzanars.eng.wayne.edu/index.html,08yfzbMAAAAJ
-Suzan Uskudarli,Boğaziçi University,http://www.cmpe.boun.edu.tr/~uskudarli,NOSCHOLARPAGE
 Suzan Üsküdarli,Boğaziçi University,http://www.cmpe.boun.edu.tr/~uskudarli,NOSCHOLARPAGE
+Suzan Uskudarli,Boğaziçi University,http://www.cmpe.boun.edu.tr/~uskudarli,NOSCHOLARPAGE
 Suzanne Embury,University of Manchester,http://www.cs.man.ac.uk/~embury,ALuTB-gAAAAJ
 Suzanne M. Shontz,University of Kansas,http://people.eecs.ku.edu/~shontz,NOSCHOLARPAGE
 Suzanne Mello-Stark,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/sim.html,NOSCHOLARPAGE
@@ -2261,10 +2269,3 @@ Szymon Jaroszewicz,IPI PAN,https://ipipan.waw.pl/instytut/pracownicy/szymon-jaro
 Szymon M. Rusinkiewicz,Princeton University,https://www.cs.princeton.edu/~smr,RaScARwAAAAJ
 Szymon Rusinkiewicz,Princeton University,https://www.cs.princeton.edu/~smr,RaScARwAAAAJ
 Szymon Torunczyk,University of Warsaw,http://www.mimuw.edu.pl/~szymtor,lclvl94AAAAJ
-Søren Debois,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/soeren-debois(d3b41838-e2bf-4735-b1cd-03f60b49c7e5).html,okin7NMAAAAJ
-Søren Hauberg,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
-Søren I. Olsen,University of Copenhagen,http://diku.dk/english/staff/?pure=en/persons/5264,NOSCHOLARPAGE
-Søren Ingvor Olsen,University of Copenhagen,http://diku.dk/english/staff/?pure=en/persons/5264,NOSCHOLARPAGE
-Søren Kimmer Schou Gregersen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
-Søren Knudsen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/soeren-knudsen(2575c800-642d-4984-9c56-41601cf07a26).html,DT6JUdcAAAAJ
-Søren Lauesen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/soeren-lauesen(ea6d10cf-6bb5-4414-8966-f1ed2591f794).html,NOSCHOLARPAGE

--- a/csrankings-t.csv
+++ b/csrankings-t.csv
@@ -26,12 +26,12 @@ Tadayoshi Kohno,University of Washington,http://homes.cs.washington.edu/~yoshi,s
 Tae Hyun Kim 0006,Hanyang University,https://sites.google.com/site/lliger9/home,NOSCHOLARPAGE
 Tae Oh,Rochester Institute of Technology,https://www.rit.edu/gccis/computingsecurity/people/tom-oh,ugbZoXwAAAAJ
 Tae-Eui	Kam,Korea University,http://mailab.korea.ac.kr,y7B2OsUAAAAJ
+Tae-Hyun Oh,POSTECH,https://ami.postech.ac.kr,dMCBjeIAAAAJ
 Tae-Kyun Kim,KAIST,https://sites.google.com/view/tkkim,j2WcLecAAAAJ
 Taegyu Kim,Pennsylvania State University,https://tgkim.gitlab.io,XYW3vWEAAAAJ
 Taeho Jung,University of Notre Dame,https://sites.nd.edu/taeho-jung,j7wN3bYAAAAJ
 Taehwan Kim,UNIST,https://sites.google.com/view/taehwankim,5dGWexcAAAAJ
 Taehyun Kim 0002,Seoul National University,https://cse.snu.ac.kr/en/professor/taehyun-kim,xLVkHSAAAAAJ
-Tae-Hyun Oh,POSTECH,https://ami.postech.ac.kr,dMCBjeIAAAAJ
 Taehyun Rhee,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/TaehyunRhee,ESQ0x2UAAAAJ
 Taejoon Park,Hanyang University,http://cai.hanyang.ac.kr/sub2_1.php,ijf6dGMAAAAJ
 Taejoong Chung,Virginia Tech,https://taejoong.github.io,_0mWbaoAAAAJ
@@ -48,8 +48,8 @@ Tai Sing Lee,Carnegie Mellon University,http://www.cnbc.cmu.edu/~tai,9TAiIIMAAAA
 Taieb F. Znati,University of Pittsburgh,https://cs.pitt.edu/~znati,UnixVNQAAAAJ
 Taieb Znati,University of Pittsburgh,https://cs.pitt.edu/~znati,UnixVNQAAAAJ
 Taiji Suzuki,University of Tokyo,http://ibis.t.u-tokyo.ac.jp/suzuki,x8osrBsAAAAJ
-Taisook Han,KAIST,https://cs.kaist.ac.kr/people/view?idx=32&kind=faculty&menu=160,NOSCHOLARPAGE
 Taisong Jin,Xiamen University,https://cs.xmu.edu.cn/info/1009/2169.htm,YoI65-0AAAAJ
+Taisook Han,KAIST,https://cs.kaist.ac.kr/people/view?idx=32&kind=faculty&menu=160,NOSCHOLARPAGE
 Taisuke Boku,University of Tsukuba,http://www.hpcs.cs.tsukuba.ac.jp/~taisuke/index-e.html,fL8Q3_IAAAAJ
 Taisuke Kobayashi,National Institute of Informatics,https://www.nii.ac.jp/en/faculty/informatics/kobayashi_taisuke/,_osNFzIAAAAJ
 Taisy Silva Weber,UFRGS,https://www.inf.ufrgs.br/site/docente/taisy-silva-weber,e62RF40AAAAJ
@@ -67,8 +67,8 @@ Takashi Inui,University of Tsukuba,http://www.nlp.mibel.cs.tsukuba.ac.jp/~inui/e
 Takashi Ishida 0002,Tokyo Institute of Technology,http://www.cb.cs.titech.ac.jp/en,kudXipEAAAAJ
 Takashi Kobayashi 0001,Tokyo Institute of Technology,http://www.sa.cs.titech.ac.jp/en,QTY3pv0AAAAJ
 Takashi Kohno,University of Tokyo,http://www.sat.t.u-tokyo.ac.jp/~kohno,0ls8AgsAAAAJ
-Takatsune Kumada,Kyoto University,http://www.genome.ist.i.kyoto-u.ac.jp/index.en.html,NOSCHOLARPAGE
 Takashi Kurimoto,National Institute of Informatics,https://www.nii.ac.jp/en/faculty/architecture/kurimoto_takashi/,NOSCHOLARPAGE
+Takatsune Kumada,Kyoto University,http://www.genome.ist.i.kyoto-u.ac.jp/index.en.html,NOSCHOLARPAGE
 Takayasu Matsuo,University of Tokyo,http://www.sr3.t.u-tokyo.ac.jp/~matsuo/eprof.html,NOSCHOLARPAGE
 Takayuki Kanda,Kyoto University,http://www.robot.soc.i.kyoto-u.ac.jp/~kanda,BL9EACgAAAAJ
 Takayuki Mizuno,National Institute of Informatics,http://research.nii.ac.jp/~mizuno/en/index.html,RPEVIW0AAAAJ
@@ -159,9 +159,9 @@ Tao Zhou 0001,UESTC,http://www.bigdata-research.org/people/faculty/4.html,MXgWgm
 Taolue Chen,Birkbeck University of London,https://www.dcs.bbk.ac.uk/about/people/academic-staff/taolue-chen,Qv_-WU4AAAAJ
 Tapan K. Saha,University of Queensland,http://researchers.uq.edu.au/researcher/83,v6njRnAAAAAJ
 Tapan Kumar Saha,University of Queensland,http://researchers.uq.edu.au/researcher/83,v6njRnAAAAAJ
-Tapomayukh Bhattacharjee,Cornell University,http://www.tapomayukh.com,X1zsXTgAAAAJ
 Tapio Elomaa,Tampere University,https://www.tuni.fi/en/tapio-elomaa,v_krQFEAAAAJ
 Tapio Lokki,Aalto University,https://users.aalto.fi/~ktlokki,vz4vC1cAAAAJ
+Tapomayukh Bhattacharjee,Cornell University,http://www.tapomayukh.com,X1zsXTgAAAAJ
 Tara Javidi,Univ. of California - San Diego,https://tjavidi.eng.ucsd.edu,G5Sg9DEAAAAJ
 Tarek ElFouly,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/tarek.php,fItzV6EAAAAJ
 Tarek Elfouly,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/tarek.php,fItzV6EAAAAJ
@@ -202,7 +202,7 @@ Taylor Johnson,Vanderbilt University,http://www.TaylorTJohnson.com,MdTkXNYAAAAJ
 Taylor T. Johnson,Vanderbilt University,http://www.TaylorTJohnson.com,MdTkXNYAAAAJ
 Te Taka Keegan,University of Waikato,http://www.cms.waikato.ac.nz/people/tetaka,qo3DLSkAAAAJ
 Teck Khim Ng,National University of Singapore,https://www.comp.nus.edu.sg/~ngtk,NOSCHOLARPAGE
-Ted "Taekyoung" Kwon,Seoul National University,http://mmlab.snu.ac.kr/~tk,ruxWSFsAAAAJ
+"Ted ""Taekyoung"" Kwon",Seoul National University,http://mmlab.snu.ac.kr/~tk,ruxWSFsAAAAJ
 Ted Brekken,Oregon State University,http://eecs.oregonstate.edu/people/brekken-ted,NOSCHOLARPAGE
 Ted Briscoe,MBZUAI,https://mbzuai.ac.ae/study/faculty/ted-briscoe,qNP6lAwAAAAJ
 Ted Herman,University of Iowa,http://homepage.cs.uiowa.edu/~herman,89vejUwAAAAJ
@@ -215,6 +215,7 @@ Tei-Wei Kuo,City University of Hong Kong,http://www.cityu.edu.hk/stfprofile/teiw
 Tejasvi Anand,Oregon State University,http://eecs.oregonstate.edu/people/anand-tejasvi,CKVSMxcAAAAJ
 Tek-Jin Nam,KAIST,http://cidr.kaist.ac.kr/members,C6Geq6AAAAAJ
 Telikepalli Kavitha,Tata Inst. of Fundamental Research,http://www.tcs.tifr.res.in/~kavitha,NOSCHOLARPAGE
+Telmo Zarraonandia,Universidad Carlos III de Madrid,https://dei.inf.uc3m.es/portal/?page=people-personal&id=9006,55BxFqIAAAAJ
 Temuulen Sankey,Northern Arizona University,https://nau.edu/cefns/natsci/seses/faculty/teki-sankey,3zszVGYAAAAJ
 Ten-Hwang Lai,Ohio State University,http://web.cse.ohio-state.edu/~lai,NOSCHOLARPAGE
 Teng Han,Chinese Academy of Sciences,http://teng-han.com,kHKwQ9gAAAAJ
@@ -233,6 +234,7 @@ Teresa K. Attwood,University of Manchester,https://www.research.manchester.ac.uk
 Teresa Maria Sa Ferreira Vazão Vasques,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist12922,NOSCHOLARPAGE
 Teresa Maria Vazão,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist12922,NOSCHOLARPAGE
 Teresa Mendes de Almeida,Universidade de Lisboa,https://sotis.tecnico.ulisboa.pt/researcher/ist13143,TWs2MCUAAAAJ
+Teresa Onorati,Universidad Carlos III de Madrid,https://dei.inf.uc3m.es/portal/?page=people-personal&id=9015,2VT20XIAAAAJ
 Teresa Romão,Universidade NOVA de Lisboa,http://www-ctp.di.fct.unl.pt/~tir,lMXOPKQAAAAJ
 Teresita Limoanco,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742696123&command=GETPROFILE,HzJ_T8QAAAAJ
 Tereza Klimosová,Ecole Normale Superieure de Lyon,http://iuuk.mff.cuni.cz/~tereza,NOSCHOLARPAGE
@@ -504,6 +506,7 @@ Tianshi Chen 0001,CUHK (SZ),https://sds.cuhk.edu.cn/en/teacher/265,CO48-XMAAAAJ
 Tianshu Qu,Peking University,http://www.cis.pku.edu.cn/auditory/Staff/Dr.Qu.html,WztllNMAAAAJ
 Tianshu Yu,CUHK (SZ),https://mypage.cuhk.edu.cn/academics/yutianshu/,MTHO7DsAAAAJ
 Tianwei Zhang,Nanyang Technological University,https://personal.ntu.edu.sg/tianwei.zhang,9vpiYDIAAAAJ
+Tianxi Ji,Texas Tech University,http://www.myweb.ttu.edu/tiji,oWXZWPoAAAAJ
 Tianyi Zhang 0001,Purdue University,https://tianyi-zhang.github.io,zGo44SQAAAAJ
 Tianyi Zhou,University of Maryland - College Park,https://www.umiacs.umd.edu/people/tianyizh,OKvgizMAAAAJ
 Tianyin Xu,Univ. of Illinois at Urbana-Champaign,https://tianyin.github.io,h5ZyE5wAAAAJ
@@ -551,7 +554,6 @@ Tim Althoff,University of Washington,http://www.timalthoff.com,yc4nBNgAAAAJ
 Tim B. Dyrby,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Tim Baarslag,Utrecht University,https://homepages.cwi.nl/~baarslag,Ic5t92AAAAAJ
 Tim Baldwin,MBZUAI,https://mbzuai.ac.ae/study/faculty/timothy-baldwin,wjBD1dkAAAAJ
-Tim D. Barfoot,University of Toronto,http://asrl.utias.utoronto.ca/~tdb,N_vPIhoAAAAJ
 Tim Beißbarth,University of Göttingen,http://bioinformatics.umg.eu,xKN6zUsAAAAJ
 Tim Bell,University of Canterbury,http://www.cosc.canterbury.ac.nz/tim.bell,NOSCHOLARPAGE
 Tim Bjørn Dyrby,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
@@ -559,6 +561,7 @@ Tim Blackwell,Goldsmiths University of London,https://www.gold.ac.uk/computing/s
 Tim Brecht,University of Waterloo,https://cs.uwaterloo.ca/~brecht,74nBKe8AAAAJ
 Tim Chen,University of Technology Sydney,https://www.uts.edu.au/staff/tim.chen,UgJAkMgAAAAJ
 Tim Chen 0001,University of Technology Sydney,https://www.uts.edu.au/staff/tim.chen,UgJAkMgAAAAJ
+Tim D. Barfoot,University of Toronto,http://asrl.utias.utoronto.ca/~tdb,N_vPIhoAAAAJ
 Tim Dwyer,Monash University,http://marvl.infotech.monash.edu/~dwyer,cOEUhBAAAAAJ
 Tim Erhan Güneysu,Ruhr-University Bochum,http://www.seceng.rub.de/chair/staff/gueneysu,QrXiIS0AAAAJ
 Tim Fernando,Trinity College Dublin,https://www.scss.tcd.ie/Tim.Fernando,NOSCHOLARPAGE
@@ -606,8 +609,8 @@ Timothy Griffin,University of Cambridge,https://www.cl.cam.ac.uk/~tgg22,bNZfDVgA
 Timothy J. Ellis,Nova Southeastern University,https://cec.nova.edu/faculty/ellis.html,NOSCHOLARPAGE
 Timothy J. Hickey,Brandeis University,http://www.cs.brandeis.edu/~tim,APFVA6sAAAAJ
 Timothy J. Norman,University of Southampton,https://www.ecs.soton.ac.uk/people/tjn1f15,8Rt0X9AAAAAJ
-Timothy L. Andersen,Boise State University,http://cs.boisestate.edu/~tim,mTErwxgAAAAJ
 Timothy J. O'Donnell,McGill University,https://mcqll.org/people/odonnell.timothy/,iYjXhYwAAAAJ
+Timothy L. Andersen,Boise State University,http://cs.boisestate.edu/~tim,mTErwxgAAAAJ
 Timothy Lethbridge,University of Ottawa,http://www.site.uottawa.ca/~tcl,PQ9tLbUAAAAJ
 Timothy M. Chan,Univ. of Illinois at Urbana-Champaign,http://tmc.web.engr.illinois.edu,NOSCHOLARPAGE
 Timothy M. Hospedales,University of Edinburgh,http://homepages.inf.ed.ac.uk/thospeda,nHhtvqkAAAAJ
@@ -669,6 +672,7 @@ Tobias Höllerer,Univ. of California - Santa Barbara,http://www.cs.ucsb.edu/~hol
 Tobias Hossfeld,University of Würzburg,http://www.comnet.informatik.uni-wuerzburg.de/team/mitarbeiter/hossfeld,AdGp9e0AAAAJ
 Tobias Hoßfeld,University of Würzburg,http://www.comnet.informatik.uni-wuerzburg.de/team/mitarbeiter/hossfeld,AdGp9e0AAAAJ
 Tobias Knopp,Hamburg University of Technology,https://www.tuhh.de/ibi/people/tobias-knopp-head-of-institute.html,5gpkOBAAAAAJ
+Tobias Koch 0001,Universidad Carlos III de Madrid,https://www.tsc.uc3m.es/~koch/,3UUIjLMAAAAJ
 Tobias Kramer,University of Koblenz-Landau,https://www.uni-koblenz-landau.de/de/koblenz/fb4/ifm/mud/team/tobias-kraemer,19ZQCsMAAAAJ
 Tobias Kuhn,VU Amsterdam,http://www.tkuhn.org,26_NNqEAAAAJ
 Tobias Meisen,University of Wuppertal,https://www.tmdt.uni-wuppertal.de/de/team/tobias-meisen-prof-dr-ing.html,fSmbntoAAAAJ
@@ -786,13 +790,13 @@ Tomohiro Yoneda,National Institute of Informatics,https://www.nii.ac.jp/en/facul
 Tomomi Matsui,Tokyo Institute of Technology,http://tomomi.my.coocan.jp/welcomeE.html,6lYy6-QAAAAJ
 Tomoyuki Takahata,University of Tokyo,http://www.leopard.t.u-tokyo.ac.jp/~takahata,NOSCHOLARPAGE
 Tona Henderson,Rochester Institute of Technology,https://www.rit.edu/gccis/igm/tona-henderson,NOSCHOLARPAGE
+Tong Geng,University of Rochester,https://www.tonytgeng.com/,1B_nk28AAAAJ
 Tong Lin,Peking University,http://www.cis.pku.edu.cn/faculty/vision/lintong/default.htm,NOSCHOLARPAGE
 Tong Lu,Nanjing University,https://cs.nju.edu.cn/lutong,NOSCHOLARPAGE
 Tong Xu 0001,USTC,http://staff.ustc.edu.cn/~tongxu,2pYJyYUAAAAJ
 Tong Yang 0003,Peking University,https://yangtonghome.github.io,zYDaX-4AAAAJ
 Tong Zhang 0001,HKUST,http://tongzhang-ml.org,LurWtuYAAAAJ
 Tong Zhao 0001,Peking University,http://net.pku.edu.cn/~zt,NOSCHOLARPAGE
-Tong Geng,University of Rochester,https://www.tonytgeng.com/,1B_nk28AAAAJ
 Tong-Yee Lee,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/depmember/teacherdetail/id/8,V3PTB98AAAAJ
 Tongliang Liu,University of Sydney,https://www.sydney.edu.au/engineering/about/our-people/academic-staff/tongliang-liu.html,EiLdZ_YAAAAJ
 Tongwei Ren,Nanjing University,https://software.nju.edu.cn//rentw/index.html,WtnXVHoAAAAJ
@@ -829,13 +833,13 @@ Tony White,Carleton University,https://carleton.ca/scs/people/tony-white,EkUL_2k
 Tony Wirth,University of Melbourne,http://people.eng.unimelb.edu.au/awirth,qVuN4MIAAAAJ
 Tor Helleseth,University of Bergen,http://www.ii.uib.no/~torh,NOSCHOLARPAGE
 Tor M. Aamodt,University of British Columbia,https://www.ece.ubc.ca/~aamodt,zCsB5XsAAAAJ
+Torben Æ. Mogensen,University of Copenhagen,http://www.diku.dk/~torbenm,vjvvUioAAAAJ
+Torben Ægidius Mogensen,University of Copenhagen,http://www.diku.dk/~torbenm,vjvvUioAAAAJ
 Torben Amtoft,Kansas State University,http://cis.ksu.edu/~tamtoft,NOSCHOLARPAGE
 Torben Amtoft Hansen,Kansas State University,http://cis.ksu.edu/~tamtoft,NOSCHOLARPAGE
 Torben Bach Pedersen,Aalborg University,http://people.cs.aau.dk/~tbp,XGzPuKEAAAAJ
 Torben Hagerup,University of Augsburg,https://thiserver.informatik.uni-augsburg.de/personen/hagerup.html,NOSCHOLARPAGE
 Torben Weis,University of Duisburg-Essen,https://www.vs.uni-due.de/mitarbeiter_weis.shtml,f2gnBw0AAAAJ
-Torben Æ. Mogensen,University of Copenhagen,http://www.diku.dk/~torbenm,vjvvUioAAAAJ
-Torben Ægidius Mogensen,University of Copenhagen,http://www.diku.dk/~torbenm,vjvvUioAAAAJ
 Tore Risch,Uppsala University,http://user.it.uu.se/~torer,NOSCHOLARPAGE
 Torleiv Kløve,University of Bergen,http://www.ii.uib.no/~torleiv/engelsk.html,NOSCHOLARPAGE
 Torsten Braun,University of Bern,http://www.iam.unibe.ch/~braun,eL8OzgIAAAAJ
@@ -905,6 +909,7 @@ Troels Bjerre Lund,IT University of Copenhagen,http://www.itu.dk/people/trbj,2tO
 Troels Bjerre Sørensen,IT University of Copenhagen,http://www.itu.dk/people/trbj,2tOriSoAAAAJ
 Trond Aalberg,NTNU,https://www.ntnu.edu/employees/trondaal,8UTZJ0wAAAAJ
 Trond Steihaug,University of Bergen,http://www.ii.uib.no/~trond,NOSCHOLARPAGE
+Trong Nghia Hoang,Washington State University,https://school.eecs.wsu.edu/faculty/profile/?nid=trongnghia.hoang,E-kZZeQAAAAJ
 Troy Bruggemann,Queensland University of Technology,https://research.qut.edu.au/qcr/people/troy-bruggemann,WcumWs8AAAAJ
 Troy Lee,University of Technology Sydney,https://www.uts.edu.au/staff/troy.lee,iSjOah4AAAAJ
 Troy McDaniel,Arizona State University,https://search.asu.edu/profile/286669,jn0yx4QAAAAJ
@@ -912,7 +917,6 @@ Trung Q. Duong,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Co
 Trung Quang Duong,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=trung.q.duong,PwsDdmEAAAAJ
 Truong Nghiem,Northern Arizona University,https://nau.edu/siccs/faculty,ELMp9FMAAAAJ
 Truong X. Nghiem,Northern Arizona University,https://nau.edu/siccs/faculty,ELMp9FMAAAAJ
-Trong Nghia Hoang,Washington State University,https://school.eecs.wsu.edu/faculty/profile/?nid=trongnghia.hoang,E-kZZeQAAAAJ
 Tsaipei Wang,National Chiao Tung University,http://www.cis.nctu.edu.tw/~wangts,NOSCHOLARPAGE
 Tse-Hsun (Peter) Chen,Concordia University,http://petertsehsun.github.io,gUBD7x0AAAAJ
 Tse-Hsun Chen,Concordia University,http://petertsehsun.github.io,gUBD7x0AAAAJ
@@ -947,8 +951,8 @@ Tun Lu,Fudan University,http://cscw.fudan.edu.cn/%E7%A7%91%E7%A0%94%E9%98%9F%E4%
 Tuna Tugcu,Boğaziçi University,http://www.cmpe.boun.edu.tr/~tugcu,aN_VUtQAAAAJ
 Tunca Dogan,Hacettepe University,http://yunus.hacettepe.edu.tr/~tuncadogan,tHnMNPEAAAAJ
 Tung Nguyen,Utah State University,http://www.math.usu.edu/nnguyen,NOSCHOLARPAGE
-Tunga Gungor,Boğaziçi University,https://www.cmpe.boun.edu.tr/~gungort,oymuGoYAAAAJ
 Tunga Güngör,Boğaziçi University,https://www.cmpe.boun.edu.tr/~gungort,oymuGoYAAAAJ
+Tunga Gungor,Boğaziçi University,https://www.cmpe.boun.edu.tr/~gungort,oymuGoYAAAAJ
 Tuo Zhao,Georgia Institute of Technology,https://www2.isye.gatech.edu/~tzhao80,EJXN6tYAAAAJ
 Tuomas Aura,Aalto University,https://people.aalto.fi/new/tuomas.aura,izj4P5gAAAAJ
 Tuomas Sandholm,Carnegie Mellon University,http://www.cs.cmu.edu/~sandholm,0DpK1EMAAAAJ
@@ -971,4 +975,3 @@ Tzipora Halevi,CUNY,https://thalevi.github.io/,LgwWoI0AAAAJ
 Tzonelih Hwang,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/depmember/teacherdetail/id/4,NOSCHOLARPAGE
 Tzu-Chien Hsiao,National Chiao Tung University,https://sites.google.com/site/labview704/About-Us/TC,JPMrsz0AAAAJ
 Tzu-Mao Li,Univ. of California - San Diego,https://people.csail.mit.edu/tzumao,Y7MCOdYAAAAJ
-Tianxi Ji,Texas Tech University,http://www.myweb.ttu.edu/tiji,oWXZWPoAAAAJ

--- a/csrankings-v.csv
+++ b/csrankings-v.csv
@@ -35,6 +35,7 @@ Vaithianathan Mani Venkatasubramanian,Washington State University,http://www.eec
 Val Breazu-Tannen,University of Pennsylvania,http://www.cis.upenn.edu/~val,NOSCHOLARPAGE
 Val Tannen,University of Pennsylvania,http://www.cis.upenn.edu/~val,NOSCHOLARPAGE
 Valdis Berzins,Naval Postgraduate School,http://faculty.nps.edu/berzins/NPSVita_berzins.htm,NOSCHOLARPAGE
+Valentin Moreno 0001,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-378,QCdCh8QAAAAJ
 Valentina A. M. Tamma,University of Liverpool,http://www.csc.liv.ac.uk/~valli,tYimqvsAAAAJ
 Valentina Boeva,ETH Zurich,http://boevalab.inf.ethz.ch,f196u4IAAAAJ
 Valentina Nisi,Universidade de Lisboa,https://www.valentinanisi.com,1vA3h5IAAAAJ
@@ -61,6 +62,7 @@ Vanderlei Bonato,USP-ICMC,http://lcr.icmc.usp.br/web/members/vanderlei-bonato/in
 Vanessa Braganholo,UFF,http://www2.ic.uff.br/~vanessa,QT9-AZ4AAAAJ
 Vanessa Braganholo Murta,UFF,http://www2.ic.uff.br/~vanessa,QT9-AZ4AAAAJ
 Vanessa Frías-Martínez,University of Maryland - College Park,https://www.cs.umd.edu/people/vfrias,R0L7Y50AAAAJ
+Vanessa Gómez-Verdejo,Universidad Carlos III de Madrid,https://vanessa.webs.tsc.uc3m.es/,Z2IZij0AAAAJ
 Vanessa J. Teague,University of Melbourne,https://people.eng.unimelb.edu.au/vjteague,3CVS_xYAAAAJ
 Vanessa P. Braganholo,UFF,http://www2.ic.uff.br/~vanessa,QT9-AZ4AAAAJ
 Vanessa Teague,University of Melbourne,https://people.eng.unimelb.edu.au/vjteague,3CVS_xYAAAAJ
@@ -194,6 +196,7 @@ Victor J. Milenkovic,University of Miami,http://www.cs.miami.edu/~vjm,NOSCHOLARP
 Victor Jauregui,UNSW,https://www.cse.unsw.edu.au/~vicj,NOSCHOLARPAGE
 Victor Manuel Fragoso,West Virginia University,https://www.statler.wvu.edu/faculty-staff/faculty/victor-fragoso,7XBDDigAAAAJ
 Victor Milenkovic,University of Miami,http://www.cs.miami.edu/~vjm,NOSCHOLARPAGE
+Víctor P. Gil Jiménez,Universidad Carlos III de Madrid,https://www.tsc.uc3m.es/~vgil/index_e.html,NOSCHOLARPAGE
 Victor Pan,CUNY,http://comet.lehman.cuny.edu/vpan,9-i5_74AAAAJ
 Victor S. Frost,University of Kansas,http://www.ittc.ku.edu/~frost,0E00iT0AAAAJ
 Victor Sanchez,University of Warwick,https://www.dcs.warwick.ac.uk/~vsanchez/Victor_Sanchez/Victor_Sanchez.html,49PNoKwAAAAJ

--- a/csrankings-y.csv
+++ b/csrankings-y.csv
@@ -20,6 +20,7 @@ Yael Amsterdamer,Bar-Ilan University,https://u.cs.biu.ac.il/~amstery,70iHzEUAAAA
 Yafei Dai,Peking University,http://eecs.pku.edu.cn/EN/People/Faculty/Detail/?ID=5999,VSvWlvkAAAAJ
 Yagiz Aksoy,Simon Fraser University,https://www.cs.sfu.ca/~yagiz,AC445kUAAAAJ
 Yağmur Güçlütürk,Radboud University,https://www.ru.nl/english/people/gucluturk-y,X2vDok4AAAAJ
+Yago Saez,Universidad Carlos III de Madrid,https://www.uc3m.es/ss/Satellite/DeptInformatica/es/DetallePersonalDept/1371330169576/idu-2626,iKfC0N0AAAAJ
 Yahya M. Tashtoush,JUST,http://www.just.edu.jo/eportfolio/Pages/Default.aspx?email=yahya-t,7lMW0DYAAAAJ
 Yair Amir,Johns Hopkins University,http://www.cs.jhu.edu/~yairamir,NOSCHOLARPAGE
 Yair Bartal,Hebrew University of Jerusalem,http://www.cs.huji.ac.il/~yair,eCXP24kAAAAJ
@@ -41,7 +42,6 @@ Yan (Michael) Zhang,Peking University,http://www.cis.pku.edu.cn/faculty/system/z
 Yan Cai 0001,Chinese Academy of Sciences,http://lcs.ios.ac.cn/~yancai,QotyxBEAAAAJ
 Yan Chen 0004,Northwestern University,http://www.cs.northwestern.edu/~ychen,98iA_ooAAAAJ
 Yan Chen 0007,UESTC,http://faculty.uestc.edu.cn/cyan,NOSCHOLARPAGE
-Yang Feng 0003,Nanjing University,https://fengyang-nju.github.io,FaMWKcsAAAAJ
 Yan Gu 0001,Univ. of California - Riverside,https://people.csail.mit.edu/guyan,BmshmX8AAAAJ
 Yan Hu,SUSTech,https://faculty.sustech.edu.cn/?p=36047&tagid=liuj&cat=2&iscss=1&snapid=1&orderby=date,NOSCHOLARPAGE
 Yan Huang 0001,Indiana University,http://homes.soic.indiana.edu/yh33,aKpQjaQAAAAJ
@@ -64,12 +64,13 @@ Yan-Qing Zhang,Georgia State University,https://grid.cs.gsu.edu/zhang,NOSCHOLARP
 Yan-Wen Guo 0001,Nanjing University,https://cs.nju.edu.cn/ywguo,NOSCHOLARPAGE
 Yanchun Sun,Peking University,http://sei.pku.edu.cn/~sunyc,NOSCHOLARPAGE
 Yanchun Zhang,Fudan University,http://homepage.fudan.edu.cn/yanchunzhang,Z6oy0YIAAAAJ
-Yanfang Ye 0001,University of Notre Dame,https://engineering.nd.edu/faculty/yanfang-fanny-ye/,egjr888AAAAJ
 Yanfang (Fanny) Ye,University of Notre Dame,https://engineering.nd.edu/faculty/yanfang-fanny-ye/,egjr888AAAAJ
+Yanfang Ye 0001,University of Notre Dame,https://engineering.nd.edu/faculty/yanfang-fanny-ye/,egjr888AAAAJ
 Yang Cai 0001,Yale University,https://cpsc.yale.edu/people/yang-cai,HMa4vcYAAAAJ
 Yang Cao 0001,Virginia Tech,http://people.cs.vt.edu/~ycao,EFD4OrIAAAAJ
 Yang Chen 0001,Fudan University,https://chenyang03.wordpress.com,O6tge4UAAAAJ
 Yang Cindy Yi,Virginia Tech,https://www.yangyi.ece.vt.edu,ceRq6DEAAAAJ
+Yang Feng 0003,Nanjing University,https://fengyang-nju.github.io,FaMWKcsAAAAJ
 Yang Gao 0001,Nanjing University,https://cs.nju.edu.cn/gaoyang,k0jjQo8AAAAJ
 Yang Gao 0021,Royal Holloway University of London,https://pure.royalholloway.ac.uk/portal/en/persons/yang-gao(6a837f7f-07f6-4ac8-b0c7-d6d444016d2f).html,AwoB-SwAAAAJ
 Yang Hao 0001,Queen Mary University of London,http://www.eecs.qmul.ac.uk/~yang,W6hvCOAAAAAJ
@@ -92,8 +93,8 @@ Yang Wang 0005,Univ. of Illinois at Urbana-Champaign,https://yangwang.ischool.il
 Yang Wang 0009,Ohio State University,https://cse.osu.edu/people/wang.7564,NOSCHOLARPAGE
 Yang Xiang,Zhejiang University,http://mypage.zju.edu.cn/yxiang,NOSCHOLARPAGE
 Yang Xiang 0004,University of Guelph,https://www.uoguelph.ca/computing/people/yang-xiang,r71D60UAAAAJ
-Yang Xu 0023,University of Toronto,https://www.cs.toronto.edu/~yangxu/,bbfGi6sAAAAJ
 Yang Xiao 0001,The University of Alabama,http://yangxiao.cs.ua.edu,HSxTENAAAAAJ
+Yang Xu 0023,University of Toronto,https://www.cs.toronto.edu/~yangxu/,bbfGi6sAAAAJ
 Yang Yang 0002,UESTC,http://cfm.uestc.edu.cn/~yangyang,PVv2xDYAAAAJ
 Yang Yang 0009,Zhejiang University,http://yangy.org,NOSCHOLARPAGE
 Yang Yang 0030,Shanghai Jiao Tong University,https://yangy09.github.io/,-PN_6coAAAAJ
@@ -112,8 +113,8 @@ Yangdong Deng,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften
 Yangdong Steve Deng,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2014/20140115102144786540201/20140115102144786540201_.html,NOSCHOLARPAGE
 Yangfan Zhou,Fudan University,http://www.y-droid.com,qPcorFEAAAAJ
 Yangfeng Ji,University of Virginia,https://engineering.virginia.edu/faculty/yangfeng-ji,pg02-e8AAAAJ
-Yangguang Tian,University of Surrey,https://www.surrey.ac.uk/people/yangguang-tian,x477g7cAAAAJ
 Yanggon Kim,Towson University,https://www.towson.edu/fcsm/departments/computerinfosci/facultystaff/ykim.html,NOSCHOLARPAGE
+Yangguang Tian,University of Surrey,https://www.surrey.ac.uk/people/yangguang-tian,x477g7cAAAAJ
 Yanghee Choi,Seoul National University,http://mmlab.snu.ac.kr/~yhchoi,Xm_UZdkAAAAJ
 Yanghua Xiao,Fudan University,http://www.cs.fudan.edu.cn/?page_id=2098,odFW4FoAAAAJ
 Yangming Li,Rochester Institute of Technology,https://people.rit.edu/ymliee,NRMhdgAAAAJ
@@ -134,8 +135,8 @@ Yanjie Fu,University of Central Florida,http://yanjiefu.com,OSArex4AAAAJ
 Yanjing Li,University of Chicago,http://people.cs.uchicago.edu/~yanjingl,NOSCHOLARPAGE
 Yanjun Qi,University of Virginia,https://www.cs.virginia.edu/yanjun,eXKdSu0AAAAJ
 Yanjun Wu,Chinese Academy of Sciences,http://people.ucas.ac.cn/~wuyanjun,hQoP0nkAAAAJ
-Yankui Sun,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101224172326748763790/20101224172326748763790_.html,NOSCHOLARPAGE
 Yankai Lin,Renmin University of China,https://linyankai.github.io/,j8K1FqEAAAAJ
+Yankui Sun,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101224172326748763790/20101224172326748763790_.html,NOSCHOLARPAGE
 Yanli Ji,UESTC,https://www.en.scse.uestc.edu.cn/info/1085/1910.htm,aGbEdhEAAAAJ
 Yanlin Weng,Zhejiang University,http://www.cs.zju.edu.cn/chinese/redir.php?catalog_id=22284&object_id=116229,NOSCHOLARPAGE
 Yanmin Qian,Shanghai Jiao Tong University,https://x-lance.sjtu.edu.cn/en/members/yanmin-qian,guG9lxgAAAAJ
@@ -335,8 +336,8 @@ Yimin Yang,Xidian University,https://web.xidian.edu.cn/ymyang/,RqH1weAAAAAJ
 Yiming Hu,University of Cincinnati,http://www.ece.uc.edu/~yhu,NOSCHOLARPAGE
 Yiming Miao,CUHK (SZ),https://myweb.cuhk.edu.cn/miaoyiming,uKUBH38AAAAJ
 Yiming Qian,University of Manitoba,https://yi-ming-qian.github.io,2xMfNpMAAAAJ&hl
-Yiming Yang,Carnegie Mellon University,http://www.cs.cmu.edu/~./yiming,MlZq4XwAAAAJ
 Yiming Xiao,Concordia University,http://www.healthx-lab.ca/,ELHjilEAAAAJ
+Yiming Yang,Carnegie Mellon University,http://www.cs.cmu.edu/~./yiming,MlZq4XwAAAAJ
 Yiming Zhang 0003,Xiamen University,http://nicexlab.com/zym.htm,c_EpscEAAAAJ
 Yin Pan,Rochester Institute of Technology,https://www.rit.edu/gccis/computingsecurity/people/yin-pan,SHJ98SkAAAAJ
 Yin Tat Lee,University of Washington,http://yintat.com,nwHfwCIAAAAJ
@@ -376,8 +377,8 @@ Yingmin Tang,Peking University,http://www.icst.pku.edu.cn/cscl?page_id=22,NOSCHO
 Yingshu Li,Georgia State University,https://grid.cs.gsu.edu/yli,sgiysmUAAAAJ
 Yingwei Luo,Peking University,http://gis.pku.edu.cn/lab/people/lyw.htm,NOSCHOLARPAGE
 Yingxia Shao,BUPT,https://shaoyx.github.io,h6gVF8YAAAAJ
-Yingying Zhu,University of Texas at Arlington,https://zyy123jy.github.io/My-Web-Sites,PMjtni8AAAAJ
 Yingxue Zhang 0002,Binghamton University,https://www.binghamton.edu/computer-science/people/profile.html?id=yzhang42,8rVes9sAAAAJ
+Yingying Zhu,University of Texas at Arlington,https://zyy123jy.github.io/My-Web-Sites,PMjtni8AAAAJ
 Yingyu Liang,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~yliang,_RVvnS4AAAAJ
 Yingzhen Li,Imperial College London,http://yingzhenli.net/home/en/?page_id=345,gcfs8N8AAAAJ
 Yingzhen Yang,Arizona State University,https://search.asu.edu/profile/3520440,36vh2hgAAAAJ
@@ -471,6 +472,7 @@ Yong Xiang 0002,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4
 Yong Xu 0001,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/xuyong,zOVgYQYAAAAJ
 Yong Yu 0001,Shanghai Jiao Tong University,http://english.seiee.sjtu.edu.cn/english/detail/841_695.htm,-84M1m0AAAAJ
 Yong Zhao 0009,UESTC,https://www.en.scse.uestc.edu.cn/info/1085/1897.htm,3mixb94AAAAJ
+Yong Zhou 0006,ShanghaiTech University,https://faculty.sist.shanghaitech.edu.cn/faculty/zhouyong/Index.html,8bpAwKcAAAAJ
 Yong-Jin Liu,Tsinghua University,http://media.cs.tsinghua.edu.cn/en/liuyj,GNDtwWQAAAAJ
 Yong-Lae Park,Carnegie Mellon University,http://www.cs.cmu.edu/~ylpark,kBsTE7AAAAAJ
 Yong-Liang Yang,University of Bath,http://www.yongliangyang.net,v2etATwAAAAJ
@@ -521,9 +523,8 @@ Yongzhen Huang,Chinese Academy of Sciences,http://www.cripac.ia.ac.cn/irds/Peopl
 Yongzhi Cao,Peking University,http://eecs.pku.edu.cn/EN/People/Faculty/Detail/?ID=6066,VEhLdikAAAAJ
 Yoni Zohar,Bar-Ilan University,https://u.cs.biu.ac.il/~zoharyo1/,WMHRQ-8AAAAJ
 Yonina C. Eldar,Weizmann Institute of Science,https://www.weizmann.ac.il/pages/search/people?language=english&single=1&person_id=67601,vyX6kpwAAAAJ
-Yong Zhou 0006,ShanghaiTech University,https://faculty.sist.shanghaitech.edu.cn/faculty/zhouyong/Index.html,8bpAwKcAAAAJ
-Yoohwan Kim,University of Nevada Las Vegas,http://www.egr.unlv.edu/~yoohwan,AnCg3JwAAAAJ
 YooJung Choi,Arizona State University,https://yoojungchoi.github.io,VCtamFwAAAAJ
+Yoohwan Kim,University of Nevada Las Vegas,http://www.egr.unlv.edu/~yoohwan,AnCg3JwAAAAJ
 Yoon Joon Lee,KAIST,http://dbserver.kaist.ac.kr/~yjlee,8NDnZuEAAAAJ
 Yoonsang Lee 0001,Hanyang University,https://sites.google.com/view/cgrlab/people,s_lHZHsAAAAJ
 Yoonsik Cheon,University of Texas - El Paso,http://www.cs.utep.edu/cheon,NOSCHOLARPAGE
@@ -601,7 +602,6 @@ Yu David Liu,Binghamton University,http://www.cs.binghamton.edu/~davidl,_KCqeIEA
 Yu F. Mong,City University of Hong Kong,https://www.cs.cityu.edu.hk/profile/csymong.html,NOSCHOLARPAGE
 Yu Feng 0001,Univ. of California - Santa Barbara,http://fredfeng.github.io,urQ9fNgAAAAJ
 Yu Hong,Soochow University,http://nlp.suda.edu.cn/~hong/index.html,NOSCHOLARPAGE
-Yuhong Nan,Sun Yat-sen University,https://nanyuhong.github.io,tkE-vsEAAAAJ
 Yu Hu 0001,Chinese Academy of Sciences,http://teacher.ucas.ac.cn/~huyu,VPA-MkkAAAAJ
 Yu Hua 0001,HUST,https://csyhua.github.io,jjvTZT8AAAAJ
 Yu Huang 0002,Nanjing University,https://cs.nju.edu.cn/yuhuang,UWquqLIAAAAJ
@@ -630,6 +630,7 @@ Yu Zhang 0030,Harbin Institute of Technology,http://homepage.hit.edu.cn/yzhang,y
 Yu Zhang 0036,Harbin Institute of Technology,http://homepage.hit.edu.cn/zhangyu145,HmQlB2UAAAAJ
 Yu Zhang 0039,HUST,http://faculty.hust.edu.cn/zhangyu1234/en/more/2359266/jsjjgd/index.htm,NOSCHOLARPAGE
 Yu Zhang 0055,Arizona State University,https://search.asu.edu/profile/2206334,n0uRPLgAAAAJ
+Yu Zhou 0027,Shenzhen University,https://yzhouszu.github.io/,7i308qgAAAAJ 
 Yu Zhuang,Texas Tech University,http://www.depts.ttu.edu/cs/faculty/faculty.php?name=Yu%20Zhuang,NOSCHOLARPAGE
 Yu-Bin Yang,Nanjing University,https://cs.nju.edu.cn/yangyubin,kLOKBgUAAAAJ
 Yu-Chee Tseng,National Chiao Tung University,https://sites.google.com/site/yc0405,BvZeOPIAAAAJ
@@ -703,8 +704,8 @@ Yuchun Ma,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/20
 Yudong Chen 0001,University of Wisconsin - Madison,https://pages.cs.wisc.edu/~yudongchen,ze5rCdwAAAAJ
 Yue Cao 0002,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/people/yue-cao,NOSCHOLARPAGE
 Yue Cheng 0001,University of Virginia,http://tddg.github.io,TMGwBH0AAAAJ
-Yue Duan,Illinois Institute of Technology,https://yueduan.github.io,q3rLf5kAAAAJ
 Yue Dong 0002,Univ. of California - Riverside,https://yuedongcs.github.io,WYkn4loAAAAJ
+Yue Duan,Illinois Institute of Technology,https://yueduan.github.io,q3rLf5kAAAAJ
 Yue Gao 0002,Tsinghua University,http://www.gaoyue.org,UTDfWocAAAAJ
 Yue Gao 0005,Shanghai Jiao Tong University,https://gaoyue.sjtu.edu.cn/biography.html,jlweMD8AAAAJ
 Yue Huang 0001,Xiamen University,https://huangyue05.github.io/,smxgn4YAAAAJ
@@ -740,6 +741,7 @@ Yuhang Zhao,University of Wisconsin - Madison,https://www.yuhangz.com,yeNjTZUAAA
 Yuhao Zhang 0001,Shanghai Jiao Tong University,http://www.zyhwtc.com,KORd9DEAAAAJ
 Yuhao Zhu 0001,University of Rochester,http://www.yuhaozhu.com,gyvpAroAAAAJ
 Yuhong Guo,Carleton University,https://carleton.ca/scs/people/yuhong-guo,Q7VKnRYAAAAJ
+Yuhong Nan,Sun Yat-sen University,https://nanyuhong.github.io,tkE-vsEAAAAJ
 Yuhong Yan,Concordia University,http://users.encs.concordia.ca/~yuhong,1LOd4w4AAAAJ
 Yuhua Li,Cardiff University,https://www.cardiff.ac.uk/people/view/1063589-li-yuhua,33T8CtwAAAAJ
 Yuhui Shi,SUSTech,https://faculty.sustech.edu.cn/shiyh,xSvAHWgAAAAJ
@@ -755,6 +757,7 @@ Yulan He 0001,University of Warwick,https://warwick.ac.uk/fac/sci/dcs/people/yul
 Yulei Sui,University of Technology Sydney,https://www.uts.edu.au/staff/yulei.sui,wGHqq1cAAAAJ
 Yulei Wu,University of Exeter,http://emps.exeter.ac.uk/computer-science/staff/yw433,NOSCHOLARPAGE
 Yulia Cherdantseva,Cardiff University,https://www.cardiff.ac.uk/people/view/118119-cherdantseva-yulia,W_CRsMsAAAAJ
+Yulia Gryaditskaya,University of Surrey,https://yulia.gryaditskaya.com/,cBB96b4AAAAJ
 Yulia Timofeeva,University of Warwick,https://warwick.ac.uk/fac/sci/dcs/people/y_timofeeva,ICL9ZiwAAAAJ
 Yulia Tsvetkov,University of Washington,https://homes.cs.washington.edu/~yuliats,SEDPkrsAAAAJ
 Yuliang Zheng 0001,University of Alabama - Birmingham,https://www.uab.edu/cas/news/announcements/item/5394-dr-yuliang-zheng-named-new-chair-of-department-of-computer-and-information-sciences,f2y_I24AAAAJ
@@ -768,8 +771,8 @@ Yuming Zhou,Nanjing University,https://cs.nju.edu.cn/zhouyuming,NOSCHOLARPAGE
 Yun Fu 0001,Northeastern University,http://www1.ece.neu.edu/~yunfu,h-JEcQ8AAAAJ
 Yun Huang 0003,Univ. of Illinois at Urbana-Champaign,https://ischool.illinois.edu/people/yun-huang,QgHcQBsAAAAJ
 Yun Kuen Cheung,Royal Holloway University of London,https://www.cs.rhul.ac.uk/home/ujac002,7rlVH7gAAAAJ
-Yun Lu 0001,University of Victoria,https://yunlupage.wordpress.com/,NOSCHOLARPAGE
 Yun Liang 0001,Peking University,http://ceca.pku.edu.cn/en/team.php?action=show&member_id=14,Ltp8loUAAAAJ
+Yun Lu 0001,University of Victoria,https://yunlupage.wordpress.com/,NOSCHOLARPAGE
 Yun S. Song,Univ. of California - Berkeley,http://www.eecs.berkeley.edu/~yss,NOSCHOLARPAGE
 Yun Sing Koh,University of Auckland,https://www.cs.auckland.ac.nz/~yunsing,0L38IrAAAAAJ
 Yun Xiong,Fudan University,http://www.cs.fudan.edu.cn/?page_id=1979,NOSCHOLARPAGE
@@ -888,5 +891,3 @@ Yvonne Coady,University of Victoria,http://www.cs.uvic.ca/~ycoady,Z4GOmPMAAAAJ
 Yvonne Dittrich,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/yvonne-dittrich(f2136570-f73c-446f-9fb0-6d9e461e2124).html,K6o-8eEAAAAJ
 Yvonne Margaret Howard,University of Southampton,https://www.ecs.soton.ac.uk/people/ymhoward,NOSCHOLARPAGE
 Yvonne Rogers,University College London,https://uclic.ucl.ac.uk/people/yvonne-rogers,qzcYcEAAAAAJ
-Yulia Gryaditskaya,University of Surrey,https://yulia.gryaditskaya.com/,cBB96b4AAAAJ
-Yu Zhou 0027,Shenzhen University,https://yzhouszu.github.io/,7i308qgAAAAJ 


### PR DESCRIPTION
Professors able to tutor phd thesis in the departments of computer science and signal and communications.



