### PR TITLE
Remove faulty Google Scholar link for SM Pizer

### DIFF
--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -1773,7 +1773,7 @@ Stephen John Maybank,Birkbeck University of London,https://www.dcs.bbk.ac.uk/abo
 Stephen Kell,King's College London,https://www.humprog.org/~stephen/,4GHlcNoAAAAJ
 Stephen Lee,University of Pittsburgh,http://www.sci.pitt.edu/faculty-and-research/faculty-directory/stephen-lee,qsjlH3AAAAAJ
 Stephen M. Blackburn,Australian National University,http://users.cecs.anu.edu.au/~steveb,HgSTO7oAAAAJ
-Stephen M. Pizer,University of North Carolina,http://www.cs.unc.edu/~smp,8UCWq-UAAAAJ
+Stephen M. Pizer,University of North Carolina,http://www.cs.unc.edu/~smp,NOSCHOLARPAGE
 Stephen M. Thebaut,University of Florida,https://www.cise.ufl.edu/people/faculty/smt,NOSCHOLARPAGE
 Stephen M. Watt,University of Waterloo,https://uwaterloo.ca/math/about/people/smwatt,O4bB0QkAAAAJ
 Stephen MacNeil,Temple University,http://stevemacn.github.io/,leLEF3wAAAAJ


### PR DESCRIPTION
Stephen Pizer does not have a Google Scholar account. Some knucklehead linked to Steve Kaiser, who works at Pfizer, instead. Lot of rhyming here but they are different, you see...