### PR TITLE
Add IEEE VIS 2022

### DIFF
--- a/util/csrankings.py
+++ b/util/csrankings.py
@@ -625,6 +625,7 @@ CGF_EUROGRAPHICS_Volume = {
 
 # TVCG special handling to count only IEEE VIS
 TVCG_Vis_Volume = {
+    2023: (29, 1),
     2022: (28, 1),
     2021: (27, 2),
     2020: (26, 1),


### PR DESCRIPTION
Hi Emery,

I found that CSrankings have not indexed the IEEE VIS 2022 papers, which were published in the first issue of IEEE TVCG, Vol. 29

DBLP page for Vol. 29: https://dblp.org/db/journals/tvcg/tvcg29.html

This PR doesn't include the regeneration of the DBLP and generated-author-info.csv files. I guess you will be able to more easily regenerate them with the commands.

Thank you!

Best,
Ran