### PR TITLE
Update csrankings-r.csv

### DIFF
--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -598,6 +598,7 @@ Ricardo G. Sanfelice,Univ. of California - Santa Cruz,https://hybrid.soe.ucsc.ed
 Ricardo Gonçalves 0001,Universidade NOVA de Lisboa,https://userweb.fct.unl.pt//~rjrg,i7FluKUAAAAJ
 Ricardo Guerra Marroquim,TU Delft,http://graphics.tudelft.nl/~marroquim,VNSYnOAAAAAJ
 Ricardo Gutierrez-Osuna,Texas A&M University,http://psi.cse.tamu.edu/people/ricardo-gutierrez-osuna,UnuQfEwAAAAJ
+Ricardo Henao,KAUST,https://cemse.kaust.edu.sa/cs/people/person/ricardo-henao,p_mm4-YAAAAJ
 Ricardo J. F. Lopes Pereira,Universidade de Lisboa,http://tagus.inesc-id.pt/~rpereira,25OSsS8AAAAJ
 Ricardo J. G. B. Campello,USP-ICMC,http://icmc.usp.br/pessoas?id=11548141,jh1yfPIAAAAJ
 Ricardo José Gabrielli Barreto Campello,USP-ICMC,http://icmc.usp.br/pessoas?id=11548141,jh1yfPIAAAAJ


### PR DESCRIPTION
Prof. Ricardo Henao is affiliated with the CS Program at KAUST. Please see here for more details: https://cemse.kaust.edu.sa/cs/people/professors. His affiliation in DBLP is being updated as well: https://dblp.org/pid/27/3207.html

