### PR TITLE
Add Jack Valmadre and Dino Sejdinovic to Adelaide

### DIFF
--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -1169,6 +1169,7 @@ Dingwen Tao,Indiana University,https://luddy.indiana.edu/contact/profile/index.h
 Dingzhu Wen,ShanghaiTech University,https://sist.shanghaitech.edu.cn/2020/0707/c7499a264268/page.htm,f-WJ1iAAAAAJ
 Dino Mandrioli,Politecnico di Milano,http://home.deib.polimi.it/mandriol,NOSCHOLARPAGE
 Dino Pedreschi,University of Pisa,http://kdd.isti.cnr.it/homes/pedreschi,5efz6osAAAAJ
+Dino Sejdinovic,University of Adelaide,https://researchers.adelaide.edu.au/profile/dino.sejdinovic,v8Dg1lIAAAAJ
 Diodato Ferraioli,University of Salerno,http://www.di-srv.unisa.it/~ferraioli,kShuH_AAAAAJ
 Diogo Barradas,University of Waterloo,https://cs.uwaterloo.ca/~dbarrada,hJcIUzkAAAAJ
 Diogo R. Ferreira,Universidade de Lisboa,http://web.tecnico.ulisboa.pt/diogo.ferreira,CSEqKy8AAAAJ

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -74,6 +74,7 @@ Jack Poulson,Georgia Institute of Technology,http://ideas.gatech.edu/hg/item/185
 Jack Sampson,Pennsylvania State University,http://www.cse.psu.edu/~jms1257,fSQCT0YAAAAJ
 Jack Snoeyink,University of North Carolina,http://www.cs.unc.edu/~snoeyink,fIoDWp8AAAAJ
 Jack Tumblin,Northwestern University,http://www.cs.northwestern.edu/~jet,NOSCHOLARPAGE
+Jack Valmadre,University of Adelaide,https://researchers.adelaide.edu.au/profile/jack.valmadre,_VSBqL0AAAAJ
 Jack W. Davidson,University of Virginia,https://engineering.virginia.edu/faculty/jack-w-davidson,n7YuWIAAAAAJ
 Jack van Wijk,TU Eindhoven,http://www.win.tue.nl/~vanwijk,1F_eX28AAAAJ
 Jackie Chi Kit Cheung,McGill University,http://cs.mcgill.ca/~jcheung,Um-wmYQAAAAJ


### PR DESCRIPTION
**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track research
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department. Faculty should also have a 75%+ time appointment (check
`old/industry.csv` for faculty who are now more than 25% in industry).

**Updating an affiliation or home page**

- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings-[a-z].csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put `NOSCHOLARPAGE`.

**Adding one or more faculty members (including an entire department)**

- [x] If the department is not yet listed in CSrankings, the entire CS faculty needs to be added (not just one faculty member).

- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings-[a-z].csv` (**the letters correspond to the first letter of the faculty members' names**); include disambiguation suffixes like `0001` as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.

- [x] If DBLP has multiple entries for this person, *all of them need to be listed*. Do not update `dblp-aliases.csv`.

- [x] If the institution you are adding is not in the US,
update `country-info.csv` and add *all* of the faculty in the CS department.