### PR TITLE
Added University of Catania

### DIFF
--- a/country-info.csv
+++ b/country-info.csv
@@ -301,6 +301,7 @@ University of Calgary,canada,ca
 University of Cambridge,europe,uk
 University of Canterbury,australasia,nz
 University of Cape Town,africa,za
+University of Catania,europe,it
 University of Cologne,europe,de
 University of Copenhagen,europe,dk
 University of Crete,europe,gr

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -636,6 +636,7 @@ Alessandro Margara,Politecnico di Milano,http://home.deib.polimi.it/margara,evbp
 Alessandro Mei,Sapienza University of Rome,http://wwwusers.di.uniroma1.it/~mei,eCiUVHcAAAAJ
 Alessandro Moschitti,University of Trento,http://disi.unitn.it/moschitti,vYUDlsEAAAAJ
 Alessandro Orso,Georgia Institute of Technology,http://www.cc.gatech.edu/home/orso,wCfYkMkAAAAJ
+Alessandro Ortis,University of Catania,about:blank,gcztqXgAAAAJ
 Alessandro Panconesi,Sapienza University of Rome,http://www.di.uniroma1.it/a/di.uniroma1.it/panco,kzYoaFYAAAAJ
 Alessandro Pandini,Brunel University London,https://www.brunel.ac.uk/people/alessandro-pandini,6hPiNCgAAAAJ
 Alessandro Provetti,Birkbeck University of London,https://www.dcs.bbk.ac.uk/about/people/academic-staff/alessandro,pwOBPBQAAAAJ
@@ -893,6 +894,7 @@ Alfredo De Santis,University of Salerno,http://www.di.unisa.it/~ads/curriculum.h
 Alfredo Ferreira,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist14275,YtEBFw0AAAAJ
 Alfredo Goldman,USP,http://www.ime.usp.br/~gold,Cgl09uMAAAAJ
 Alfredo Goldman vel Lejbman,USP,http://www.ime.usp.br/~gold,Cgl09uMAAAAJ
+Alfredo Pulvirenti,University of Catania,https://www.dmi.unict.it/~apulvirenti/site/,eU40mWYAAAAJ
 Alfredo Weitzenfeld,University of South Florida,http://robolat.org,0QFPg3oAAAAJ
 Alfredo Weitzenfeld Ridel,University of South Florida,http://robolat.org,0QFPg3oAAAAJ
 Alham Fikri Aji,MBZUAI,https://mbzuai.ac.ae/study/faculty/alham-fikri-aji,0Cyfqv4AAAAJ
@@ -1363,6 +1365,7 @@ Andrea Burattin,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Andrea C. Arpaci-Dusseau,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~dusseau,8VkvOEEAAAAJ
 Andrea C. Dusseau,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~dusseau,8VkvOEEAAAAJ
 Andrea Calì,Birkbeck University of London,https://www.dcs.bbk.ac.uk/about/people/academic-staff/andrea,GfDVWmEAAAAJ
+Andrea Calvagna,University of Catania,https://web.dmi.unict.it/docenti/andrea.calvagna,inoCd6MAAAAJ
 Andrea Capiluppi,Brunel University London,https://www.brunel.ac.uk/people/andrea-capiluppi,pWVTJ3YAAAAJ
 Andrea Cavallaro,Queen Mary University of London,http://www.eecs.qmul.ac.uk/~andrea,KZmcljoAAAAJ
 Andrea Celli,Bocconi University,https://andcelli.github.io,9wQscqEAAAAJ
@@ -1896,6 +1899,7 @@ Antonia Zhai,University of Minnesota,http://www-users.cs.umn.edu/~zhai,NOSCHOLAR
 Antonija Mitrovic,University of Canterbury,http://www.cosc.canterbury.ac.nz/tanja.mitrovic,qIf7b10AAAAJ
 Antonín Kucera 0001,Masaryk University,https://www.muni.cz/en/people/2508,HxIvytQAAAAJ
 Antonina Kolokolova,Memorial University of Newfoundland,https://www.mun.ca/computerscience/people/kol.php,Zluq9OgAAAAJ
+Antonino Furnari,University of Catania,http://www.antoninofurnari.it/,eXREn_EAAAAJ
 Antonino Santos,University of A Coruña,https://pdi.udc.es/en/File/Pdi/ZD99E,ksY1gFgAAAAJ
 Antonio A. F. Loureiro,UFMG,http://homepages.dcc.ufmg.br/~loureiro,GOGlTIMAAAAJ
 Antonio Alfredo Ferreira Loureiro,UFMG,http://homepages.dcc.ufmg.br/~loureiro,GOGlTIMAAAAJ

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -636,7 +636,7 @@ Alessandro Margara,Politecnico di Milano,http://home.deib.polimi.it/margara,evbp
 Alessandro Mei,Sapienza University of Rome,http://wwwusers.di.uniroma1.it/~mei,eCiUVHcAAAAJ
 Alessandro Moschitti,University of Trento,http://disi.unitn.it/moschitti,vYUDlsEAAAAJ
 Alessandro Orso,Georgia Institute of Technology,http://www.cc.gatech.edu/home/orso,wCfYkMkAAAAJ
-Alessandro Ortis,University of Catania,about:blank,gcztqXgAAAAJ
+Alessandro Ortis,University of Catania,https://www.dmi.unict.it/ortis/homepage.php,gcztqXgAAAAJ
 Alessandro Panconesi,Sapienza University of Rome,http://www.di.uniroma1.it/a/di.uniroma1.it/panco,kzYoaFYAAAAJ
 Alessandro Pandini,Brunel University London,https://www.brunel.ac.uk/people/alessandro-pandini,6hPiNCgAAAAJ
 Alessandro Provetti,Birkbeck University of London,https://www.dcs.bbk.ac.uk/about/people/academic-staff/alessandro,pwOBPBQAAAAJ

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -1184,6 +1184,7 @@ Claude-Guy Quimper,Université Laval,http://www2.ift.ulaval.ca/~quimper,9YHTzQwA
 Claude-Pierre Jeannerod,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/nathalie.revol,FoNMhe8AAAAJ
 Cláudia Antunes,Universidade de Lisboa,http://web.ist.utl.pt/claudia.antunes,yQPwt38AAAAJ
 Claudia Bauzer Medeiros,UNICAMP,http://www.ic.unicamp.br/~cmbm,Kf2m1twAAAAJ
+Claudia Cavallaro,University of Catania,https://web.dmi.unict.it/docenti/claudia.cavallaro,u8_Y23YAAAAJ
 Claudia Díaz,KU Leuven,https://homes.esat.kuleuven.be/~cdiaz,AUGbCSkAAAAJ
 Claudia Eckert 0001,TU Munich,https://www.sec.in.tum.de/claudia-eckert,wGd3KhEAAAAJ
 Claudia Fohry,University of Kassel,http://www.uni-kassel.de/eecs/fachgebiete/plm/team/claudia-fohry.html,NOSCHOLARPAGE
@@ -1331,6 +1332,7 @@ Cornelia Verspoor 0001,University of Melbourne,http://findanexpert.unimelb.edu.a
 Cornelis Huizing,TU Eindhoven,https://www.win.tue.nl/~keesh,j-Uuvt0AAAAJ
 Cornelius Greither,Bundeswehr University Munich,https://www.unibw.de/timor/mitarbeiter/greither/univ-prof-dr-cornelius-greither,NOSCHOLARPAGE
 Corrado Aaron Visaggio,University of Sannio,https://www.unisannio.it/it/users/corrado-aaron-visaggio,bNMLhsIAAAAJ
+Corrado Santoro,University of Catania,https://www.dmi.unict.it/santoro/,tFCFUlMAAAAJ
 Cory Barker,Brigham Young University,https://cs.byu.edu/faculty/barker,iZfqmbMAAAAJ
 Cory Beard,University of Missouri - Kansas City,http://sce2.umkc.edu/csee/beardc/Beard_CV.pdf,-0KiLnsAAAAJ
 Cory C. Beard,University of Missouri - Kansas City,http://sce2.umkc.edu/csee/beardc/Beard_CV.pdf,-0KiLnsAAAAJ

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -425,6 +425,8 @@ Daqing Zhang 0001,Peking University,http://www.sei.pku.edu.cn/people/dqzhang,qn8
 Dar-Jen Chang,University of Louisville,http://louisville.edu/speed/people/faculty/changDarJen,NOSCHOLARPAGE
 Darek Kowalski,University of Liverpool,https://www.liverpool.ac.uk/computer-science/staff/dariusz-kowalski,HbzofJcAAAAJ
 Daria Siekhaus,IST Austria,https://ist.ac.at/research/research-groups/siekhaus-group,NOSCHOLARPAGE
+Dario Allegra,University of Catania,https://web.dmi.unict.it/docenti/dario.allegra,ua6QhmQAAAAJ
+Dario Catalano,University of Catania,https://catalano.dmi.unict.it/,Gg7nd14AAAAJ
 Darío Correal,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/dcorreal/es/inicio,Bo4lXDAtq9QC
 Dario Colazzo,Université Paris Dauphine,https://www.lamsade.dauphine.fr/~colazzo/,mdE4fyoAAAAJ
 Dario D. Salvucci,Drexel University,http://www.mcs.drexel.edu/~salvucci,i1VJMhgAAAAJ
@@ -1265,6 +1267,7 @@ Doina Caragea,Kansas State University,http://people.cs.ksu.edu/~dcaragea,GuO4Uhs
 Dokyung Song,Yonsei University,https://cysec.yonsei.ac.kr/~dokyungs,NE-Q-HIAAAAJ
 Dolores DeGroff,Florida Atlantic University,http://www.eng.fau.edu/directory/faculty/degroff,NOSCHOLARPAGE
 Dolores F. De Groff,Florida Atlantic University,http://www.eng.fau.edu/directory/faculty/degroff,NOSCHOLARPAGE
+Domenico Cantone,University of Catania,https://www.dmi.unict.it/cantone/,HRSHaG0AAAAJ
 Domenico Giustiniano,IMDEA Networks Institute,http://people.networks.imdea.org/~domenico_giustiniano,L38f7A0AAAAJ
 Domenico Lembo,Sapienza University of Rome,http://www.diag.uniroma1.it/lembo,wW0kz-cAAAAJ
 Domenico Parente,University of Salerno,http://www.di.unisa.it/~parente,45LUzAwAAAAJ

--- a/csrankings-e.csv
+++ b/csrankings-e.csv
@@ -361,6 +361,7 @@ Emil Sekerinski,McMaster University,http://www.cas.mcmaster.ca/~emil,h-WLnf8AAAA
 Emiliano Casalicchio,Sapienza University of Rome,https://sites.google.com/view/emilianocasalicchio,oHPKVJgAAAAJ
 Emiliano De Cristofaro,Univ. of California - Riverside,https://profiles.ucr.edu/app/home/profile/emiliand,1wfzUuEAAAAJ
 Emiliano Garcia-Palacios,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=e.garcia,NOSCHOLARPAGE
+Emiliano Tramontana,University of Catania,https://www.dmi.unict.it/tramonta/,NOSCHOLARPAGE
 Emilie Kaufmann,CRIStAL,http://chercheurs.lille.inria.fr/ekaufman,9GE1vx4AAAAJ
 Emilie Morvant,Université Jean Monnet,http://perso.univ-st-etienne.fr/me63854h,4dzYdBsAAAAJ
 Emilio Ferrara,University of Southern California,http://www.emilio.ferrara.name/,0r7Syh0AAAAJ

--- a/csrankings-f.csv
+++ b/csrankings-f.csv
@@ -60,6 +60,7 @@ Fabrizio Ferrandi,Politecnico di Milano,http://home.deib.polimi.it/ferrandi,_woi
 Fabrizio Granelli,University of Trento,https://www.granelli-lab.org/staff/fabrizio-granelli,Qk5Ni_IAAAAJ
 Fabrizio Luccio,University of Pisa,http://www.di.unipi.it/~luccio,NOSCHOLARPAGE
 Fabrizio Maria Maggi,University of Tartu,https://www.etis.ee/Portal/Persons/Display/a37d438b-3add-4c4f-8e49-dfacab570f23,NOSCHOLARPAGE
+Fabrizio Messina,University of Catania,https://www.dmi.unict.it/messina/,iF1u8psAAAAJ
 Fabrizio Silvestri,Sapienza University of Rome,https://sites.google.com/diag.uniroma1.it/fabriziosilvestri,pi985dQAAAAJ
 Fabrizio d'Amore,Sapienza University of Rome,http://www.diag.uniroma1.it/users/fabrizio%20damore,NOSCHOLARPAGE
 Facundo Mémoli,Ohio State University,https://people.math.osu.edu/memoli.2,E3APGcgAAAAJ
@@ -322,6 +323,7 @@ Filipo Sharevski,DePaul University,https://www.cdm.depaul.edu/Faculty-and-Staff/
 Filippo Bonchi,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/filippo.bonchi,RMy4gDsAAAAJ
 Filippo Menczer,Indiana University,http://cnets.indiana.edu/fil,f_kGJwkAAAAJ
 Filippo Radicchi,Indiana University,http://homes.sice.indiana.edu/filiradi,ErokNqgAAAAJ
+Filippo Stanco,University of Catania,https://www.dmi.unict.it/fstanco/personal-site/index.php,VgtfwzYAAAAJ
 Filippos Tzaferis,University of Athens,http://www.di.uoa.gr/eng/staff/1028,NOSCHOLARPAGE
 Fillia Makedon,University of Texas at Arlington,http://heracleia.uta.edu/~makedon,NOSCHOLARPAGE
 Filomena Ferrucci,University of Salerno,http://salerno.academia.edu/FilomenaFerrucci,6LDD4w0AAAAJ
@@ -412,7 +414,6 @@ Francesca Levi,University of Pisa,http://www.di.unipi.it/~levifran,NOSCHOLARPAGE
 Francesca Saglietti,University of Erlangen–Nuremberg,http://www11.informatik.uni-erlangen.de/index.html,NOSCHOLARPAGE
 Francesca Spezzano,Boise State University,https://sites.google.com/site/francescaspezzano,u_5TCGoAAAAJ
 Francesca Toni,Imperial College London,http://www.doc.ic.ac.uk/~ft,L9dwO2cAAAAJ
-Francesco A. N. Palmieri,University of Salerno,http://www.unisa.it/docenti/francescopalmieri/en/index,Ly2epXgAAAAJ
 Francesco Amigoni,Politecnico di Milano,http://home.deib.polimi.it/amigoni,qsOtJtsAAAAJ
 Francesco Belardinelli,Imperial College London,https://www.doc.ic.ac.uk/~fbelard,Mr35r1EAAAAJ
 Francesco Bronzino,Ecole Normale Superieure de Lyon,https://fbronzino.com,rsG2csgAAAAJ
@@ -429,7 +430,7 @@ Francesco Musumeci,Politecnico di Milano,http://home.deib.polimi.it/musumeci,RsM
 Francesco Orabona,Boston University,http://francesco.orabona.com,g1ha-iYAAAAJ
 Francesco Orciuoli,University of Salerno,http://www.unisa.it/docenti/francescoorciuoli/en/index,hrsHqX4AAAAJ
 Francesco Palmieri,University of Salerno,http://www.unisa.it/docenti/francescopalmieri/en/index,Ly2epXgAAAAJ
-Francesco Palmieri 0001,University of Salerno,http://www.unisa.it/docenti/francescopalmieri/en/index,Ly2epXgAAAAJ
+Francesco Pappalardo,University of Catania,https://www.dsf.unict.it/docenti/francesco.pappalardo,MZ5T15EAAAAJ
 Francesco Parisi-Presicce,Sapienza University of Rome,http://wwwusers.di.uniroma1.it/~parisi,BnSDUgwAAAAJ
 Francesco Ranzato,University of Padova,https://www.math.unipd.it/~ranzato,NvNaBzEAAAAJ
 Francesco Regazzoni 0001,University of Amsterdam,https://cci-research.nl/author/francesco-regazzoni/,ERvZONQAAAAJ
@@ -467,6 +468,7 @@ Francisco Sepulveda,University of Essex,https://www.essex.ac.uk/people/sepul3950
 Francisco Servant,Virginia Tech,http://people.cs.vt.edu/fservant,6F5tt2sAAAAJ
 Franck Leprévost,University of Luxembourg,http://wwwen.uni.lu/snt/people/franck_leprevost,NOSCHOLARPAGE
 Franck van Breugel,York University,http://eecs.lassonde.yorku.ca/faculty/franck-van-breugel,NOSCHOLARPAGE
+Franco Barbanera,University of Catania,https://www.dmi.unict.it/barba/,NOSCHOLARPAGE
 Franco Frattolillo,University of Sannio,https://www.unisannio.it/en/users/franco-frattolillo,x7TNVskAAAAJ
 Franco M. Luque,Universidad Nacional de Córdoba,https://cs.famaf.unc.edu.ar/~francolq,edh9Nv4AAAAJ
 Franco Martín Luque,Universidad Nacional de Córdoba,https://cs.famaf.unc.edu.ar/~francolq,edh9Nv4AAAAJ

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -432,6 +432,7 @@ Giacomo Oliveri,University of Trento,http://www.soi.unitn.it/staff/giacomo-olive
 Giacomo Poderi,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/giacomo-poderi(534a54a6-fa36-466a-a1c1-461c54660bcc).html,PhnSRJwAAAAJ
 Giacomo Tarroni,City University of London,https://www.city.ac.uk/people/academics/giacomo-tarroni,6nlDNyoAAAAJ
 Giacomo Verticale,Politecnico di Milano,http://home.deib.polimi.it/verticale,FVl1fRUAAAAJ
+Giampaolo Bella,University of Catania,https://www.dmi.unict.it/giamp/,yBoGdJUAAAAJ
 Giampiero Pecelli,University of Massachusetts Lowell,https://www.uml.edu/Sciences/computer-science/faculty/pecelli-giampiero.aspx,NOSCHOLARPAGE
 Gian Carlo Bongiovanni,Sapienza University of Rome,https://sites.google.com/a/di.uniroma1.it/bongiovanni,ZZUIEqgAAAAJ
 Gian Pietro Picco,University of Trento,http://disi.unitn.it/~picco,DqcmXQ8AAAAJ
@@ -509,8 +510,10 @@ Giovanni Agosta,Politecnico di Milano,http://home.deib.polimi.it/agosta,eLxnBysA
 Giovanni Comarela,Universidade Federal de Viçosa,http://www.dpi.ufv.br/~gcom,onfmt40AAAAJ
 Giovanni Da San Martino,University of Padova,https://www.unipd.it/en/contatti/rubrica/?detail=Y&ruolo=1&checkout=cerca&persona=DA%20SAN%20MARTINO&key=92B9FC5AFB76ECA91B1FFDE427C41AF5,URABLy0AAAAJ
 Giovanni De Micheli,EPFL,http://si2.epfl.ch/~demichel,7SUnVDsAAAAJ
+Giovanni Gallo,University of Catania,https://web.dmi.unict.it/docenti/gallo.giovanni,wCx_ImYAAAAJ
 Giovanni Iacca,University of Trento,https://sites.google.com/site/giovanniiacca,qSw6YfcAAAAJ
 Giovanni M. di Liberto,Trinity College Dublin,https://www.tcd.ie/mecheng/staff/gdiliber/,0NWmnJYAAAAJ
+Giovanni Maria Farinella,University of Catania,https://www.dmi.unict.it/farinella/,YwQboCoAAAAJ
 Giovanni Moretti,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=455100,NOSCHOLARPAGE
 Giovanni Quattrone,Middlesex University,https://www.mdx.ac.uk/about-us/our-people/staff-directory/profile/quattrone-giovanni,cN4fbBsAAAAJ
 Giovanni Russello,University of Auckland,https://www.cs.auckland.ac.nz/~russello,sXvrlqgAAAAJ
@@ -551,6 +554,7 @@ Giuseppe De Giacomo,Sapienza University of Rome,http://www.diag.uniroma1.it/degi
 Giuseppe Destefanis,Brunel University London,https://www.brunel.ac.uk/people/giuseppe-destefanis,o2KkJXIAAAAJ
 Giuseppe Fenza,University of Salerno,https://docenti.unisa.it/021699/home,0C3IjEIAAAAJ
 Giuseppe Lipari,CRIStAL,http://cristal.univ-lille.fr/~lipari,rnBRPpQAAAAJ
+Giuseppe Pappalardo,University of Catania,https://www.dmi.unict.it/pappalardo/,NOSCHOLARPAGE
 Giuseppe Pelagatti,Politecnico di Milano,http://home.deib.polimi.it/pelagatt,NOSCHOLARPAGE
 Giuseppe Persiano,University of Salerno,http://www.di.unisa.it/~giuper,wbQQcfQAAAAJ
 Giuseppe Pirrò,Sapienza University of Rome,http://wwwusers.di.uniroma1.it/~pirro,3zY1VlIAAAAJ

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -423,6 +423,7 @@ Márcio Sarroglia Pinho,PUC-RS,http://www.inf.pucrs.br/pinho,HOUAzukAAAAJ
 Márcio de Carvalho,UFMG,http://homepages.dcc.ufmg.br/~mlbc,05AnG9wAAAAJ
 Mária Bieliková,Kempelen Institute - KInIT,https://kinit.sk/member/maria-bielikova/,wGB6dnEAAAAJ
 Mária Lucká,Kempelen Institute - KInIT,https://kinit.sk/member/maria-lucka/,1bQwDSgAAAAJ
+Maria Madonia,University of Catania,https://web.dmi.unict.it/docenti/maria.serafina.madonia,NOSCHOLARPAGE
 Marián Simko,Kempelen Institute - KInIT,https://kinit.sk/member/marian-simko/,t0WixXUAAAAJ
 Marco A. Casanova,PUC-RIO,http://www.inf.puc-rio.br/~casanova,zWh25xcAAAAJ
 Marco A. Wiering,University of Groningen,http://www.ai.rug.nl/~mwiering,880vFIgAAAAJ
@@ -473,6 +474,7 @@ Marco Romano,University of Salerno,https://www.marcoromano.eu,EEVgWLMAAAAJ
 Marco Ronchetti,University of Trento,http://latemar.science.unitn.it/segue/index.php?&login=logout&action=site&site=ronchet,4cbD9aEAAAAJ
 Marco Roveri,University of Trento,https://sites.google.com/view/marco-roveri/home,wFLeBBkAAAAJ
 Marco Ruffini,Trinity College Dublin,https://www.scss.tcd.ie/Marco.Ruffini,9-0yX78AAAAJ
+Marco Russo,University of Catania,https://www.dfa.unict.it/faculty/marco.russo,NOSCHOLARPAGE
 Marco Schaerf,Sapienza University of Rome,http://www.diag.uniroma1.it/users/marco%20schaerf,7Wju9ggAAAAJ
 Marco Serafini,University of Massachusetts Amherst,https://scholar.google.es/citations?user=IJECSdkAAAAJ,IJECSdkAAAAJ
 Marco Servetto,Victoria University of Wellington,https://ecs.victoria.ac.nz/Main/MarcoServetto,X7AUaVIAAAAJ
@@ -676,6 +678,7 @@ Mario Berta,Imperial College London,http://marioberta.info,pc_5htgAAAAJ
 Mario Calha,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/mcalha,GSDogzwAAAAJ
 Mario Costa Sousa,University of Calgary,http://www.cpsc.ucalgary.ca/~mario,xRhWiGAAAAAJ
 Mario Di Francesco,Aalto University,https://users.aalto.fi/~difram1,xuJ3KAYAAAAJ
+Mario Di Raimondo,University of Catania,https://diraimondo.dmi.unict.it/,tSezx-YAAAAJ
 Mario E. Magaña,Oregon State University,http://eecs.oregonstate.edu/people/magana-mario,ieSEZuYAAAAJ
 Mario E. Sánchez,Universidad de los Andes,http://profesores.virtual.uniandes.edu.co/mar-san1,M1CE-nIAAAAJ
 Mario Edgardo Magaña,Oregon State University,http://eecs.oregonstate.edu/people/magana-mario,ieSEZuYAAAAJ
@@ -690,6 +693,7 @@ Mario Linares-Vásquez,Universidad de los Andes,https://profesores.virtual.unian
 Mario Lopez,University of Denver,http://portfolio.du.edu/mlopez,NOSCHOLARPAGE
 Mario Lúcio Côrtes,UNICAMP,http://www.ic.unicamp.br/~cortes,NOSCHOLARPAGE
 Mario Marchand,Université Laval,http://www2.ift.ulaval.ca/~mmarchand,M792u2sAAAAJ
+Mario Pavone,University of Catania,https://www.dmi.unict.it/mpavone/,SfOIaw0AAAAJ
 Mario Porrmann,University of Osnabrück,https://www.informatik-cms.uni-osnabrueck.de/arbeitsgruppen/technische_informatik/team/mario_porrmann.html,8xaTavMAAAAJ
 Mario R. F. Benevides,UFRJ,http://www.cos.ufrj.br/~mario,O3lJvk4AAAAJ
 Mario Roberto Folhadela Benevides,UFRJ,http://www.cos.ufrj.br/~mario,O3lJvk4AAAAJ

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -127,6 +127,7 @@ Salvatore J. Stolfo,Columbia University,http://www.cs.columbia.edu/~sal,DknsgF8A
 Salvatore La Torre,University of Salerno,http://www.di.unisa.it/professori/latorre,aWRR6EAAAAAJ
 Salvatore Pontarelli,Sapienza University of Rome,https://www.di.uniroma1.it/it/docenti/pontarelli-salvatore,iTWBxPMAAAAJ
 Salvatore Rampone,University of Sannio,https://www.unisannio.it/it/users/salvatore-rampone,SONRi2UAAAAJ
+Salvatore Riccobene,University of Catania,https://dmi.unict.it/docenti/salvatore.antonio.riccobene,NOSCHOLARPAGE
 Salvatore Romeo,Qatar Computing Research Institute,http://www.qcri.org/our-people/bio?pid=242&amp;par=acc&amp;name=SalvatoreRomeo,rE8OSHwAAAAJ
 Salvatore Ruggieri,University of Pisa,http://www.di.unipi.it/~ruggieri,q41ZMpAAAAAJ
 Sam Buss,Univ. of California - San Diego,http://www.math.ucsd.edu/~sbuss,HlXPvCoAAAAJ
@@ -573,6 +574,7 @@ Sebastian Wandelt,Beihang University,http://m3nets.de/group/sw.html,lL0jebkAAAAJ
 Sebastian Wild,University of Liverpool,https://www.liverpool.ac.uk/computer-science/staff/sebastian-wild/publications,aMyZiK0AAAAJ
 Sebastian Zug,TU Freiberg,https://tu-freiberg.de/fakult1/inf/professuren/softwaretechnologie-und-robotik/team,D6A7l-MAAAAJ
 Sebastian von Mammen,University of Würzburg,http://hci.uni-wuerzburg.de/people/sebastian-von-mammen,Rni2mdIAAAAJ
+Sebastiano Battiato,University of Catania,https://www.dmi.unict.it/~battiato/,OplbtHgAAAAJ
 Sébastien Gambs,Université du Québec à Montréal,https://sebastiengambs.openum.ca/,2q1NjMgAAAAJ
 Sébastien Mosser 0001,McMaster University,https://mosser.github.io/,jaLC6KgAAAAJ
 Sébastien Roy 0001,University of Montreal,http://www.iro.umontreal.ca/~roys/en_index.shtml,KfWhAlsAAAAJ
@@ -1324,6 +1326,7 @@ Simone Aonzo,EURECOM,https://simoneaonzo.it/,h1RL7s4AAAAJ
 Simone Campanoni,Northwestern University,http://www.mccormick.northwestern.edu/research-faculty/directory/profiles/campanoni-simone.html,bY5WiJIAAAAJ
 Simone D. J. Barbosa,PUC-RIO,http://www-di.inf.puc-rio.br/~simone,DEayOYgAAAAJ
 Simone Diniz Junqueira Barbosa,PUC-RIO,http://www-di.inf.puc-rio.br/~simone,DEayOYgAAAAJ
+Simone Faro,University of Catania,https://www.dmi.unict.it/faro/,4-fzfJEAAAAJ
 Simone Frintrop,University of Hamburg,https://www.inf.uni-hamburg.de/en/inst/ab/cv/people-alt/frintrop.html,OLiU7JkAAAAJ
 Simone L. Martins,UFF,http://www2.ic.uff.br/~simone,oEIT_KQAAAAJ
 Simone Linz,University of Auckland,https://unidirectory.auckland.ac.nz/profile/slin498,9lCabZsAAAAJ


### PR DESCRIPTION
The proposed names are extracted from the official database maintained by the Italian government.
This is the link to the database: http://cercauniversita.cineca.it/php5/docenti/cerca.php

To verify the names proceed as follows:

    1. select "professori ordinari, professori associati, ricercatori" as Ruolo and select "confermato"
    [this will include all full, associate and assistant professors with tenure]
    2. select "Catania" as Ateneo
    3a).  select "01/B1 Informatica" as macrosettore;
    finally click on "invio.
