### PR TITLE
Modify Yunhai Wang's affiliation

### DIFF
--- a/csrankings-y.csv
+++ b/csrankings-y.csv
@@ -897,7 +897,7 @@ Yung-Nien Sun,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_cs
 Yung-Yu Chuang,National Taiwan University,https://www.csie.ntu.edu.tw/~cyy,uSS3FwQAAAAJ
 Yungang Bao,Chinese Academy of Sciences,http://asg.ict.ac.cn/baoyg,F2vVbs8AAAAJ
 Yunhai Tong,Peking University,http://www.cis.pku.edu.cn/faculty/system/tongyunhai/tongyunhai.htm,NOSCHOLARPAGE
-Yunhai Wang,Shandong University,http://www.yunhaiwang.net,ngPMK7QAAAAJ
+Yunhai Wang,Renmin University of China,http://www.yunhaiwang.net,ngPMK7QAAAAJ
 Yunhao Liu 0001,Michigan State University,https://www.cse.msu.edu/~liuyunha,hon00PIAAAAJ
 Yunhe Feng,University of North Texas,https://computerscience.engineering.unt.edu/people/faculty/yunhe-feng,E7hCUPgAAAAJ
 Yunhe Pan,Zhejiang University,http://mypage.zju.edu.cn/panyunhe,NOSCHOLARPAGE


### PR DESCRIPTION
Modify Yunhai Wang's affiliation as he has moved from Shandong University to Renmin University of China. You can check his website for details: http://www.yunhaiwang.net/
