### PR TITLE
fix DBLP name of Gerhard Weber

### DIFF
--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -388,7 +388,7 @@ Gerhard Sagerer,Bielefeld University,http://aiweb.techfak.uni-bielefeld.de/user/
 Gerhard Schwabe,University of Zurich,http://www.ifi.uzh.ch/imrg/people/schwabe.html,_a7cvK0AAAAJ
 Gerhard Sommer,Graz University of Technology,https://www.biomech.tugraz.at/index.php/people/gerhard_sommer,gD2-pFUAAAAJ
 Gerhard W. Dueck,University of New Brunswick,http://www.cs.unb.ca/~gdueck,lozv7bIAAAAJ
-Gerhard Weber,TU Dresden,https://tu-dresden.de/ing/informatik/institut-fuer-angewandte-informatik/mci,eoQw-CMAAAAJ
+Gerhard Weber 0002,TU Dresden,https://tu-dresden.de/ing/informatik/institut-fuer-angewandte-informatik/mci,eoQw-CMAAAAJ
 Gerhard Weikum [INF],Max Planck Society,http://www.mpi-inf.mpg.de/~weikum,vNAD0mAAAAAJ
 Gerhard Weiss 0001,Maastricht University,http://www.weiss-gerhard.info,3TofHnIAAAAJ
 Gerhard Wellein,University of Erlangen–Nuremberg,https://hpc.fau.de/person/gerhard-wellein,1fQ6-mEAAAAJ


### PR DESCRIPTION
# Contributing to CSrankings

Gerhard Weber at TU Dresden is https://dblp.org/pid/w/GerhardWeber2.html, i.e., Gerhard Weber 0002. This PR solves the problem of disambiguation and adds the correct DBLP suffix.
