### PR TITLE
Fix IEEE S&P to cover alternate booktitles in some years

### DIFF
--- a/filter.xq
+++ b/filter.xq
@@ -36,6 +36,7 @@
 //article[journal="IEEE Trans. Vis. Comput. Graph."],
 //article[journal="IEEE Trans. Comput. Aided Des. Integr. Circuits Syst."],
 //inproceedings[booktitle="IEEE Symposium on Security and Privacy"],
+//inproceedings[booktitle="S&P"],
 //inproceedings[booktitle="SP"],
 //inproceedings[booktitle="ACM Conference on Computer and Communications Security"],
 //inproceedings[booktitle="CCS"],

--- a/util/csrankings.py
+++ b/util/csrankings.py
@@ -216,6 +216,7 @@ areadict: Dict[Area, List[Conference]] = {
     Area("oakland"): [
         Conference("IEEE Symposium on Security and Privacy"),
         Conference("SP"),
+        Conference("S&P"),
     ],
     Area("usenixsec"): [
         Conference("USENIX Security Symposium"),


### PR DESCRIPTION
In some years (e.g., 2002, 2006, 2007) IEEE used "S&P" as booktitle for the Oakland proceedings. This seems to be a recent regression. With this additional booktitle, several missing years are picked up and parsed/included correctly.

