### PR TITLE
Update University of Chicago Faculty list. 

### DIFF
--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -682,6 +682,7 @@ Alex Huth,University of Texas at Austin,http://www.cs.utexas.edu/~huth,JNXWWkIAA
 Alex H. Ihler,Univ. of California - Irvine,http://www.ics.uci.edu/~ihler,ffdt7gMAAAAJ
 Alex J. Gammerman,Royal Holloway University of London,https://pure.royalholloway.ac.uk/portal/en/persons/alex-gammerman_66fed543-6231-42fe-920c-92ba917c2ce1.html,uoWoR4gAAAAJ
 Alex Jung,Aalto University,https://users.aalto.fi/~junga1,mHjdZdwAAAAJ
+Alex Kale,University of Chicago,https://people.cs.uchicago.edu/~kalea,zqj99EYAAAAJ
 Alex Kirlik,Univ. of Illinois at Urbana-Champaign,https://cs.illinois.edu/directory/profile/kirlik,ZS-2t_AAAAAJ
 Alex Lascarides,University of Edinburgh,http://homepages.inf.ed.ac.uk/alex,fVRKVf4AAAAJ
 Alex Liu,Michigan State University,http://www.cse.msu.edu/~alexliu,qRjO51UAAAAJ

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -1544,7 +1544,6 @@ Andrew D. Richardson,Northern Arizona University,https://nau.edu/siccs/faculty,G
 Andrew David Ker,University of Oxford,http://www.cs.ox.ac.uk/andrew.ker/home.html,9fTPyU0AAAAJ
 Andrew Dekker,University of Queensland,http://researchers.uq.edu.au/researcher/15139,JKSGdVIAAAAJ
 Andrew Delong,Concordia University,http://explore.concordia.ca/andrew-delong,-FEYIEMAAAAJ
-Andrew Drucker,University of Chicago,http://people.cs.uchicago.edu/~adrucker1,NOSCHOLARPAGE
 Andrew E. Johnson,University of Illinois at Chicago,https://www.evl.uic.edu/aej,Bv6qOYsAAAAJ
 Andrew Gordon Wilson,New York University,https://cims.nyu.edu/~andrewgw,twWX2LIAAAAJ
 Andrew H. Fagg,University of Oklahoma,http://www.ou.edu/coe/cs/people/fagg,bv_o8b0AAAAJ

--- a/csrankings-e.csv
+++ b/csrankings-e.csv
@@ -506,7 +506,6 @@ Eric Harley,Toronto Metropolitan University,https://www.scs.torontomu.ca/~eharle
 Eric J. Pauwels,CWI,https://www.cwi.nl/people/1302,NOSCHOLARPAGE
 Eric J. Schwabe,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=728,NOSCHOLARPAGE
 Eric John Koskinen,Stevens Institute of Technology,http://www.erickoskinen.com,XUhd_LwAAAAJ
-Eric Jonas,University of Chicago,http://ericjonas.com,e4MjcOEAAAAJ
 Eric K. Ringger,Brigham Young University,https://faculty.cs.byu.edu/~ringger,XkkU-hwAAAAJ
 Eric Keller,University of Colorado Boulder,https://eric-keller.github.io,ngLX-kwAAAAJ
 Eric Knauss,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/eric-knauss.aspx,jlnAa9cAAAAJ

--- a/csrankings-w.csv
+++ b/csrankings-w.csv
@@ -444,6 +444,7 @@ William L. Scherlis,Carnegie Mellon University,http://www.cs.cmu.edu/~wls,F6Lzqw
 William L. Steiger,Rutgers University,http://www.cs.rutgers.edu/~steiger,8rnvCfgAAAAJ
 William L. Whittaker,Carnegie Mellon University,http://www.ri.cmu.edu/person.html?person_id=339,ouKJUyEAAAAJ
 William M. Farmer,McMaster University,http://imps.mcmaster.ca/wmfarmer,zNX4etkAAAAJ
+William M. Hoza,University of Chicago,https://williamhoza.com,sORZkb4AAAAJ
 William Mansky,University of Illinois at Chicago,https://www.cs.uic.edu/~mansky,-BGmHzcAAAAJ
 William Moloney,University of Massachusetts Lowell,https://www.uml.edu/Sciences/computer-science/faculty/moloney-william.aspx,gHYMJZ0AAAAJ
 William N. L. Browne,Queensland University of Technology,https://research.qut.edu.au/qcr/people/will-browne,syWBlr8AAAAJ


### PR DESCRIPTION
We would like to update 4 faculty entires (2 removals and 2 additions) for University of Chicago. 