### PR TITLE
adding Jakub Marecek

### DIFF
--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -178,6 +178,7 @@ Jakob Rehof,TU Dortmund,https://ls14-www.cs.uni-dortmund.de/cms/de/home,lhc6Jn4A
 Jakob Runge,TU Berlin,https://www.eecs.tu-berlin.de/menue/einrichtungen/professuren/professorinnen/runge/parameter/en/,wtXVvuUAAAAJ
 Jakub Kowalski,University of Wroclaw,http://ii.uni.wroc.pl/instytut/pracownicy/64,31AWuosAAAAJ
 Jakub M. Tomczak,VU Amsterdam,https://jmtomczak.github.io/index.html,XB99pR4AAAAJ
+Jakub Marecek,Czech Technical University,https://www.aic.fel.cvut.cz/research-areas/optimization,Ew8TNsMAAAAJ
 Jakub Michaliszyn,University of Wroclaw,http://www.ii.uni.wroc.pl/~jmi,KxpyIIYAAAAJ
 Jakub Mikolaj Tomczak,VU Amsterdam,https://jmtomczak.github.io/index.html,XB99pR4AAAAJ
 Jakub Pawlewicz,University of Warsaw,https://chessprogramming.wikispaces.com/Jakub+Pawlewicz,95JYFDQAAAAJ


### PR DESCRIPTION
Adding Jakub Marecek to the listing for CTU's CS department. Jakub heads the optimization team:
https://www.aic.fel.cvut.cz/research-areas/optimization
https://www.aic.fel.cvut.cz/members/jakub-marecek