### PR TITLE
Add Richard Lange to RIT

### DIFF
--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -686,6 +686,7 @@ Richard Chapman,Auburn University,https://www.eng.auburn.edu/comp/faculty,Ncn4Iv
 Richard Cleve,University of Waterloo,http://cleve.iqc.uwaterloo.ca,dNq5mN4AAAAJ
 Richard Cole 0001,New York University,http://cs.nyu.edu/cole,p2ttvlEAAAAJ
 Richard D. Green,University of Canterbury,http://www.cosc.canterbury.ac.nz/richard.green,NOSCHOLARPAGE
+Richard D. Lange,Rochester Institute of Technology,https://sites.google.com/view/bonsai-lab/home,xc-Z4CoAAAAJ
 Richard David Evans,Dalhousie University,https://www.dal.ca/faculty/computerscience/faculty-staff/richard-evans.html,NqlOPkMAAAAJ
 Richard DeFrancisco,Augusta University,https://www3.cs.stonybrook.edu/~rdefrancisco,tcGjTOoAAAAJ
 Richard E. Jones,University of Kent,https://www.cs.kent.ac.uk/~rej,WL9WBgoAAAAJ


### PR DESCRIPTION
**The Basics**

- [x] All pull requests and issues must come from non-anonymous accounts. Make sure your GitHub profile contains your full name.

- [x] Use a reasonable title that explains what the PR corresponds to (as in, not "Update csrankings-x.csv").

- [x] Combine multiple updates to a single institution into a **single PR.**

- [x] Only submit one pull request per institution.

- [x] Do not modify any files except `csrankings-[a-z].csv` or (if needed) `country-info.csv` and `old/industry.csv` (see below).

- [x] Do not use Excel to edit any .csv files; Excel incorrectly tries to
convert some Google Scholar entries to formulas, corrupting the
database. Use the GitHub user interface or a text editor like emacs or NotePad instead.

- [x] Insert new faculty **in alphabetical order** (not at the end) in the appropriate `csrankings-[a-z].csv` files. **Do not modify `csrankings.csv`, which is auto-generated.**

- [x] Check to make sure that you have no spaces after commas, or any missing fields.

- [x] Check to make sure the home page is correct.

- [x] Make sure the Google Scholar IDs are just the alphanumeric identifier (not a URL or with `&hl=en`).

- [x] Check to make sure the name corresponds to the DBLP entry (look it up at http://dblp.org).

- [x] If a faculty member is not in a CS department or similar, include a comment explaining how they meet the inclusion criteria (see below).

**Inclusion criteria**

- [x] Make sure that any faculty you add meet the inclusion
criteria. Eligible faculty include only full-time, tenure-track research
faculty members on a given campus who can *solely* advise PhD students in
Computer Science. Faculty not in a CS department or similar who can
advise PhD students in CS can be included regardless of their home
department. **Provide justification, pointing to specific home pages
showing how faculty not in a CS department meet the inclusion criteria,
e.g. showing a courtesy appointment in CS.** Faculty must also have a 75%+ time appointment (check
`old/industry.csv` for faculty who are now more than 25% in industry).