### PR TITLE
Affilition change: Oliver Hohlfeld

### DIFF
--- a/csrankings-o.csv
+++ b/csrankings-o.csv
@@ -92,7 +92,7 @@ Oliver Diessel,UNSW,http://www.cse.unsw.edu.au/~odiessel,mVtckacAAAAJ
 Oliver E. Theel,University of Oldenburg,https://uol.de/svs/personen/oliver-theel,NOSCHOLARPAGE
 Oliver Eulenstein,Iowa State University,http://www.cs.iastate.edu/~oeulenst,HWF6UxgAAAAJ
 Oliver G. Staadt,University of Rostock,http://vcg.informatik.uni-rostock.de/~ostaadt,I1hnzusAAAAJ
-Oliver Hohlfeld,Brandenburg University of Technology,http://www.ohohlfeld.com,2dy3cC4AAAAJ
+Oliver Hohlfeld,University of Kassel,https://www.ohohlfeld.com,2dy3cC4AAAAJ
 Oliver Kennedy,University at Buffalo,http://www.cse.buffalo.edu/people/?u=okennedy,9Q9tiCsAAAAJ
 Oliver Keszöcze,University of Erlangen–Nuremberg,https://www.cs12.tf.fau.de/person/oliver-keszoecze,mGiqyPMAAAAJ
 Oliver Kohlbacher,University of Tübingen,https://kohlbacherlab.org/oliver_kohlbacher,8sb5XNIAAAAJ


### PR DESCRIPTION
Affiliation change: Brandenburg University of Technology to University of Kassel