### PR TITLE
Update CMU / SCS / CompBio Faculty

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,35 +9,35 @@ You must read and check **all** the boxes below by filling them in with an X or 
 
 **The Basics**
 
-- [ ] All pull requests and issues must come from non-anonymous accounts. Make sure your GitHub profile contains your full name.
+- [X] All pull requests and issues must come from non-anonymous accounts. Make sure your GitHub profile contains your full name.
 
-- [ ] Use a reasonable title that explains what the PR corresponds to (as in, not "Update csrankings-x.csv").
+- [X] Use a reasonable title that explains what the PR corresponds to (as in, not "Update csrankings-x.csv").
 
-- [ ] Combine multiple updates to a single institution into a **single PR.**
+- [X] Combine multiple updates to a single institution into a **single PR.**
 
-- [ ] Only submit one pull request per institution.
+- [X] Only submit one pull request per institution.
 
-- [ ] Do not modify any files except `csrankings-[a-z].csv` or (if needed) `country-info.csv` and `old/industry.csv` (see below).
+- [X] Do not modify any files except `csrankings-[a-z].csv` or (if needed) `country-info.csv` and `old/industry.csv` (see below).
 
-- [ ] Do not use Excel to edit any .csv files; Excel incorrectly tries to
+- [X] Do not use Excel to edit any .csv files; Excel incorrectly tries to
 convert some Google Scholar entries to formulas, corrupting the
 database. Use the GitHub user interface or a text editor like emacs or NotePad instead.
 
-- [ ] Insert new faculty **in alphabetical order** (not at the end) in the appropriate `csrankings-[a-z].csv` files. **Do not modify `csrankings.csv`, which is auto-generated.**
+- [X] Insert new faculty **in alphabetical order** (not at the end) in the appropriate `csrankings-[a-z].csv` files. **Do not modify `csrankings.csv`, which is auto-generated.**
 
-- [ ] Check to make sure that you have no spaces after commas, or any missing fields.
+- [X] Check to make sure that you have no spaces after commas, or any missing fields.
 
-- [ ] Check to make sure the home page is correct.
+- [X] Check to make sure the home page is correct.
 
-- [ ] Make sure the Google Scholar IDs are just the alphanumeric identifier (not a URL or with `&hl=en`).
+- [X] Make sure the Google Scholar IDs are just the alphanumeric identifier (not a URL or with `&hl=en`).
 
-- [ ] Check to make sure the name corresponds to the DBLP entry (look it up at http://dblp.org).
+- [X] Check to make sure the name corresponds to the DBLP entry (look it up at http://dblp.org).
 
-- [ ] If a faculty member is not in a CS department or similar, include a comment explaining how they meet the inclusion criteria (see below).
+- [X] If a faculty member is not in a CS department or similar, include a comment explaining how they meet the inclusion criteria (see below).
 
 **Inclusion criteria**
 
-- [ ] Make sure that any faculty you add meet the inclusion
+- [X] Make sure that any faculty you add meet the inclusion
 criteria. Eligible faculty include only full-time, tenure-track research
 faculty members on a given campus who can *solely* advise PhD students in
 Computer Science. Faculty not in a CS department or similar who can
@@ -49,17 +49,17 @@ e.g. showing a courtesy appointment in CS.** Faculty must also have a 75%+ time 
 
 **Updating an affiliation or home page**
 
-- [ ] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings-[a-z].csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put `NOSCHOLARPAGE`.
+- [X] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings-[a-z].csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put `NOSCHOLARPAGE`.
 
 **Adding one or more faculty members (including an entire department)**
 
-- [ ] If the department is not yet listed in CSrankings, the entire CS faculty needs to be added (not just one faculty member).
+- [X] If the department is not yet listed in CSrankings, the entire CS faculty needs to be added (not just one faculty member).
 
-- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings-[a-z].csv` (**the letters correspond to the first letter of the faculty members' names**); include disambiguation suffixes like `0001` as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.
+- [X] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings-[a-z].csv` (**the letters correspond to the first letter of the faculty members' names**); include disambiguation suffixes like `0001` as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.
 
-- [ ] If DBLP has multiple entries for this person, *all of them need to be listed*. Do not update `dblp-aliases.csv`.
+- [X] If DBLP has multiple entries for this person, *all of them need to be listed*. Do not update `dblp-aliases.csv`.
 
-- [ ] If the institution you are adding is not in the US,
+- [X] If the institution you are adding is not in the US,
 update `country-info.csv` and add *all* of the faculty in the CS department.
 
 **(Advanced) Quick contribution via a shallow clone** 

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -1479,7 +1479,6 @@ Andreas Pavlogiannis,Aarhus University,https://cs.au.dk/~pavlogiannis/,9QvqaqUAA
 Andreas Peter,University of Oldenburg,https://uol.de/informatik/ssi/team/prof-dr-andreas-peter,ipKtYWgAAAAJ
 Andreas Peter Burg,EPFL,https://people.epfl.ch/andreas.burg,Uf6DIFMAAAAJ
 Andreas Peter,University of Oldenburg,https://uol.de/informatik/ssi/team/prof-dr-andreas-peter,ipKtYWgAAAAJ
-Andreas R. Pfenning,Carnegie Mellon University,https://cbd.cmu.edu/people/pfenning.html,Q6VLB4gAAAAJ
 Andreas Pieris,University of Edinburgh,http://www.inf.ed.ac.uk/people/staff/Andreas_Pieris.html,T1vZCrcAAAAJ
 Andreas Podelski,University of Freiburg,https://swt.informatik.uni-freiburg.de/podelski,UAF-ud8AAAAJ
 Andreas Polze,Hasso Plattner Institute,https://hpi.de/en/the-hpi/people/professors/prof-dr-andreas-polze.html,NOSCHOLARPAGE

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -1479,6 +1479,7 @@ Andreas Pavlogiannis,Aarhus University,https://cs.au.dk/~pavlogiannis/,9QvqaqUAA
 Andreas Peter,University of Oldenburg,https://uol.de/informatik/ssi/team/prof-dr-andreas-peter,ipKtYWgAAAAJ
 Andreas Peter Burg,EPFL,https://people.epfl.ch/andreas.burg,Uf6DIFMAAAAJ
 Andreas Peter,University of Oldenburg,https://uol.de/informatik/ssi/team/prof-dr-andreas-peter,ipKtYWgAAAAJ
+Andreas R. Pfenning,Carnegie Mellon University,https://cbd.cmu.edu/people/pfenning.html,Q6VLB4gAAAAJ
 Andreas Pieris,University of Edinburgh,http://www.inf.ed.ac.uk/people/staff/Andreas_Pieris.html,T1vZCrcAAAAJ
 Andreas Podelski,University of Freiburg,https://swt.informatik.uni-freiburg.de/podelski,UAF-ud8AAAAJ
 Andreas Polze,Hasso Plattner Institute,https://hpi.de/en/the-hpi/people/professors/prof-dr-andreas-polze.html,NOSCHOLARPAGE

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -777,6 +777,7 @@ Christian Borgelt,University of Konstanz,http://www.borgelt.net,T50Bxb8AAAAJ
 Christian Breiteneder,TU Wien,https://www.ims.tuwien.ac.at/people/christian-breiteneder,AvNBy7MAAAAJ
 Christian Chiarcos,Goethe University Frankfurt,http://acoli.informatik.uni-frankfurt.de,IYbsrxUAAAAJ
 Christian Colombo,University of Malta,http://staff.um.edu.mt/christian.colombo,eFR8lkgAAAAJ
+Christian Cuba-Samaniego,Carnegie Mellon University,https://cbd.cmu.edu/people/cuba-samaneigo.html,F5JTlEcAAAAJ
 Christian D. Newman,Rochester Institute of Technology,https://www.rit.edu/studentaffairs/religion/catholiccampusministry.php,hb_08rUAAAAJ
 Christian Damsgaard Jensen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Christian Darken,Naval Postgraduate School,http://faculty.nps.edu/cjdarken,NOSCHOLARPAGE

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -101,6 +101,7 @@ Dan C. Marinescu,University of Central Florida,https://www.cs.ucf.edu/~dcm,YoLdE
 Dan Chen 0001,Wuhan University,https://cs.whu.edu.cn/info/1019/2891.htm,wAzo3GUAAAAJ
 Dan E. Tamir,Texas State University,http://www.cs.txstate.edu/~dt19,zcdcbaIAAAAJ
 Dan E. Willard,University at Albany - SUNY,https://www.albany.edu/ceas/dan-willard.php,NOSCHOLARPAGE
+Dan F. DeBlasio,Carnegie Mellon University,https://www.dandeblasio.com/,3xE2SbUAAAAJ
 Dan Feldman,University of Haifa,http://people.csail.mit.edu/dannyf,67QZN0gAAAAJ
 Dan Feng 0001,HUST,http://faculty.hust.edu.cn/dfeng/en/index.htm,g57OG4QAAAAJ
 Dan Garber,Technion,https://dangar.net.technion.ac.il,kUe1sZEAAAAJ

--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -863,6 +863,7 @@ Horst Reichel,TU Dresden,https://wwwtcs.inf.tu-dresden.de/~reichel,NOSCHOLARPAGE
 Horst-Michael Gross,TU Ilmenau,https://www.tu-ilmenau.de/neurob/team/prof-dr-horst-michael-gross,eKw3T1EAAAAJ
 Horst-Michael Groß,TU Ilmenau,https://www.tu-ilmenau.de/neurob/team/prof-dr-horst-michael-gross,eKw3T1EAAAAJ
 Hosagrahar Visvesvaraya Jagadish,University of Michigan,http://web.eecs.umich.edu/~jag,SKVnHakAAAAJ
+Hosein Mohimani,Carnegie Mellon University,https://cbd.cmu.edu/people/mohimani.html,fN8qBDgAAAAJ
 Hosna Jabbari,University of Victoria,https://onlineacademiccommunity.uvic.ca/cobra,CiBbx70AAAAJ
 Hossam A. Gabbar,Ontario Tech University,https://engineering.ontariotechu.ca/people/ecse/hossam.gaber.php,xjWM54EAAAAJ
 Hossam H. Hassanein,Queen’s University,http://research.cs.queensu.ca/home/hossam,lHX_OIoAAAAJ

--- a/csrankings-i.csv
+++ b/csrankings-i.csv
@@ -299,6 +299,7 @@ Irena Spasic,Cardiff University,https://www.cardiff.ac.uk/people/view/118164-spa
 Irene Amerini,Sapienza University of Rome,http://www.diag.uniroma1.it/users/irene%20amerini,4ZDhr6UAAAAJ
 Irene Cheng 0001,University of Alberta,https://webdocs.cs.ualberta.ca/~crome/mrc/people/irene_cheng/,76DyMqoAAAAJ
 Irene Loiseau,University of Buenos Aires,https://www.dc.uba.ar/People/loiseau,NOSCHOLARPAGE
+Irene M. Kaplow,Carnegie Mellon University,https://cbd.cmu.edu/people/kaplow.html,_IfiZD4AAAAJ
 Irene Ntoutsi,Freie Universitaet Berlin,https://www.mi.fu-berlin.de/inf/groups/ag-KIML/members/Professoren/Ntoutsi.html,RdA9uxYAAAAJ
 Irfan A. Essa,Georgia Institute of Technology,http://prof.irfanessa.com,XM97iScAAAAJ
 Irfan Ahmed,Virginia Commonwealth University,http://www.people.vcu.edu/~iahmed3,JXrXUC4AAAAJ

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -2133,6 +2133,7 @@ Joshua A. Levine,University of Arizona,https://jalevine.bitbucket.io,eYA1nLIAAAA
 Joshua Allen McCoy,Univ. of California - Davis,https://faculty.engineering.ucdavis.edu/mccoy,pdSgBVQAAAAJ
 Joshua Clifford Bongard,University of Vermont,http://www.cs.uvm.edu/~jbongard,Dj-kPasAAAAJ
 Joshua D. Guttman,Worcester Polytechnic Institute,http://www.cs.wpi.edu/~guttman,UgTnZDwAAAAJ
+Joshua D. Kangas,Carnegie Mellon University,https://cbd.cmu.edu/people/kangas.html,nLXQg7oAAAAJ
 Joshua D. Reiss,Queen Mary University of London,http://www.eecs.qmul.ac.uk/~josh,fVlS_EgAAAAJ
 Joshua E. Siegel,Michigan State University,http://www.siegelautomation.com,Y7530HwAAAAJ
 Joshua Ellul,University of Malta,http://staff.um.edu.mt/joshua.ellul,U757tgQAAAAJ

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -1999,6 +1999,7 @@ José Júlio Alferes,Universidade NOVA de Lisboa,https://userweb.fct.unl.pt//~jj
 José L. Abellán,University of Murcia,https://sites.google.com/view/jlabellan/,pvuLntsAAAAJ
 José Legatheaux Martins,Universidade NOVA de Lisboa,http://legatheaux.eu,jWrKqacAAAAJ
 José Losada,University of A Coruña,https://pdi.udc.es/en/File/Pdi/DJ5HF,NOSCHOLARPAGE
+Jose Lugo-Martinez,Carnegie Mellon University,https://cbd.cmu.edu/people/lugo-martinez.html,7Zf_LXIAAAAJ
 José Luis Abellán Miguel,University of Murcia,https://sites.google.com/view/jlabellan/,pvuLntsAAAAJ
 José Luis Borbinha,Universidade de Lisboa,http://joslusborbinha.cgpublisher.com/product/pub.222/prod.27,NOSCHOLARPAGE
 José Luis Brinquete Borbinha,Universidade de Lisboa,http://joslusborbinha.cgpublisher.com/product/pub.222/prod.27,NOSCHOLARPAGE

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -1533,6 +1533,7 @@ Joël Lefebvre,Université du Québec à Montréal,https://joel-lefebvre.uqam.ca
 Joel Luis Carbonera,UFRGS,https://www.inf.ufrgs.br/site/docente/joel-luis-carbonera,oMtHaoQAAAAJ
 Joel Luís Carbonera,UFRGS,https://www.inf.ufrgs.br/site/docente/joel-luis-carbonera,oMtHaoQAAAAJ
 Joël M. H. Karel,Maastricht University,https://dke.maastrichtuniversity.nl/joel.karel,QDYgJMEAAAAJ
+Joel McManus,Carnegie Mellon University,https://cbd.cmu.edu/people/mcmanus.html,28yZqbcAAAAJ
 Joel Moses,Massachusetts Institute of Technology,https://esd.mit.edu/Faculty_Pages/moses/moses.htm,NOSCHOLARPAGE
 Joël Ouaknine [SWS],Max Planck Society,https://people.mpi-sws.org/~joel,ZfE4iQ4AAAAJ
 Joel P. Ilao,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742738160&command=GETPROFILE,gd8W9ecAAAAJ

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -2136,6 +2136,7 @@ Min Hun Lee,Singapore Management University,https://scis.smu.edu.sg/faculty/prof
 Min Li 0007,Central South University,https://faculty.csu.edu.cn/limin1/zh_CN/index.htm,w47WJE4AAAAJ
 Min Long,Boise State University,http://flash.uchicago.edu/~long,Ex_raoQAAAAJ
 Min Lu 0002,Shenzhen University,http://deardeer.github.io,xFAU798AAAAJ
+Min Xu 0009,Carnegie Mellon University,https://cbd.cmu.edu/people/xu.html,Y3Cqt0cAAAAJ
 Minmei Wang,University of Connecticut,https://archer-w.github.io,d_yUM3QAAAAJ
 Min C. Shin,UNC - Charlotte,https://viscenter.uncc.edu/min-shin,T50sdQ8AAAAJ
 Min Peng,Wuhan University,https://cs.whu.edu.cn/info/1019/2893.htm,NOSCHOLARPAGE

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -1012,6 +1012,7 @@ Martin J. Russell,University of Birmingham,https://www.birmingham.ac.uk/staff/pr
 Martin J. Shepperd,Brunel University London,https://www.brunel.ac.uk/people/martin-shepperd,VqZsDvUAAAAJ
 Martin J. Strauss,University of Michigan,http://web.eecs.umich.edu/~martinjs,FTv-o-UAAAAJ
 Martin J. Wainwright,Univ. of California - Berkeley,https://www.eecs.berkeley.edu/~wainwrig,J5Rvh6gAAAAJ
+Martin J. Zhang,Carnegie Mellon University,https://cbd.cmu.edu/people/zhang.html,zjr6n-QAAAAJ
 Martin Jacobsson,Uppsala University,http://www.jacobsson.nl/research,NOSCHOLARPAGE
 Martin Jägersand,University of Alberta,https://webdocs.cs.ualberta.ca/~jag,kxAlIY4AAAAJ
 Martin Jaggi,EPFL,https://people.epfl.ch/martin.jaggi,r1TJBr8AAAAJ

--- a/csrankings-o.csv
+++ b/csrankings-o.csv
@@ -1,5 +1,6 @@
 name,affiliation,homepage,scholarid
 O-Joun Lee,The Catholic University of Korea,https://o-jounlee.github.io/cv/CV/,43GFjoYAAAAJ
+Oana Carja,Carnegie Mellon University,https://cbd.cmu.edu/people/carja.html,BtnXFFYAAAAJ
 Octav Chipara,University of Iowa,https://www.cs.uiowa.edu/people/octav-chipara,uBbYp8gAAAAJ
 Odalric Maillard,CRIStAL,https://www.cristal.univ-lille.fr/profil/omaillar,7EweMdoAAAAJ
 Odalric-Ambrym Maillard,CRIStAL,https://www.cristal.univ-lille.fr/profil/omaillar,7EweMdoAAAAJ

--- a/csrankings-y.csv
+++ b/csrankings-y.csv
@@ -879,6 +879,7 @@ Yun Liang 0001,Peking University,http://ceca.pku.edu.cn/en/team.php?action=show&
 Yun S. Song,Univ. of California - Berkeley,http://www.eecs.berkeley.edu/~yss,NOSCHOLARPAGE
 Yun Sing Koh,University of Auckland,https://www.cs.auckland.ac.nz/~yunsing,0L38IrAAAAAJ
 Yun Xiong,Fudan University,http://www.cs.fudan.edu.cn/?page_id=1979,NOSCHOLARPAGE
+Yun William Yu,Carnegie Mellon University,https://cbd.cmu.edu/people/yu.html,h9r7yWkAAAAJ
 Yun-Gyung Cheong,Sungkyunkwan University,https://inglab.github.io/,yhfGHeIAAAAJ
 Yun-Heh Chen-Burger,Heriot-Watt University,https://researchportal.hw.ac.uk/en/persons/yun-heh-chen-burger,GKiqYxoAAAAJ
 Yun-Heh Jessica Chen-Burger,Heriot-Watt University,https://researchportal.hw.ac.uk/en/persons/yun-heh-chen-burger,GKiqYxoAAAAJ


### PR DESCRIPTION
Update of new voting faculty from CMU / School of Computer Science / Computational Biology Department, as listed here:
https://cbd.cmu.edu/people/voting-faculty.html

All of these faculty listed have sole supervision privileges.

===================
Note that two of the newly listed faculty have an official title of "teaching professor", but they too have sole advising privileges, as core training faculty. See documentation below.

Names listed on core faculty: https://www.compbio.cmu.edu/people/core-faculty.html

CPCB PhD student handbook, Section 8A (page 21, second paragraph):
https://www.compbio.cmu.edu/about-us/images/cpcb-handbook-june-2022-v10-updated-5-19-22.pdf