### PR TITLE
Adding sis at uncc

### DIFF
--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -556,6 +556,7 @@ Albert M. Lai,Washington University in St. Louis,https://i2db.wustl.edu/people/a
 Albert Levi,Sabancı University,http://people.sabanciuniv.edu/levi,ls6NkwEAAAAJ
 Albert M. K. Cheng,University of Houston,http://www2.cs.uh.edu/~acheng/acheng.html,cBzNurgAAAAJ
 Albert Mo Kim Cheng,University of Houston,http://www2.cs.uh.edu/~acheng/acheng.html,cBzNurgAAAAJ
+Albert Park,UNC - Charlotte,https://cci.charlotte.edu/directory/albert-park/,2yOn5RgAAAAJ
 Albert R. Meyer,Massachusetts Institute of Technology,http://people.csail.mit.edu/meyer,yRTPMIUAAAAJ
 Albert Y. Zomaya,University of Sydney,https://www.sydney.edu.au/engineering/about/our-people/academic-staff/albert-zomaya.html,ak35bjgAAAAJ
 Albert Zündorf,University of Kassel,http://forschung.uni-kassel.de/converis/portal/Person/951793?auxfun=&lang=de_DE,WUWph3oAAAAJ

--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -477,6 +477,7 @@ Bill Aiello,University of British Columbia,https://www.cs.ubc.ca/people/bill-aie
 Bill Barrett,Brigham Young University,https://cs.byu.edu/faculty/barrett,yLWfq68AAAAJ
 Bill Campbell,University of Massachusetts Boston,https://www.umb.edu/academics/csm/faculty_staff/bill_campbell,ekic9BkAAAAJ
 Bill Carroll,University of Texas at Arlington,http://ranger.uta.edu/~carroll,b77CHHoAAAAJ
+Bill Chu,UNC - Charlotte,https://cci.charlotte.edu/directory/bill-chu/,NOSCHOLARPAGE
 Bill Dally,Stanford University,http://csl.stanford.edu/~billd,YZHj-Y4AAAAJ
 Bill Fefferman,University of Chicago,http://www.billfefferman.com,EBIByAIAAAAJ
 Bill Freeman,Massachusetts Institute of Technology,https://billf.mit.edu,0zZnyMEAAAAJ

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -1383,6 +1383,7 @@ Cornelis Huizing,TU Eindhoven,https://www.win.tue.nl/~keesh,j-Uuvt0AAAAJ
 Cornelius Greither,Bundeswehr University Munich,https://www.unibw.de/timor/mitarbeiter/greither/univ-prof-dr-cornelius-greither,NOSCHOLARPAGE
 Corrado Aaron Visaggio,University of Sannio,https://www.unisannio.it/it/users/corrado-aaron-visaggio,bNMLhsIAAAAJ
 Corrado Santoro,University of Catania,https://www.dmi.unict.it/santoro/,tFCFUlMAAAAJ
+Cori Faklaris,UNC - Charlotte,https://cci.charlotte.edu/directory/cori-faklaris/,QyK75JQAAAAJ
 Cory Barker,Brigham Young University,https://cs.byu.edu/faculty/barker,iZfqmbMAAAAJ
 Cory Beard,University of Missouri - Kansas City,http://sce2.umkc.edu/csee/beardc/Beard_CV.pdf,-0KiLnsAAAAJ
 Cory C. Beard,University of Missouri - Kansas City,http://sce2.umkc.edu/csee/beardc/Beard_CV.pdf,-0KiLnsAAAAJ

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -959,6 +959,7 @@ Denys Poshyvanyk,College of William and Mary,http://www.cs.wm.edu/~denys,gyLFs0I
 Deokgun Park,University of Texas at Arlington,http://crystal.uta.edu/~park,cK1bhQUAAAAJ
 Depei Qian,Beihang University,http://scse.buaa.edu.cn/info/1029/2906.htm,tl9JLZkAAAAJ
 Depeng Li,University of Hawaii at Manoa,http://www2.hawaii.edu/~depengli,zH0qyf0AAAAJ
+Depeng Xu,UNC - Charlotte,https://cci.charlotte.edu/directory/depeng-xu/,GIVbIEgAAAAJ
 Deqing Zou,HUST,http://faculty.hust.edu.cn/zoudeqing/en/index.htm,NOSCHOLARPAGE
 Dequan Wang,Shanghai Jiao Tong University,https://dequan.wang/,OZ7PjVoAAAAJ
 Der-Chen Chang,Georgetown University,http://explore.georgetown.edu/people/chang,eVj0PpgAAAAJ

--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -460,6 +460,7 @@ He Zhu 0001,Rutgers University,http://herowanzhu.github.io,3X9GC2gAAAAJ
 Heather Anne Crawford,Florida Institute of Technology,https://www.fit.edu/faculty-profiles/3/heather-crawford/?tracks=hcrawford,_jZd3F4AAAAJ
 Heather Crawford,Florida Institute of Technology,https://www.fit.edu/faculty-profiles/3/heather-crawford/?tracks=hcrawford,_jZd3F4AAAAJ
 Heather Culbertson,University of Southern California,https://sites.usc.edu/culbertson/,Q5yf4F4AAAAJ
+Heather Lipford,UNC - Charlotte,https://cci.charlotte.edu/directory/heather-lipford/,xzb1IqwAAAAJ
 Heather Miller,Carnegie Mellon University,http://heather.miller.am,dpghk3cAAAAJ
 Heather S. Packer,University of Southampton,https://www.ecs.soton.ac.uk/people/hsp2m10,GxnvRXkAAAAJ
 Heather Zheng,University of Chicago,https://people.cs.uchicago.edu/~htzheng,XrIr0nYAAAAJ

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -1307,6 +1307,7 @@ Jingjing Wang,Soochow University,http://scst.suda.edu.cn/11250/list.htm,NOSCHOLA
 Jingke Li,Portland State University,https://www.pdx.edu/computer-science/jingke-li,NOSCHOLARPAGE
 Jingkuan Song,UESTC,http://cfm.uestc.edu.cn/~songjingkuan,F5Zy9V4AAAAJ
 Jingling Xue,UNSW,http://www.cse.unsw.edu.au/~jingling,oZlds-AAAAAJ
+Jinpeng Wei,UNC - Charlotte,https://cci.charlotte.edu/directory/jinpeng-wei/,2J9Nd4wAAAAJ
 Jingqiang Lin,Chinese Academy of Sciences,http://www.escience.cn/people/linjingqiang/index.html,UimjP5sAAAAJ
 Jingru Zhang,Cleveland State University,http://cis.csuohio.edu/~zhang,HxjNIUIAAAAJ
 Jingrui He,Univ. of Illinois at Urbana-Champaign,https://www.hejingrui.org,hXpZynkAAAAJ

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -290,6 +290,7 @@ Mantis Cheng,University of Victoria,http://www.csc.uvic.ca/~mcheng,NOSCHOLARPAGE
 Manton M. Matthews,University of South Carolina,https://cse.sc.edu/~matthews,NOSCHOLARPAGE
 Manu Kaul,IIT Hyderabad,http://www.iith.ac.in/~mkaul,jNroyK4AAAAJ
 Manu Sridharan,Univ. of California - Riverside,https://manu.sridharan.net,iNtk_EQAAAAJ
+Manuel A. Pérez-Quiñones,UNC - Charlotte,https://cci.charlotte.edu/directory/manuel-pc3a9rez-quic3b1ones-0/,gD8fgzcAAAAJ
 Manuel Alejandro Pajuelo Gonzalez,Polytechnic University of Catalonia,https://www.bsc.es/cv-mateo/8-theses,NOSCHOLARPAGE
 Manuel Álvarez Díaz,University of A Coruña,https://pdi.udc.es/es/File/Pdi/WJ6AF,aqGNCqIAAAAJ
 Manuel Blum 0001,Carnegie Mellon University,https://www.cs.cmu.edu/~mblum,7S-LSKoAAAAJ
@@ -1111,6 +1112,7 @@ Mary Jean Amon,University of Central Florida,https://www.ist.ucf.edu/People/IST-
 Mary K. Biagini,University of Pittsburgh,http://www.sci.pitt.edu/faculty-and-research/faculty-directory/mary-k-biagini,NOSCHOLARPAGE
 Mary L. Cummings,George Mason University,https://cs.gmu.edu/directory/detail/174/,TqARAGcAAAAJ
 Mary Lauren Benton,Baylor University,https://www.ecs.baylor.edu/index.php?id=972637,NOSCHOLARPAGE
+Mary Lou Maher,UNC - Charlotte,https://cci.charlotte.edu/directory/mary-lou-maher/,2COOamwAAAAJ
 Mary Lou Soffa,University of Virginia,http://www.cs.virginia.edu/~soffa/index.html%3Fp=6.html,KWiJaj8AAAAJ
 Mary Shaw,Carnegie Mellon University,http://www.cs.cmu.edu/~shaw,CTXoO1AAAAAJ
 Mary Sheeran,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/mary-sheeran.aspx,NOSCHOLARPAGE
@@ -1460,6 +1462,7 @@ Medha Atre,IIT Kanpur,http://www.cse.iitk.ac.in/users/atrem,N_manZoAAAAJ
 Meelis Kull,University of Tartu,https://www.ut.ee/en/meelis-kull,yJwctG4AAAAJ
 Meena Mahajan,IMSc,http://www.imsc.res.in/~meena,HYLNAGUAAAAJ
 Meenakshisundaram Gopi,Univ. of California - Irvine,http://www.ics.uci.edu/~gopi,DI8bU-0AAAAJ
+Meera Sridhar,UNC - Charlotte,https://cci.charlotte.edu/directory/meera-sridhar/,UQKzUI4AAAAJ
 Meera Sitharam,University of Florida,http://www.cise.ufl.edu/~sitharam,NOSCHOLARPAGE
 Meeyoung Cha,KAIST,http://mia.kaist.ac.kr,iFlnVCoAAAAJ
 Megan Hofmann,Northeastern University,https://www.khoury.northeastern.edu/people/megan-hofmann/,hcr5P90AAAAJ
@@ -2375,6 +2378,7 @@ Mohamed Mejri,Université Laval,http://www2.ift.ulaval.ca/~mejri,NOSCHOLARPAGE
 Mohamed N. Moustafa 0001,American University in Cairo,https://www.aucegypt.edu/fac/mohamedmoustafa,QGdReUEAAAAJ
 Mohamed Nassar 0001,American University of Beirut,http://www.aub.edu.lb/pages/profile.aspx?memberId=mn115,GrvxLaUAAAAJ
 Mohamed Sarwat,Arizona State University,http://faculty.engineering.asu.edu/sarwat,kOc0x0MAAAAJ
+Mohamed Shehab,UNC - Charlotte,https://cci.charlotte.edu/directory/mohamed-shehab/,l07_FHkAAAAJ
 Mohamed Taleb,Concordia University,https://www.concordia.ca/encs/computer-science-software-engineering/faculty.html.html?fpid=mohamed-taleb,kG5niJsAAAAJ
 Mohamed Wiem Mkaouer,Rochester Institute of Technology,https://www.rit.edu/gccis/mohamed-wiem-mkaouer,UoHgCukAAAAJ
 Mohamed Y. Eltabakh,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/mye.html,KBiBATkAAAAJ

--- a/csrankings-w.csv
+++ b/csrankings-w.csv
@@ -186,6 +186,7 @@ Wei-Tek Tsai,Arizona State University,https://cidse.engineering.asu.edu/director
 Wei-ming Lu 0001,Zhejiang University,http://mypage.zju.edu.cn/lwm,NOSCHOLARPAGE
 Weibin Wu 0002,Sun Yat-sen University,http://sse.sysu.edu.cn/teacher/249,6mtEjCEAAAAJ
 Weibo Gong,University of Massachusetts Amherst,https://ece.umass.edu/faculty/weibo-gong,NOSCHOLARPAGE
+Weichao Wang,UNC - Charlotte,https://cci.charlotte.edu/directory/weichao-wang/,AQeAemYAAAAJ
 Weichang Du,University of New Brunswick,https://www.cs.unb.ca/~wdu,NOSCHOLARPAGE
 Weichen Liu,Nanyang Technological University,https://personal.ntu.edu.sg/liu,UozjxW8AAAAJ
 Weicheng Xie 0001,Shenzhen University,http://csse.szu.edu.cn/en/peopleaa2d.html?109452,S2uh8OIAAAAJ

--- a/csrankings-x.csv
+++ b/csrankings-x.csv
@@ -15,6 +15,7 @@ Xenofontas A. Dimitropoulos,University of Crete,http://www.inspire.edu.gr/~fonta
 Xi Chen 0001,Columbia University,http://www.cs.columbia.edu/~xichen/Homepage/Welcome.html,P_UgxSYAAAAJ
 Xi He 0001,University of Waterloo,https://cs.uwaterloo.ca/~xihe/,DlTQ320AAAAJ
 Xi Li 0001,Zhejiang University,http://mypage.zju.edu.cn/xilics,TYNPJQMAAAAJ
+Xi Niu,UNC - Charlotte,https://cci.charlotte.edu/directory/xi-sunshine-niu/,8s12jxMAAAAJ
 Xi Peng 0005,University of Delaware,https://sites.google.com/site/xipengcshomepage/home,DWw4v0kAAAAJ
 Xi Yang 0011,Xidian University,https://web.xidian.edu.cn/yangx/index.html,W5c-LSYAAAAJ
 Xi Zhang 0008,BUPT,https://scss.bupt.edu.cn/info/1063/3293.htm,6sRtx0cAAAAJ


### PR DESCRIPTION
# Adding Faculty from CCI at UNC - Charlotte to CSrankings

Added 12 faculty from the College of Computing and Informatics to the repository. These are all tenure track CS faculty that reside in the Software and Information Systems (SIS) department.  The SIS Department shares with the CS Department a single undergraduate degree (Computer Science BS and BA) and single PhD program (Computing and Information Systems). All tenure track faculty in the college can advise students in the PhD program independent of which department they reside. Departmental separation is somewhat arbitrary and internal to the College of Computing; internally all faculty in SIS are Computer Science faculty. The SIS department houses HCI, Cybersecurity, Software Engineering among other CS areas.

