### PR TITLE
Added Uni Göttingen people

### DIFF
--- a/csrankings-l.csv
+++ b/csrankings-l.csv
@@ -606,6 +606,7 @@ Liqiong Tang,Massey University,http://www.massey.ac.nz/massey/expertise/profile.
 Liqun Chen 0002,University of Surrey,https://www.surrey.ac.uk/people/liqun-chen,3IH9iokAAAAJ
 Lirong Xia,Rensselaer Polytechnic Institute,http://www.cs.rpi.edu/~xial,C19mgCgAAAAJ
 Lisa Anthony,University of Florida,https://lisa-anthony.com,GUucp2UAAAAJ
+Lisa Beinborn,University of Göttingen,https://clap-lab.github.io,Mh5y8L0AAAAJ
 Lisa Bylinina,University of Groningen,https://bylinina.github.io/,8ZBQ3bsAAAAJ
 Lisa Cingiser DiPippo,University of Rhode Island,https://web.uri.edu/cs/meet/lisa-dipippo/,NOSCHOLARPAGE
 Lisa Fan,University of Regina,http://www.cs.uregina.ca/People/Profiles/LisaFan.html,NOSCHOLARPAGE


### PR DESCRIPTION
Lisa Beinborn, at University of Göttingen CS department since April 2024

