### PR TITLE
Emily Wenger moved to Duke

### DIFF
--- a/csrankings-e.csv
+++ b/csrankings-e.csv
@@ -383,6 +383,7 @@ Emily Mower Provost,University of Michigan,http://web.eecs.umich.edu/~emilykmp,2
 Emily Prud'hommeaux,Boston College,http://cs.bc.edu/~prudhome,9Lmv4joAAAAJ
 Emily Tucker Prud'hommeaux,Boston College,http://cs.bc.edu/~prudhome,9Lmv4joAAAAJ
 Emily Wall,Emory University,https://emilywall.github.io,YfcphqMAAAAJ
+Emily Wenger,Duke University,https://www.emilywenger.com/,_xYN0z0AAAAJ
 Emily Whiting,Boston University,http://cs-people.bu.edu/whiting/#,_TU9kGYAAAAJ
 Emine Yilmaz,University College London,https://emineyilmaz.cs.ucl.ac.uk,ocmAN4YAAAAJ
 Emir Demirović,TU Delft,http://emirdemirovic.com,QUhD6A0AAAAJ


### PR DESCRIPTION
Updating csrankings-e.csv with Emily Wenger's affiliation info. 

