### PR TITLE
Fixed issue #6858: missing SIGGRAPH Asia Conference Papers fetch from DBLP

### DIFF
--- a/filter.xq
+++ b/filter.xq
@@ -154,6 +154,7 @@
 //article[journal="ACM Trans. Embed. Comput. Syst."],
 //inproceedings[booktitle="SIGGRAPH"],
 //inproceedings[booktitle="SIGGRAPH (Conference Paper Track)"],
+//inproceedings[booktitle="SIGGRAPH Asia"],
 //article[journal="Comput. Graph. Forum"],
 //inproceedings[booktitle="ASE"],
 //inproceedings[booktitle="ICSE"],


### PR DESCRIPTION
discussed in issue #6858. Modified "filter.xq".

See explanation and discussion in https://github.com/emeryberger/CSrankings/issues/6858