### PR TITLE
Affiliation Change for Hadi Hemmati to York University

### DIFF
--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -27,7 +27,7 @@ Hacer Yalim Keles,Hacettepe University,http://web.cs.hacettepe.edu.tr/~hacerkele
 Hadas Kress-Gazit,Cornell University,https://www.mae.cornell.edu/people/profile.cfm?netid=hk478,duOys3YAAAAJ
 Hadas Shachnai,Technion,http://www.cs.technion.ac.il/~hadas,NOSCHOLARPAGE
 Hadi Amiri,University of Massachusetts Lowell,https://scholar.harvard.edu/hadi,fyUpZ5EAAAAJ
-Hadi Hemmati, York University,https://lassonde.yorku.ca/users/hhemmati,TznXpSIAAAAJ
+Hadi Hemmati,York University,https://lassonde.yorku.ca/users/hhemmati,TznXpSIAAAAJ
 Hadi Hosseini,Pennsylvania State University,https://faculty.ist.psu.edu/hadi,bnvEtsMAAAAJ
 Hadrien Hours,Ecole Normale Superieure de Lyon,https://branded.me/hadrienhours,NOSCHOLARPAGE
 Hady W. Lauw,Singapore Management University,https://scis.smu.edu.sg/faculty/profile/341/hady-w--lauw,HTC1z2gAAAAJ

--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -27,7 +27,7 @@ Hacer Yalim Keles,Hacettepe University,http://web.cs.hacettepe.edu.tr/~hacerkele
 Hadas Kress-Gazit,Cornell University,https://www.mae.cornell.edu/people/profile.cfm?netid=hk478,duOys3YAAAAJ
 Hadas Shachnai,Technion,http://www.cs.technion.ac.il/~hadas,NOSCHOLARPAGE
 Hadi Amiri,University of Massachusetts Lowell,https://scholar.harvard.edu/hadi,fyUpZ5EAAAAJ
-Hadi Hemmati,University of Manitoba,http://sealab.cs.umanitoba.ca/?page_id=149,TznXpSIAAAAJ
+Hadi Hemmati, York University,https://lassonde.yorku.ca/users/hhemmati,TznXpSIAAAAJ
 Hadi Hosseini,Pennsylvania State University,https://faculty.ist.psu.edu/hadi,bnvEtsMAAAAJ
 Hadrien Hours,Ecole Normale Superieure de Lyon,https://branded.me/hadrienhours,NOSCHOLARPAGE
 Hady W. Lauw,Singapore Management University,https://scis.smu.edu.sg/faculty/profile/341/hady-w--lauw,HTC1z2gAAAAJ


### PR DESCRIPTION
Affiliation change for Hadi Hemmati From University of Manitoba to York University.
Homepage: https://lassonde.yorku.ca/users/hhemmati
Scholar: https://scholar.google.com/citations?hl=en&user=TznXpSIAAAAJ&view_op=list_works&sortby=pubdate
DBLP: https://dblp.org/pid/92/4860.html