### PR TITLE
Update csrankings-p.csv with Pepa Atanasova joining UCPH, Denmark

### DIFF
--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -600,6 +600,7 @@ Penny Kyburz,Australian National University,https://cs.anu.edu.au/people/penny-k
 Penny Rheingans,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~rheingan,1k0rojcAAAAJ
 Penny Sanderson,University of Queensland,https://www.psy.uq.edu.au/people/personal.html?id=533,eMywJ4sAAAAJ
 Penny Sweetser,Australian National University,https://cs.anu.edu.au/people/penny-kyburz,mrvBuvsAAAAJ
+Pepa Atanasova,University of Copenhagen,https://apepa.github.io/,CLOC3rEAAAAJ
 Per Andersson,Lund University,http://www.svet.lu.se/en/per-andersson,38DogacAAAAJ
 Per Austrin,KTH Royal Institute of Technology,http://www.nada.kth.se/~austrin,ttQM0ocAAAAJ
 Per B. Brockhoff,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE


### PR DESCRIPTION
Proof: https://di.ku.dk/english/staff/vip/researchers_nlp/?pure=en/persons/644356

