### PR TITLE
Add new tenure-track faculty to TU Kaiserslautern

### DIFF
--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -1543,6 +1543,7 @@ Sophia Ananiadou,University of Manchester,http://www.manchester.ac.uk/research/S
 Sophia Drossopoulou,Imperial College London,https://wp.doc.ic.ac.uk/sd,5g4VizIAAAAJ
 Sophia Tsoka,King's College London,https://www.kcl.ac.uk/people/sophia-tsoka,LUU0EFgAAAAJ
 Sophia Yakoubov,Aarhus University,https://pure.au.dk/portal/da/persons/sophia-yakoubov(818cd271-6e5e-4980-b248-4a337b7c0603).html,Y_XwzKQAAAAJ
+Sophie Fellenz,TU Kaiserslautern,https://ml.informatik.uni-kl.de/people/sophie-burkhardt.php,DUtm1_IAAAAJ
 Sophie Jörg,Clemson University,https://people.cs.clemson.edu/~sjoerg,vIuCdRQAAAAJ
 Sophie Tison,CRIStAL,http://cristal.univ-lille.fr/~tison,TlhLBFYAAAAJ
 Soraia Raupp Musse,PUC-RS,http://www.inf.pucrs.br/~smusse,MyKLYVMAAAAJ


### PR DESCRIPTION

Sophie Fellenz is a tenure-track, full-time faculty at TU Kaiserslautern. She is listed as one of the professors in the list of groups in the CS department:
https://www.cs.rptu.de/organisation/ags/

