### PR TITLE
Automatically mark as stale and eventually close PRs with failed CI

### DIFF
--- a/.github/workflows/commit_validation.yml
+++ b/.github/workflows/commit_validation.yml
@@ -1,9 +1,14 @@
 name: Commit Validation
 
 on:
-  push:
-
   pull_request:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  # needed for github actions
+  repository-projects: read
 
 jobs:
   commit_validation:
@@ -37,4 +42,27 @@ jobs:
         run: |
           pip install -r requirements.txt
           python validate_commit.py $DIFF
-          
+
+      - name: Make comment and mark stale if failed
+        if: failure()
+        run: |
+          echo "Mark as stale"
+          gh pr edit "$BRANCH" --add-label stale
+          gh pr comment "$BRANCH" --body 'The validity checks failed. Please look at the logs (click the red X) and correct the errors. Your PR will be closed automatically in 2 days if not fixed.'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.head_ref }}
+
+      - name: Mark unstale if success
+        if: success()
+        run: |
+          if gh pr view "$BRANCH" --json labels | grep stale ; then
+            echo "No longer stale"
+            gh pr edit "$BRANCH" --remove-label stale
+            gh pr comment "$BRANCH" --body 'The validity checks are now passing. Thank you.'
+          else
+            echo "Was already not stale"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.head_ref }}

--- a/.github/workflows/commit_validation.yml
+++ b/.github/workflows/commit_validation.yml
@@ -47,22 +47,22 @@ jobs:
         if: failure()
         run: |
           echo "Mark as stale"
-          gh pr edit "$BRANCH" --add-label stale
-          gh pr comment "$BRANCH" --body 'The validity checks failed. Please look at the logs (click the red X) and correct the errors. Your PR will be closed automatically in 2 days if not fixed.'
+          gh pr edit "$PR_NUMBER" --add-label stale
+          gh pr comment "$PR_NUMBER" --body 'The validity checks failed. Please look at the logs (click the red X) and correct the errors. Your PR will be closed automatically in 2 days if not fixed.'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.number }}
 
       - name: Mark unstale if success
         if: success()
         run: |
-          if gh pr view "$BRANCH" --json labels | grep stale ; then
+          if gh pr view "$PR_NUMBER" --json labels | grep stale ; then
             echo "No longer stale"
-            gh pr edit "$BRANCH" --remove-label stale
-            gh pr comment "$BRANCH" --body 'The validity checks are now passing. Thank you.'
+            gh pr edit "$PR_NUMBER" --remove-label stale
+            gh pr comment "$PR_NUMBER" --body 'The validity checks are now passing. Thank you.'
           else
             echo "Was already not stale"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: ${{ github.head_ref }}
+          PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: 'Close stale PRs'
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-pr-label: 'stale'
+          stale-pr-message: 'This PR is stale because it has been open for 90 days with no activity. It will be closed in 2 days if there is no further activity.'
+          close-pr-message: 'This PR is being closed due to inactivity.'
+          days-before-pr-stale: 90
+          days-before-pr-close: 2
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
We also mark succeeding PRs that are old as stale and later close them.
