### PR TITLE
Fix permissions issues with autoclose

### DIFF
--- a/.github/workflows/commit_validation.yml
+++ b/.github/workflows/commit_validation.yml
@@ -3,13 +3,6 @@ name: Commit Validation
 on:
   pull_request:
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
-  # needed for github actions
-  repository-projects: read
-
 jobs:
   commit_validation:
     runs-on: ubuntu-latest
@@ -42,27 +35,3 @@ jobs:
         run: |
           pip install -r requirements.txt
           python validate_commit.py $DIFF
-
-      - name: Make comment and mark stale if failed
-        if: failure()
-        run: |
-          echo "Mark as stale"
-          gh pr edit "$PR_NUMBER" --add-label stale
-          gh pr comment "$PR_NUMBER" --body 'The validity checks failed. Please look at the logs (click the red X) and correct the errors. Your PR will be closed automatically in 2 days if not fixed.'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}
-
-      - name: Mark unstale if success
-        if: success()
-        run: |
-          if gh pr view "$PR_NUMBER" --json labels | grep stale ; then
-            echo "No longer stale"
-            gh pr edit "$PR_NUMBER" --remove-label stale
-            gh pr comment "$PR_NUMBER" --body 'The validity checks are now passing. Thank you.'
-          else
-            echo "Was already not stale"
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/handle_validation_result.yml
+++ b/.github/workflows/handle_validation_result.yml
@@ -1,0 +1,55 @@
+name: Handle Validation Result
+
+on:
+  workflow_run:
+    workflows: ["Commit Validation"]
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  # needed because gh cli fetches unnecessary extra data
+  repository-projects: read
+
+jobs:
+  handle-validation-result:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Get PR number"
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let prNumber = context.payload.workflow_run.pull_requests[0].number;
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.txt`, prNumber.toString());
+
+      - name: Mark unstale if success
+        if: ${{ github.event.workflow_run.conclusion == "success" }}
+        run: |
+          export PR_NUMBER=$(cat pr_number.txt)
+          echo "In repo $GH_REPO on PR $PR_NUMBER"
+
+          if gh pr view -R"$GH_REPO" "$PR_NUMBER" --json labels | grep stale ; then
+            echo "No longer stale"
+            gh pr edit -R"$GH_REPO" "$PR_NUMBER" --remove-label stale
+            gh pr comment -R"$GH_REPO" "$PR_NUMBER" --body 'The validity checks are now passing. Thank you.'
+          else
+            echo "Was already not stale"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.event.repository.full_name }}
+
+      - name: Make comment and mark stale if failed
+        if: ${{ github.event.workflow_run.conclusion == "failure" }}
+        run: |
+          export PR_NUMBER=$(cat pr_number.txt)
+          echo "In repo $GH_REPO on PR $PR_NUMBER"
+
+          echo "Mark as stale"
+          gh pr edit -R"$GH_REPO" "$PR_NUMBER" --add-label stale
+          gh pr comment -R"$GH_REPO" "$PR_NUMBER" --body 'The validity checks failed. Please look at the logs (click the red X) and correct the errors. Your PR will be closed automatically in 2 days if not fixed.'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.event.repository.full_name }}


### PR DESCRIPTION
Workflows with `pull_request` targets running on PRs from forks do not
get write permission, to avoid granting privileges to untrusted code.
However, we need to validate the pull request's commits and then also
make a comment on or modify the labels of the PR. So, instead, split it
into two stages. The first is identical to the old version of "Commit
Validation". The second runs when Commit Validation completes (no matter
whether it succeeded or failed). It receives write permission because it
runs outside the PR (in fact not even in a checkout of the repo), and
then adjusts the labels and/or comments.
