### PR TITLE
autoclose: Save PR number as an Actions artifact

### DIFF
--- a/.github/workflows/commit_validation.yml
+++ b/.github/workflows/commit_validation.yml
@@ -3,6 +3,8 @@ name: Commit Validation
 on:
   pull_request:
 
+permissions: read-all
+
 jobs:
   commit_validation:
     runs-on: ubuntu-latest
@@ -35,3 +37,18 @@ jobs:
         run: |
           pip install -r requirements.txt
           python validate_commit.py $DIFF
+
+  upload:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          mkdir -p ./pr
+          echo $PR_NUMBER > ./pr/pr_number.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr_number.txt
+          path: pr/

--- a/.github/workflows/handle_validation_result.yml
+++ b/.github/workflows/handle_validation_result.yml
@@ -6,6 +6,7 @@ on:
     types: [completed]
 
 permissions:
+  actions: read
   contents: read
   issues: write
   pull-requests: write
@@ -16,13 +17,29 @@ jobs:
   handle-validation-result:
     runs-on: ubuntu-latest
     steps:
-      - name: "Get PR number"
+      - name: 'Download PR number artifact'
         uses: actions/github-script@v6
         with:
           script: |
-            let prNumber = context.payload.workflow_run.pull_requests[0].number;
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr_number.txt"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
             let fs = require('fs');
-            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.txt`, prNumber.toString());
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr_number.zip`, Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip pr_number.zip
 
       - name: Mark unstale if success
         if: ${{ github.event.workflow_run.conclusion == 'success' }}


### PR DESCRIPTION
This should hopefully avoid be more reliable than the workflow_run
payload since it's adapted from an example in the official GitHub docs.
