### PR TITLE
updates CSE faculty @ University of Nevada, Reno, Fall 2024

### DIFF
--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -1838,6 +1838,7 @@ Anjan Dutta 0001,University of Exeter,http://emps.exeter.ac.uk/computer-science/
 Anjolina Grisi de Oliveira,UFPE,https://lattes.cnpq.br/9932708325371272,NOSCHOLARPAGE
 Ankit Agrawal 0002,Saint Louis University,https://www.slu.edu/science-and-engineering/academics/computer-science/faculty-and-staff/ankit-agrawal.php/index.php,grOcC68AAAAJ
 Ankit Rajpal,University of Delhi,http://people.du.ac.in/~arajpal/,KUh24kwAAAAJ
+Ankita Shukla, University of Nevada, https://ankita-shukla.github.io, c-S0ouYAAAAJ
 Ankur Agarwal,Florida Atlantic University,http://www.eng.fau.edu/directory/faculty/agarwal,lHvOG4EAAAAJ
 Ankur Mali,University of South Florida,https://ankurmali.github.io/,ogxlzgcAAAAJ
 Ankur Mali,University of South Florida,https://ankurmali.github.io/,ogxlzgcAAAAJ

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -1838,7 +1838,7 @@ Anjan Dutta 0001,University of Exeter,http://emps.exeter.ac.uk/computer-science/
 Anjolina Grisi de Oliveira,UFPE,https://lattes.cnpq.br/9932708325371272,NOSCHOLARPAGE
 Ankit Agrawal 0002,Saint Louis University,https://www.slu.edu/science-and-engineering/academics/computer-science/faculty-and-staff/ankit-agrawal.php/index.php,grOcC68AAAAJ
 Ankit Rajpal,University of Delhi,http://people.du.ac.in/~arajpal/,KUh24kwAAAAJ
-Ankita Shukla, University of Nevada, https://ankita-shukla.github.io, c-S0ouYAAAAJ
+Ankita Shukla,University of Nevada,https://ankita-shukla.github.io,c-S0ouYAAAAJ
 Ankur Agarwal,Florida Atlantic University,http://www.eng.fau.edu/directory/faculty/agarwal,lHvOG4EAAAAJ
 Ankur Mali,University of South Florida,https://ankurmali.github.io/,ogxlzgcAAAAJ
 Ankur Mali,University of South Florida,https://ankurmali.github.io/,ogxlzgcAAAAJ

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -1432,7 +1432,6 @@ Dong-Sun Kim 0001,Kyungpook National University,http://www.darkrsw.net,Rmzs0QIAA
 DongGyun Han,Royal Holloway University of London,https://pure.royalholloway.ac.uk/en/persons/donggyun-han,gfAdVBwAAAAJ
 Dongbing Gu,University of Essex,https://www.essex.ac.uk/people/gudon81301/dongbing-gu,U-3knAUAAAAJ
 Dongfang Liu,Rochester Institute of Technology,https://dongfang-liu.github.io/,uICY0vEAAAAJ
-Dongfang Zhao 0001,University of Nevada,https://www.unr.edu/nevada-engineering/2016/faculty-2016/zhao,ZFsLVTwAAAAJ
 Donggang Cao,Peking University,http://sei.pku.edu.cn/~caodg,NOSCHOLARPAGE
 Dongha Lee 0003,Yonsei University,https://donalee.github.io,driVwKwAAAAJ
 Donghong Ji,Wuhan University,https://cse.whu.edu.cn/info/1258/3290.htm,2Q-7u3AAAAAJ

--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -323,7 +323,6 @@ Hao Zheng 0001,University of South Florida,http://www.csee.usf.edu/~zheng,BT95Le
 Hao Zheng 0005,University of Central Florida,http://haozheng.us,NOSCHOLARPAGE
 Hao Zhong 0001,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/~zhonghao,Vhe3-JsAAAAJ
 Hao-Chuan Wang,Univ. of California - Davis,http://www.haochuanwang.info,2cAqDukAAAAJ
-Hao-Ting Shen,University of Nevada,https://www.unr.edu/cse/people/haoting-shen,Zah7r3MAAAAJ
 Haodi Feng,Shandong University,http://www.cs.sdu.edu.cn/info/1112/2723.htm,NOSCHOLARPAGE
 Haodi Zhang,Shenzhen University,https://hdzhangust.github.io,Xev_4JMAAAAJ
 Haodong Wang,Cleveland State University,http://cis.csuohio.edu/~hwang/publications.html,NOSCHOLARPAGE

--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -1022,6 +1022,7 @@ Pinar Yolum,Utrecht University,https://www.uu.nl/staff/PYolumBirbil,lbdyKlYAAAAJ
 Pinar Öztürk,NTNU,https://www.ntnu.edu/employees/pinar,wL7HNLsAAAAJ
 Ping Ji 0002,CUNY,http://jjcweb.jjay.cuny.edu/pji,tQiUbtEAAAAJ
 Ping Kuang,UESTC,https://www.is.uestc.edu.cn/teachers.do?id=1067,NOSCHOLARPAGE
+Ping Liu 0004, University of Nevada,https://pinglmlcv.github.io/pingliu264/, KRz4JecAAAAJ
 Ping Luo 0001,Chinese Academy of Sciences,http://mldm.ict.ac.cn/MLDM/luoping,d5L-OV4AAAAJ
 Ping Luo 0002,University of Hong Kong,http://luoping.me,aXdjxb4AAAAJ
 Ping Sun,Tongji University,https://sse.tongji.edu.cn/Data/View/2831,NOSCHOLARPAGE

--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -162,6 +162,7 @@ Paraschos Koutris,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~pa
 Parastoo Abtahi,Princeton University,https://www.cs.princeton.edu/people/profile/abtahi,u3eIIOsAAAAJ
 Pardis Emami Naeini,Duke University,http://www.cs.duke.edu/~pe48,l0fXzvIAAAAJ
 Pari Delir Haghighi,Monash University,http://monash.edu/research/explore/en/persons/pari-delir-haghighi(70b2eef2-f84e-44ac-b48b-381f2ab4ec69).html,zvNKqskAAAAJ
+Parikshit Maini,University of Nevada,http://parikshitmaini.com/,9GEAUlcAAAAJ
 Parimala Thulasiraman,University of Manitoba,http://www.cs.umanitoba.ca/~thulasir,NOSCHOLARPAGE
 Parinaz Naghizadeh,Univ. of California - San Diego,https://jacobsschool.ucsd.edu/people/profile/parinaz-naghizadeh,rbleSIcAAAAJ
 Parinya Chalermsook,Aalto University,https://people.aalto.fi/new/parinya.chalermsook,Cw6NQasAAAAJ

--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -426,6 +426,7 @@ Rattikorn Hewett,Texas Tech University,http://www.depts.ttu.edu/cs/faculty/facul
 Ratul Mahajan,University of Washington,https://ratul.org,Sh1yq5QAAAAJ
 Raul Castro Fernandez,University of Chicago,http://raulcastrofernandez.com,bBHxY_MAAAAJ
 Raul Fervari,Universidad Nacional de Córdoba,http://cs.famaf.unc.edu.ar/~rfervari,3dg1ASwAAAAJ
+Raúl Rojas 0001, University of Nevada, https://www.unr.edu/math/people/raul-rojas, xAs1vMkAAAAJ
 Raul Vicente,University of Tartu,https://nail.cs.ut.ee/index.php/team/raul-vicente/,oQc8avwAAAAJ
 Ravi Chugh,University of Chicago,http://people.cs.uchicago.edu/~rchugh,DKuq2fIAAAAJ
 Ravi Janardan,University of Minnesota,http://umn.edu/home/janardan,NOSCHOLARPAGE

--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -1415,6 +1415,7 @@ Rui Dai 0002,University of Cincinnati,http://www.ceas3.uc.edu/profiles/dairi,5Fp
 Rui Fan 0004,ShanghaiTech University,https://sist.shanghaitech.edu.cn/sist_en/2020/0814/c7582a54758/page.htm,NOSCHOLARPAGE
 Rui Filipe Lima Maranhão de Abreu,Universidade de Lisboa,https://ruimaranhao.com,x25BFgEAAAAJ
 Rui Huang 0001,CUHK (SZ),https://myweb.cuhk.edu.cn/ruihuang,t8UduWwAAAAJ
+Rui Hu 0005,University of Nevada,https://sites.google.com/view/ruihu/home,3o5dRvsAAAAJ
 Rui Kuang,University of Minnesota,http://www-users.cs.umn.edu/~kuang,NOSCHOLARPAGE
 Rui Li 0002,Rochester Institute of Technology,https://www.rit.edu/directory/rxlics-rui-li,AHx53ngAAAAJ
 Rui Mao 0001,Shenzhen University,https://www.sics.ac.cn/mao/szu/eng,MVbJ9wQAAAAJ

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -832,7 +832,6 @@ Shahin Kamali,University of Manitoba,http://www.cs.umanitoba.ca/~kamalis,hQXlVLs
 Shahram Ghandeharizadeh,University of Southern California,https://www.flslab.org/,FI5-sZEAAAAJ
 Shahram ShahbazPanahi,Ontario Tech University,https://engineering.ontariotechu.ca/people/ecse/shahram.shahbazpanahi.php,-kZ8x08AAAAJ
 Shahram Shahbazpanahi,Ontario Tech University,https://engineering.ontariotechu.ca/people/ecse/shahram.shahbazpanahi.php,-kZ8x08AAAAJ
-Shahriar Badsha,University of Nevada,https://www.unr.edu/cse/people/shahriar-badsha,Zvr9kOwAAAAJ
 Shahriar Nirjon,University of North Carolina,http://cs.unc.edu/~nirjon,CsGlDGEAAAAJ
 Shahryar Rahnamayan,Ontario Tech University,https://engineering.ontariotechu.ca/people/ecse/shahryar.rahnamayan.php,6ipYkfYAAAAJ
 Shai Avidan,Tel Aviv University,http://www.eng.tau.ac.il/~avidan,hpItE1QAAAAJ

--- a/csrankings-x.csv
+++ b/csrankings-x.csv
@@ -315,6 +315,7 @@ Xiaoyu Xia 0001,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/a
 Xiaoyuan Jing,Wuhan University,http://mla.whu.edu.cn,NOSCHOLARPAGE
 Xiaoyuan Xie,Wuhan University,http://xiaoyuanxie.github.io,VlHMPKoAAAAJ
 Xiaoyun Wang 0001,Tsinghua University,http://www.tsinghua.edu.cn/publish/casen/1695/2010/20101224093253705266640/20101224093253705266640_.html,5pUP56sAAAAJ
+Xiaoxue Zhang 0001 , University of Nevada, https://xzhan330z.github.io, c9MBgn0AAAAJ
 Xiaozhong Liu,Worcester Polytechnic Institute,https://www.wpi.edu/people/faculty/xliu14,1BUByMcAAAAJ
 Xiapu Luo,The Hong Kong Polytechnic University,https://www4.comp.polyu.edu.hk/~csxluo,uvedrYMAAAAJ
 Xiatian Zhu,University of Surrey,https://xiatian-zhu.github.io/,ZbA-z1cAAAAJ


### PR DESCRIPTION
agree to all guidelines. 

Added Parikshit Maini, Rui Hu, Ping Liu, XiaoXue Zhang, Ankita Shukla as new faculty and Raul Rojas as affiliated faculty (is CSE graduate faculty). 

Removed Haoting Shen, Donfang Zhao, and Shahriar Badsha // left for other universities. 