### PR TITLE
Add Professor Hwajung Hong (Industrial Design, KAIST) to CSrankings

### DIFF
--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -1081,6 +1081,7 @@ Huy T. Vo,CUNY,https://www-cs.ccny.cuny.edu/~hvo/,HNwwWQgAAAAJ
 Huzefa Rangwala,George Mason University,https://cs.gmu.edu/~hrangwal,yWJ9BqEAAAAJ
 Huzur Saran,IIT Delhi,http://www.cse.iitd.ernet.in/~saran,NOSCHOLARPAGE
 Hwa-Chun Lin,National Tsing Hua University,http://alpha5.cs.nthu.edu.tw/labweb/advisor.html,NOSCHOLARPAGE
+Hwajung Hong,KAIST,https://dxd-lab.github.io,W6dBWJkAAAAJ
 Hwangjun Song,POSTECH,http://mcnl.postech.ac.kr,3w4oYn8AAAAJ
 Hwanjo Yu,POSTECH,http://hwanjoyu.org,LbrCa7EAAAAJ
 Hwann-Tzong Chen,National Tsing Hua University,http://www.cs.nthu.edu.tw/~htchen,mwFy9kkAAAAJ

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,35 +9,35 @@ You must read and check **all** the boxes below by filling them in with an X or 
 
 **The Basics**
 
-- [ ] All pull requests and issues must come from non-anonymous accounts. Make sure your GitHub profile contains your full name.
+- [x] All pull requests and issues must come from non-anonymous accounts. Make sure your GitHub profile contains your full name.
 
-- [ ] Use a reasonable title that explains what the PR corresponds to (as in, not "Update csrankings-x.csv").
+- [x] Use a reasonable title that explains what the PR corresponds to (as in, not "Update csrankings-x.csv").
 
-- [ ] Combine multiple updates to a single institution into a **single PR.**
+- [x] Combine multiple updates to a single institution into a **single PR.**
 
-- [ ] Only submit one pull request per institution.
+- [x] Only submit one pull request per institution.
 
-- [ ] Do not modify any files except `csrankings-[a-z].csv` or (if needed) `country-info.csv` and `old/industry.csv` (see below).
+- [x] Do not modify any files except `csrankings-[a-z].csv` or (if needed) `country-info.csv` and `old/industry.csv` (see below).
 
-- [ ] Do not use Excel to edit any .csv files; Excel incorrectly tries to
+- [x] Do not use Excel to edit any .csv files; Excel incorrectly tries to
 convert some Google Scholar entries to formulas, corrupting the
 database. Use the GitHub user interface or a text editor like emacs or NotePad instead.
 
-- [ ] Insert new faculty **in alphabetical order** (not at the end) in the appropriate `csrankings-[a-z].csv` files. **Do not modify `csrankings.csv`, which is auto-generated.**
+- [x] Insert new faculty **in alphabetical order** (not at the end) in the appropriate `csrankings-[a-z].csv` files. **Do not modify `csrankings.csv`, which is auto-generated.**
 
-- [ ] Check to make sure that you have no spaces after commas, or any missing fields.
+- [x] Check to make sure that you have no spaces after commas, or any missing fields.
 
-- [ ] Check to make sure the home page is correct.
+- [x] Check to make sure the home page is correct.
 
-- [ ] Make sure the Google Scholar IDs are just the alphanumeric identifier (not a URL or with `&hl=en`).
+- [x] Make sure the Google Scholar IDs are just the alphanumeric identifier (not a URL or with `&hl=en`).
 
-- [ ] Check to make sure the name corresponds to the DBLP entry (look it up at http://dblp.org).
+- [x] Check to make sure the name corresponds to the DBLP entry (look it up at http://dblp.org).
 
-- [ ] If a faculty member is not in a CS department or similar, include a comment explaining how they meet the inclusion criteria (see below).
+- [x] If a faculty member is not in a CS department or similar, include a comment explaining how they meet the inclusion criteria (see below).
 
 **Inclusion criteria**
 
-- [ ] Make sure that any faculty you add meet the inclusion
+- [x] Make sure that any faculty you add meet the inclusion
 criteria. Eligible faculty include only full-time, tenure-track research
 faculty members on a given campus who can *solely* advise PhD students in
 Computer Science. Faculty not in a CS department or similar who can
@@ -49,17 +49,17 @@ e.g. showing a courtesy appointment in CS.** Faculty must also have a 75%+ time 
 
 **Updating an affiliation or home page**
 
-- [ ] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings-[a-z].csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put `NOSCHOLARPAGE`.
+- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings-[a-z].csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put `NOSCHOLARPAGE`.
 
 **Adding one or more faculty members (including an entire department)**
 
-- [ ] If the department is not yet listed in CSrankings, the entire CS faculty needs to be added (not just one faculty member).
+- [x] If the department is not yet listed in CSrankings, the entire CS faculty needs to be added (not just one faculty member).
 
-- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings-[a-z].csv` (**the letters correspond to the first letter of the faculty members' names**); include disambiguation suffixes like `0001` as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.
+- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings-[a-z].csv` (**the letters correspond to the first letter of the faculty members' names**); include disambiguation suffixes like `0001` as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.
 
-- [ ] If DBLP has multiple entries for this person, *all of them need to be listed*. Do not update `dblp-aliases.csv`.
+- [x] If DBLP has multiple entries for this person, *all of them need to be listed*. Do not update `dblp-aliases.csv`.
 
-- [ ] If the institution you are adding is not in the US,
+- [x] If the institution you are adding is not in the US,
 update `country-info.csv` and add *all* of the faculty in the CS department.
 
 **(Advanced) Quick contribution via a shallow clone** 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,35 +9,35 @@ You must read and check **all** the boxes below by filling them in with an X or 
 
 **The Basics**
 
-- [x] All pull requests and issues must come from non-anonymous accounts. Make sure your GitHub profile contains your full name.
+- [ ] All pull requests and issues must come from non-anonymous accounts. Make sure your GitHub profile contains your full name.
 
-- [x] Use a reasonable title that explains what the PR corresponds to (as in, not "Update csrankings-x.csv").
+- [ ] Use a reasonable title that explains what the PR corresponds to (as in, not "Update csrankings-x.csv").
 
-- [x] Combine multiple updates to a single institution into a **single PR.**
+- [ ] Combine multiple updates to a single institution into a **single PR.**
 
-- [x] Only submit one pull request per institution.
+- [ ] Only submit one pull request per institution.
 
-- [x] Do not modify any files except `csrankings-[a-z].csv` or (if needed) `country-info.csv` and `old/industry.csv` (see below).
+- [ ] Do not modify any files except `csrankings-[a-z].csv` or (if needed) `country-info.csv` and `old/industry.csv` (see below).
 
-- [x] Do not use Excel to edit any .csv files; Excel incorrectly tries to
+- [ ] Do not use Excel to edit any .csv files; Excel incorrectly tries to
 convert some Google Scholar entries to formulas, corrupting the
 database. Use the GitHub user interface or a text editor like emacs or NotePad instead.
 
-- [x] Insert new faculty **in alphabetical order** (not at the end) in the appropriate `csrankings-[a-z].csv` files. **Do not modify `csrankings.csv`, which is auto-generated.**
+- [ ] Insert new faculty **in alphabetical order** (not at the end) in the appropriate `csrankings-[a-z].csv` files. **Do not modify `csrankings.csv`, which is auto-generated.**
 
-- [x] Check to make sure that you have no spaces after commas, or any missing fields.
+- [ ] Check to make sure that you have no spaces after commas, or any missing fields.
 
-- [x] Check to make sure the home page is correct.
+- [ ] Check to make sure the home page is correct.
 
-- [x] Make sure the Google Scholar IDs are just the alphanumeric identifier (not a URL or with `&hl=en`).
+- [ ] Make sure the Google Scholar IDs are just the alphanumeric identifier (not a URL or with `&hl=en`).
 
-- [x] Check to make sure the name corresponds to the DBLP entry (look it up at http://dblp.org).
+- [ ] Check to make sure the name corresponds to the DBLP entry (look it up at http://dblp.org).
 
-- [x] If a faculty member is not in a CS department or similar, include a comment explaining how they meet the inclusion criteria (see below).
+- [ ] If a faculty member is not in a CS department or similar, include a comment explaining how they meet the inclusion criteria (see below).
 
 **Inclusion criteria**
 
-- [x] Make sure that any faculty you add meet the inclusion
+- [ ] Make sure that any faculty you add meet the inclusion
 criteria. Eligible faculty include only full-time, tenure-track research
 faculty members on a given campus who can *solely* advise PhD students in
 Computer Science. Faculty not in a CS department or similar who can
@@ -49,17 +49,17 @@ e.g. showing a courtesy appointment in CS.** Faculty must also have a 75%+ time 
 
 **Updating an affiliation or home page**
 
-- [x] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings-[a-z].csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put `NOSCHOLARPAGE`.
+- [ ] Update affiliations, home pages, and Google Scholar entries by modifying `csrankings-[a-z].csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put `NOSCHOLARPAGE`.
 
 **Adding one or more faculty members (including an entire department)**
 
-- [x] If the department is not yet listed in CSrankings, the entire CS faculty needs to be added (not just one faculty member).
+- [ ] If the department is not yet listed in CSrankings, the entire CS faculty needs to be added (not just one faculty member).
 
-- [x] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings-[a-z].csv` (**the letters correspond to the first letter of the faculty members' names**); include disambiguation suffixes like `0001` as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.
+- [ ] Enter each faculty member's [DBLP](http://dblp.org) name, home page, and Google Scholar entry (just the alphanumeric identifier, not the whole URL) by modifying `csrankings-[a-z].csv` (**the letters correspond to the first letter of the faculty members' names**); include disambiguation suffixes like `0001` as needed. If the faculty entry is currently ambiguous, please do not include them. Send mail to the DBLP maintainers (dblp@dagstuhl.de) with a few publications by a particular faculty member; also, open an issue so that when the DBLP database is updated, that faculty member's information can be added.
 
-- [x] If DBLP has multiple entries for this person, *all of them need to be listed*. Do not update `dblp-aliases.csv`.
+- [ ] If DBLP has multiple entries for this person, *all of them need to be listed*. Do not update `dblp-aliases.csv`.
 
-- [x] If the institution you are adding is not in the US,
+- [ ] If the institution you are adding is not in the US,
 update `country-info.csv` and add *all* of the faculty in the CS department.
 
 **(Advanced) Quick contribution via a shallow clone** 


### PR DESCRIPTION
This pull request adds Professor Hwajung Hong to the CSrankings database. 

Although Professor Hong is not part of a traditional Computer Science department—her primary affiliation is with Industrial Design—her research focus in Human-Computer Interaction (HCI) and AI aligns well with the CS research areas (https://scholar.google.com/citations?hl=ko&user=W6dBWJkAAAAJ). Furthermore, her inclusion is supported by precedent: other faculty members from the (same) KAIST Industrial Design department, such as Professor Andrea Bianchi and Professor Tek-Jin Nam, are already part of the CSrankings list. Their presence underscores that the criteria for inclusion are based on research contributions and relevance to CS rather than solely on departmental affiliation.

Given Professor Hong’s significant contributions to HCI and AI, I believe her addition to the list is well justified and will provide a more accurate representation of interdisciplinary research in our rankings.