### PR TITLE
Updated Ruhr-University Bochum faculty

### DIFF
--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -486,6 +486,7 @@ Bijoy Chand Chatterjee,South Asian University,https://www.bijoycc.site,mYKBDyYAA
 Biju K. Raveendran,BITS Pilani-Goa,https://www.bits-pilani.ac.in/goa/biju/profile,wpRpGpwAAAAJ
 Bikramjit Banerjee,University of Southern Mississippi,https://www.usm.edu/computing/faculty/bikramjit-banerjee,WHs9gMMAAAAJ
 Bilal Khan,CUNY,https://www.gc.cuny.edu/Page-Elements/Academics-Research-Centers-Initiatives/Doctoral-Programs/Computer-Science/Faculty-Bios/Bilal-Khan,uOBB1tEAAAAJ
+Bilal Zafar,Ruhr-University Bochum,https://informatik.rub.de/zafar/,keWdp0AAAAAJ
 Bilel Derbel,CRIStAL,https://www.cristal.univ-lille.fr/profil/derbel,NOSCHOLARPAGE
 Bilge Mutlu,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~bilge,VGr54BoAAAAJ
 Bill Aiello,University of British Columbia,https://www.cs.ubc.ca/people/bill-aiello,7gbCeoEAAAAJ

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -1283,6 +1283,7 @@ Dirk Fahland,TU Eindhoven,https://www.win.tue.nl/~dfahland,qLkK5JAAAAAJ
 Dirk Grunwald,University of Colorado Boulder,http://systems.cs.colorado.edu/people/faculty/dirk-grunwald,3Ws6G2AAAAAJ
 Dirk Henri Nowotka,University of Kiel,https://www.zs.informatik.uni-kiel.de/en/team/nowotka,-oLw6tMAAAAJ
 Dirk Hovy,Bocconi University,http://dirkhovy.com,7xluaTAAAAAJ
+Dirk Jancke,Ruhr-University Bochum,https://www.ini.rub.de/the_institute/people/dirk-jancke/,RkHDpzIAAAAJ
 Dirk Nowotka,University of Kiel,https://www.zs.informatik.uni-kiel.de/en/team/nowotka,-oLw6tMAAAAJ
 Dirk Nuyens,KU Leuven,https://people.cs.kuleuven.be/~dirk.nuyens,QurueO4AAAAJ
 Dirk Oliver Theis,University of Tartu,http://ac.cs.ut.ee/people/dot,b1nM_OUAAAAJ

--- a/csrankings-f.csv
+++ b/csrankings-f.csv
@@ -374,6 +374,7 @@ Flavio D. Garcia,University of Birmingham,https://www.birmingham.ac.uk/staff/pro
 Flavio Esposito,Saint Louis University,https://cs.slu.edu/~esposito/,kqKzPS8AAAAJ
 Flavio Keidi Miyazawa,UNICAMP,http://www.ic.unicamp.br/~fkm,YV0kVoIAAAAJ
 Flavio S. Corrêa da Silva,USP,http://www.ime.usp.br/~fcs,NOSCHOLARPAGE
+Flavio Toffalini,Ruhr-University Bochum,https://flaviotoffalini.info/,3NPpxGIAAAAJ
 Flavio V. D. de Figueiredo,UFMG,http://homepages.dcc.ufmg.br/~flaviovdf,4QhxTFYAAAAJ
 Flavio Vinicius Diniz de Figueiredo,UFMG,http://homepages.dcc.ufmg.br/~flaviovdf,4QhxTFYAAAAJ
 Flavio de Figueiredo,UFMG,http://homepages.dcc.ufmg.br/~flaviovdf,4QhxTFYAAAAJ

--- a/csrankings-i.csv
+++ b/csrankings-i.csv
@@ -392,6 +392,7 @@ Ivan De Oliveira Nunes,Rochester Institute of Technology,https://www.rit.edu/dir
 Ivan Dokmanic,University of Basel,https://dmi.unibas.ch/de/personen/ivan-dokmanic/,0SQnwL4AAAAJ
 Ivan Flechais,University of Oxford,https://www.cs.ox.ac.uk/people/ivan.flechais,w6PR9pkAAAAJ
 Ivan Garibay,University of Central Florida,https://www.cs.ucf.edu/~garibay,rPuLfoMAAAAJ
+Ivan Habernal,Ruhr-University Bochum,https://www.trusthlt.org/,ERp8VTsAAAAJ
 Ivan Hal Sudborough,University of Texas at Dallas,https://explorer.utdallas.edu/editprofile.php?pid=13187,NOSCHOLARPAGE
 Ivan Herman,CWI,http://homepages.cwi.nl/~ivan,ofRrImEAAAAJ
 Ivan I. Garibay,University of Central Florida,https://www.cs.ucf.edu/~garibay,rPuLfoMAAAAJ

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -289,7 +289,7 @@ Katharina Breininger,University of Würzburg,https://www.caidas.uni-wuerzburg.de
 Katharina E. Kinder-Kurlanda,University of Klagenfurt,https://katharinakinderkurlanda.net,VVms_qoAAAAJ
 Katharina Kann,University of Colorado Boulder,https://kelina.github.io,3XF5bqEAAAAJ
 Katharina Kinder-Kurlanda,University of Klagenfurt,https://katharinakinderkurlanda.net,VVms_qoAAAAJ
-Katharina Kohls,Radboud University,https://kkohls.org/index.html,HQ8HblYAAAAJ
+Katharina Kohls,Ruhr-University Bochum,https://kkohls.info,HQ8HblYAAAAJ
 Katharina Krombholz,CISPA Helmholtz Center,https://cispa.saarland/people/katharina.krombholz,BkeawyUAAAAJ
 Katharina Morik,TU Dortmund,https://www-ai.cs.tu-dortmund.de/PERSONAL/morik.html,LfmjF2UAAAAJ
 Katharina Reinecke,University of Washington,https://www.cs.washington.edu/people/faculty/reinecke,_4EISRwAAAAJ

--- a/csrankings-t.csv
+++ b/csrankings-t.csv
@@ -636,6 +636,7 @@ Tim Kovacs,University of Bristol,http://www.cs.bris.ac.uk/~kovacs,pil1zQsAAAAJ
 Tim Kraska,Massachusetts Institute of Technology,https://people.csail.mit.edu/kraska/,biuxbRsAAAAJ
 Tim Landgraf,Freie Universitaet Berlin,https://www.mi.fu-berlin.de/inf/groups/ag-ki/members/Professoren/Tim_Landgraf.html,ChX0opIAAAAJ
 Tim Littler,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=t.littler,ebzTOKsAAAAJ
+Tim A. Majchrzak,Ruhr-University Bochum,https://informatik.rub.de/majchrzak/,QAAAAJ
 Tim McInerney,Toronto Metropolitan University,https://www.scs.torontomu.ca/~tmcinern,4jp8rwgAAAAJ
 Tim Menzies,North Carolina State University,http://menzies.us,7htTUTgmLtUC
 Tim Merritt,Aalborg University,http://www.ixd.net,RBhmAmkAAAAJ

--- a/csrankings-v.csv
+++ b/csrankings-v.csv
@@ -137,7 +137,7 @@ Vedran Dunjko,Leiden University,https://sites.google.com/view/quantumatliacs/,sy
 Vedran Sekara,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/vedran-sekara(db64c222-0674-4eab-9f09-7f9ea1c483e3).html,u_dmO4UAAAAJ
 Vedrana Andersen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Vedrana Andersen Dahl,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
-Veelasha Moonsamy,Radboud University,https://www.veelasha.org,lMDHW00AAAAJ
+Veelasha Moonsamy,Ruhr-University Bochum,https://www.veelasha.org,lMDHW00AAAAJ
 Veena Goswami,KIIT Bhubaneswar,https://ksca.kiit.ac.in/profiles/veena-goswami/,tJHsyCMAAAAJ
 Veezhinathan Kamakoti,IIT Madras,http://rise.cse.iitm.ac.in/people/faculty/kama/kama.html,n_Ck-8UAAAAJ
 Veikko Surakka,Tampere University,https://www.tuni.fi/en/veikko-surakka,7h-zuycAAAAJ


### PR DESCRIPTION
Updated affiation of Veelasha Moonsamy and Katharina Kohls, added Habernal, Toffalini, jancke, zafar and majchrzak
The official faculty list is on https://informatik.rub.de/fakultaet/professuren/