### PR TITLE
update ruhr Uni Bochum

### DIFF
--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -486,6 +486,7 @@ Bijoy Chand Chatterjee,South Asian University,https://www.bijoycc.site,mYKBDyYAA
 Biju K. Raveendran,BITS Pilani-Goa,https://www.bits-pilani.ac.in/goa/biju/profile,wpRpGpwAAAAJ
 Bikramjit Banerjee,University of Southern Mississippi,https://www.usm.edu/computing/faculty/bikramjit-banerjee,WHs9gMMAAAAJ
 Bilal Khan,CUNY,https://www.gc.cuny.edu/Page-Elements/Academics-Research-Centers-Initiatives/Doctoral-Programs/Computer-Science/Faculty-Bios/Bilal-Khan,uOBB1tEAAAAJ
+Bilal Zafar,Ruhr-University Bochum,https://informatik.rub.de/zafar/,keWdp0AAAAAJ
 Bilel Derbel,CRIStAL,https://www.cristal.univ-lille.fr/profil/derbel,NOSCHOLARPAGE
 Bilge Mutlu,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~bilge,VGr54BoAAAAJ
 Bill Aiello,University of British Columbia,https://www.cs.ubc.ca/people/bill-aiello,7gbCeoEAAAAJ

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -1283,6 +1283,7 @@ Dirk Fahland,TU Eindhoven,https://www.win.tue.nl/~dfahland,qLkK5JAAAAAJ
 Dirk Grunwald,University of Colorado Boulder,http://systems.cs.colorado.edu/people/faculty/dirk-grunwald,3Ws6G2AAAAAJ
 Dirk Henri Nowotka,University of Kiel,https://www.zs.informatik.uni-kiel.de/en/team/nowotka,-oLw6tMAAAAJ
 Dirk Hovy,Bocconi University,http://dirkhovy.com,7xluaTAAAAAJ
+Dirk Jancke,Ruhr-University Bochum,https://www.ini.rub.de/the_institute/people/dirk-jancke/,RkHDpzIAAAAJ
 Dirk Nowotka,University of Kiel,https://www.zs.informatik.uni-kiel.de/en/team/nowotka,-oLw6tMAAAAJ
 Dirk Nuyens,KU Leuven,https://people.cs.kuleuven.be/~dirk.nuyens,QurueO4AAAAJ
 Dirk Oliver Theis,University of Tartu,http://ac.cs.ut.ee/people/dot,b1nM_OUAAAAJ

--- a/csrankings-f.csv
+++ b/csrankings-f.csv
@@ -374,6 +374,7 @@ Flavio D. Garcia,University of Birmingham,https://www.birmingham.ac.uk/staff/pro
 Flavio Esposito,Saint Louis University,https://cs.slu.edu/~esposito/,kqKzPS8AAAAJ
 Flavio Keidi Miyazawa,UNICAMP,http://www.ic.unicamp.br/~fkm,YV0kVoIAAAAJ
 Flavio S. Corrêa da Silva,USP,http://www.ime.usp.br/~fcs,NOSCHOLARPAGE
+Flavio Toffalini,Ruhr-University Bochum,https://flaviotoffalini.info/,3NPpxGIAAAAJ
 Flavio V. D. de Figueiredo,UFMG,http://homepages.dcc.ufmg.br/~flaviovdf,4QhxTFYAAAAJ
 Flavio Vinicius Diniz de Figueiredo,UFMG,http://homepages.dcc.ufmg.br/~flaviovdf,4QhxTFYAAAAJ
 Flavio de Figueiredo,UFMG,http://homepages.dcc.ufmg.br/~flaviovdf,4QhxTFYAAAAJ

--- a/csrankings-i.csv
+++ b/csrankings-i.csv
@@ -392,6 +392,7 @@ Ivan De Oliveira Nunes,Rochester Institute of Technology,https://www.rit.edu/dir
 Ivan Dokmanic,University of Basel,https://dmi.unibas.ch/de/personen/ivan-dokmanic/,0SQnwL4AAAAJ
 Ivan Flechais,University of Oxford,https://www.cs.ox.ac.uk/people/ivan.flechais,w6PR9pkAAAAJ
 Ivan Garibay,University of Central Florida,https://www.cs.ucf.edu/~garibay,rPuLfoMAAAAJ
+Ivan Habernal,Ruhr-University Bochum,https://www.trusthlt.org/,ERp8VTsAAAAJ
 Ivan Hal Sudborough,University of Texas at Dallas,https://explorer.utdallas.edu/editprofile.php?pid=13187,NOSCHOLARPAGE
 Ivan Herman,CWI,http://homepages.cwi.nl/~ivan,ofRrImEAAAAJ
 Ivan I. Garibay,University of Central Florida,https://www.cs.ucf.edu/~garibay,rPuLfoMAAAAJ

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -289,7 +289,7 @@ Katharina Breininger,University of Würzburg,https://www.caidas.uni-wuerzburg.de
 Katharina E. Kinder-Kurlanda,University of Klagenfurt,https://katharinakinderkurlanda.net,VVms_qoAAAAJ
 Katharina Kann,University of Colorado Boulder,https://kelina.github.io,3XF5bqEAAAAJ
 Katharina Kinder-Kurlanda,University of Klagenfurt,https://katharinakinderkurlanda.net,VVms_qoAAAAJ
-Katharina Kohls,Radboud University,https://kkohls.org/index.html,HQ8HblYAAAAJ
+Katharina Kohls,Ruhr-University Bochum,https://kkohls.info,HQ8HblYAAAAJ
 Katharina Krombholz,CISPA Helmholtz Center,https://cispa.saarland/people/katharina.krombholz,BkeawyUAAAAJ
 Katharina Morik,TU Dortmund,https://www-ai.cs.tu-dortmund.de/PERSONAL/morik.html,LfmjF2UAAAAJ
 Katharina Reinecke,University of Washington,https://www.cs.washington.edu/people/faculty/reinecke,_4EISRwAAAAJ

--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -488,6 +488,7 @@ Rebecca M. Williams,Univ. of Maryland - Baltimore County,https://www.csee.umbc.e
 Rebecca Schulman,Johns Hopkins University,https://engineering.jhu.edu/faculty/rebecca-schulman/,segdJQYAAAAJ
 Rebecca Willett,University of Chicago,https://voices.uchicago.edu/willett,bGRVPl8AAAAJ
 Rebekka Burkholz,CISPA Helmholtz Center,https://sites.google.com/view/rebekkaburkholz/rebekka-burkholz,vkWBb2wAAAAJ
+Rebekah Overdorf,Ruhr-University Bochum,https://informatik.rub.de/overdorf/,eYiHQAAAAJ
 Red Whittaker,Carnegie Mellon University,http://www.ri.cmu.edu/person.html?person_id=339,ouKJUyEAAAAJ
 Reda A. Ammar,University of Connecticut,http://www.engr.uconn.edu/~reda,NOSCHOLARPAGE
 Reda Alhajj,University of Calgary,http://alhajj.cpsc.ucalgary.ca,NOSCHOLARPAGE

--- a/csrankings-t.csv
+++ b/csrankings-t.csv
@@ -612,6 +612,7 @@ Tilmann Rabl,Hasso Plattner Institute,https://hpi.de/das-hpi/personen/professore
 Tilo Burghardt,University of Bristol,http://www.cs.bris.ac.uk/~burghard,lqM244QAAAAJ
 Tilo Böhmann,University of Hamburg,https://www.inf.uni-hamburg.de/en/inst/ab/itmc/team/boehmann.html,xGzSaOUAAAAJ
 Tim A. C. Willemse,TU Eindhoven,http://www.win.tue.nl/~timw,URsjU7oAAAAJ
+Tim A. Majchrzak,Ruhr-University Bochum,https://informatik.rub.de/majchrzak/,9lxp7-QAAAAJ
 Tim Althoff,University of Washington,http://www.timalthoff.com,yc4nBNgAAAAJ
 Tim B. Dyrby,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Tim Baarslag,Utrecht University,https://homepages.cwi.nl/~baarslag,Ic5t92AAAAAJ

--- a/csrankings-v.csv
+++ b/csrankings-v.csv
@@ -137,7 +137,7 @@ Vedran Dunjko,Leiden University,https://sites.google.com/view/quantumatliacs/,sy
 Vedran Sekara,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/vedran-sekara(db64c222-0674-4eab-9f09-7f9ea1c483e3).html,u_dmO4UAAAAJ
 Vedrana Andersen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Vedrana Andersen Dahl,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
-Veelasha Moonsamy,Radboud University,https://www.veelasha.org,lMDHW00AAAAJ
+Veelasha Moonsamy,Ruhr-University Bochum,https://www.veelasha.org,lMDHW00AAAAJ
 Veena Goswami,KIIT Bhubaneswar,https://ksca.kiit.ac.in/profiles/veena-goswami/,tJHsyCMAAAAJ
 Veezhinathan Kamakoti,IIT Madras,http://rise.cse.iitm.ac.in/people/faculty/kama/kama.html,n_Ck-8UAAAAJ
 Veikko Surakka,Tampere University,https://www.tuni.fi/en/veikko-surakka,7h-zuycAAAAJ


### PR DESCRIPTION

This PR adds eight new Computer Science researchers from Ruhr-Universität Bochum to the RUB section:

1. **Veelasha Moonsamy** (moved from Radboud)  
2. **Katharina Kohls** (moved from Radboud)  
3. **Ivan Habernal**  
4. **Flavio Toffalini**  
5. **Dirk Jancke**  
6. **Bilal Zafar**  
7. **Rebekah Overdorf**  
8. **Tim A. Majchrzak**