### PR TITLE
Include Juan M. Cebrian from University of Murcia into csrankings-j.csv 

### DIFF
--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -2270,6 +2270,7 @@ Juan L. Reutter,Pontificia Universidad Catolica de Chile,https://jreutter.sitios
 Juan Liu 0007,Wuhan University,https://cs.whu.edu.cn/info/1019/2890.htm,YXLdpNIAAAAJ
 Juan Luo,Hunan University,http://csee.hnu.edu.cn/people/luojuan,NOSCHOLARPAGE
 Juan M. Banda,Georgia State University,http://www.jmbanda.com,lCgSjYAAAAAJ
+Juan M. Cebrian,University of Murcia,https://webs.um.es/jcebrian/,paUsMTEAAAAJ
 Juan P. Galeotti,University of Buenos Aires,http://lafhis.dc.uba.ar/en/~jgaleotti,xeL-QIoAAAAJ
 Juan Pablo Bello,New York University,https://engineering.nyu.edu/faculty/juan-pablo-bello,PMHXcoAAAAAJ
 Juan Pablo Galeotti,University of Buenos Aires,http://lafhis.dc.uba.ar/en/~jgaleotti,xeL-QIoAAAAJ


### PR DESCRIPTION
Juan M. Cebrian recently got a permanent position and is requesting to join the CSRanking for the University of Murcia.

