### PR TITLE
Updating Libo 0005 (Beihang University) in csrankings-b.csv

### DIFF
--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -643,7 +643,7 @@ Bo Ji 0001,Virginia Tech,http://people.cs.vt.edu/boji,9ILgtvAAAAAJ
 Bo Jiang 0003,Shanghai Jiao Tong University,https://jhc.sjtu.edu.cn/~bjiang,WxAIZtMAAAAJ
 Bo Lang,Beihang University,http://scse.buaa.edu.cn/info/1078/2660.htm,NOSCHOLARPAGE
 Bo Li 0001,HKUST,https://www.cse.ust.hk/~bli,BMkV-YoAAAAJ
-Bo Li 0005,Beihang University,http://scse.buaa.edu.cn/info/1078/2639.htm,NOSCHOLARPAGE
+Bo Li 0005,Beihang University,https://scse.buaa.edu.cn/info/1078/11964.htm,CvjqOuwAAAAJ
 Bo Li 0037,The Hong Kong Polytechnic University,https://www4.comp.polyu.edu.hk/~bo2li,JsT0JNYAAAAJ
 Bo Liu 0006,Auburn University,https://liubo-cs.github.io,8MliTo4AAAAJ
 Bo Luo,University of Kansas,http://www.ittc.ku.edu/~bluo,roY9L1oAAAAJ


### PR DESCRIPTION
Updating Libo 0005 (Beihang University) in csrankings-b.csv, including the homepage and scholar ID.