### PR TITLE
Removed non-CS faculty from IST Austria (ISTA)

### DIFF
--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -136,7 +136,6 @@ Gary T. Leavens,University of Central Florida,http://www.cs.ucf.edu/~leavens/hom
 Gary Tyson,Florida State University,http://www.cs.fsu.edu/~tyson,vC_bjb0gU4EC
 Gary W. Meyer,University of Minnesota,http://umn.edu/home/meyer172,7P_WgjYAAAAJ
 Gary William Grewal,University of Guelph,http://www.uoguelph.ca/~ggrewal,NOSCHOLARPAGE
-Gasper Tkacik,IST Austria,https://gtkacik.pages.ist.ac.at,arjXIL8AAAAJ
 Gaurav Harit,IIT Jodhpur,http://home.iitj.ac.in/~gharit,puzdkHAAAAAJ
 Gaurav S. Sukhatme,University of Southern California,http://www-robotics.usc.edu/~gaurav,lRUi-A8AAAAJ
 Gaurav Sharma,University of Rochester,https://hajim.rochester.edu/ece/sites/gsharma,OlsDoroAAAAJ
@@ -1011,3 +1010,4 @@ Günther R. Raidl,TU Wien,https://www.ac.tuwien.ac.at/people/raidl,NOSCHOLARPAGE
 Günther Ruhe,University of Calgary,http://ruhe.cpsc.ucalgary.ca,5nL_z0oAAAAJ
 Günther Schatter,Bauhaus University Weimar,https://www.uni-weimar.de/de/medien/professuren/medieninformatik/vernetzte-medien/personen/apl-prof-dr-guenther-schatter,NOSCHOLARPAGE
 Günther Specht,University of Innsbruck,https://dbis-informatik.uibk.ac.at/specht,Csj85-oAAAAJ
+

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -1010,4 +1010,3 @@ Günther R. Raidl,TU Wien,https://www.ac.tuwien.ac.at/people/raidl,NOSCHOLARPAGE
 Günther Ruhe,University of Calgary,http://ruhe.cpsc.ucalgary.ca,5nL_z0oAAAAJ
 Günther Schatter,Bauhaus University Weimar,https://www.uni-weimar.de/de/medien/professuren/medieninformatik/vernetzte-medien/personen/apl-prof-dr-guenther-schatter,NOSCHOLARPAGE
 Günther Specht,University of Innsbruck,https://dbis-informatik.uibk.ac.at/specht,Csj85-oAAAAJ
-

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -2604,7 +2604,6 @@ Sylvain Martel,Polytechnique Montreal,https://www.polymtl.ca/expertises/en/marte
 Sylvain Salvati,CRIStAL,https://www.cristal.univ-lille.fr/profil/ssalvati,NOSCHOLARPAGE
 Sylvain Schmitz,Ecole Normale Superieure de Cachan,http://www.lsv.ens-cachan.fr/~schmitz,mMktcHwAAAAJ
 Sylvia C. Boyd,University of Ottawa,http://www.site.uottawa.ca/~sylvia,P7mb9zgAAAAJ
-Sylvia Cremer,IST Austria,http://ist.ac.at/research/research-groups/cremer-group,_Gm-T9IAAAAJ
 Sylvia L. Herbert,Univ. of California - San Diego,http://sylviaherbert.com,IUH8CWEAAAAJ
 Sylvia L. Osborn,Western University,http://www.csd.uwo.ca/faculty/sylvia,NOSCHOLARPAGE
 Sylvia Perez-Hardy,Rochester Institute of Technology,https://www.rit.edu/gccis/sylvia-perez-hardy,NOSCHOLARPAGE
@@ -2645,3 +2644,4 @@ Søren Ingvor Olsen,University of Copenhagen,http://diku.dk/english/staff/?pure=
 Søren Kimmer Schou Gregersen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Søren Knudsen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/soeren-knudsen(2575c800-642d-4984-9c56-41601cf07a26).html,DT6JUdcAAAAJ
 Søren Lauesen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/soeren-lauesen(ea6d10cf-6bb5-4414-8966-f1ed2591f794).html,NOSCHOLARPAGE
+

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -2644,4 +2644,3 @@ Søren Ingvor Olsen,University of Copenhagen,http://diku.dk/english/staff/?pure=
 Søren Kimmer Schou Gregersen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE
 Søren Knudsen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/soeren-knudsen(2575c800-642d-4984-9c56-41601cf07a26).html,DT6JUdcAAAAJ
 Søren Lauesen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/soeren-lauesen(ea6d10cf-6bb5-4414-8966-f1ed2591f794).html,NOSCHOLARPAGE
-

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -8870,7 +8870,6 @@ Gary Tan,National University of Singapore,http://www.comp.nus.edu.sg/~gtan,3XI4p
 Gary Tyson,Florida State University,http://www.cs.fsu.edu/~tyson,vC_bjb0gU4EC
 Gary W. Meyer,University of Minnesota,http://umn.edu/home/meyer172,7P_WgjYAAAAJ
 Gary William Grewal,University of Guelph,http://www.uoguelph.ca/~ggrewal,NOSCHOLARPAGE
-Gasper Tkacik,IST Austria,https://gtkacik.pages.ist.ac.at,arjXIL8AAAAJ
 Gaurav Harit,IIT Jodhpur,http://home.iitj.ac.in/~gharit,puzdkHAAAAAJ
 Gaurav S. Sukhatme,University of Southern California,http://www-robotics.usc.edu/~gaurav,lRUi-A8AAAAJ
 Gaurav Sharma,University of Rochester,https://hajim.rochester.edu/ece/sites/gsharma,OlsDoroAAAAJ
@@ -26621,7 +26620,6 @@ Sylvain Martel,Polytechnique Montreal,https://www.polymtl.ca/expertises/en/marte
 Sylvain Salvati,CRIStAL,https://www.cristal.univ-lille.fr/profil/ssalvati,NOSCHOLARPAGE
 Sylvain Schmitz,Ecole Normale Superieure de Cachan,http://www.lsv.ens-cachan.fr/~schmitz,mMktcHwAAAAJ
 Sylvia C. Boyd,University of Ottawa,http://www.site.uottawa.ca/~sylvia,P7mb9zgAAAAJ
-Sylvia Cremer,IST Austria,http://ist.ac.at/research/research-groups/cremer-group,_Gm-T9IAAAAJ
 Sylvia L. Herbert,Univ. of California - San Diego,http://sylviaherbert.com,IUH8CWEAAAAJ
 Sylvia L. Osborn,Western University,http://www.csd.uwo.ca/faculty/sylvia,NOSCHOLARPAGE
 Sylvia Lee Herbert,Univ. of California - San Diego,http://sylviaherbert.com,IUH8CWEAAAAJ

--- a/generated-author-info.csv
+++ b/generated-author-info.csv
@@ -68403,7 +68403,6 @@ Gary W. Meyer,University of Minnesota,vis,1.0,0.25,2005
 Gary William Grewal,University of Guelph,dac,1.0,0.16667,2019
 Gary William Grewal,University of Guelph,iccad,1.0,0.2,2016
 Gary William Grewal,University of Guelph,micro,1.0,0.5,2001
-Gasper Tkacik,IST Austria,nips,2.0,0.83333,2016
 Gaurav S. Sukhatme,University of Southern California,aaai,1.0,0.25,2024
 Gaurav S. Sukhatme,University of Southern California,iclr,1.0,0.2,2023
 Gaurav S. Sukhatme,University of Southern California,iclr,1.0,0.16667,2024
@@ -209772,7 +209771,6 @@ Sylvain Schmitz,Ecole Normale Superieure de Cachan,lics,1.0,0.25,2017
 Sylvain Schmitz,Ecole Normale Superieure de Cachan,lics,2.0,1.0,2019
 Sylvain Schmitz,Ecole Normale Superieure de Cachan,lics,1.0,0.25,2024
 Sylvain Schmitz,Ecole Normale Superieure de Cachan,pods,1.0,0.33333,2019
-Sylvia Cremer,IST Austria,nips,1.0,0.2,2024
 Sylvia L. Herbert,Univ. of California - San Diego,icml,1.0,0.33333,2024
 Sylvia L. Herbert,Univ. of California - San Diego,icra,1.0,0.33333,2017
 Sylvia L. Herbert,Univ. of California - San Diego,icra,1.0,0.2,2018


### PR DESCRIPTION
I have removed two faculty members from IST Austria (ISTA) who are not actually in the field of Computer Science. They had probably ended up in the original database because of co-authored papers, but they do target CS venues with their publications and they do not supervised CS students. 