### PR TITLE
Fix homepage link for Prof. Yiyu Shi at University of Notre Dame

### DIFF
--- a/csrankings-y.csv
+++ b/csrankings-y.csv
@@ -568,7 +568,7 @@ Yiyi Zhou,Xiamen University,https://informatics.xmu.edu.cn/info/1019/21489.htm,w
 Yiying Tong,Michigan State University,http://www.cse.msu.edu/~ytong,2Dz330cAAAAJ
 Yiying Zhang 0005,Univ. of California - San Diego,https://cseweb.ucsd.edu/~yiying,5AWXENIAAAAJ
 Yiyu Chen 0001,TU Delft,https://www.lydiaychen.com,xXu_fMcAAAAJ
-Yiyu Shi 0001,University of Notre Dame,https://engineering.nd.edu/profiles/yshi,LrjbEkIAAAAJ
+Yiyu Shi 0001,University of Notre Dame,https://engineering.nd.edu/faculty/yiyu-shi/,LrjbEkIAAAAJ
 Yiyu Yao,University of Regina,http://www.cs.uregina.ca/People/Profiles/YiyuYao.html,_aL0fcQAAAAJ
 Yizhai Zhang,NWPU,https://teacher.nwpu.edu.cn/en/zhangyizhai.html,NOSCHOLARPAGE
 Yizhen Lao,Hunan University,https://yizhenlao.github.io,OhPsgH0AAAAJ


### PR DESCRIPTION
The homepage link for Prof. Yiyu Shi (University of Notre Dame) was incorrect.
Updated to the official homepage: https://engineering.nd.edu/faculty/yiyu-shi/

Checklist:
- [x] All pull requests come from a non-anonymous account
- [x] Reasonable PR title provided
- [x] Only modified csrankings-y.csv
- [x] CSV formatting preserved (no extra spaces/commas)
- [x] Homepage verified to be the correct one