### PR TITLE
Add Dimitris/Dimitrios Mitropoulos (University of Athens)

### DIFF
--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -1237,6 +1237,8 @@ Dimitris K. Despotis,University of Piraeus,https://www.unipi.gr/unipi/en/despoti
 Dimitris Karagiannis,University of Vienna,https://cs.univie.ac.at/dimitris.karagiannis,NOSCHOLARPAGE
 Dimitris Koutsouris,NTUA,http://www2.biomed.ntua.gr/%CE%B4%CE%B9%CE%B5%CF%85%CE%B8%CF%85%CE%BD%CF%84%CE%AE%CF%82,tTm7CCAAAAAJ
 Dimitris Makrakis,University of Ottawa,http://www.site.uottawa.ca/~dimitris,wsKoAKcAAAAJ
+Dimitris Mitropoulos,University of Athens,https://dimitro.gr/,ryow8hIAAAAJ
+Dimitrios Mitropoulos,University of Athens,https://dimitro.gr/,ryow8hIAAAAJ
 Dimitris N. Metaxas,Rutgers University,https://www.cs.rutgers.edu/~dnm,a7VNhCIAAAAJ
 Dimitris P. Tsakiris,Aberystwyth University,https://www.aber.ac.uk/en/cs/staff-profiles/listing/profile/dit5,05r1hHoAAAAJ
 Dimitris Papadias,HKUST,https://www.cse.ust.hk/faculty/dimitris,7BPMWSkAAAAJ

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -1239,7 +1239,6 @@ Dimitris Koutsouris,NTUA,http://www2.biomed.ntua.gr/%CE%B4%CE%B9%CE%B5%CF%85%CE%
 Dimitris Makrakis,University of Ottawa,http://www.site.uottawa.ca/~dimitris,wsKoAKcAAAAJ
 Dimitris N. Metaxas,Rutgers University,https://www.cs.rutgers.edu/~dnm,a7VNhCIAAAAJ
 Dimitris Mitropoulos,University of Athens,https://dimitro.gr/,ryow8hIAAAAJ
-Dimitrios Mitropoulos,University of Athens,https://dimitro.gr/,ryow8hIAAAAJ
 Dimitris P. Tsakiris,Aberystwyth University,https://www.aber.ac.uk/en/cs/staff-profiles/listing/profile/dit5,05r1hHoAAAAJ
 Dimitris Papadias,HKUST,https://www.cse.ust.hk/faculty/dimitris,7BPMWSkAAAAJ
 Dimitris Pezaros,University of Glasgow,http://www.dcs.gla.ac.uk/~dp,7_7cAlgAAAAJ

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -1237,9 +1237,9 @@ Dimitris K. Despotis,University of Piraeus,https://www.unipi.gr/unipi/en/despoti
 Dimitris Karagiannis,University of Vienna,https://cs.univie.ac.at/dimitris.karagiannis,NOSCHOLARPAGE
 Dimitris Koutsouris,NTUA,http://www2.biomed.ntua.gr/%CE%B4%CE%B9%CE%B5%CF%85%CE%B8%CF%85%CE%BD%CF%84%CE%AE%CF%82,tTm7CCAAAAAJ
 Dimitris Makrakis,University of Ottawa,http://www.site.uottawa.ca/~dimitris,wsKoAKcAAAAJ
+Dimitris N. Metaxas,Rutgers University,https://www.cs.rutgers.edu/~dnm,a7VNhCIAAAAJ
 Dimitris Mitropoulos,University of Athens,https://dimitro.gr/,ryow8hIAAAAJ
 Dimitrios Mitropoulos,University of Athens,https://dimitro.gr/,ryow8hIAAAAJ
-Dimitris N. Metaxas,Rutgers University,https://www.cs.rutgers.edu/~dnm,a7VNhCIAAAAJ
 Dimitris P. Tsakiris,Aberystwyth University,https://www.aber.ac.uk/en/cs/staff-profiles/listing/profile/dit5,05r1hHoAAAAJ
 Dimitris Papadias,HKUST,https://www.cse.ust.hk/faculty/dimitris,7BPMWSkAAAAJ
 Dimitris Pezaros,University of Glasgow,http://www.dcs.gla.ac.uk/~dp,7_7cAlgAAAAJ


### PR DESCRIPTION
Adding faculty entry for Dimitris Mitropoulos / Dimitrios Mitropoulos, Associate Professor at University of Athens. Included both name variants to match DBLP records. Homepage: https://dimitro.gr/, Scholar ID: ryow8hIAAAAJ
