### PR TITLE
Add Yu Fu (University of Central Florida)Update csrankings-y.csv

### DIFF
--- a/csrankings-y.csv
+++ b/csrankings-y.csv
@@ -813,6 +813,7 @@ Yu David Liu,Binghamton University,http://www.cs.binghamton.edu/~davidl,_KCqeIEA
 Yu F. Mong,City University of Hong Kong,https://www.cs.cityu.edu.hk/profile/csymong.html,NOSCHOLARPAGE
 Yu Feng 0001,Univ. of California - Santa Barbara,http://fredfeng.github.io,urQ9fNgAAAAJ
 Yu Feng 0007,Shanghai Jiao Tong University,https://yufenguofr.github.io,APlmoG8AAAAJ
+Yu Fu 0010,University of Central Florida,https://www.cs.ucf.edu/person/yufu/,EuXCJ08AAAAJ
 Yu Hen Hu,University of Wisconsin - Madison,https://directory.engr.wisc.edu/ece/Faculty/Hu_Yu-hen,5CAjat0AAAAJ
 Yu Hong,Soochow University,http://nlp.suda.edu.cn/~hong/index.html,NOSCHOLARPAGE
 Yu Hu 0001,Chinese Academy of Sciences,http://teacher.ucas.ac.cn/~huyu,VPA-MkkAAAAJ


### PR DESCRIPTION
Adding Yu Fu (Assistant Professor, University of Central Florida).

DBLP ID: https://dblp.org/pid/09/3263-10.html
Homepage: https://www.cs.ucf.edu/person/yufu/
Google Scholar: https://scholar.google.com/citations?user=EuXCJ08AAAAJ
