### PR TITLE
[FIX] revert inadvertent deletion of Chengmo Yang in dced29c

### DIFF
--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -566,6 +566,7 @@ Chengkai Li 0001,University of Texas at Arlington,http://ranger.uta.edu/~cli,v8Z
 Chenglin Miao,Iowa State University,https://clmiao.github.io,QFs2tZoAAAAJ
 Chenglu Wen,Xiamen University,https://asc.xmu.edu.cn/t/wenchenglu,JOoZUmUAAAAJ
 Chengming Zhang 0006,University of Houston,https://www.linkedin.com/in/chengming-zhang-71a3b1120,F4TtJZEAAAAJ
+Chengmo Yang,University of Delaware,https://www.eecis.udel.edu/~chengmo/,d8KWMt8AAAAJ
 Chengnian Sun,University of Waterloo,https://chengniansun.bitbucket.io,rwbI5qAAAAAJ
 Chengqi Zhang,The Hong Kong Polytechnic University,https://chengqi-zhang.github.io,B6lBmqEAAAAJ
 Chengqing Li,Hunan University,http://www.chengqingli.com,i4a0j8IAAAAJ

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -566,7 +566,7 @@ Chengkai Li 0001,University of Texas at Arlington,http://ranger.uta.edu/~cli,v8Z
 Chenglin Miao,Iowa State University,https://clmiao.github.io,QFs2tZoAAAAJ
 Chenglu Wen,Xiamen University,https://asc.xmu.edu.cn/t/wenchenglu,JOoZUmUAAAAJ
 Chengming Zhang 0006,University of Houston,https://www.linkedin.com/in/chengming-zhang-71a3b1120,F4TtJZEAAAAJ
-Chengmo Yang,University of Delaware,https://www.eecis.udel.edu/~chengmo/,d8KWMt8AAAAJ
+Chengmo Yang,University of Delaware,https://www.eecis.udel.edu/~chengmo,d8KWMt8AAAAJ
 Chengnian Sun,University of Waterloo,https://chengniansun.bitbucket.io,rwbI5qAAAAAJ
 Chengqi Zhang,The Hong Kong Polytechnic University,https://chengqi-zhang.github.io,B6lBmqEAAAAJ
 Chengqing Li,Hunan University,http://www.chengqingli.com,i4a0j8IAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -4395,6 +4395,7 @@ Chengkai Li 0001,University of Texas at Arlington,http://ranger.uta.edu/~cli,v8Z
 Chenglin Miao,Iowa State University,https://clmiao.github.io,QFs2tZoAAAAJ
 Chenglu Wen,Xiamen University,https://asc.xmu.edu.cn/t/wenchenglu,JOoZUmUAAAAJ
 Chengming Zhang 0006,University of Houston,https://www.linkedin.com/in/chengming-zhang-71a3b1120,F4TtJZEAAAAJ
+Chengmo Yang,University of Delaware,https://www.eecis.udel.edu/~chengmo,d8KWMt8AAAAJ
 Chengnian Sun,University of Waterloo,https://chengniansun.bitbucket.io,rwbI5qAAAAAJ
 Chengqi Zhang,The Hong Kong Polytechnic University,https://chengqi-zhang.github.io,B6lBmqEAAAAJ
 Chengqing Li,Hunan University,http://www.chengqingli.com,i4a0j8IAAAAJ

--- a/generated-author-info.csv
+++ b/generated-author-info.csv
@@ -33386,6 +33386,19 @@ Chengming Zhang 0006,University of Houston,ics,1.0,0.11111,2023
 Chengming Zhang 0006,University of Houston,kdd,1.0,0.25,2020
 Chengming Zhang 0006,University of Houston,nips,1.0,0.090909,2024
 Chengming Zhang 0006,University of Houston,vldb,1.0,0.125,2021
+Chengmo Yang,University of Delaware,dac,2.0,0.58333,2017
+Chengmo Yang,University of Delaware,dac,2.0,0.5,2018
+Chengmo Yang,University of Delaware,dac,2.0,0.33333,2019
+Chengmo Yang,University of Delaware,dac,1.0,0.2,2020
+Chengmo Yang,University of Delaware,emsoft,1.0,0.2,2011
+Chengmo Yang,University of Delaware,emsoft,1.0,0.2,2015
+Chengmo Yang,University of Delaware,emsoft,1.0,0.2,2021
+Chengmo Yang,University of Delaware,iccad,1.0,0.33333,2018
+Chengmo Yang,University of Delaware,iccad,1.0,0.16667,2020
+Chengmo Yang,University of Delaware,iccad,1.0,0.5,2024
+Chengmo Yang,University of Delaware,pets,1.0,0.33333,2017
+Chengmo Yang,University of Delaware,usenixsec,1.0,0.25,2021
+Chengmo Yang,University of Delaware,usenixsec,1.0,0.2,2023
 Chengnian Sun,University of Waterloo,ase,1.0,0.25,2011
 Chengnian Sun,University of Waterloo,ase,1.0,0.2,2012
 Chengnian Sun,University of Waterloo,ase,2.0,0.36667,2013


### PR DESCRIPTION
Chengmo Yang was inadvertently deleted in commit https://github.com/emeryberger/CSrankings/commit/dced29c0f5144e1d3ee9cab9c10f6683fe88b360

This PR reverts this deletion.

Chengmo Yang is a valid entry and an active CS faculty at UD: https://www.cis.udel.edu/people/faculty/chengmo-yang/

Original PR: https://github.com/emeryberger/CSrankings/pull/5044