### PR TITLE
Updating EURECOM's faculty members

### DIFF
--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -2383,7 +2383,7 @@ Arun K. Kulshreshth,University of Louisiana - Lafayette,https://computing.louisi
 Arun Kumar 0001,Univ. of California - San Diego,http://cseweb.ucsd.edu/~arunkk,hZQ57XcAAAAJ
 Arun Lakhotia,University of Louisiana - Lafayette,https://cacs.louisiana.edu/~arun/home/index.html,NOSCHOLARPAGE
 Arun Natarajan 0001,Oregon State University,http://eecs.oregonstate.edu/people/natarajan-arun,FAfbKa8AAAAJ
-Arun Padakandla,EURECOM,https://www.eurecom.fr/fr/people/padakandla-arun,4o_dRdUAAAAJ
+Arun Padakandla,EURECOM,https://www.eurecom.fr/fr/people/padakandla-arun/publications,4o_dRdUAAAAJ
 Arun Rajkumar,IIT Madras,https://sites.google.com/view/arun-rajkumar,gytfaaoAAAAJ
 Arun Ross,Michigan State University,http://www.cse.msu.edu/~rossarun,7IiUQDkAAAAJ
 Arun S. Natarajan 0001,Oregon State University,http://eecs.oregonstate.edu/people/natarajan-arun,FAfbKa8AAAAJ

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -2105,7 +2105,7 @@ Antonio Carzaniga,Università della Svizzera italiana,http://www.inf.usi.ch/carz
 Antonio Cicchetti,Mälardalen University,http://www.es.mdh.se/staff/198-Antonio_Cicchetti,I-9eMoMAAAAJ
 Antonio Cisternino,University of Pisa,http://www.di.unipi.it/~cisterni,SiCtgi8AAAAJ
 Antonio Della Cioppa,University of Salerno,http://docenti.unisa.it/004367/home,yBW3PZsAAAAJ
-Antonio Faonio,EURECOM,https://faonio.eurecom.io/,omnEYdkAAAAJ
+Antonio Faonio,EURECOM,https://faonio.eurecom.io,omnEYdkAAAAJ
 Antonio Fariña,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=8,MvZTjYkAAAAJ
 Antonio Fernández 0001,IMDEA Software Institute,https://software.imdea.org/people/antonio.fernandez,kh4x8goAAAAJ
 Antonio Fernández Anta,IMDEA Software Institute,https://software.imdea.org/people/antonio.fernandez,kh4x8goAAAAJ

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -2105,6 +2105,7 @@ Antonio Carzaniga,Università della Svizzera italiana,http://www.inf.usi.ch/carz
 Antonio Cicchetti,Mälardalen University,http://www.es.mdh.se/staff/198-Antonio_Cicchetti,I-9eMoMAAAAJ
 Antonio Cisternino,University of Pisa,http://www.di.unipi.it/~cisterni,SiCtgi8AAAAJ
 Antonio Della Cioppa,University of Salerno,http://docenti.unisa.it/004367/home,yBW3PZsAAAAJ
+Antonio Faonio,EURECOM,https://faonio.eurecom.io/,omnEYdkAAAAJ
 Antonio Fariña,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=8,MvZTjYkAAAAJ
 Antonio Fernández 0001,IMDEA Software Institute,https://software.imdea.org/people/antonio.fernandez,kh4x8goAAAAJ
 Antonio Fernández Anta,IMDEA Software Institute,https://software.imdea.org/people/antonio.fernandez,kh4x8goAAAAJ
@@ -2382,6 +2383,7 @@ Arun K. Kulshreshth,University of Louisiana - Lafayette,https://computing.louisi
 Arun Kumar 0001,Univ. of California - San Diego,http://cseweb.ucsd.edu/~arunkk,hZQ57XcAAAAJ
 Arun Lakhotia,University of Louisiana - Lafayette,https://cacs.louisiana.edu/~arun/home/index.html,NOSCHOLARPAGE
 Arun Natarajan 0001,Oregon State University,http://eecs.oregonstate.edu/people/natarajan-arun,FAfbKa8AAAAJ
+Arun Padakandla,EURECOM,https://www.eurecom.fr/fr/people/padakandla-arun,4o_dRdUAAAAJ
 Arun Rajkumar,IIT Madras,https://sites.google.com/view/arun-rajkumar,gytfaaoAAAAJ
 Arun Ross,Michigan State University,http://www.cse.msu.edu/~rossarun,7IiUQDkAAAAJ
 Arun S. Natarajan 0001,Oregon State University,http://eecs.oregonstate.edu/people/natarajan-arun,FAfbKa8AAAAJ

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -634,6 +634,7 @@ Chiang Lee,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/
 Chiara Bodei,University of Pisa,http://www.di.unipi.it/~chiara,bvjdFB4AAAAJ
 Chiara Bordin,UiT The Arctic University of Norway,https://uit.no/ansatte/chiara.bordin,KF7StJsAAAAJ
 Chiara Francalanci,Politecnico di Milano,http://home.deib.polimi.it/francala,NOSCHOLARPAGE
+Chiara Galdi,EURECOM,http://www.eurecom.fr/~galdi/,1Ku9GUkAAAAJ
 Chiara Petrioli,Sapienza University of Rome,http://senseslab.di.uniroma1.it,urH-SksAAAAJ
 Chicheng Zhang,University of Arizona,https://zcc1307.github.io,mho7MawAAAAJ
 Chidchanok Lursinsap,Chulalongkorn University,http://www.math.sc.chula.ac.th/en/profile/chidchanok.l,NOSCHOLARPAGE

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -634,7 +634,7 @@ Chiang Lee,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/
 Chiara Bodei,University of Pisa,http://www.di.unipi.it/~chiara,bvjdFB4AAAAJ
 Chiara Bordin,UiT The Arctic University of Norway,https://uit.no/ansatte/chiara.bordin,KF7StJsAAAAJ
 Chiara Francalanci,Politecnico di Milano,http://home.deib.polimi.it/francala,NOSCHOLARPAGE
-Chiara Galdi,EURECOM,http://www.eurecom.fr/~galdi/,1Ku9GUkAAAAJ
+Chiara Galdi,EURECOM,http://www.eurecom.fr/~galdi,1Ku9GUkAAAAJ
 Chiara Petrioli,Sapienza University of Rome,http://senseslab.di.uniroma1.it,urH-SksAAAAJ
 Chicheng Zhang,University of Arizona,https://zcc1307.github.io,mho7MawAAAAJ
 Chidchanok Lursinsap,Chulalongkorn University,http://www.math.sc.chula.ac.th/en/profile/chidchanok.l,NOSCHOLARPAGE

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -1030,6 +1030,7 @@ Derek Ruths,McGill University,http://www.derekruths.com,WZWeI0MAAAAJ
 Derek Somerville,University of Glasgow,https://www.gla.ac.uk/schools/computing/staff/dereksomerville,xOckHdkAAAAJ
 Deren Chen,Zhejiang University,http://mypage.zju.edu.cn/0073012,NOSCHOLARPAGE
 Derick Wood,HKUST,https://www.cse.ust.hk/derickwood,KVpdzBkAAAAJ
+Derya Malak,EURECOM,https://sites.google.com/site/deryamalak/home,phfqv1QAAAAJ
 Des Greer,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=des.greer,0DWNagMAAAAJ
 Desh Ranjan,Old Dominion University,http://odu.edu/directory/people/d/dranjan,NOSCHOLARPAGE
 Deshen Moodley,University of Cape Town,https://people.cs.uct.ac.za/~deshen,GfuDovEAAAAJ

--- a/csrankings-f.csv
+++ b/csrankings-f.csv
@@ -413,7 +413,7 @@ Florian Benjamin Müller,TU Darmstadt,https://flomue.com,slfzfQIAAAAJ
 Florian Daniel,Politecnico di Milano,http://home.deib.polimi.it/daniel,wF6n9-0AAAAJ
 Florian Echtler,Aalborg University,https://floe.butterbrot.org,sZssYagAAAAJ
 Florian Erhard,University of Regensburg,https://erhard-lab.de,EXgQANwAAAAJ
-Florian Kaltenberger,EURECOM,http://www.eurecom.fr/~kaltenbe,R1R9668AAAAJ
+Florian Kaltenberger,EURECOM,https://www.eurecom.fr/fr/people/kaltenberger-florian,R1R9668AAAAJ
 Florian Kammueller,Middlesex University,http://www.cs.mdx.ac.uk/people/florian-kammueller,DaQ8dGMAAAAJ
 Florian Kammüller,Middlesex University,http://www.cs.mdx.ac.uk/people/florian-kammueller,DaQ8dGMAAAAJ
 Florian Kerschbaum,University of Waterloo,https://cs.uwaterloo.ca/~fkerschb,aP-_mb8AAAAJ
@@ -461,7 +461,6 @@ Foster J. Provost,New York University,https://fosterprovost.com,-Km63D4AAAAJ
 Foteini Baldimtsi,George Mason University,http://www.baldimtsi.com,Wrx-9LUAAAAJ
 Foteini Paraskeva,University of Piraeus,https://www.ds.unipi.gr/en/faculty/fparaske-en,IeaP7wIAAAAJ
 Fotios Spyridonis,Brunel University London,https://www.brunel.ac.uk/people/fotios-spyridonis,XaVPz0MAAAAJ
-Fotios Stavrou,EURECOM,http://www.photios-stavrou.com/index.html,s7KQ1fcAAAAJ
 Fotis Liarokapis,Masaryk University,https://www.muni.cz/en/people/235197,snY7XXkAAAAJ
 Fotis Spyridonis,Brunel University London,https://www.brunel.ac.uk/people/fotios-spyridonis,XaVPz0MAAAAJ
 Foutse Khomh,Polytechnique Montreal,http://www.khomh.net,YYXb3KIAAAAJ

--- a/csrankings-f.csv
+++ b/csrankings-f.csv
@@ -461,6 +461,7 @@ Foster J. Provost,New York University,https://fosterprovost.com,-Km63D4AAAAJ
 Foteini Baldimtsi,George Mason University,http://www.baldimtsi.com,Wrx-9LUAAAAJ
 Foteini Paraskeva,University of Piraeus,https://www.ds.unipi.gr/en/faculty/fparaske-en,IeaP7wIAAAAJ
 Fotios Spyridonis,Brunel University London,https://www.brunel.ac.uk/people/fotios-spyridonis,XaVPz0MAAAAJ
+Fotios Stavrou,EURECOM,http://www.photios-stavrou.com/index.html,s7KQ1fcAAAAJ
 Fotis Liarokapis,Masaryk University,https://www.muni.cz/en/people/235197,snY7XXkAAAAJ
 Fotis Spyridonis,Brunel University London,https://www.brunel.ac.uk/people/fotios-spyridonis,XaVPz0MAAAAJ
 Foutse Khomh,Polytechnique Montreal,http://www.khomh.net,YYXb3KIAAAAJ

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -579,7 +579,7 @@ Giuliano Antoniol,Polytechnique Montreal,http://www.antoniol.net,136elhQAAAAJ
 Giuliano Casale,Imperial College London,http://wp.doc.ic.ac.uk/gcasale,Os1VLoQAAAAJ
 Giulio Antoniol,Polytechnique Montreal,http://www.antoniol.net,136elhQAAAAJ
 Giulio Chiribella,University of Hong Kong,https://i.cs.hku.hk/~giulio,4ob0VU4AAAAJ
-Giulio Franzese,EURECOM,https://www.eurecom.fr/fr/people/franzese-giulio,kEtx_WwAAAAJ
+Giulio Franzese,EURECOM,https://www.eurecom.fr/fr/people/franzese-giulio/publications,kEtx_WwAAAAJ
 Giulio Iacucci,University of Helsinki,https://researchportal.helsinki.fi/en/persons/giulio-jacucci,cmpzu9sAAAAJ
 Giulio Jacucci,University of Helsinki,https://researchportal.helsinki.fi/en/persons/giulio-jacucci,cmpzu9sAAAAJ
 Giulio Malavolta,Bocconi University,https://sites.google.com/view/giuliomalavolta,_pYEarUAAAAJ

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -579,6 +579,7 @@ Giuliano Antoniol,Polytechnique Montreal,http://www.antoniol.net,136elhQAAAAJ
 Giuliano Casale,Imperial College London,http://wp.doc.ic.ac.uk/gcasale,Os1VLoQAAAAJ
 Giulio Antoniol,Polytechnique Montreal,http://www.antoniol.net,136elhQAAAAJ
 Giulio Chiribella,University of Hong Kong,https://i.cs.hku.hk/~giulio,4ob0VU4AAAAJ
+Giulio Franzese,EURECOM,https://www.eurecom.fr/fr/people/franzese-giulio,kEtx_WwAAAAJ
 Giulio Iacucci,University of Helsinki,https://researchportal.helsinki.fi/en/persons/giulio-jacucci,cmpzu9sAAAAJ
 Giulio Jacucci,University of Helsinki,https://researchportal.helsinki.fi/en/persons/giulio-jacucci,cmpzu9sAAAAJ
 Giulio Malavolta,Bocconi University,https://sites.google.com/view/giuliomalavolta,_pYEarUAAAAJ

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -876,7 +876,6 @@ Jeroen J. A. Keiren,TU Eindhoven,https://www.jeroenkeiren.nl,_nrYKCoAAAAJ
 Jeroen Keiren,TU Eindhoven,https://www.jeroenkeiren.nl,_nrYKCoAAAAJ
 Jeroen Keppens,King's College London,https://www.kcl.ac.uk/people/jeroen-keppens,6uEtmfoAAAAJ
 Jeroen van de Graaf,UFMG,http://homepages.dcc.ufmg.br/~jvdg,-w8olWwAAAAJ
-Jérôme Härri,EURECOM,https://www.eurecom.fr/fr/people/haerri-jerome,QSAclH8AAAAJ
 Jerome Knopp,University of Missouri - Kansas City,https://sce.umkc.edu/about/directory/name/jerome-knopp-ph-d,NOSCHOLARPAGE
 Jerry Alan Fails,Boise State University,https://www.boisestate.edu/coen-cs/people/faculty/jerry-alan-fails,eO71_M8AAAAJ
 Jerry Chou,National Tsing Hua University,https://lsalab.cs.nthu.edu.tw/home,5lJoLIEAAAAJ
@@ -2680,6 +2679,7 @@ János Csirik,University of Szeged,https://www.inf.u-szeged.hu/~csirik,HQe8ScYAA
 Jérémie Dequidt,CRIStAL,https://www.cristal.univ-lille.fr/profil/jdequidt,ySTwAskAAAAJ
 Jérémy Barbay,Universidad de Chile,http://www.dcc.uchile.cl/~jbarbay,x7L1W0rvHwsC
 Jérôme Feret,Ecole Normale Superieure,http://www.di.ens.fr/~feret,TcO5mvwAAAAJ
+Jérôme Härri,EURECOM,https://www.eurecom.fr/fr/people/haerri-jerome,QSAclH8AAAAJ
 Jérôme Lang,Université Paris Dauphine,https://www.lamsade.dauphine.fr/~lang,cNgZXNcAAAAJ
 Jérôme Waldispühl,McGill University,http://www.cs.mcgill.ca/~jeromew,IVZp2gQAAAAJ
 Jéssyka Vilela,UFPE,https://www.cin.ufpe.br/~jffv,P-KKg3EAAAAJ

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -876,7 +876,7 @@ Jeroen J. A. Keiren,TU Eindhoven,https://www.jeroenkeiren.nl,_nrYKCoAAAAJ
 Jeroen Keiren,TU Eindhoven,https://www.jeroenkeiren.nl,_nrYKCoAAAAJ
 Jeroen Keppens,King's College London,https://www.kcl.ac.uk/people/jeroen-keppens,6uEtmfoAAAAJ
 Jeroen van de Graaf,UFMG,http://homepages.dcc.ufmg.br/~jvdg,-w8olWwAAAAJ
-Jerome Harri,EURECOM,http://www.eurecom.fr/~haerri,QSAclH8AAAAJ
+Jérôme Härri,EURECOM,https://www.eurecom.fr/fr/people/haerri-jerome,QSAclH8AAAAJ
 Jerome Knopp,University of Missouri - Kansas City,https://sce.umkc.edu/about/directory/name/jerome-knopp-ph-d,NOSCHOLARPAGE
 Jerry Alan Fails,Boise State University,https://www.boisestate.edu/coen-cs/people/faculty/jerry-alan-fails,eO71_M8AAAAJ
 Jerry Chou,National Tsing Hua University,https://lsalab.cs.nthu.edu.tw/home,5lJoLIEAAAAJ

--- a/csrankings-l.csv
+++ b/csrankings-l.csv
@@ -383,6 +383,7 @@ Leslie F. Greengard,New York University,https://math.nyu.edu/~greengar,lW-MnjMAA
 Leslie G. Valiant,Harvard University,http://people.seas.harvard.edu/~valiant,H509xdsAAAAJ
 Leslie Greengard,New York University,https://math.nyu.edu/~greengar,lW-MnjMAAAAJ
 Leslie Pack Kaelbling,Massachusetts Institute of Technology,http://people.csail.mit.edu/lpk,NOSCHOLARPAGE
+Lesly-Ann Daniel,EURECOM,https://leslyann-daniel.fr/,pbph4eUAAAAJ
 Leszek Antoni Gasieniec,University of Liverpool,http://www.csc.liv.ac.uk/~leszek,TbQXQ7EAAAAJ
 Leszek Gasieniec,University of Liverpool,http://www.csc.liv.ac.uk/~leszek,TbQXQ7EAAAAJ
 Leszek Lilien,Western Michigan University,https://cs.wmich.edu/llilien,5iB3-eMAAAAJ

--- a/csrankings-l.csv
+++ b/csrankings-l.csv
@@ -383,7 +383,7 @@ Leslie F. Greengard,New York University,https://math.nyu.edu/~greengar,lW-MnjMAA
 Leslie G. Valiant,Harvard University,http://people.seas.harvard.edu/~valiant,H509xdsAAAAJ
 Leslie Greengard,New York University,https://math.nyu.edu/~greengar,lW-MnjMAAAAJ
 Leslie Pack Kaelbling,Massachusetts Institute of Technology,http://people.csail.mit.edu/lpk,NOSCHOLARPAGE
-Lesly-Ann Daniel,EURECOM,https://leslyann-daniel.fr/,pbph4eUAAAAJ
+Lesly-Ann Daniel,EURECOM,https://leslyann-daniel.fr,pbph4eUAAAAJ
 Leszek Antoni Gasieniec,University of Liverpool,http://www.csc.liv.ac.uk/~leszek,TbQXQ7EAAAAJ
 Leszek Gasieniec,University of Liverpool,http://www.csc.liv.ac.uk/~leszek,TbQXQ7EAAAAJ
 Leszek Lilien,Western Michigan University,https://cs.wmich.edu/llilien,5iB3-eMAAAAJ

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -1237,7 +1237,7 @@ Massimiliano Albanese,George Mason University,https://computing.gmu.edu/profiles
 Massimiliano Di Penta,University of Sannio,http://www.ing.unisannio.it/mdipenta,j6ucyOAAAAAJ
 Massimiliano Pierobon,University of Nebraska,http://cse.unl.edu/~pierobon,Rhu5LQIAAAAJ
 Massimiliano Pontil,University College London,http://www0.cs.ucl.ac.uk/staff/M.Pontil,lcOacs8AAAAJ
-Massimiliano Todisco,EURECOM,http://www.massimilianotodisco.eu/,m5JUU1UAAAAJ
+Massimiliano Todisco,EURECOM,http://www.massimilianotodisco.eu,m5JUU1UAAAAJ
 Massimiliano de Leoni,University of Padova,https://www.math.unipd.it/~deleoni,OejM6_AAAAAJ
 Massimo De Santo,University of Salerno,http://www.unisa.it/docenti/massimodesanto/index,h9tkpyYAAAAJ
 Massimo DiPierro,DePaul University,https://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=343,NOSCHOLARPAGE

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -1237,6 +1237,7 @@ Massimiliano Albanese,George Mason University,https://computing.gmu.edu/profiles
 Massimiliano Di Penta,University of Sannio,http://www.ing.unisannio.it/mdipenta,j6ucyOAAAAAJ
 Massimiliano Pierobon,University of Nebraska,http://cse.unl.edu/~pierobon,Rhu5LQIAAAAJ
 Massimiliano Pontil,University College London,http://www0.cs.ucl.ac.uk/staff/M.Pontil,lcOacs8AAAAJ
+Massimiliano Todisco,EURECOM,http://www.massimilianotodisco.eu/,m5JUU1UAAAAJ
 Massimiliano de Leoni,University of Padova,https://www.math.unipd.it/~deleoni,OejM6_AAAAAJ
 Massimo De Santo,University of Salerno,http://www.unisa.it/docenti/massimodesanto/index,h9tkpyYAAAAJ
 Massimo DiPierro,DePaul University,https://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=343,NOSCHOLARPAGE
@@ -1475,7 +1476,7 @@ Mauricio Kischinhevsky,UFF,http://www2.ic.uff.br/~kisch,U5qX4hsAAAAJ
 Mauricio Papa,University of Tulsa,https://faculty.utulsa.edu/~/mauricio-papa,NOSCHOLARPAGE
 Maurits R. R. de Planque,University of Southampton,https://www.ecs.soton.ac.uk/people/mrdp1x07,mGK_vD0AAAAJ
 Maurits de Planque,University of Southampton,https://www.ecs.soton.ac.uk/people/mrdp1x07,mGK_vD0AAAAJ
-Maurizio Filippone,EURECOM,http://www.eurecom.fr/~filippon,ILUeAloAAAAJ
+Maurizio Filippone,KAUST,https://www.kaust.edu.sa/en/study/faculty/maurizio-filippone,ILUeAloAAAAJ
 Maurizio Lenzerini,Sapienza University of Rome,http://www.diag.uniroma1.it/lenzerini,EYxaICEAAAAJ
 Maurizio Mancini,Sapienza University of Rome,http://www.mauriziomancini.org,RJLyh1wAAAAJ
 Maurizio Marchese,University of Trento,https://webapps.unitn.it/du/en/Persona/PER0000526/Didattica,Bir37L0AAAAJ

--- a/csrankings-n.csv
+++ b/csrankings-n.csv
@@ -224,7 +224,7 @@ Naveen Garg 0001,IIT Delhi,http://www.cse.iitd.ernet.in/~naveen,wNRE148AAAAJ
 Naveen Kumar 0001,University of Delhi,http://people.du.ac.in/~nk,NOSCHOLARPAGE
 Naveen Sharma,Rochester Institute of Technology,https://www.rit.edu/gccis/naveen-sharma-0,91QFhTMAAAAJ
 Naveena Karusala,Georgia Institute of Technology,https://naveena-karusala-870740.webflow.io,S3yqENkAAAAJ
-Navid Nikaein,EURECOM,http://www.eurecom.fr/~nikaeinn,uNoaxDIAAAAJ
+Navid Nikaein,EURECOM,https://www.eurecom.fr/en/people/nikaein-navid,uNoaxDIAAAAJ
 Navneet Goyal,BITS Pilani,http://universe.bits-pilani.ac.in/pilani/goel/profile,YHN0TYMAAAAJ
 Nawaf Alkharboush,King Abdulaziz University,http://www.kau.edu.sa/Contacts.aspx?Site_ID=861&Lng=EN&Cont=16331,NOSCHOLARPAGE
 Nawfal F. Fadhel,University of Southampton,https://www.ecs.soton.ac.uk/people/nf1m14,tjgBWiQAAAAJ

--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -973,6 +973,7 @@ Phoebe Sengers,Cornell University,http://www.cs.cornell.edu/people/sengers,6c5cf
 Phokion G. Kolaitis,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~kolaitis,Lu7biGYAAAAJ
 Phone Lin,National Taiwan University,https://www.csie.ntu.edu.tw/~plin,NOSCHOLARPAGE
 Phong Nguyen,Ecole Normale Superieure,http://www.di.ens.fr/~pnguyen,hnS8fnUAAAAJ
+Photios A. Stavrou,EURECOM,http://www.photios-stavrou.com/index.html,s7KQ1fcAAAAJ
 Phu Dung Le,Monash University,http://monash.edu/research/explore/en/persons/phu-le(7745eb6e-9b22-4d68-b566-116bc0280aa8).html,NOSCHOLARPAGE
 Phuc Nguyen 0002,University of Massachusetts Amherst,http://wsslab.org/vpnguyen,pBf2M3QAAAAJ
 Phyllis G. Frankl,New York University,http://engineering.nyu.edu/people/phyllis-frankl,XE683E8AAAAJ

--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -973,7 +973,7 @@ Phoebe Sengers,Cornell University,http://www.cs.cornell.edu/people/sengers,6c5cf
 Phokion G. Kolaitis,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~kolaitis,Lu7biGYAAAAJ
 Phone Lin,National Taiwan University,https://www.csie.ntu.edu.tw/~plin,NOSCHOLARPAGE
 Phong Nguyen,Ecole Normale Superieure,http://www.di.ens.fr/~pnguyen,hnS8fnUAAAAJ
-Photios A. Stavrou,EURECOM,http://www.photios-stavrou.com/index.html,s7KQ1fcAAAAJ
+Photios A. Stavrou,EURECOM,https://www.eurecom.fr/fr/people/stavrou-fotios/publications,s7KQ1fcAAAAJ
 Phu Dung Le,Monash University,http://monash.edu/research/explore/en/persons/phu-le(7745eb6e-9b22-4d68-b566-116bc0280aa8).html,NOSCHOLARPAGE
 Phuc Nguyen 0002,University of Massachusetts Amherst,http://wsslab.org/vpnguyen,pBf2M3QAAAAJ
 Phyllis G. Frankl,New York University,http://engineering.nyu.edu/people/phyllis-frankl,XE683E8AAAAJ

--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -1088,6 +1088,7 @@ Roberto Marcondes Cesar Junior,USP,http://www.ime.usp.br/~cesar,NOSCHOLARPAGE
 Roberto Martin Martin,University of Texas at Austin,https://robertomartinmartin.com,XOJE8OEAAAAJ
 Roberto Martín-Martín,University of Texas at Austin,https://robertomartinmartin.com,XOJE8OEAAAAJ
 Roberto Martínez-Maldonado,Monash University,https://research.monash.edu/en/persons/roberto-martinez-maldonado,sWXrhB0AAAAJ
+Roberto Morabito,EURECOM,https://www.eurecom.fr/fr/people/morabito-roberto,R21oWZsAAAAJ
 Roberto Navigli,Sapienza University of Rome,http://wwwusers.di.uniroma1.it/~navigli,BsgVJ-EAAAAJ
 Roberto Palmieri,Lehigh University,http://www.cse.lehigh.edu/~palmieri,iipJ5hsAAAAJ
 Roberto Passerone,University of Trento,http://disi.unitn.it/~roby,ziBaxi0AAAAJ

--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -1088,7 +1088,7 @@ Roberto Marcondes Cesar Junior,USP,http://www.ime.usp.br/~cesar,NOSCHOLARPAGE
 Roberto Martin Martin,University of Texas at Austin,https://robertomartinmartin.com,XOJE8OEAAAAJ
 Roberto Martín-Martín,University of Texas at Austin,https://robertomartinmartin.com,XOJE8OEAAAAJ
 Roberto Martínez-Maldonado,Monash University,https://research.monash.edu/en/persons/roberto-martinez-maldonado,sWXrhB0AAAAJ
-Roberto Morabito,EURECOM,https://www.eurecom.fr/fr/people/morabito-roberto,R21oWZsAAAAJ
+Roberto Morabito,EURECOM,https://www.eurecom.fr/fr/people/morabito-roberto/publications,R21oWZsAAAAJ
 Roberto Navigli,Sapienza University of Rome,http://wwwusers.di.uniroma1.it/~navigli,BsgVJ-EAAAAJ
 Roberto Palmieri,Lehigh University,http://www.cse.lehigh.edu/~palmieri,iipJ5hsAAAAJ
 Roberto Passerone,University of Trento,http://disi.unitn.it/~roby,ziBaxi0AAAAJ

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -1532,7 +1532,7 @@ Simone L. Martins,UFF,http://www2.ic.uff.br/~simone,oEIT_KQAAAAJ
 Simone Linz,University of Auckland,https://unidirectory.auckland.ac.nz/profile/slin498,9lCabZsAAAAJ
 Simone Paolo Ponzetto,University of Mannheim,https://www.uni-mannheim.de/dws/people/professors/prof-dr-simone-paolo-ponzetto,VmIFG0EAAAAJ
 Simone R. S. Souza,USP-ICMC,http://icmc.usp.br/pessoas?id=3685313,EhrqxfYAAAAJ
-Simone Rossi,EURECOM,https://www.eurecom.fr/fr/people/rossi-simone,lTt86awAAAAJ
+Simone Rossi,EURECOM,https://www.eurecom.fr/fr/people/rossi-simone/publications,lTt86awAAAAJ
 Simone Scalabrino,University of Molise,https://dibt.unimol.it/sscalabrino,FBP0Z64AAAAJ
 Simone Silvestri,University of Kentucky,http://www.cs.uky.edu/~silvestri,r4hdOZMAAAAJ
 Simone Stumpf,City University of London,https://www.city.ac.uk/people/academics/simone-stumpf,NESjxsAAAAAJ

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -1532,6 +1532,7 @@ Simone L. Martins,UFF,http://www2.ic.uff.br/~simone,oEIT_KQAAAAJ
 Simone Linz,University of Auckland,https://unidirectory.auckland.ac.nz/profile/slin498,9lCabZsAAAAJ
 Simone Paolo Ponzetto,University of Mannheim,https://www.uni-mannheim.de/dws/people/professors/prof-dr-simone-paolo-ponzetto,VmIFG0EAAAAJ
 Simone R. S. Souza,USP-ICMC,http://icmc.usp.br/pessoas?id=3685313,EhrqxfYAAAAJ
+Simone Rossi,EURECOM,https://www.eurecom.fr/fr/people/rossi-simone,lTt86awAAAAJ
 Simone Scalabrino,University of Molise,https://dibt.unimol.it/sscalabrino,FBP0Z64AAAAJ
 Simone Silvestri,University of Kentucky,http://www.cs.uky.edu/~silvestri,r4hdOZMAAAAJ
 Simone Stumpf,City University of London,https://www.city.ac.uk/people/academics/simone-stumpf,NESjxsAAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -2498,7 +2498,7 @@ Arun K. Kulshreshth,University of Louisiana - Lafayette,https://computing.louisi
 Arun Kumar 0001,Univ. of California - San Diego,http://cseweb.ucsd.edu/~arunkk,hZQ57XcAAAAJ
 Arun Lakhotia,University of Louisiana - Lafayette,https://cacs.louisiana.edu/~arun/home/index.html,NOSCHOLARPAGE
 Arun Natarajan 0001,Oregon State University,http://eecs.oregonstate.edu/people/natarajan-arun,FAfbKa8AAAAJ
-Arun Padakandla,EURECOM,https://www.eurecom.fr/fr/people/padakandla-arun,4o_dRdUAAAAJ
+Arun Padakandla,EURECOM,https://www.eurecom.fr/fr/people/padakandla-arun/publications,4o_dRdUAAAAJ
 Arun Rajkumar,IIT Madras,https://sites.google.com/view/arun-rajkumar,gytfaaoAAAAJ
 Arun Ross,Michigan State University,http://www.cse.msu.edu/~rossarun,7IiUQDkAAAAJ
 Arun S. Natarajan 0001,Oregon State University,http://eecs.oregonstate.edu/people/natarajan-arun,FAfbKa8AAAAJ
@@ -8483,7 +8483,7 @@ Florian Benjamin Müller,TU Darmstadt,https://flomue.com,slfzfQIAAAAJ
 Florian Daniel,Politecnico di Milano,http://home.deib.polimi.it/daniel,wF6n9-0AAAAJ
 Florian Echtler,Aalborg University,https://floe.butterbrot.org,sZssYagAAAAJ
 Florian Erhard,University of Regensburg,https://erhard-lab.de,EXgQANwAAAAJ
-Florian Kaltenberger,EURECOM,http://www.eurecom.fr/~kaltenbe,R1R9668AAAAJ
+Florian Kaltenberger,EURECOM,https://www.eurecom.fr/fr/people/kaltenberger-florian,R1R9668AAAAJ
 Florian Kammueller,Middlesex University,http://www.cs.mdx.ac.uk/people/florian-kammueller,DaQ8dGMAAAAJ
 Florian Kammüller,Middlesex University,http://www.cs.mdx.ac.uk/people/florian-kammueller,DaQ8dGMAAAAJ
 Florian Kerschbaum,University of Waterloo,https://cs.uwaterloo.ca/~fkerschb,aP-_mb8AAAAJ
@@ -8533,7 +8533,6 @@ Foteini Baldimtsi,George Mason University,http://www.baldimtsi.com,Wrx-9LUAAAAJ
 Foteini Paraskeva,University of Piraeus,https://www.ds.unipi.gr/en/faculty/fparaske-en,IeaP7wIAAAAJ
 Fotini Paraskeva,University of Piraeus,https://www.ds.unipi.gr/en/faculty/fparaske-en,IeaP7wIAAAAJ
 Fotios Spyridonis,Brunel University London,https://www.brunel.ac.uk/people/fotios-spyridonis,XaVPz0MAAAAJ
-Fotios Stavrou,EURECOM,http://www.photios-stavrou.com/index.html,s7KQ1fcAAAAJ
 Fotis Liarokapis,Masaryk University,https://www.muni.cz/en/people/235197,snY7XXkAAAAJ
 Fotis Spyridonis,Brunel University London,https://www.brunel.ac.uk/people/fotios-spyridonis,XaVPz0MAAAAJ
 Foutse Khomh,Polytechnique Montreal,http://www.khomh.net,YYXb3KIAAAAJ
@@ -9460,7 +9459,7 @@ Giuliano Antoniol,Polytechnique Montreal,http://www.antoniol.net,136elhQAAAAJ
 Giuliano Casale,Imperial College London,http://wp.doc.ic.ac.uk/gcasale,Os1VLoQAAAAJ
 Giulio Antoniol,Polytechnique Montreal,http://www.antoniol.net,136elhQAAAAJ
 Giulio Chiribella,University of Hong Kong,https://i.cs.hku.hk/~giulio,4ob0VU4AAAAJ
-Giulio Franzese,EURECOM,https://www.eurecom.fr/fr/people/franzese-giulio,kEtx_WwAAAAJ
+Giulio Franzese,EURECOM,https://www.eurecom.fr/fr/people/franzese-giulio/publications,kEtx_WwAAAAJ
 Giulio Iacucci,University of Helsinki,https://researchportal.helsinki.fi/en/persons/giulio-jacucci,cmpzu9sAAAAJ
 Giulio Jacucci,University of Helsinki,https://researchportal.helsinki.fi/en/persons/giulio-jacucci,cmpzu9sAAAAJ
 Giulio Malavolta,Bocconi University,https://sites.google.com/view/giuliomalavolta,_pYEarUAAAAJ
@@ -12546,7 +12545,6 @@ Jeroen J. A. Keiren,TU Eindhoven,https://www.jeroenkeiren.nl,_nrYKCoAAAAJ
 Jeroen Keiren,TU Eindhoven,https://www.jeroenkeiren.nl,_nrYKCoAAAAJ
 Jeroen Keppens,King's College London,https://www.kcl.ac.uk/people/jeroen-keppens,6uEtmfoAAAAJ
 Jeroen van de Graaf,UFMG,http://homepages.dcc.ufmg.br/~jvdg,-w8olWwAAAAJ
-Jerome Harri,EURECOM,http://www.eurecom.fr/~haerri,QSAclH8AAAAJ
 Jerome Knopp,University of Missouri - Kansas City,https://sce.umkc.edu/about/directory/name/jerome-knopp-ph-d,NOSCHOLARPAGE
 Jerry Alan Fails,Boise State University,https://www.boisestate.edu/coen-cs/people/faculty/jerry-alan-fails,eO71_M8AAAAJ
 Jerry Chou,National Tsing Hua University,https://lsalab.cs.nthu.edu.tw/home,5lJoLIEAAAAJ
@@ -14481,6 +14479,7 @@ János Csirik,University of Szeged,https://www.inf.u-szeged.hu/~csirik,HQe8ScYAA
 Jérémie Dequidt,CRIStAL,https://www.cristal.univ-lille.fr/profil/jdequidt,ySTwAskAAAAJ
 Jérémy Barbay,Universidad de Chile,http://www.dcc.uchile.cl/~jbarbay,x7L1W0rvHwsC
 Jérôme Feret,Ecole Normale Superieure,http://www.di.ens.fr/~feret,TcO5mvwAAAAJ
+Jérôme Härri,EURECOM,https://www.eurecom.fr/fr/people/haerri-jerome,QSAclH8AAAAJ
 Jérôme Lang,Université Paris Dauphine,https://www.lamsade.dauphine.fr/~lang,cNgZXNcAAAAJ
 Jérôme Waldispühl,McGill University,http://www.cs.mcgill.ca/~jeromew,IVZp2gQAAAAJ
 Jéssyka Vilela,UFPE,https://www.cin.ufpe.br/~jffv,P-KKg3EAAAAJ
@@ -20136,7 +20135,7 @@ Naveen Garg 0001,IIT Delhi,http://www.cse.iitd.ernet.in/~naveen,wNRE148AAAAJ
 Naveen Kumar 0001,University of Delhi,http://people.du.ac.in/~nk,NOSCHOLARPAGE
 Naveen Sharma,Rochester Institute of Technology,https://www.rit.edu/gccis/naveen-sharma-0,91QFhTMAAAAJ
 Naveena Karusala,Georgia Institute of Technology,https://naveena-karusala-870740.webflow.io,S3yqENkAAAAJ
-Navid Nikaein,EURECOM,http://www.eurecom.fr/~nikaeinn,uNoaxDIAAAAJ
+Navid Nikaein,EURECOM,https://www.eurecom.fr/en/people/nikaein-navid,uNoaxDIAAAAJ
 Navneet Goyal,BITS Pilani,http://universe.bits-pilani.ac.in/pilani/goel/profile,YHN0TYMAAAAJ
 Nawaf Alkharboush,King Abdulaziz University,http://www.kau.edu.sa/Contacts.aspx?Site_ID=861&Lng=EN&Cont=16331,NOSCHOLARPAGE
 Nawfal F. Fadhel,University of Southampton,https://www.ecs.soton.ac.uk/people/nf1m14,tjgBWiQAAAAJ
@@ -22065,7 +22064,7 @@ Phoebe Sengers,Cornell University,http://www.cs.cornell.edu/people/sengers,6c5cf
 Phokion G. Kolaitis,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~kolaitis,Lu7biGYAAAAJ
 Phone Lin,National Taiwan University,https://www.csie.ntu.edu.tw/~plin,NOSCHOLARPAGE
 Phong Nguyen,Ecole Normale Superieure,http://www.di.ens.fr/~pnguyen,hnS8fnUAAAAJ
-Photios A. Stavrou,EURECOM,http://www.photios-stavrou.com/index.html,s7KQ1fcAAAAJ
+Photios A. Stavrou,EURECOM,https://www.eurecom.fr/fr/people/stavrou-fotios/publications,s7KQ1fcAAAAJ
 Phu Dung Le,Monash University,http://monash.edu/research/explore/en/persons/phu-le(7745eb6e-9b22-4d68-b566-116bc0280aa8).html,NOSCHOLARPAGE
 Phuc Nguyen 0002,University of Massachusetts Amherst,http://wsslab.org/vpnguyen,pBf2M3QAAAAJ
 Phyllis G. Frankl,New York University,http://engineering.nyu.edu/people/phyllis-frankl,XE683E8AAAAJ
@@ -23704,7 +23703,7 @@ Roberto Martín-Martín,University of Texas at Austin,https://robertomartinmarti
 Roberto Martínez Maldonado,Monash University,https://research.monash.edu/en/persons/roberto-martinez-maldonado,sWXrhB0AAAAJ
 Roberto Martínez-Maldonado,Monash University,https://research.monash.edu/en/persons/roberto-martinez-maldonado,sWXrhB0AAAAJ
 Roberto Medeiros de Souza,University of Calgary,https://www.ai2lab.ca,G2V4oBIAAAAJ
-Roberto Morabito,EURECOM,https://www.eurecom.fr/fr/people/morabito-roberto,R21oWZsAAAAJ
+Roberto Morabito,EURECOM,https://www.eurecom.fr/fr/people/morabito-roberto/publications,R21oWZsAAAAJ
 Roberto Navigli,Sapienza University of Rome,http://wwwusers.di.uniroma1.it/~navigli,BsgVJ-EAAAAJ
 Roberto Palmieri,Lehigh University,http://www.cse.lehigh.edu/~palmieri,iipJ5hsAAAAJ
 Roberto Passerone,University of Trento,http://disi.unitn.it/~roby,ziBaxi0AAAAJ
@@ -25852,7 +25851,7 @@ Simone L. Martins,UFF,http://www2.ic.uff.br/~simone,oEIT_KQAAAAJ
 Simone Linz,University of Auckland,https://unidirectory.auckland.ac.nz/profile/slin498,9lCabZsAAAAJ
 Simone Paolo Ponzetto,University of Mannheim,https://www.uni-mannheim.de/dws/people/professors/prof-dr-simone-paolo-ponzetto,VmIFG0EAAAAJ
 Simone R. S. Souza,USP-ICMC,http://icmc.usp.br/pessoas?id=3685313,EhrqxfYAAAAJ
-Simone Rossi,EURECOM,https://www.eurecom.fr/fr/people/rossi-simone,lTt86awAAAAJ
+Simone Rossi,EURECOM,https://www.eurecom.fr/fr/people/rossi-simone/publications,lTt86awAAAAJ
 Simone Scalabrino,University of Molise,https://dibt.unimol.it/sscalabrino,FBP0Z64AAAAJ
 Simone Silvestri,University of Kentucky,http://www.cs.uky.edu/~silvestri,r4hdOZMAAAAJ
 Simone Stumpf,City University of London,https://www.city.ac.uk/people/academics/simone-stumpf,NESjxsAAAAAJ

--- a/csrankings.csv
+++ b/csrankings.csv
@@ -2204,6 +2204,7 @@ Antonio Carzaniga,Università della Svizzera italiana,http://www.inf.usi.ch/carz
 Antonio Cicchetti,Mälardalen University,http://www.es.mdh.se/staff/198-Antonio_Cicchetti,I-9eMoMAAAAJ
 Antonio Cisternino,University of Pisa,http://www.di.unipi.it/~cisterni,SiCtgi8AAAAJ
 Antonio Della Cioppa,University of Salerno,http://docenti.unisa.it/004367/home,yBW3PZsAAAAJ
+Antonio Faonio,EURECOM,https://faonio.eurecom.io,omnEYdkAAAAJ
 Antonio Fariña,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=8,MvZTjYkAAAAJ
 Antonio Fernández 0001,IMDEA Software Institute,https://software.imdea.org/people/antonio.fernandez,kh4x8goAAAAJ
 Antonio Fernández Anta,IMDEA Software Institute,https://software.imdea.org/people/antonio.fernandez,kh4x8goAAAAJ
@@ -2497,6 +2498,7 @@ Arun K. Kulshreshth,University of Louisiana - Lafayette,https://computing.louisi
 Arun Kumar 0001,Univ. of California - San Diego,http://cseweb.ucsd.edu/~arunkk,hZQ57XcAAAAJ
 Arun Lakhotia,University of Louisiana - Lafayette,https://cacs.louisiana.edu/~arun/home/index.html,NOSCHOLARPAGE
 Arun Natarajan 0001,Oregon State University,http://eecs.oregonstate.edu/people/natarajan-arun,FAfbKa8AAAAJ
+Arun Padakandla,EURECOM,https://www.eurecom.fr/fr/people/padakandla-arun,4o_dRdUAAAAJ
 Arun Rajkumar,IIT Madras,https://sites.google.com/view/arun-rajkumar,gytfaaoAAAAJ
 Arun Ross,Michigan State University,http://www.cse.msu.edu/~rossarun,7IiUQDkAAAAJ
 Arun S. Natarajan 0001,Oregon State University,http://eecs.oregonstate.edu/people/natarajan-arun,FAfbKa8AAAAJ
@@ -4468,6 +4470,7 @@ Chiang Lee,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/
 Chiara Bodei,University of Pisa,http://www.di.unipi.it/~chiara,bvjdFB4AAAAJ
 Chiara Bordin,UiT The Arctic University of Norway,https://uit.no/ansatte/chiara.bordin,KF7StJsAAAAJ
 Chiara Francalanci,Politecnico di Milano,http://home.deib.polimi.it/francala,NOSCHOLARPAGE
+Chiara Galdi,EURECOM,http://www.eurecom.fr/~galdi,1Ku9GUkAAAAJ
 Chiara Petrioli,Sapienza University of Rome,http://senseslab.di.uniroma1.it,urH-SksAAAAJ
 Chicheng Zhang,University of Arizona,https://zcc1307.github.io,mho7MawAAAAJ
 Chidchanok Lursinsap,Chulalongkorn University,http://www.math.sc.chula.ac.th/en/profile/chidchanok.l,NOSCHOLARPAGE
@@ -6538,6 +6541,7 @@ Derek Ruths,McGill University,http://www.derekruths.com,WZWeI0MAAAAJ
 Derek Somerville,University of Glasgow,https://www.gla.ac.uk/schools/computing/staff/dereksomerville,xOckHdkAAAAJ
 Deren Chen,Zhejiang University,http://mypage.zju.edu.cn/0073012,NOSCHOLARPAGE
 Derick Wood,HKUST,https://www.cse.ust.hk/derickwood,KVpdzBkAAAAJ
+Derya Malak,EURECOM,https://sites.google.com/site/deryamalak/home,phfqv1QAAAAJ
 Des Greer,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=des.greer,0DWNagMAAAAJ
 Desh Ranjan,Old Dominion University,http://odu.edu/directory/people/d/dranjan,NOSCHOLARPAGE
 Deshen Moodley,University of Cape Town,https://people.cs.uct.ac.za/~deshen,GfuDovEAAAAJ
@@ -8529,6 +8533,7 @@ Foteini Baldimtsi,George Mason University,http://www.baldimtsi.com,Wrx-9LUAAAAJ
 Foteini Paraskeva,University of Piraeus,https://www.ds.unipi.gr/en/faculty/fparaske-en,IeaP7wIAAAAJ
 Fotini Paraskeva,University of Piraeus,https://www.ds.unipi.gr/en/faculty/fparaske-en,IeaP7wIAAAAJ
 Fotios Spyridonis,Brunel University London,https://www.brunel.ac.uk/people/fotios-spyridonis,XaVPz0MAAAAJ
+Fotios Stavrou,EURECOM,http://www.photios-stavrou.com/index.html,s7KQ1fcAAAAJ
 Fotis Liarokapis,Masaryk University,https://www.muni.cz/en/people/235197,snY7XXkAAAAJ
 Fotis Spyridonis,Brunel University London,https://www.brunel.ac.uk/people/fotios-spyridonis,XaVPz0MAAAAJ
 Foutse Khomh,Polytechnique Montreal,http://www.khomh.net,YYXb3KIAAAAJ
@@ -9455,6 +9460,7 @@ Giuliano Antoniol,Polytechnique Montreal,http://www.antoniol.net,136elhQAAAAJ
 Giuliano Casale,Imperial College London,http://wp.doc.ic.ac.uk/gcasale,Os1VLoQAAAAJ
 Giulio Antoniol,Polytechnique Montreal,http://www.antoniol.net,136elhQAAAAJ
 Giulio Chiribella,University of Hong Kong,https://i.cs.hku.hk/~giulio,4ob0VU4AAAAJ
+Giulio Franzese,EURECOM,https://www.eurecom.fr/fr/people/franzese-giulio,kEtx_WwAAAAJ
 Giulio Iacucci,University of Helsinki,https://researchportal.helsinki.fi/en/persons/giulio-jacucci,cmpzu9sAAAAJ
 Giulio Jacucci,University of Helsinki,https://researchportal.helsinki.fi/en/persons/giulio-jacucci,cmpzu9sAAAAJ
 Giulio Malavolta,Bocconi University,https://sites.google.com/view/giuliomalavolta,_pYEarUAAAAJ
@@ -16080,6 +16086,7 @@ Leslie F. Greengard,New York University,https://math.nyu.edu/~greengar,lW-MnjMAA
 Leslie G. Valiant,Harvard University,http://people.seas.harvard.edu/~valiant,H509xdsAAAAJ
 Leslie Greengard,New York University,https://math.nyu.edu/~greengar,lW-MnjMAAAAJ
 Leslie Pack Kaelbling,Massachusetts Institute of Technology,http://people.csail.mit.edu/lpk,NOSCHOLARPAGE
+Lesly-Ann Daniel,EURECOM,https://leslyann-daniel.fr,pbph4eUAAAAJ
 Leszek Antoni Gasieniec,University of Liverpool,http://www.csc.liv.ac.uk/~leszek,TbQXQ7EAAAAJ
 Leszek Gasieniec,University of Liverpool,http://www.csc.liv.ac.uk/~leszek,TbQXQ7EAAAAJ
 Leszek Lilien,Western Michigan University,https://cs.wmich.edu/llilien,5iB3-eMAAAAJ
@@ -18071,6 +18078,7 @@ Massimiliano Albanese,George Mason University,https://computing.gmu.edu/profiles
 Massimiliano Di Penta,University of Sannio,http://www.ing.unisannio.it/mdipenta,j6ucyOAAAAAJ
 Massimiliano Pierobon,University of Nebraska,http://cse.unl.edu/~pierobon,Rhu5LQIAAAAJ
 Massimiliano Pontil,University College London,http://www0.cs.ucl.ac.uk/staff/M.Pontil,lcOacs8AAAAJ
+Massimiliano Todisco,EURECOM,http://www.massimilianotodisco.eu,m5JUU1UAAAAJ
 Massimiliano de Leoni,University of Padova,https://www.math.unipd.it/~deleoni,OejM6_AAAAAJ
 Massimo De Santo,University of Salerno,http://www.unisa.it/docenti/massimodesanto/index,h9tkpyYAAAAJ
 Massimo DiPierro,DePaul University,https://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=343,NOSCHOLARPAGE
@@ -18322,7 +18330,7 @@ Mauricio Kischinhevsky,UFF,http://www2.ic.uff.br/~kisch,U5qX4hsAAAAJ
 Mauricio Papa,University of Tulsa,https://faculty.utulsa.edu/~/mauricio-papa,NOSCHOLARPAGE
 Maurits R. R. de Planque,University of Southampton,https://www.ecs.soton.ac.uk/people/mrdp1x07,mGK_vD0AAAAJ
 Maurits de Planque,University of Southampton,https://www.ecs.soton.ac.uk/people/mrdp1x07,mGK_vD0AAAAJ
-Maurizio Filippone,EURECOM,http://www.eurecom.fr/~filippon,ILUeAloAAAAJ
+Maurizio Filippone,KAUST,https://www.kaust.edu.sa/en/study/faculty/maurizio-filippone,ILUeAloAAAAJ
 Maurizio Lenzerini,Sapienza University of Rome,http://www.diag.uniroma1.it/lenzerini,EYxaICEAAAAJ
 Maurizio Mancini,Sapienza University of Rome,http://www.mauriziomancini.org,RJLyh1wAAAAJ
 Maurizio Marchese,University of Trento,https://webapps.unitn.it/du/en/Persona/PER0000526/Didattica,Bir37L0AAAAJ
@@ -22057,6 +22065,7 @@ Phoebe Sengers,Cornell University,http://www.cs.cornell.edu/people/sengers,6c5cf
 Phokion G. Kolaitis,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~kolaitis,Lu7biGYAAAAJ
 Phone Lin,National Taiwan University,https://www.csie.ntu.edu.tw/~plin,NOSCHOLARPAGE
 Phong Nguyen,Ecole Normale Superieure,http://www.di.ens.fr/~pnguyen,hnS8fnUAAAAJ
+Photios A. Stavrou,EURECOM,http://www.photios-stavrou.com/index.html,s7KQ1fcAAAAJ
 Phu Dung Le,Monash University,http://monash.edu/research/explore/en/persons/phu-le(7745eb6e-9b22-4d68-b566-116bc0280aa8).html,NOSCHOLARPAGE
 Phuc Nguyen 0002,University of Massachusetts Amherst,http://wsslab.org/vpnguyen,pBf2M3QAAAAJ
 Phyllis G. Frankl,New York University,http://engineering.nyu.edu/people/phyllis-frankl,XE683E8AAAAJ
@@ -23695,6 +23704,7 @@ Roberto Martín-Martín,University of Texas at Austin,https://robertomartinmarti
 Roberto Martínez Maldonado,Monash University,https://research.monash.edu/en/persons/roberto-martinez-maldonado,sWXrhB0AAAAJ
 Roberto Martínez-Maldonado,Monash University,https://research.monash.edu/en/persons/roberto-martinez-maldonado,sWXrhB0AAAAJ
 Roberto Medeiros de Souza,University of Calgary,https://www.ai2lab.ca,G2V4oBIAAAAJ
+Roberto Morabito,EURECOM,https://www.eurecom.fr/fr/people/morabito-roberto,R21oWZsAAAAJ
 Roberto Navigli,Sapienza University of Rome,http://wwwusers.di.uniroma1.it/~navigli,BsgVJ-EAAAAJ
 Roberto Palmieri,Lehigh University,http://www.cse.lehigh.edu/~palmieri,iipJ5hsAAAAJ
 Roberto Passerone,University of Trento,http://disi.unitn.it/~roby,ziBaxi0AAAAJ
@@ -25842,6 +25852,7 @@ Simone L. Martins,UFF,http://www2.ic.uff.br/~simone,oEIT_KQAAAAJ
 Simone Linz,University of Auckland,https://unidirectory.auckland.ac.nz/profile/slin498,9lCabZsAAAAJ
 Simone Paolo Ponzetto,University of Mannheim,https://www.uni-mannheim.de/dws/people/professors/prof-dr-simone-paolo-ponzetto,VmIFG0EAAAAJ
 Simone R. S. Souza,USP-ICMC,http://icmc.usp.br/pessoas?id=3685313,EhrqxfYAAAAJ
+Simone Rossi,EURECOM,https://www.eurecom.fr/fr/people/rossi-simone,lTt86awAAAAJ
 Simone Scalabrino,University of Molise,https://dibt.unimol.it/sscalabrino,FBP0Z64AAAAJ
 Simone Silvestri,University of Kentucky,http://www.cs.uky.edu/~silvestri,r4hdOZMAAAAJ
 Simone Stumpf,City University of London,https://www.city.ac.uk/people/academics/simone-stumpf,NESjxsAAAAAJ

--- a/generated-author-info.csv
+++ b/generated-author-info.csv
@@ -15723,6 +15723,11 @@ Antonio Carzaniga,Università della Svizzera italiana,icse,1.0,0.2,2013
 Antonio Carzaniga,Università della Svizzera italiana,icse,1.0,0.2,2014
 Antonio Carzaniga,Università della Svizzera italiana,icse,1.0,0.33333,2015
 Antonio Carzaniga,Università della Svizzera italiana,sigcomm,1.0,0.5,2003
+Antonio Faonio,EURECOM,ccs,1.0,0.33333,2024
+Antonio Faonio,EURECOM,crypto,1.0,0.5,2019
+Antonio Faonio,EURECOM,crypto,1.0,0.2,2020
+Antonio Faonio,EURECOM,eurocrypt,1.0,0.14286,2021
+Antonio Faonio,EURECOM,eurocrypt,1.0,0.33333,2025
 Antonio Fariña,University of A Coruña,sigir,1.0,0.25,2005
 Antonio Fariña,University of A Coruña,sigir,1.0,0.25,2008
 Antonio Fernández 0001,IMDEA Software Institute,aaai,1.0,0.14286,2024
@@ -72741,6 +72746,11 @@ Giuliano Casale,Imperial College London,sigmetrics,1.0,0.33333,2010
 Giuliano Casale,Imperial College London,sigmetrics,1.0,1.0,2017
 Giuliano Casale,Imperial College London,ubicomp,1.0,0.33333,2025
 Giuliano Casale,Imperial College London,vldb,1.0,0.33333,2022
+Giulio Franzese,EURECOM,iclr,1.0,0.33333,2024
+Giulio Franzese,EURECOM,iclr,1.0,0.2,2025
+Giulio Franzese,EURECOM,icml,1.0,0.25,2022
+Giulio Franzese,EURECOM,icml,1.0,0.33333,2024
+Giulio Franzese,EURECOM,nips,2.0,0.41667,2023
 Giulio Jacucci,University of Helsinki,chiconf,1.0,0.14286,2006
 Giulio Jacucci,University of Helsinki,chiconf,1.0,0.2,2007
 Giulio Jacucci,University of Helsinki,chiconf,1.0,0.125,2008
@@ -128269,6 +128279,12 @@ Leslie Pack Kaelbling,Massachusetts Institute of Technology,rss,1.0,0.16667,2019
 Leslie Pack Kaelbling,Massachusetts Institute of Technology,rss,1.0,0.14286,2021
 Leslie Pack Kaelbling,Massachusetts Institute of Technology,rss,1.0,0.2,2023
 Leslie Pack Kaelbling,Massachusetts Institute of Technology,rss,3.0,0.43452,2024
+Lesly-Ann Daniel,EURECOM,ccs,1.0,0.16667,2023
+Lesly-Ann Daniel,EURECOM,ccs,1.0,0.25,2024
+Lesly-Ann Daniel,EURECOM,ndss,1.0,0.33333,2021
+Lesly-Ann Daniel,EURECOM,oakland,1.0,0.33333,2020
+Lesly-Ann Daniel,EURECOM,oakland,2.0,0.4,2024
+Lesly-Ann Daniel,EURECOM,usenixsec,1.0,0.16667,2023
 Leszek Gasieniec,University of Liverpool,focs,1.0,0.125,1993
 Leszek Gasieniec,University of Liverpool,focs,1.0,0.33333,2000
 Leszek Gasieniec,University of Liverpool,focs,1.0,0.16667,2021
@@ -143510,6 +143526,7 @@ Massimiliano Pontil,University College London,nips,4.0,1.4167,2021
 Massimiliano Pontil,University College London,nips,4.0,0.95,2022
 Massimiliano Pontil,University College London,nips,3.0,0.61667,2023
 Massimiliano Pontil,University College London,nips,4.0,0.86667,2024
+Massimiliano Todisco,EURECOM,nips,1.0,0.076923,2023
 Massimo Mecella,Sapienza University of Rome,vldb,1.0,0.2,2005
 Massimo Mecella,Sapienza University of Rome,www,1.0,0.25,2006
 Massimo Poesio,Queen Mary University of London,aaai,1.0,0.5,1991
@@ -145629,23 +145646,23 @@ Mauricio A. Álvarez,University of Manchester,nips,1.0,0.25,2020
 Mauricio A. Álvarez,University of Manchester,nips,3.0,1.1667,2021
 Mauricio A. Álvarez,University of Manchester,nips,1.0,0.16667,2022
 Mauricio A. Álvarez,University of Manchester,nips,2.0,0.44444,2023
-Maurizio Filippone,EURECOM,ccs,1.0,0.5,2015
-Maurizio Filippone,EURECOM,iclr,1.0,0.11111,2025
-Maurizio Filippone,EURECOM,icml,1.0,0.5,2015
-Maurizio Filippone,EURECOM,icml,2.0,0.5,2016
-Maurizio Filippone,EURECOM,icml,1.0,0.25,2017
-Maurizio Filippone,EURECOM,icml,1.0,0.5,2018
-Maurizio Filippone,EURECOM,icml,1.0,0.33333,2019
-Maurizio Filippone,EURECOM,icml,2.0,0.58333,2021
-Maurizio Filippone,EURECOM,icml,1.0,0.25,2022
-Maurizio Filippone,EURECOM,icml,1.0,0.25,2023
-Maurizio Filippone,EURECOM,icml,1.0,0.04,2024
-Maurizio Filippone,EURECOM,nips,1.0,0.25,2015
-Maurizio Filippone,EURECOM,nips,1.0,0.2,2018
-Maurizio Filippone,EURECOM,nips,1.0,0.25,2019
-Maurizio Filippone,EURECOM,nips,1.0,0.33333,2020
-Maurizio Filippone,EURECOM,nips,1.0,0.16667,2021
-Maurizio Filippone,EURECOM,nips,2.0,0.41667,2023
+Maurizio Filippone,KAUST,ccs,1.0,0.5,2015
+Maurizio Filippone,KAUST,iclr,1.0,0.11111,2025
+Maurizio Filippone,KAUST,icml,1.0,0.5,2015
+Maurizio Filippone,KAUST,icml,2.0,0.5,2016
+Maurizio Filippone,KAUST,icml,1.0,0.25,2017
+Maurizio Filippone,KAUST,icml,1.0,0.5,2018
+Maurizio Filippone,KAUST,icml,1.0,0.33333,2019
+Maurizio Filippone,KAUST,icml,2.0,0.58333,2021
+Maurizio Filippone,KAUST,icml,1.0,0.25,2022
+Maurizio Filippone,KAUST,icml,1.0,0.25,2023
+Maurizio Filippone,KAUST,icml,1.0,0.04,2024
+Maurizio Filippone,KAUST,nips,1.0,0.25,2015
+Maurizio Filippone,KAUST,nips,1.0,0.2,2018
+Maurizio Filippone,KAUST,nips,1.0,0.25,2019
+Maurizio Filippone,KAUST,nips,1.0,0.33333,2020
+Maurizio Filippone,KAUST,nips,1.0,0.16667,2021
+Maurizio Filippone,KAUST,nips,2.0,0.41667,2023
 Maurizio Lenzerini,Sapienza University of Rome,aaai,1.0,0.5,1990
 Maurizio Lenzerini,Sapienza University of Rome,aaai,1.0,0.5,1991
 Maurizio Lenzerini,Sapienza University of Rome,aaai,1.0,0.5,1994


### PR DESCRIPTION
Added missing Faculty at EURECOM and updated affiliation of one who left.

One is present twice as he appears with a different writing  (Photios A. Stavrou /  Fotios Stavrou).

Some home pages are currently broken, but those were reported and should be fixed (if URLs ends up changing, I'll make another commit).