### PR TITLE
Add Dimitrios Mitropoulos (name variant)

### DIFF
--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -1240,6 +1240,7 @@ Dimitris Karagiannis,University of Vienna,https://cs.univie.ac.at/dimitris.karag
 Dimitris Koutsouris,NTUA,http://www2.biomed.ntua.gr/%CE%B4%CE%B9%CE%B5%CF%85%CE%B8%CF%85%CE%BD%CF%84%CE%AE%CF%82,tTm7CCAAAAAJ
 Dimitris Makrakis,University of Ottawa,http://www.site.uottawa.ca/~dimitris,wsKoAKcAAAAJ
 Dimitris Mitropoulos,University of Athens,https://dimitro.gr,ryow8hIAAAAJ
+Dimitrios Mitropoulos,University of Athens,https://dimitro.gr,ryow8hIAAAAJ
 Dimitris N. Metaxas,Rutgers University,https://www.cs.rutgers.edu/~dnm,a7VNhCIAAAAJ
 Dimitris P. Tsakiris,Aberystwyth University,https://www.aber.ac.uk/en/cs/staff-profiles/listing/profile/dit5,05r1hHoAAAAJ
 Dimitris Papadias,HKUST,https://www.cse.ust.hk/faculty/dimitris,7BPMWSkAAAAJ


### PR DESCRIPTION
Adding the second name variant (Dimitrios) as requested in:

https://github.com/emeryberger/CSrankings/pull/9215.

The Dimitris variant was already present.