### PR TITLE
Update Christan Grant: OU → UF, add homepage and Scholar ID

### DIFF
--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -789,8 +789,8 @@ Chris Wilson,University of Oregon,http://ix.cs.uoregon.edu/~cwilson,NOSCHOLARPAG
 Chris Wojtan,IST Austria,http://pub.ist.ac.at/group_wojtan,OGdXlpcAAAAJ
 Chris Xiaoxuan Lu,University College London,https://christopherlu.github.io,idu78-EAAAAJ
 Christabel Gonsalvez,Monash University,https://research.monash.edu/en/persons/christabel-gonsalvez,NOSCHOLARPAGE
-Christan Earl Grant,University of Oklahoma,http://www.ou.edu/coe/cs/people/cgrant,NOSCHOLARPAGE
-Christan Grant,University of Oklahoma,http://www.ou.edu/coe/cs/people/cgrant,NOSCHOLARPAGE
+Christan Earl Grant,University of Florida,https://ceg.me,qIQ3IwYAAAAJ
+Christan Grant,University of Florida,https://ceg.me,qIQ3IwYAAAAJ
 Christel Baier,TU Dresden,https://wwwtcs.inf.tu-dresden.de/~baier,p8sX7r0AAAAJ
 Christena Nippert-Eng,Indiana University,https://luddy.indiana.edu/contact/profile/?profile_id=388,NOSCHOLARPAGE
 Christian Andersson Naesseth,University of Amsterdam,https://naesseth.github.io,GQ6rOssAAAAJ


### PR DESCRIPTION
## Summary
- Updated affiliation from University of Oklahoma to University of Florida for both name variants
- Added homepage: https://ceg.me
- Added Google Scholar ID: qIQ3IwYAAAAJ

## Changes
Both entries for Christan Earl Grant and Christan Grant have been updated in `csrankings-c.csv`.

## Verification
- DBLP entries: [Christan Grant](https://dblp.org/pid/136/3030.html)
- Google Scholar: https://scholar.google.com/citations?user=qIQ3IwYAAAAJ
- Homepage: https://ceg.me