### PR TITLE
Updating CityU HK CS faculty members

### DIFF
--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -980,7 +980,7 @@ Howard Blair,Syracuse University,https://experts.syr.edu/en/persons/howard-a-bla
 Howard Bowman,University of Kent,https://www.cs.kent.ac.uk/people/staff/hb5,pcKQix4AAAAJ
 Howard C. Elman,University of Maryland - College Park,https://www.cs.umd.edu/users/elman,7zf7xGkAAAAJ
 Howard J. Hamilton,University of Regina,http://www.cs.uregina.ca/People/Profiles/HowardHamilton.html,S8kGH3cAAAAJ
-Howard Leung,City University of Hong Kong,https://www.cs.cityu.edu.hk/~howard,EPaaCOgAAAAJ
+Howard Leung,City University of Hong Kong,https://scholars.cityu.edu.hk/en/persons/howard/,EPaaCOgAAAAJ
 Howard Rosenbaum,Indiana University,https://ella.sice.indiana.edu/~hrosenba,zM9oIWUAAAAJ
 Howard Straubing,Boston College,http://www.cs.bc.edu/~straubin,VdkpR4kAAAAJ
 Howie Choset,Carnegie Mellon University,http://www.cs.cmu.edu/~./choset,4fvo61oAAAAJ

--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -980,6 +980,7 @@ Howard Blair,Syracuse University,https://experts.syr.edu/en/persons/howard-a-bla
 Howard Bowman,University of Kent,https://www.cs.kent.ac.uk/people/staff/hb5,pcKQix4AAAAJ
 Howard C. Elman,University of Maryland - College Park,https://www.cs.umd.edu/users/elman,7zf7xGkAAAAJ
 Howard J. Hamilton,University of Regina,http://www.cs.uregina.ca/People/Profiles/HowardHamilton.html,S8kGH3cAAAAJ
+Howard Leung,City University of Hong Kong,https://www.cs.cityu.edu.hk/~howard,EPaaCOgAAAAJ
 Howard Rosenbaum,Indiana University,https://ella.sice.indiana.edu/~hrosenba,zM9oIWUAAAAJ
 Howard Straubing,Boston College,http://www.cs.bc.edu/~straubin,VdkpR4kAAAAJ
 Howie Choset,Carnegie Mellon University,http://www.cs.cmu.edu/~./choset,4fvo61oAAAAJ

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -1167,7 +1167,7 @@ Jianye Yang,Hunan University,http://csee.hnu.edu.cn/people/yangjianye,NOSCHOLARP
 Jianying Zhou 0001,SUTD,http://jianying.space,T-Uf3dYAAAAJ
 Jianyong Chen,Shenzhen University,https://csse.szu.edu.cn/en/pages/user/index?id=519,cG_sUoYAAAAJ
 Jianyong Wang 0001,Tsinghua University,http://dbgroup.cs.tsinghua.edu.cn/wangjy,VfBaiG8AAAAJ
-Jianyuan guo,City University of Hong Kong,https://ggjy.github.io,UnAbd4gAAAAJ
+Jianyuan Guo,City University of Hong Kong,https://ggjy.github.io,UnAbd4gAAAAJ
 Jianyun Nie,University of Montreal,http://rali.iro.umontreal.ca/nie/jian-yun-nie-en,W7uYg0UAAAAJ
 Jianzhong Li 0001,Harbin Institute of Technology,http://homepage.hit.edu.cn/jianzhongli,RLFOrxsAAAAJ
 Jianzhong Qi 0001,University of Melbourne,http://people.eng.unimelb.edu.au/jianzhongq,mxS6eHYAAAAJ

--- a/csrankings-z.csv
+++ b/csrankings-z.csv
@@ -303,7 +303,7 @@ Zhirong Yang,NTNU,https://www.ntnu.no/ansatte/zhirong.yang,jxOrsf4AAAAJ
 Zhiru Zhang,Cornell University,http://www.csl.cornell.edu/~zhiruz,x05pUHsAAAAJ
 Zhishan Guo,North Carolina State University,https://www.csc.ncsu.edu/people/zguo32,e3_l6fwAAAAJ
 Zhisheng Yan,George Mason University,https://mason.gmu.edu/~zyan4/index.html,i6ePuTMAAAAJ
-Zhisong Zhang,City University of Hong Kong,https://zzsfornlp.github.io/,373vlUEAAAAJ
+Zhisong Zhang,City University of Hong Kong,https://scholars.cityu.edu.hk/en/persons/zzhan36/,373vlUEAAAAJ
 Zhitao Ying,Yale University,https://cpsc.yale.edu/people/zhitao-ying,6fqNXooAAAAJ
 Zhiting Hu,Univ. of California - San Diego,http://zhiting.ucsd.edu,N7_xhHoAAAAJ
 Zhiwei Jiang 0001,Nanjing University,https://zhiweinju.github.io,RMeCJCoAAAAJ

--- a/csrankings-z.csv
+++ b/csrankings-z.csv
@@ -175,6 +175,7 @@ Zheni Zeng,Nanjing University,https://is.nju.edu.cn/czn/main.htm,CM3VSeQAAAAJ
 Zhenjian Lu,University of Victoria,https://luzhenjian.github.io,UKxXFzwAAAAJ
 Zhenjiang Hu,Peking University,http://sei.pku.edu.cn/~hu,MvGKdLoAAAAJ
 Zhenjiang Li,City University of Hong Kong,https://www.cs.cityu.edu.hk/~zhenjili,Q9AV25UAAAAJ
+Zhenliang Lu,City University of Hong Kong,https://zhenlianglu.github.io/,TUIQe5kAAAAJ
 Zhenkai Liang,National University of Singapore,https://www.comp.nus.edu.sg/~liangzk,SXfOJjcAAAAJ
 Zhenkai Zhang 0002,Clemson University,https://zhenkai-zhang.github.io,DFI-VpcAAAAJ
 Zhenlin An,University of Georgia,https://anplus.github.io,RnYRx7cAAAAJ
@@ -302,6 +303,7 @@ Zhirong Yang,NTNU,https://www.ntnu.no/ansatte/zhirong.yang,jxOrsf4AAAAJ
 Zhiru Zhang,Cornell University,http://www.csl.cornell.edu/~zhiruz,x05pUHsAAAAJ
 Zhishan Guo,North Carolina State University,https://www.csc.ncsu.edu/people/zguo32,e3_l6fwAAAAJ
 Zhisheng Yan,George Mason University,https://mason.gmu.edu/~zyan4/index.html,i6ePuTMAAAAJ
+Zhisong Zhang,City University of Hong Kong,https://zzsfornlp.github.io/,373vlUEAAAAJ
 Zhitao Ying,Yale University,https://cpsc.yale.edu/people/zhitao-ying,6fqNXooAAAAJ
 Zhiting Hu,Univ. of California - San Diego,http://zhiting.ucsd.edu,N7_xhHoAAAAJ
 Zhiwei Jiang 0001,Nanjing University,https://zhiweinju.github.io,RMeCJCoAAAAJ


### PR DESCRIPTION
This PR updates faculty records for City University of Hong Kong (CityU HK) to add missing tenure-track Assistant Professors and fix data consistency:

Add Zhisong Zhang (Assistant Professor, CS)

Official Profile: https://scholars.cityu.edu.hk/en/persons/zzhan36/

File: csrankings-z.csv

Add Zhenliang Lu (Assistant Professor, CS)

Official Profile: https://scholars.cityu.edu.hk/en/persons/zhenlilu/

File: csrankings-l.csv

Add Howard Leung (Associate Professor, CS)

Reason: Adding name alias to link DBLP publications under "Howard Leung" to existing "Wing Ho" records.

Official Profile: https://scholars.cityu.edu.hk/en/persons/howard/

File: csrankings-h.csv

Fix Jianyuan Guo (Assistant Professor, CS)

Change: Corrected surname capitalization from "guo" to "Guo" in csrankings-j.csv.

Official Listing: Presidential Assistant Professors Listing

## Required Checklist

Read [CONTRIBUTING.md](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md) and check **all** boxes that apply.
Delete any lines that don't apply to your PR.

### Identity & Format
- [x] My GitHub profile shows my full name[^1]
- [x] PR title is descriptive (not "Update csrankings-x.csv")[^2]
- [x] One PR per institution, all changes combined[^3]
- [x] Only modified `csrankings-[a-z].csv` or `old/industry.csv`[^4]
- [x] Did NOT use Excel[^5]
- [x] No spaces after commas, no missing fields[^6]
- [x] Entries in alphabetical order by full name[^7]

### Data Accuracy
- [x] Name matches [DBLP](https://dblp.org) exactly (including 0001 suffixes)[^8]
- [x] Homepage URL works and shows name + affiliation[^9]
- [x] Google Scholar ID is the 12-character code only[^10]

### Eligibility
- [x] Faculty is full-time, tenure-track[^11]
- [x] Can **solely** advise CS PhD students[^12]
- [x] If not in CS department: included justification with links[^13]

### New Institutions
- [x] If adding new institution: opened issue first[^14]
- [x] Adding **all** CS faculty (not just one)[^15]

---

[^1]: Anonymous submissions are rejected to ensure accountability. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#non-anonymous)
[^2]: Generic titles make the PR queue difficult to manage. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#pr-title)
[^3]: Multiple PRs for one institution create merge conflicts. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#one-pr)
[^4]: Other files are auto-generated or require maintainer access. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#allowed-files)
[^5]: Excel corrupts Google Scholar IDs by converting them to formulas. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#no-excel)
[^6]: Malformed CSV lines break the data pipeline. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#csv-format)
[^7]: Alphabetical order makes entries easy to find and reduces merge conflicts. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#alphabetical)
[^8]: Publications are matched by exact DBLP name; mismatches = zero papers counted. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#dblp-name)
[^9]: Automated validation fetches homepage to verify affiliation. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#homepage)
[^10]: Full URLs or `&hl=en` suffixes break the Scholar lookup. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#scholar-id)
[^11]: Adjuncts, visitors, and part-time faculty are excluded. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#tenure-track)
[^12]: Faculty who can only co-advise don't meet inclusion criteria. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#sole-advising)
[^13]: E.g., courtesy appointment in CS, or graduate program membership. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#non-cs-dept)
[^14]: Institution must be added to `institutions.csv` first by maintainer. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#new-institution)
[^15]: Partial departments skew rankings; all-or-nothing ensures fairness. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#entire-dept)
