### PR TITLE
Added people to U of Latvia

### DIFF
--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -938,6 +938,7 @@ Jesús Martínez del Rincón,Queen's University Belfast,https://www.qub.ac.uk/sc
 Jesús Vilares,University of A Coruña,http://www.grupolys.org/~jvilares,fZHz0B0AAAAJ
 Jesús Vilares Ferro,University of A Coruña,http://www.grupolys.org/~jvilares,fZHz0B0AAAAJ
 Jetty Kleijn,Leiden University,https://liacs.leidenuniv.nl/~kleijnhcm,NOSCHOLARPAGE
+Jevgenijs Vihrovs,University of Latvia,https://quantum.lu.lv/people/,3F4yQG4AAAAJ
 Jey Han Lau,University of Melbourne,https://findanexpert.unimelb.edu.au/profile/385601-jey-han-lau,MFi65f4AAAAJ
 Jeyan Thiyagalingam,University of Liverpool,https://www.liverpool.ac.uk/electrical-engineering-and-electronics/staff/jeyan-thiyagalingam,qe4dPiwAAAAJ
 Jeyarajan Thiyagalingam,University of Liverpool,https://www.liverpool.ac.uk/electrical-engineering-and-electronics/staff/jeyan-thiyagalingam,qe4dPiwAAAAJ
@@ -2661,6 +2662,7 @@ Junzhou Zhao,Xi'an Jiaotong University,https://junzhouzhao.github.io,hBLT754AAAA
 Juraj Hromkovic,ETH Zurich,https://www.inf.ethz.ch/department/faculty-profs/person-detail.html?persid=102124,NOSCHOLARPAGE
 Juraj Somorovsky,Paderborn University,https://www.uni-paderborn.de/person/83504,aPYih6YAAAAJ
 Jurgen J. Vinju,CWI,http://homepages.cwi.nl/~jurgenv,NOSCHOLARPAGE
+Juris Smotrovs,University of Latvia,https://quantum.lu.lv/people/,qrYIC7cAAAAJ
 Jurriaan Hage,Utrecht University,http://www.staff.science.uu.nl/~hage0101,CIVjbcwAAAAJ
 Jurriaan Rot,Radboud University,http://jurriaan.me,o5kqbqIAAAAJ
 Juscimara Gomes Avelino,UFPE,https://portal.cin.ufpe.br/staff/?alias=jga2,nbkiDxMAAAAJ
@@ -2774,3 +2776,4 @@ Jürgen Steimle,Saarland University,https://hci.cs.uni-saarland.de/people/juerge
 Jürgen Teich,University of Erlangen–Nuremberg,https://www.cs12.tf.fau.de/person/juergen-teich,Hj3eizAAAAAJ
 Jürgen W. Hesser,Heidelberg University,http://medphyssrv1.medma.uni-heidelberg.de/cms,NOSCHOLARPAGE
 Jürgen Ziegler 0001,University of Duisburg-Essen,https://interactivesystems.info/team/juergen-ziegler,UD-ha3YAAAAJ
+


### PR DESCRIPTION
Unfortunately, their university has a very outdated homepage

## Required Checklist

Read [CONTRIBUTING.md](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md) and check **all** boxes that apply.
Delete any lines that don't apply to your PR.

### Identity & Format
- [x] My GitHub profile shows my full name[^1]
- [x] PR title is descriptive (not "Update csrankings-x.csv")[^2]
- [x] One PR per institution, all changes combined[^3]
- [x] Only modified `csrankings-[a-z].csv` or `old/industry.csv`[^4]
- [x] Did NOT use Excel[^5]
- [x] No spaces after commas, no missing fields[^6]
- [x] Entries in alphabetical order by full name[^7]

### Data Accuracy
- [x] Name matches [DBLP](https://dblp.org) exactly (including 0001 suffixes)[^8]
- [x] Homepage URL works and shows name + affiliation[^9]
- [x] Google Scholar ID is the 12-character code only[^10]

### Eligibility
- [x] Faculty is full-time, tenure-track[^11]
- [x] Can **solely** advise CS PhD students[^12]
- [x] If not in CS department: included justification with links[^13]

### New Institutions
- [x] If adding new institution: opened issue first[^14]
- [x] Adding **all** CS faculty (not just one)[^15]

---

[^1]: Anonymous submissions are rejected to ensure accountability. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#non-anonymous)
[^2]: Generic titles make the PR queue difficult to manage. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#pr-title)
[^3]: Multiple PRs for one institution create merge conflicts. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#one-pr)
[^4]: Other files are auto-generated or require maintainer access. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#allowed-files)
[^5]: Excel corrupts Google Scholar IDs by converting them to formulas. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#no-excel)
[^6]: Malformed CSV lines break the data pipeline. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#csv-format)
[^7]: Alphabetical order makes entries easy to find and reduces merge conflicts. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#alphabetical)
[^8]: Publications are matched by exact DBLP name; mismatches = zero papers counted. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#dblp-name)
[^9]: Automated validation fetches homepage to verify affiliation. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#homepage)
[^10]: Full URLs or `&hl=en` suffixes break the Scholar lookup. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#scholar-id)
[^11]: Adjuncts, visitors, and part-time faculty are excluded. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#tenure-track)
[^12]: Faculty who can only co-advise don't meet inclusion criteria. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#sole-advising)
[^13]: E.g., courtesy appointment in CS, or graduate program membership. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#non-cs-dept)
[^14]: Institution must be added to `institutions.csv` first by maintainer. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#new-institution)
[^15]: Partial departments skew rankings; all-or-nothing ensures fairness. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#entire-dept)
