### PR TITLE
Dynamically generate year slider range based on current year

### DIFF
--- a/csrankings.js
+++ b/csrankings.js
@@ -2318,6 +2318,7 @@ var CSRankings;
             toYearSelect.appendChild(toOption);
         }
     }
+    CSRankings.populateYearSelects = populateYearSelects;
     /* Initialize the year range slider */
     function initYearSlider(onChangeCallback) {
         const sliderElement = document.getElementById('year-slider');
@@ -4037,6 +4038,8 @@ var CSRankings;
                 ]);
                 console.log(`All CSV files loaded in ${(performance.now() - loadStart).toFixed(1)}ms`);
                 this.setAllOn();
+                // Populate year selects before URL resolution so options exist when params are parsed
+                CSRankings.populateYearSelects();
                 this.navigoRouter.on({
                     '/index': (params, query) => this.navigation(params, query),
                     '/fromyear/:fromyear/toyear/:toyear/index': (params, query) => this.navigation(params, query)
@@ -4347,6 +4350,12 @@ var CSRankings;
         }
         navigation(params, query) {
             CSRankings.handleNavigation(params, query, () => this.invalidateCheckboxCache());
+            // If year params changed, trigger full recomputation
+            if (params && (params['fromyear'] || params['toyear'])) {
+                this.invalidateIncrementalCache();
+                this.recomputeAuthorAreas();
+            }
+            this.rank();
         }
         addListeners() {
             const callbacks = {

--- a/csrankings.js
+++ b/csrankings.js
@@ -2291,6 +2291,33 @@ var CSRankings;
     const DEFAULT_TO_YEAR = MAX_YEAR;
     // Store the callback for use in year input handlers
     let yearChangeCallback = null;
+    /* Populate the hidden year select elements dynamically */
+    function populateYearSelects() {
+        const fromYearSelect = document.getElementById('fromyear');
+        const toYearSelect = document.getElementById('toyear');
+        if (!fromYearSelect || !toYearSelect)
+            return;
+        // Clear existing options
+        fromYearSelect.innerHTML = '';
+        toYearSelect.innerHTML = '';
+        // Populate with years from MIN_YEAR to MAX_YEAR
+        for (let year = MIN_YEAR; year <= MAX_YEAR; year++) {
+            const fromOption = document.createElement('option');
+            fromOption.value = year.toString();
+            fromOption.textContent = year.toString();
+            if (year === DEFAULT_FROM_YEAR) {
+                fromOption.selected = true;
+            }
+            fromYearSelect.appendChild(fromOption);
+            const toOption = document.createElement('option');
+            toOption.value = year.toString();
+            toOption.textContent = year.toString();
+            if (year === DEFAULT_TO_YEAR) {
+                toOption.selected = true;
+            }
+            toYearSelect.appendChild(toOption);
+        }
+    }
     /* Initialize the year range slider */
     function initYearSlider(onChangeCallback) {
         const sliderElement = document.getElementById('year-slider');
@@ -2299,6 +2326,15 @@ var CSRankings;
             return;
         }
         yearChangeCallback = onChangeCallback;
+        // Populate hidden selects dynamically
+        populateYearSelects();
+        // Initialize display spans with default values
+        const fromDisplay = document.getElementById('year-display-from');
+        const toDisplay = document.getElementById('year-display-to');
+        if (fromDisplay)
+            fromDisplay.textContent = DEFAULT_FROM_YEAR.toString();
+        if (toDisplay)
+            toDisplay.textContent = DEFAULT_TO_YEAR.toString();
         // Get initial values from hidden selects (for URL param support)
         const fromYearSelect = document.getElementById('fromyear');
         const toYearSelect = document.getElementById('toyear');

--- a/index.html
+++ b/index.html
@@ -371,53 +371,13 @@
 		    </optgroup>
 		  </select>
 		  <span class="year-slider-container" title="Filter by publication year range">
-		    <span id="year-display-from" class="year-display" title="Start year">2015</span>
+		    <span id="year-display-from" class="year-display" title="Start year"></span>
 		    <div id="year-slider" class="year-slider" title="Drag handles to select year range"></div>
-		    <span id="year-display-to" class="year-display" title="End year">2025</span>
+		    <span id="year-display-to" class="year-display" title="End year"></span>
 		  </span>
-		  <!-- Hidden selects for URL compatibility -->
-		  <select id="fromyear" name="fromyear" style="display:none;">
-		    <option value="1970">1970</option>
-		    <option value="1975">1975</option>
-		    <option value="1980">1980</option>
-		    <option value="1985">1985</option>
-		    <option value="1990">1990</option>
-		    <option value="1995">1995</option>
-		    <option value="2000">2000</option>
-		    <option value="2005">2005</option>
-		    <option value="2010">2010</option>
-		    <option selected="selected" value="2015">2015</option>
-		    <option value="2016">2016</option>
-		    <option value="2017">2017</option>
-		    <option value="2018">2018</option>
-		    <option value="2019">2019</option>
-		    <option value="2020">2020</option>
-		    <option value="2021">2021</option>
-		    <option value="2022">2022</option>
-		    <option value="2023">2023</option>
-		    <option value="2024">2024</option>
-		    <option value="2025">2025</option>
-		  </select>
-		  <select id="toyear" name="toyear" style="display:none;">
-		    <option value="1980">1980</option>
-		    <option value="1985">1985</option>
-		    <option value="1990">1990</option>
-		    <option value="1995">1995</option>
-		    <option value="2000">2000</option>
-		    <option value="2005">2005</option>
-		    <option value="2010">2010</option>
-		    <option value="2015">2015</option>
-		    <option value="2016">2016</option>
-		    <option value="2017">2017</option>
-		    <option value="2018">2018</option>
-		    <option value="2019">2019</option>
-		    <option value="2020">2020</option>
-		    <option value="2021">2021</option>
-		    <option value="2022">2022</option>
-		    <option value="2023">2023</option>
-		    <option value="2024">2024</option>
-		    <option selected="selected" value="2025">2025</option>
-		  </select>
+		  <!-- Hidden selects for URL compatibility (populated dynamically by year-slider.ts) -->
+		  <select id="fromyear" name="fromyear" style="display:none;"></select>
+		  <select id="toyear" name="toyear" style="display:none;"></select>
 		  <span class="area-indicators" title="Area selection status">
 		    <span class="area-indicator ai-indicator" data-area="ai" title="AI areas: Click to toggle">AI</span>
 		    <span class="area-indicator systems-indicator" data-area="systems" title="Systems areas: Click to toggle">Systems</span>

--- a/src/app.ts
+++ b/src/app.ts
@@ -218,6 +218,8 @@ namespace CSRankings {
                 ]);
                 console.log(`All CSV files loaded in ${(performance.now() - loadStart).toFixed(1)}ms`);
                 this.setAllOn();
+                // Populate year selects before URL resolution so options exist when params are parsed
+                populateYearSelects();
                 this.navigoRouter.on({
                     '/index': (params: { [key: string]: string }, query: string) => this.navigation(params, query),
                     '/fromyear/:fromyear/toyear/:toyear/index': (params: { [key: string]: string }, query: string) => this.navigation(params, query)
@@ -648,6 +650,12 @@ namespace CSRankings {
 
         public navigation(params: { [key: string]: string }, query: string): void {
             handleNavigation(params, query, () => this.invalidateCheckboxCache());
+            // If year params changed, trigger full recomputation
+            if (params && (params['fromyear'] || params['toyear'])) {
+                this.invalidateIncrementalCache();
+                this.recomputeAuthorAreas();
+            }
+            this.rank();
         }
 
         private addListeners(): void {

--- a/src/year-slider.ts
+++ b/src/year-slider.ts
@@ -32,6 +32,37 @@ namespace CSRankings {
     // Store the callback for use in year input handlers
     let yearChangeCallback: (() => void) | null = null;
 
+    /* Populate the hidden year select elements dynamically */
+    function populateYearSelects(): void {
+        const fromYearSelect = document.getElementById('fromyear') as HTMLSelectElement;
+        const toYearSelect = document.getElementById('toyear') as HTMLSelectElement;
+
+        if (!fromYearSelect || !toYearSelect) return;
+
+        // Clear existing options
+        fromYearSelect.innerHTML = '';
+        toYearSelect.innerHTML = '';
+
+        // Populate with years from MIN_YEAR to MAX_YEAR
+        for (let year = MIN_YEAR; year <= MAX_YEAR; year++) {
+            const fromOption = document.createElement('option');
+            fromOption.value = year.toString();
+            fromOption.textContent = year.toString();
+            if (year === DEFAULT_FROM_YEAR) {
+                fromOption.selected = true;
+            }
+            fromYearSelect.appendChild(fromOption);
+
+            const toOption = document.createElement('option');
+            toOption.value = year.toString();
+            toOption.textContent = year.toString();
+            if (year === DEFAULT_TO_YEAR) {
+                toOption.selected = true;
+            }
+            toYearSelect.appendChild(toOption);
+        }
+    }
+
     /* Initialize the year range slider */
     export function initYearSlider(onChangeCallback: () => void): void {
         const sliderElement = document.getElementById('year-slider');
@@ -41,6 +72,15 @@ namespace CSRankings {
         }
 
         yearChangeCallback = onChangeCallback;
+
+        // Populate hidden selects dynamically
+        populateYearSelects();
+
+        // Initialize display spans with default values
+        const fromDisplay = document.getElementById('year-display-from');
+        const toDisplay = document.getElementById('year-display-to');
+        if (fromDisplay) fromDisplay.textContent = DEFAULT_FROM_YEAR.toString();
+        if (toDisplay) toDisplay.textContent = DEFAULT_TO_YEAR.toString();
 
         // Get initial values from hidden selects (for URL param support)
         const fromYearSelect = document.getElementById('fromyear') as HTMLSelectElement;

--- a/src/year-slider.ts
+++ b/src/year-slider.ts
@@ -33,7 +33,7 @@ namespace CSRankings {
     let yearChangeCallback: (() => void) | null = null;
 
     /* Populate the hidden year select elements dynamically */
-    function populateYearSelects(): void {
+    export function populateYearSelects(): void {
         const fromYearSelect = document.getElementById('fromyear') as HTMLSelectElement;
         const toYearSelect = document.getElementById('toyear') as HTMLSelectElement;
 


### PR DESCRIPTION
## Summary
- Replace hardcoded year options in HTML with JavaScript-generated options
- The year slider now automatically shows a 10-year range ending with the current year
- Eliminates the need for manual HTML updates each year

## Changes
- **index.html**: Remove hardcoded year options from hidden selects, leave empty for JS to populate
- **src/year-slider.ts**: Add `populateYearSelects()` function that generates options from 1970 to current year
- **src/app.ts**: Call `populateYearSelects()` before URL resolution; update `navigation()` to trigger re-ranking when year params change
- **csrankings.js**: Compiled output

## Test plan
- [X] Load the page and verify year slider shows current year range (e.g., 2016-2026)
- [X] Test URL parameters with custom year ranges (e.g., `/fromyear/2020/toyear/2024/index?all`) - verify ranking updates
- [X] Verify slider interaction updates the display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)