### PR TITLE
Added more people to U of Latvia

### DIFF
--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -234,6 +234,7 @@ Karl-Erik Årzén,Lund University,http://www.control.lth.se/Staff/KarlErikArzen.
 Karl-Heinz Zimmermann,Hamburg University of Technology,https://www.tuhh.de/es/aeg/people/khzimmermann.html,NOSCHOLARPAGE
 Karl-Rudolf Moll,TU Munich,http://wwwbroy.informatik.tu-muenchen.de/~moll,NOSCHOLARPAGE
 Karla A. Badillo-Urquiola,University of Notre Dame,https://cse.nd.edu/faculty/karla-badillo-urquiola,xwr6OaIAAAAJ
+Karlis Cerans,University of Latvia,https://lumii.lv/18/,QZeNPf8AAAAJ
 Karol Myszkowski [INF],Max Planck Society,https://people.mpi-inf.mpg.de/~karol,eZ40F-MAAAAJ
 Karola Marky,Ruhr-University Bochum,https://karolamarky.pinyto.de/en/home,FycJHgUAAAAJ
 Karon E. MacLean,University of British Columbia,https://www.cs.ubc.ca/~maclean,qANkJFwAAAAJ
@@ -272,6 +273,7 @@ Kashif Munir,King Abdulaziz University,http://fcit2.kau.edu.sa:9002/reports/rwse
 Kasim Selçuk Candan,Arizona State University,http://aria.asu.edu/candan,keO-0s0AAAAJ
 Kasim Sinan Yildirim,University of Trento,http://https://sinanyil81.github.io,LXUvnL0AAAAJ
 Kasim Terzic,University of St Andrews,https://kt54.host.cs.st-andrews.ac.uk,kSIPwxMAAAAJ
+Kaspars Balodis,University of Latvia,https://www.linkedin.com/in/kaspars-balodis-243098173,Ez8v4AYAAAAJ
 Kasper Bonne Rasmussen,University of Oxford,http://www.cs.ox.ac.uk/people/kasper.rasmussen,SiRUrasAAAAJ
 Kasper Dalgaard Larsen,Aarhus University,https://cs.au.dk/~larsen,ZluoxUcAAAAJ
 Kasper Green Larsen,Aarhus University,https://cs.au.dk/~larsen,ZluoxUcAAAAJ
@@ -1114,3 +1116,4 @@ Kyungwoo Song,Yonsei University,https://mlai.yonsei.ac.kr,HWxRii4AAAAJ
 Kyuseok Shim,Seoul National University,http://kdd.snu.ac.kr/~shim,3Y254i4AAAAJ
 Kôiti Hasida,University of Tokyo,http://www.i.u-tokyo.ac.jp/edu/course/ice/members_e.shtml,d3CnvP8AAAAJ
 Kübra Kalkan,Özyeğin University,https://faculty.ozyegin.edu.tr/kubrakalkan,xE0INEMAAAAJ
+


### PR DESCRIPTION
same problem as always (uni homepages are outdated)

## Required Checklist

Read [CONTRIBUTING.md](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md) and check **all** boxes that apply.
Delete any lines that don't apply to your PR.

### Identity & Format
- [x] My GitHub profile shows my full name[^1]
- [x] PR title is descriptive (not "Update csrankings-x.csv")[^2]
- [x] One PR per institution, all changes combined[^3]
- [x] Only modified `csrankings-[a-z].csv` or `old/industry.csv`[^4]
- [x] Did NOT use Excel[^5]
- [x] No spaces after commas, no missing fields[^6]
- [x] Entries in alphabetical order by full name[^7]

### Data Accuracy
- [x] Name matches [DBLP](https://dblp.org) exactly (including 0001 suffixes)[^8]
- [x] Homepage URL works and shows name + affiliation[^9]
- [x] Google Scholar ID is the 12-character code only[^10]

### Eligibility
- [x] Faculty is full-time, tenure-track[^11]
- [x] Can **solely** advise CS PhD students[^12]
- [x] If not in CS department: included justification with links[^13]

### New Institutions
- [x] If adding new institution: opened issue first[^14]
- [x] Adding **all** CS faculty (not just one)[^15]

---

[^1]: Anonymous submissions are rejected to ensure accountability. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#non-anonymous)
[^2]: Generic titles make the PR queue difficult to manage. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#pr-title)
[^3]: Multiple PRs for one institution create merge conflicts. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#one-pr)
[^4]: Other files are auto-generated or require maintainer access. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#allowed-files)
[^5]: Excel corrupts Google Scholar IDs by converting them to formulas. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#no-excel)
[^6]: Malformed CSV lines break the data pipeline. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#csv-format)
[^7]: Alphabetical order makes entries easy to find and reduces merge conflicts. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#alphabetical)
[^8]: Publications are matched by exact DBLP name; mismatches = zero papers counted. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#dblp-name)
[^9]: Automated validation fetches homepage to verify affiliation. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#homepage)
[^10]: Full URLs or `&hl=en` suffixes break the Scholar lookup. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#scholar-id)
[^11]: Adjuncts, visitors, and part-time faculty are excluded. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#tenure-track)
[^12]: Faculty who can only co-advise don't meet inclusion criteria. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#sole-advising)
[^13]: E.g., courtesy appointment in CS, or graduate program membership. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#non-cs-dept)
[^14]: Institution must be added to `institutions.csv` first by maintainer. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#new-institution)
[^15]: Partial departments skew rankings; all-or-nothing ensures fairness. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#entire-dept)
