### PR TITLE
Switch from gzip to xz compression for DBLP data

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-dblp.xml.gz filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/monthly-dblp-update.yml
+++ b/.github/workflows/monthly-dblp-update.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           persist-credentials: true
           fetch-depth: 0  # Fetch full history for git pull --rebase
-          lfs: true  # Enable Git LFS for dblp.xml.gz
 
       - name: Set up Git identity
         run: |

--- a/.github/workflows/post-merge-rebuild.yml
+++ b/.github/workflows/post-merge-rebuild.yml
@@ -51,7 +51,6 @@ jobs:
         with:
           persist-credentials: true  # Required to push back
           fetch-depth: 0  # Fetch full history for git pull --rebase
-          lfs: true  # Enable Git LFS for dblp.xml.gz
 
       - name: Set up Git identity
         run: |

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ download-dblp:
 
 shrink-dblp:
 	@echo "Shrinking the DBLP file (streaming, low memory)."
-	gunzip -dc dblp-original.xml.gz | $(PYTHON) util/filter-dblp.py | gzip > dblp.xml.gz
-	@echo "Filtered DBLP saved to dblp.xml.gz"
+	gunzip -dc dblp-original.xml.gz | $(PYTHON) util/filter-dblp.py | xz -9 > dblp.xml.xz
+	@echo "Filtered DBLP saved to dblp.xml.xz"
 
 faculty-affiliations.csv homepages.csv scholar.csv csrankings.csv: csrankings-*.csv
 	@echo "Splitting main datafile."
@@ -90,12 +90,12 @@ fix-affiliations: faculty-affiliations.csv
 	@rm /tmp/f1.csv
 	@mv /tmp/f2.csv faculty-affiliations.csv
 
-faculty-coauthors.csv: dblp.xml.gz util/generate-faculty-coauthors.py util/csrankings.py
+faculty-coauthors.csv: dblp.xml.xz util/generate-faculty-coauthors.py util/csrankings.py
 	@echo "Rebuilding the co-author database (faculty-coauthors.csv)."
 	$(PYTHON) util/generate-faculty-coauthors.py
 	@echo "Done."
 
-generated-author-info.csv: faculty-affiliations.csv dblp.xml.gz util/regenerate_data.py util/csrankings.py dblp-aliases.csv
+generated-author-info.csv: faculty-affiliations.csv dblp.xml.xz util/regenerate_data.py util/csrankings.py dblp-aliases.csv
 	@echo "Rebuilding the publication database (generated-author-info.csv)."
 	@$(PYPY) util/split-csv.py
 	@$(PYPY) util/regenerate_data.py

--- a/util/build-orcid-csv.py
+++ b/util/build-orcid-csv.py
@@ -16,7 +16,7 @@ Takes ~45 minutes due to ORCID API rate limiting.
 
 import argparse
 import csv
-import gzip
+import lzma
 import re
 import urllib.request
 import urllib.parse
@@ -38,7 +38,7 @@ def extract_dblp_orcids(dblp_path: str) -> Dict[str, str]:
     orcids = {}
     pattern = re.compile(r'<author orcid="([^"]+)">([^<]+)</author>')
 
-    with gzip.open(dblp_path, 'rt', encoding='utf-8') as f:
+    with lzma.open(dblp_path, 'rt', encoding='utf-8') as f:
         for line in f:
             for match in pattern.finditer(line):
                 orcid = match.group(1)
@@ -205,7 +205,7 @@ def search_and_verify(name: str, institution: str) -> Tuple[str, Optional[str]]:
 
 def main():
     parser = argparse.ArgumentParser(description="Build orcid.csv from DBLP and ORCID API")
-    parser.add_argument("--dblp", default="dblp.xml.gz", help="Path to DBLP XML (default: dblp.xml.gz)")
+    parser.add_argument("--dblp", default="dblp.xml.xz", help="Path to DBLP XML (default: dblp.xml.xz)")
     parser.add_argument("--output", default="orcid.csv", help="Output file (default: orcid.csv)")
     parser.add_argument("--skip-api", action="store_true", help="Skip ORCID API queries (DBLP only)")
     parser.add_argument("--include-old", action="store_true", help="Include old/*.csv faculty")

--- a/util/generate-all-pubs.py
+++ b/util/generate-all-pubs.py
@@ -1,5 +1,5 @@
 import csrankings
-import gzip
+import lzma
 from lxml import etree as ElementTree
 
 startyear = 2013
@@ -12,7 +12,7 @@ def parseDBLP(facultydict):
     authorscores = {}
     authorscoresAdjusted = {}
 
-    with gzip.open("dblp.xml.gz") as f:
+    with lzma.open("dblp.xml.xz") as f:
 
         oldnode = None
 

--- a/util/generate-faculty-coauthors.py
+++ b/util/generate-faculty-coauthors.py
@@ -1,6 +1,6 @@
 from csrankings import *
 import json
-import gzip
+import lzma
 
 authorPaperCountThreshold = 0
 
@@ -12,7 +12,7 @@ def parseDBLP(facultydict):
     coauthors = {}
     papersWritten = {}
     counter = 0
-    with gzip.open("dblp.xml.gz") as f:
+    with lzma.open("dblp.xml.xz") as f:
 
         oldnode = None
 

--- a/util/regenerate_data.py
+++ b/util/regenerate_data.py
@@ -12,7 +12,7 @@ Optimizations:
 """
 
 import argparse
-import gzip
+import lzma
 import json
 import csv
 import sys
@@ -335,9 +335,9 @@ def do_it() -> None:
     include_all = args.all
 
     # Use iterparse for memory-efficient streaming
-    with gzip.open("dblp.xml.gz", 'rb') as gz:
+    with lzma.open("dblp.xml.xz", 'rb') as xz:
         context = etree.iterparse(
-            gz,
+            xz,
             events=('end',),
             tag=('inproceedings', 'article'),
             load_dtd=True,


### PR DESCRIPTION
## Summary
- Switch `dblp.xml.gz` to `dblp.xml.xz` using `xz -9` compression, reducing file size from ~51MB to ~30MB
- Remove Git LFS dependency since the file now fits within GitHub's size limits
- Update all Python scripts to use `lzma` module instead of `gzip`

## Test plan
- [ ] Verify `dblp.xml.xz` is ~30MB: `ls -la dblp.xml.xz`
- [ ] Test data regeneration: `python3 util/regenerate_data.py`
- [ ] Verify ORCID extraction: `python3 util/build-orcid-csv.py --skip-api --output orcid-test.csv`
- [ ] CI workflows run successfully without LFS

🤖 Generated with [Claude Code](https://claude.com/claude-code)