### PR TITLE
Add GIST (Gwangju Institute of Science and Technology) faculty

### DIFF
--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -706,6 +706,7 @@ Bobak Mortazavi,Texas A&M University,http://faculty.cse.tamu.edu/bobakm,TOAg4GkA
 Bobby Bhattacharjee,Univ. of Maryland - College Park,http://www.cs.umd.edu/~bobby,NOSCHOLARPAGE,0000-0000-0000-0000
 Bobby Bodenheimer,Vanderbilt University,https://engineering.vanderbilt.edu/bio/?pid=robert-bodenheimer,hI4XguUAAAAJ,0000-0002-0616-5936
 Bobby Schnabel,University of Colorado Boulder,https://www.colorado.edu/cs/bobby-schnabel,NOSCHOLARPAGE,0000-0000-0000-0000
+Bochang Moon,GIST,https://cglab.gist.ac.kr/people/bochang.html,5aZuIAsAAAAJ,0000-0000-0000-0000
 Bodhisatwa Mazumdar,IIT Indore,http://cse.iiti.ac.in/faculty.html,ea-e9TwAAAAJ,0000-0003-1883-4639
 Bodo Rosenhahn,University of Hannover,http://www.tnt.uni-hannover.de/staff/rosenhahn,qq3TxtcAAAAJ,0000-0000-0000-0000
 Bodo Urban,University of Rostock,https://www.igd.fraunhofer.de/institut/ueber-uns/alumni/bodo-urban,NOSCHOLARPAGE,0000-0003-4968-4506

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -339,6 +339,7 @@ Chang Hyun Park 0001,Uppsala University,https://iamchanghyunpark.github.io,T9ro2
 Chang Lou,University of Virginia,https://changlousys.github.io,ogozoZUAAAAJ,0009-0001-3056-5729
 Chang Ming Wu,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/wu.html,R1UPxsMAAAAJ,0000-0000-0000-0000
 Chang Wen Chen,The Hong Kong Polytechnic Univ.,https://www4.comp.polyu.edu.hk/~chencw/Home.html,w2HXPUUAAAAJ,0000-0002-6720-234X
+Chang Wook Ahn,GIST,https://sites.google.com/view/gist-memi/people/professor?authuser=0,tG9d6PYAAAAJ,0000-0000-0000-0000
 Chang Xu 0001,Nanjing University,https://cs.nju.edu.cn/changxu,jlZOlxIAAAAJ,0000-0002-6299-4704
 Chang Xu 0002,University of Sydney,https://sydney.edu.au/engineering/about/our-people/academic-staff/c-xu.html,N4F_3eoAAAAJ,0000-0002-4756-0609
 Chang-Dong Wang 0001,Sun Yat-sen University,http://www.scholat.com/changdongwang.en,omqnB70AAAAJ,0000-0001-5972-559X

--- a/csrankings-e.csv
+++ b/csrankings-e.csv
@@ -728,6 +728,7 @@ Eui-Nam Huh,Kyung Hee University,http://icnslab.net/#/introduction,0ATpZl0AAAAJ,
 Eui-nam Huh,Kyung Hee University,http://icnslab.net/#/introduction,0ATpZl0AAAAJ,0000-0000-0000-0000
 Euijin Choo,University of Alberta,https://alleychoo.github.io,ISmS4C8AAAAJ,0009-0007-0344-6904
 Euijong Whang,KAIST,http://stevenwhang.com,w6hts30AAAAJ,0000-0000-0000-0000
+Euiseok Hwang,GIST,https://iis.gist.ac.kr/prog/gsPerson/isp/P/view.do?siteCode=isp&mno=sub02_01_01&tmplId=template_d1&personId=P00001644,ub7gGGUAAAAJ,0000-0000-0000-0000
 Euiseong Seo,Sungkyunkwan University,http://csl.skku.edu,VjycY14AAAAJ,0000-0003-2103-8019
 Euiwoong Lee,University of Michigan,https://web.eecs.umich.edu/~euiwoong,9Yxhn6oAAAAJ,0000-0003-1454-7587
 Eul Gyu Im,Hanyang University,http://usecurity.hanyang.ac.kr/people/professor,DTq34zQAAAAJ,0000-0000-0000-0000

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -220,6 +220,7 @@ Geoffrey S. Smith,Florida International University,http://www.cis.fiu.edu/~smith
 Geoffrey Smith,Florida International University,http://www.cis.fiu.edu/~smithg,OCmc_bYAAAAJ,0000-0000-0000-0000
 Geoffrey Smith 0001,Florida International University,http://www.cis.fiu.edu/~smithg,OCmc_bYAAAAJ,0000-0000-0000-0000
 Geoffrey Werner Challen,University at Buffalo,https://blue.cse.buffalo.edu/people/gwa,lR34_8YAAAAJ,0000-0000-0000-0000
+Geonho Hwang,GIST,https://sites.google.com/view/geonhohwang,NHpe_8IAAAAJ,0000-0000-0000-0000
 Georg Carle,TU Munich,https://www.net.in.tum.de/members/carle,l5xqmTIAAAAJ,0000-0000-0000-0000
 Georg Fuchsbauer,TU Wien,http://www.di.ens.fr/~fuchsbau,CxHsVWwAAAAJ,0000-0001-5672-5850
 Georg Gottlob,University of Oxford,https://www.cs.ox.ac.uk/people/georg.gottlob,i72_SkUAAAAJ,0000-0002-2353-5230
@@ -894,6 +895,7 @@ Gul Çalikli,University of Glasgow,https://gulcalikli.github.io,lShgfvwAAAAJ,000
 Gultekin Özsoyoglu,Case Western Reserve University,http://engineering.case.edu/eecs/faculty-staff,NOSCHOLARPAGE,0000-0000-0000-0000
 Gunes Acar,Radboud University,https://gunesacar.net,B6yKiPQAAAAJ,0000-0002-1621-8333
 Gunhee Kim,Seoul National University,https://vision.snu.ac.kr/gunhee,CiSdOV0AAAAJ,0000-0002-9543-7453
+Gunhyuk Park,GIST,https://sites.google.com/view/gist-hamlab/people?authuser=0,LY8SM4IAAAAJ,0000-0000-0000-0000
 Guni Sharon,Texas A&M University,http://faculty.cse.tamu.edu/guni,Vwx9fo4AAAAJ,0000-0001-9306-369X
 Gunilla Borgefors,Uppsala University,http://www.cb.uu.se/~gunilla,cN7GJ1EAAAAJ,0000-0000-0000-0000
 Gunilla Kreiss,Uppsala University,https://katalog.uu.se/empinfo/?id=N1-389,NOSCHOLARPAGE,0000-0001-8865-8218

--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -723,6 +723,7 @@ Hesham El-Sayed,UAEU,https://www.uaeu.ac.ae/en/cit/profile.shtml?email=helsayed@
 HeuiSeok Lim,Korea University,http://nlp.korea.ac.kr,HMTkz7oAAAAJ,0000-0002-9269-1157
 Heung-Il Suk,Korea University,https://milab.korea.ac.kr,dl_oZLwAAAAJ,0000-0001-7019-8962
 Heung-Kyu Lee,KAIST,http://hklee.kaist.ac.kr,f7uaLWEAAAAJ,0000-0000-0000-0000
+Heung-No Lee,GIST,https://eecs.gist.ac.kr/m31_view.php?cate=001001&idx=15,lRlN_40AAAAJ,0000-0000-0000-0000
 Heyan Chai 0001,Shenzhen University,https://csse.szu.edu.cn/en/pages/user/index?id=1340,5EsW7mUAAAAJ,0000-0003-4470-9364
 Heysem Kaya,Utrecht University,https://www.uu.nl/staff/HKaya,mPI3SpkAAAAJ,0000-0001-7947-5508
 Hiba Baroud,Vanderbilt University,https://engineering.vanderbilt.edu/bio/hiba-baroud,1IjEUscAAAAJ,0000-0003-3641-6449
@@ -849,6 +850,7 @@ Hong Hu 0004,Pennsylvania State University,https://huhong789.github.io,3aaJwkoAA
 Hong Huang 0001,HUST,http://faculty.hust.edu.cn/honghuang/en/index.htm,-3d0B50AAAAJ,0000-0002-5282-551X
 Hong Jiang 0001,University of Texas at Arlington,http://ranger.uta.edu/~jiang,u6wmNbQAAAAJ,0000-0002-1477-9751
 Hong Jin Kang,University of Sydney,https://kanghj.github.io,I0aA7bQAAAAJ,0000-0001-7335-7295
+Hong Kook Kim,GIST,https://sites.google.com/view/gist-aiter/members/professor?authuser=0,uDxv3dkAAAAJ,0000-0000-0000-0000
 Hong Linh Truong 0001,Aalto University,https://research.aalto.fi/en/persons/linh-truong,juCwRycAAAAJ,0000-0003-1465-9722
 Hong Lu 0001,Fudan University,http://homepage.fudan.edu.cn/honglu,bR8b-WIAAAAJ,0000-0000-0000-0000
 Hong Mei 0001,Peking University,http://sei.pku.edu.cn/~meih/index_en.html,b-ZYIwoAAAAJ,0000-0003-2380-3976
@@ -1201,6 +1203,7 @@ Hyungsoo Jung 0001,Seoul National University,https://dbx.snu.ac.kr/people,TY1har
 Hyungsub Kim,Indiana University,https://kimhyungsub.github.io,hBC5-VsAAAAJ,0009-0001-4201-4086
 Hyunguk Yoo,University of New Orleans,https://www.uno.edu/profile/faculty/hyunguk_yoo,M2nERckAAAAJ,0000-0000-0000-0000
 Hyunjin Park,Sungkyunkwan University,http://hyunjinpark.blogspot.com,Pt2N0C8AAAAJ,0000-0000-0000-0000
+Hyunju Lee,GIST,https://combio.gist.ac.kr/prog/gsPerson/combio/P/view.do?siteCode=combio&mno=sub02_01_01&tmplId=template_a3&personId=P0000988,5QyrGvsAAAAJ,0000-0000-0000-0000
 Hyunjung Shim,KAIST,https://sites.google.com/view/cvml-kaist,KB5XZGIAAAAJ,0000-0001-6796-1058
 Hyunseung Choo,Sungkyunkwan University,http://monet.skku.ac.kr/main,ITYIxrUAAAAJ,0000-0000-0000-0000
 Hyunsoo Yoon,KAIST,http://nslab.kaist.ac.kr/members_professor.htm,bmGTi6YAAAAJ,0000-0000-0000-0000

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -128,6 +128,7 @@ Jae Joon Kim,Seoul National University,https://vlsi.snu.ac.kr/team,Ee994T0AAAAJ,
 Jae Jun Yoo,UNIST,https://sites.google.com/view/jaejunyoo,7NBlQw4AAAAJ,0000-0000-0000-0000
 Jae S. Lim,Massachusetts Inst. of Technology,http://www.rle.mit.edu/people/directory/jae-lim,ClH0XTsAAAAJ,0000-0000-0000-0000
 Jae W. Lee,Seoul National University,https://cse.snu.ac.kr/en/professor/jae-wook-lee,PA-QN6IAAAAJ,0000-0002-4266-4919
+Jae Woong Soh,GIST,https://sites.google.com/view/gist-ivl,Wmhi6jgAAAAJ,0000-0000-0000-0000
 Jae-Gil Lee 0001,KAIST,http://dm.kaist.ac.kr/jaegil,h9mbv9MAAAAJ,0000-0002-8711-7732
 Jae-Pil Heo,Sungkyunkwan University,https://sites.google.com/site/vclabskku,VXyJ_ssAAAAJ,0000-0001-9684-7641
 Jae-Soo Kim,Kyungpook National University,http://computer.knu.ac.kr,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -1365,6 +1366,7 @@ Jin Zhao 0001,Fudan University,http://www.cs.fudan.edu.cn/?page_id=2033,NOSCHOLA
 Jin Zhou 0003,University of Jinan,https://faculty.ujn.edu.cn/zhoujin/zh_CN/index.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Jin-Hee Cho,Virginia Tech,http://people.cs.vt.edu/~jicho,wToVkEUAAAAJ,0000-0002-5908-4662
 Jin-Ho Lee,Seoul National University,https://aisys.snu.ac.kr/team,pm3Fso0AAAAJ,0000-0000-0000-0000
+Jin-Hyuk Hong,GIST,https://iit.gist.ac.kr/prog/gsPerson/sci/P/view.do?siteCode=sci&mno=sub02_01&tmplId=template_d1&personId=P00002575,iTu5G9QAAAAJ,0000-0000-0000-0000
 Jin-Jin Li,Shanghai Jiao Tong University,https://dmne.sjtu.edu.cn/dmne/faculty/lijinjin,NOSCHOLARPAGE,0000-0003-1660-387X
 Jin-Soo Kim 0001,Seoul National University,https://cse.snu.ac.kr/en/professor/jin-soo-kim,U7b2CX0AAAAJ,0000-0003-1065-9362
 Jin-Yi Cai,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~jyc,Yn-Lm_QAAAAJ,0000-0000-0000-0000
@@ -1542,6 +1544,7 @@ Jiwon Seo 0002,Seoul National University,https://mlsys.snu.ac.kr/members,O1WC6TA
 Jiwu Shu,Tsinghua University,http://storage.cs.tsinghua.edu.cn/~jiwu-shu,VccUDSgAAAAJ,0000-0002-7362-2789
 Jiyan Wu,Shenzhen University,https://sites.google.com/site/wujiyanweb,3aTNQsgAAAAJ,0000-0000-0000-0000
 Jiyao An,Hunan University,http://csee.hnu.edu.cn/people/anjiyao,BeWWwfsAAAAJ,0000-0002-9439-9563
+Jiyeon Kang,GIST,https://www.awearlab.com/principal-investigator,PrXIfgwAAAAJ,0000-0000-0000-0000
 Jiying Zhao,University of Ottawa,http://www.site.uottawa.ca/~jyzhao,zHFUSYMAAAAJ,0000-0000-0000-0000
 Jiyuan Wang,Tulane University,https://www.cs.tulane.edu/~wjiyuan,YFsKZUkAAAAJ,0009-0005-2778-8840
 Jize Yan,University of Southampton,https://www.ecs.soton.ac.uk/people/jy12g15,tITMbskAAAAJ,0000-0000-0000-0000
@@ -1977,6 +1980,7 @@ Jong Chul Ye,KAIST,https://bispl.weebly.com/professor.html,HNMjoNEAAAAJ,0000-000
 Jong Hwan Ko,Sungkyunkwan University,http://iris.skku.edu,UN_OIs4AAAAJ,0000-0003-4434-4318
 Jong Kim 0001,POSTECH,https://hpc.postech.ac.kr/~jkim,6t2VQFwAAAAJ,0000-0000-0000-0000
 Jong Taek Lee,Kyungpook National University,https://sites.google.com/view/k-vislab,NZ55Q-AAAAAJ,0000-0002-6962-3148
+Jong Won Shin,GIST,https://sapl.gist.ac.kr/professor,-UyXLxcAAAAJ,0000-0000-0000-0000
 Jong-Hoon Kim,Kent State University,http://www.atr.cs.kent.edu/people/jong-hoon_kim,FdTOhw0AAAAJ,0000-0001-5536-9823
 Jong-Hwan Lee,Korea University,https://bspl.korea.ac.kr,jiT6fH0AAAAJ,0000-0000-0000-0000
 Jong-Hyeok Lee,POSTECH,http://kle.postech.ac.kr/people/professor,Ly38HXAAAAAJ,0000-0000-0000-0000
@@ -1999,6 +2003,7 @@ Jongok Kim,Korea University,https://sites.google.com/a/icq.korea.ac.kr/iml,kVkB3
 Jongouk Choi,University of Central Florida,https://www.cs.ucf.edu/person/jongouk-choi,1R1m3poAAAAJ,0000-0001-7378-6196
 Jongse Park,KAIST,https://jongse-park.github.io,4Fw2ma4AAAAJ,0000-0002-6629-449X
 Jongsun Park,Korea University,http://vlsisp.korea.ac.kr/main/main.html,KyE7WAEAAAAJ,0000-0003-3251-0024
+JongWon Kim 0001,GIST,https://netai.smartx.kr/people/professor,VKULYHAAAAAJ,0000-0000-0000-0000
 Jongwoo Lim,Seoul National University,https://sites.google.com/view/snu-rvlab/people,5_uwsGAAAAAJ,0000-0000-0000-0000
 Jongwuk Lee,Sungkyunkwan University,https://jongwuklee.weebly.com,A3V_4fIAAAAJ,0000-0001-9213-7706
 Joni-Kristian Kämäräinen,Tampere University,https://www.tuni.fi/en/joni-kamarainen,r6Y4nacAAAAJ,0000-0000-0000-0000
@@ -2614,6 +2619,7 @@ Junghoo Cho,Univ. of California - Los Angeles,http://www.cs.ucla.edu/~cho,DSLqux
 Jungong Han,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/jungong-han,hNi1gxAAAAAJ,0000-0003-4361-956X
 Jungrae Kim,Sungkyunkwan University,https://scalable-arch.github.io,Jbpv5q0AAAAJ,0000-0003-1587-0677
 Jungseul Ok,POSTECH,https://sites.google.com/view/jungseulok,KWG3UUMAAAAJ,0000-0003-4742-2473
+Jungwon Yoon,GIST,https://iit.gist.ac.kr/medrobotics/sub01_81165.do,oG-utS8AAAAJ,0000-0000-0000-0000
 Jungwoo Lee 0001,Seoul National University,https://cml.snu.ac.kr/?page_id=5948,j98IWfoAAAAJ,0000-0000-0000-0000
 Jungyong Kim,Kent State University,https://www.kent.edu/cs/jungyoon-kim,z2BCKT4AAAAJ,0000-0000-0000-0000
 Junhao Gan,University of Melbourne,https://findanexpert.unimelb.edu.au/profile/831627-junhao-gan,XvguMc0AAAAJ,0000-0001-9101-1503

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -159,6 +159,7 @@ Kanchana Thilakarathna,University of Sydney,https://sydney.edu.au/engineering/pe
 Kanchi Gopinath,Plaksha University,https://plaksha.edu.in/faculty-details/dr-k-gopinath,ribzpr4AAAAJ,0000-0000-0000-0000
 Kang Chen,Tsinghua University,http://madsys.cs.tsinghua.edu.cn/~kangchen,fXtFkIoAAAAJ,0000-0002-8368-1109
 Kang G. Shin,University of Michigan,http://web.eecs.umich.edu/~kgshin,vY7MdLYAAAAJ,0000-0003-0086-8777
+Kang Il Kim,GIST,https://irrlab.github.io/people/professor/,RZggOtkAAAAJ,0000-0000-0000-0000
 Kang Li 0001,University of Georgia,http://cobweb.cs.uga.edu/~kangli,LLcNeeYAAAAJ,0000-0000-0000-0000
 Kang Liu 0001,Chinese Academy of Sciences,http://www.nlpr.ia.ac.cn/cip/~liukang/index.html,DtZCfl0AAAAJ,0000-0000-0000-0000
 Kang Wook Lee 0001,University of Wisconsin - Madison,https://kangwooklee.com,sCEl8r-n5VEC,0000-0000-0000-0000
@@ -1061,6 +1062,7 @@ Kwan Woo Ryu,Kyungpook National University,http://isaac.knu.ac.kr,NOSCHOLARPAGE,
 Kwan-Liu Ma,Univ. of California - Davis,http://www.cs.ucdavis.edu/~ma,LgL2HpkAAAAJ,0000-0001-8086-0366
 Kwan-Yee K. Wong,University of Hong Kong,https://i.cs.hku.hk/~kykwong,Dxpvy4EAAAAJ,0000-0001-8560-9007
 Kwan-Yee Kenneth Wong,University of Hong Kong,https://i.cs.hku.hk/~kykwong,Dxpvy4EAAAAJ,0000-0001-8560-9007
+Kwan-Young Kim,GIST,https://sites.google.com/view/kwanyoung-kim/,uvHIHbkAAAAJ,0000-0000-0000-0000
 Kwang In Kim,POSTECH,https://sites.google.com/view/kimki,0wIdMGEAAAAJ,0000-0002-6470-4571
 Kwang Moo Yi,University of British Columbia,https://cs.ubc.ca/~kmyi,pr6rIJEAAAAJ,0000-0001-9036-3822
 Kwang-Sung Jun,University of Arizona,https://kwangsungjun.github.io,VgvC7o8AAAAJ,0000-0001-5483-3161
@@ -1096,6 +1098,7 @@ Kyomin Jung,Seoul National University,http://milab.snu.ac.kr/kjung/index.html,u3
 Kyong Hoon Kim,Kyungpook National University,http://rtc.knu.ac.kr,j6B_Z-cAAAAJ,0000-0002-1351-3265
 Kyong Hwan Jin,Korea University,https://ipa.korea.ac.kr,aLYNnyoAAAAJ,0000-0001-7885-4792
 Kyong-Ho Lee,Yonsei University,http://icl.yonsei.ac.kr/member-prof.html,xFohNkYAAAAJ,0000-0002-1581-917X
+Kyoobin Lee,GIST,https://sites.google.com/view/gistailab,QVihy5MAAAAJ,0000-0000-0000-0000
 Kyoung Mu Lee,Seoul National University,https://cv.snu.ac.kr/~kmlee,Hofj9kAAAAAJ,0000-0001-7210-1036
 Kyoung-Don Kang,Binghamton University,https://www.binghamton.edu/cs/people/kang.html,5Qrq3p0AAAAJ,0000-0002-3686-9301
 KyoungSoo Park,KAIST,https://www.ndsl.kaist.edu/~kyoungsoo,ZrPrFicAAAAJ,0009-0008-3108-2893
@@ -1107,6 +1110,7 @@ Kyu Hyung Lee,University of Georgia,http://cobweb.cs.uga.edu/~kyuhlee,oHcacuIAAA
 Kyu Min Lee,Worcester Polytechnic Institute,http://web.cs.wpi.edu/~kmlee,zQKRsSEAAAAJ,0000-0000-0000-0000
 Kyu-Young Whang,KAIST,http://dblab.kaist.ac.kr/Prof/main_eng.html,LZSo1YEAAAAJ,0000-0000-0000-0000
 Kyumin Lee,Worcester Polytechnic Institute,http://web.cs.wpi.edu/~kmlee,zQKRsSEAAAAJ,0000-0002-9004-1740
+Kyung-Joong Kim,GIST,https://cilab.gist.ac.kr/hp/,YBYE93sAAAAJ,0000-0000-0000-0000
 Kyung-Su Kim 0002,Seoul National University,https://aibl.snu.ac.kr/team,RbJDbtgAAAAJ,0000-0000-0000-0000
 KyungHyun Cho,New York University,http://www.kyunghyuncho.me,0RAmmIAAAAAJ,0000-0000-0000-0000
 Kyungdon Joo,UNIST,https://kdjoo369.wixsite.com/kdjoo,hNxIPzMAAAAJ,0000-0000-0000-0000

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -327,7 +327,7 @@ Mansi A. Radke,VNIT Nagpur,https://vnit.ac.in/engineering/cse/dr-mansi-a-radke,J
 Mansi Anup Radke,VNIT Nagpur,https://vnit.ac.in/engineering/cse/dr-mansi-a-radke,J7lO0fwAAAAJ,0000-0000-0000-0000
 Mansooreh Zahedi,University of Melbourne,https://findanexpert.unimelb.edu.au/profile/893364-mansooreh-zahedi,-mrcwTwAAAAJ,0000-0001-6276-9956
 Mansour Jamzad,Sharif University of Technology,http://sharif.edu/~jamzad,oKz2WAkAAAAJ,0000-0000-0000-0000
-Mansu Kim,The Catholic University of Korea,https://mansooru.github.io,Mfp3So0AAAAJ,0000-0002-0785-4514
+Mansu Kim,GIST,https://www.aimed-lab.com/,Mfp3So0AAAAJ,0000-0000-0000-0000
 Mantas Mikaitis,University of Leeds,https://eps.leeds.ac.uk/computing/staff/12197/dr-mantas-mikaitis,1-PVhOEAAAAJ,0000-0001-8706-1436
 Mantas Simkus,TU Wien,https://dbai.tuwien.ac.at/staff/simkus,iWJoqO8AAAAJ,0000-0003-0632-0294
 Mantis Cheng,University of Victoria,http://www.csc.uvic.ca/~mcheng,NOSCHOLARPAGE,0000-0000-0000-0000

--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -1269,6 +1269,7 @@ Pushpak Jagtap,IISc Bangalore,https://www.pushpakjagtap.com,Szd98jUAAAAJ,0000-00
 Pushpakanthie Wijekoon,University of Peradeniya,https://sci.pdn.ac.lk/scs/staff/Pushpakanthie-Wijekoon,UKEe2AsAAAAJ,0000-0000-0000-0000
 Pushpendra Singh 0001,IIIT Delhi,https://www.pushpendrasingh.info,FniYr_MAAAAJ,0000-0003-2152-1027
 Puwei Wang,Renmin University of China,http://iir.ruc.edu.cn/~pwwang,NOSCHOLARPAGE,0000-0000-0000-0000
+Pyojin Kim,GIST,https://mpil-gist.github.io/people/Pyojin_Kim/,UJ_Mw6YAAAAJ,0000-0000-0000-0000
 Pádraig Cunningham,University College Dublin,https://people.ucd.ie/padraig.cunningham,HqGgUVAAAAAJ,0000-0002-3499-0810
 Pável Calado,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist14497,7Udj_YAAAAAJ,0000-0001-6478-229X
 Péter Gács,Boston University,http://www.cs.bu.edu/~gacs,vNCcKo0AAAAJ,0000-0000-0000-0000

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -598,6 +598,7 @@ Scott T. Leutenegger,University of Denver,http://www.cs.du.edu/~leut,UDOTNC0AAAA
 Scott. D. Goodwin,University of Windsor,http://www.uwindsor.ca/science/computerscience/1036/dr-scott-goodwin,NOSCHOLARPAGE,0000-0000-0000-0000
 Se Young Chun,Seoul National University,https://icl.snu.ac.kr/members,3jLuG64AAAAJ,0000-0001-8739-8960
 Se-Young Yun,KAIST,https://fbsqkd.github.io,X_IAjb8AAAAJ,0000-0000-0000-0000
+SeungJun Kim,GIST,https://sites.google.com/view/gist-hcis-lab/people?authuser=0,AjfRd6wAAAAJ,0000-0000-0000-0000
 SeYoung Yun,KAIST,https://fbsqkd.github.io,X_IAjb8AAAAJ,0000-0000-0000-0000
 Sea Ling,Monash University,http://monash.edu/research/explore/en/persons/chris-ling(12fc1dc1-ee0e-4294-a74d-7b6f2218dc2a).html,16YOBUgAAAAJ,0000-0000-0000-0000
 Seah Hock Soon,Nanyang Technological University,http://www.ntu.edu.sg/home/ashsseah,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -2468,6 +2469,7 @@ Sundar Balasubramaniam,BITS Pilani,http://www.bits-pilani.ac.in/pilani/sundarb/p
 Sundar Vishwanathan,IIT Bombay,https://www.cse.iitb.ac.in/~sundar,8CK3IY4AAAAJ,0000-0000-0000-0000
 Sundaraja Sitharama Iyengar,Florida International University,http://users.cis.fiu.edu/~iyengar,eNONM8AAAAAJ,0000-0000-0000-0000
 Sundaresan Raman,BITS Pilani,http://www.bits-pilani.ac.in/pilani/sundaresanraman/profile,NOSCHOLARPAGE,0000-0000-0000-0000
+Sundong Kim,GIST,https://sundong.kim/,3yQIQfAAAAAJ,0000-0000-0000-0000
 Sune Darkner,University of Copenhagen,http://www.diku.dk/english/staff/?pure=en/persons/383640,Z_bvPmcAAAAJ,0000-0001-6114-7100
 Sune Lehmann Jørgensen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE,0000-0000-0000-0000
 Sung Ju Hwang,KAIST,http://www.sungjuhwang.com,RP4Qx3QAAAAJ,0000-0002-9675-2324

--- a/csrankings-u.csv
+++ b/csrankings-u.csv
@@ -15,6 +15,7 @@ Udo Kebschull,Goethe University Frankfurt,https://www.fias.science/de/fellows/de
 Udo Kelter,University of Siegen,http://pi.informatik.uni-siegen.de/kelter,NOSCHOLARPAGE,0000-0000-0000-0000
 Udo Kruschwitz,University of Regensburg,https://www.uni-regensburg.de/sprache-literatur-kultur/informationswissenschaft/mitarbeiter/udo-kruschwitz/index.html,ZCaIF_wAAAAJ,0000-0002-5503-0341
 Udo R. Krieger,University of Bamberg,https://www.uni-bamberg.de/ktr/mitarbeiter/krieger,NOSCHOLARPAGE,0000-0000-0000-0000
+Ue-Hwan Kim,GIST,https://uehwan.github.io/people/Ue-Hwan-Kim/,EPliWZIAAAAJ,0000-0000-0000-0000
 Ueli M. Maurer,ETH Zurich,https://www.crypto.ethz.ch/~maurer,TSsq3GMAAAAJ,0000-0000-0000-0000
 Ueli Maurer,ETH Zurich,https://www.crypto.ethz.ch/~maurer,TSsq3GMAAAAJ,0000-0000-0000-0000
 Uffe Høgsbro Thygesen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE,0000-0000-0000-0000


### PR DESCRIPTION
## Summary

- Closes #11341
- Resubmission of previous PR #9193 (closed as stale) and issue #9192
- Adds **23 CS faculty members** from GIST (Gwangju Institute of Science and Technology)
- Institution was already added to `institutions.csv` and `country-info.csv` by @emeryberger in the previous round

## Institution

**Gwangju Institute of Science and Technology (GIST)** is a national research university in Gwangju, South Korea. CS faculty are in the **School of Electrical Engineering and Computer Science (EECS)** and the **AI Graduate School**. All listed faculty are full-time, tenure-track, and can solely advise CS PhD students.

## Faculty Added (23)

| # | Name (DBLP) | File | Scholar ID |
|---|------------|------|-----------|
| 1 | Bochang Moon | csrankings-b.csv | 5aZuIAsAAAAJ |
| 2 | Chang Wook Ahn | csrankings-c.csv | tG9d6PYAAAAJ |
| 3 | Euiseok Hwang | csrankings-e.csv | ub7gGGUAAAAJ |
| 4 | Geonho Hwang | csrankings-g.csv | NHpe_8IAAAAJ |
| 5 | Gunhyuk Park | csrankings-g.csv | LY8SM4IAAAAJ |
| 6 | Heung-No Lee | csrankings-h.csv | lRlN_40AAAAJ |
| 7 | Hong Kook Kim | csrankings-h.csv | uDxv3dkAAAAJ |
| 8 | Hyunju Lee | csrankings-h.csv | 5QyrGvsAAAAJ |
| 9 | Jae Woong Soh | csrankings-j.csv | Wmhi6jgAAAAJ |
| 10 | Jin-Hyuk Hong | csrankings-j.csv | iTu5G9QAAAAJ |
| 11 | Jiyeon Kang | csrankings-j.csv | PrXIfgwAAAAJ |
| 12 | Jong Won Shin | csrankings-j.csv | -UyXLxcAAAAJ |
| 13 | JongWon Kim 0001 | csrankings-j.csv | VKULYHAAAAAJ |
| 14 | Jungwon Yoon | csrankings-j.csv | oG-utS8AAAAJ |
| 15 | Kang Il Kim | csrankings-k.csv | RZggOtkAAAAJ |
| 16 | Kwan-Young Kim | csrankings-k.csv | uvHIHbkAAAAJ |
| 17 | Kyoobin Lee | csrankings-k.csv | QVihy5MAAAAJ |
| 18 | Kyung-Joong Kim | csrankings-k.csv | YBYE93sAAAAJ |
| 19 | Mansu Kim *(affiliation update)* | csrankings-m.csv | Mfp3So0AAAAJ |
| 20 | Pyojin Kim | csrankings-p.csv | UJ_Mw6YAAAAJ |
| 21 | SeungJun Kim | csrankings-s.csv | AjfRd6wAAAAJ |
| 22 | Sundong Kim | csrankings-s.csv | 3yQIQfAAAAAJ |
| 23 | Ue-Hwan Kim | csrankings-u.csv | EPliWZIAAAAJ |

## Changes from previous PR #9193

- **Removed**: Hojung Nam (left GIST), and 5 non-CS faculty
- **Added**: Bochang Moon, Jae Woong Soh, Geonho Hwang, Jungwon Yoon, Kyoobin Lee, Pyojin Kim, Kwan-Young Kim
- **Name corrections** (aligned to DBLP): Jin Hyuk Hong → Jin-Hyuk Hong, Jongwon Kim → JongWon Kim 0001
- **Mansu Kim**: Updated affiliation from Catholic University of Korea to GIST (moved)
- **Homepage URLs**: Updated to pages that clearly display faculty names

## Notes on homepage validation

- Some GIST faculty homepages are on Korean-language university pages (e.g., `gist.ac.kr`). The faculty member's name appears on the page but may require scrolling or may be partially in Korean.
- **Jiyeon Kang**: Homepage at https://www.awearlab.com/principal-investigator shows her name and affiliation clearly in English.

## Checklist

- [x] All names match DBLP exactly
- [x] Faculty inserted in alphabetical order within each file
- [x] No spaces after commas in CSV entries
- [x] All homepages verified and accessible
- [x] Google Scholar IDs verified
- [x] Only modified `csrankings-[a-z].csv` files (did NOT touch `institutions.csv`, `country-info.csv`, or `csrankings.csv`)
- [x] Did not use Excel for editing
- [x] Institution already exists in `institutions.csv` (added by maintainer)