### PR TITLE
Update Univ. of California - Berkeley

### DIFF
--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -290,7 +290,7 @@ Aditi Raghunathan,Carnegie Mellon University,https://www.cs.cmu.edu/~aditirag,Ch
 Aditya Akella,University of Texas at Austin,http://pages.cs.wisc.edu/~akella,d_rxnzAAAAAJ,0000-0002-5920-170X
 Aditya Bhaskara,University of Utah,http://www.cs.utah.edu/~bhaskara,tqxTaiAAAAAJ,0000-0001-5505-3140
 Aditya Challa,BITS Pilani-Goa,https://www.bits-pilani.ac.in/goa/adityac/Profile,_XkD5AkAAAAJ,0000-0000-0000-0000
-Aditya G. Parameswaran,Univ. of California - Berkeley,https://cs.illinois.edu/directory/profile/adityagp,VeB3UbcAAAAJ,0000-0002-4538-4752
+Aditya G. Parameswaran,Univ. of California - Berkeley,https://people.eecs.berkeley.edu/~adityagp/,VeB3UbcAAAAJ,0000-0002-4538-4752
 Aditya Gilra,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/aditya-gilra,VpxnuTgAAAAJ,0000-0002-8628-1864
 Aditya Grover,Univ. of California - Los Angeles,https://aditya-grover.github.io,oOhnPUgAAAAJ,0000-0002-4217-6624
 Aditya Johri,George Mason University,https://cs.gmu.edu/directory/detail/183,Mv2dCeEAAAAJ,0000-0001-9018-7574
@@ -2726,5 +2726,6 @@ Aïda Ouangraoua,Université de Sherbrooke,https://www.usherbrooke.ca/informatiq
 Ángeles Saavedra,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=5,IYkBYzQAAAAJ,0000-0000-0000-0000
 Ángeles Saavedra Places,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=5,IYkBYzQAAAAJ,0000-0000-0000-0000
 Åse Jevinger,Malmö University,https://mau.se/en/persons/ase.jevinger,NOSCHOLARPAGE,0000-0002-6019-1182
+
 
 

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -1165,7 +1165,7 @@ Alvaro Barreiro,University of A Coruña,https://www.dc.fi.udc.es/~barreiro,73tqF
 Alvaro Soto,UC Chile,https://asoto.ing.puc.cl,gOVVRk4AAAAJ,0000-0000-0000-0000
 Alvaro Velasquez,University of Colorado Boulder,https://www.colorado.edu/cs/alvaro-velasquez,1g3pA4cAAAAJ,0000-0001-6757-105X
 Alvin Chan Guo Wei,Nanyang Technological University,https://dr.ntu.edu.sg/entities/person/Alvin-Chan-Guo-Wei,SP4eIUYAAAAJ,0000-0002-1041-3891
-Alvin Cheung,Univ. of California - Berkeley,https://homes.cs.washington.edu/~akcheung,NOSCHOLARPAGE,0000-0001-6261-6263
+Alvin Cheung,Univ. of California - Berkeley,https://people.eecs.berkeley.edu/~akcheung/,NOSCHOLARPAGE,0000-0001-6261-6263
 Alvin S. Lim,Auburn University,http://www.eng.auburn.edu/~lim,8yA8n4sAAAAJ,0000-0000-0000-0000
 Alvin W. Y. Su,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/depmember/teacherdetail/id/12,NOSCHOLARPAGE,0000-0000-0000-0000
 Alvin Wen-Yu Su,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/depmember/teacherdetail/id/12,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -2726,6 +2726,7 @@ Aïda Ouangraoua,Université de Sherbrooke,https://www.usherbrooke.ca/informatiq
 Ángeles Saavedra,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=5,IYkBYzQAAAAJ,0000-0000-0000-0000
 Ángeles Saavedra Places,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=5,IYkBYzQAAAAJ,0000-0000-0000-0000
 Åse Jevinger,Malmö University,https://mau.se/en/persons/ase.jevinger,NOSCHOLARPAGE,0000-0002-6019-1182
+
 
 
 

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -1448,7 +1448,6 @@ Anastassia Ailamaki,EPFL,https://people.epfl.ch/anastasia.ailamaki,YdrkeNwAAAAJ,
 Anat Bremler-Barr,Tel Aviv University,https://english.tau.ac.il/profile/anatbr,FyH0iNgAAAAJ,0000-0002-8165-2558
 Anat Paskin,Ariel University,http://www.ariel.ac.il/Projects/trp/GeneralInformation.asp?numRec=483&numtafrit=1&id_lang=1&d=,XcyQbAYAAAAJ,0000-0001-6566-2644
 Anat Paskin-Cherniavsky,Ariel University,http://www.ariel.ac.il/Projects/trp/GeneralInformation.asp?numRec=483&numtafrit=1&id_lang=1&d=,XcyQbAYAAAAJ,0000-0001-6566-2644
-Anca D. Dragan,Univ. of California - Berkeley,http://www.eecs.berkeley.edu/~anca,UgHB5oAAAAAJ,0000-0000-0000-0000
 Anca D. Jurcut,University College Dublin,https://people.ucd.ie/anca.jurcut,rzHu7gYAAAAJ,0000-0000-0000-0000
 Anca Delia Jurcut,University College Dublin,https://people.ucd.ie/anca.jurcut,rzHu7gYAAAAJ,0000-0000-0000-0000
 Anca Jurcut,University College Dublin,https://people.ucd.ie/anca.jurcut,rzHu7gYAAAAJ,0000-0000-0000-0000
@@ -2727,4 +2726,5 @@ Aïda Ouangraoua,Université de Sherbrooke,https://www.usherbrooke.ca/informatiq
 Ángeles Saavedra,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=5,IYkBYzQAAAAJ,0000-0000-0000-0000
 Ángeles Saavedra Places,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=5,IYkBYzQAAAAJ,0000-0000-0000-0000
 Åse Jevinger,Malmö University,https://mau.se/en/persons/ase.jevinger,NOSCHOLARPAGE,0000-0002-6019-1182
+
 

--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -2641,7 +2641,6 @@ Avery Miller,University of Manitoba,http://www.cs.umanitoba.ca/~amiller,BvvdwvIA
 Avesta Sasan,Univ. of California - Davis,https://www.ece.ucdavis.edu/~avesta/index.html,BMmfOCEAAAAJ,0000-0002-4052-8075
 Avi Silberschatz,Yale University,http://www.cs.yale.edu/~avi,-YvgZDEAAAAJ,0000-0000-0000-0000
 Aviad Rubinstein,Stanford University,https://cs.stanford.edu/~aviad,ZTsHfNAAAAAJ,0000-0002-6900-8612
-Avideh Zakhor,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/zakhor.html,XV8QLVQAAAAJ,0000-0003-4770-6353
 Aviezri S. Fraenkel,Weizmann Institute of Science,https://www.weizmann.ac.il/pages/search/people?language=english&single=1&person_id=3774,NOSCHOLARPAGE,0000-0000-0000-0000
 Avigdor Gal,Technion,https://agp.iem.technion.ac.il/avigal,APs1p2oAAAAJ,0000-0002-7028-661X
 Avinash Gautam,BITS Pilani,http://universe.bits-pilani.ac.in/pilani/avinash/profile,V6-4CfQAAAAJ,0000-0000-0000-0000
@@ -2728,3 +2727,4 @@ Aïda Ouangraoua,Université de Sherbrooke,https://www.usherbrooke.ca/informatiq
 Ángeles Saavedra,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=5,IYkBYzQAAAAJ,0000-0000-0000-0000
 Ángeles Saavedra Places,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=5,IYkBYzQAAAAJ,0000-0000-0000-0000
 Åse Jevinger,Malmö University,https://mau.se/en/persons/ase.jevinger,NOSCHOLARPAGE,0000-0002-6019-1182
+

--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -390,7 +390,7 @@ Bernd Hellingrath,University of Münster,https://www.wi.uni-muenster.de/de/insti
 Bernd Jähne,Heidelberg University,https://www.iup.uni-heidelberg.de/de/bernd-jaehne,5vANGgcAAAAJ,0000-0000-0000-0000
 Bernd Ludwig,University of Regensburg,https://www.uni-regensburg.de/sprache-literatur-kultur/informationswissenschaft/mitarbeiter/bernd-ludwig/index.html,OvOGKVAAAAAJ,0000-0003-3599-2081
 Bernd Meyer 0001,Monash University,https://research.monash.edu/en/persons/bernd-meyer,9rl-K3IAAAAJ,0000-0000-0000-0000
-Bernd Sturmfels,Univ. of California - Berkeley,https://math.berkeley.edu/~bernd,5zTUNsQAAAAJ,0000-0000-0000-0000
+Bernd Sturmfels,Max Planck Society,https://www.mis.mpg.de/people/bernd-sturmfels,5zTUNsQAAAAJ,0000-0000-0000-0000
 Bernd-Christian Renner,Hamburg University of Technology,https://www.tuhh.de/smartport/team/christian-renner.html,ONg4SKoAAAAJ,0000-0002-6936-6444
 Bernd-Holger Schlingloff,Humboldt University of Berlin,http://www2.informatik.hu-berlin.de/svt,NOSCHOLARPAGE,0000-0001-9601-157X
 Bernhard Bauer,University of Augsburg,https://www.uni-augsburg.de/de/fakultaet/fai/informatik/prof/swtpvs/team/bernhard-bauer,d9b5tgMAAAAJ,0000-0000-0000-0000
@@ -1016,3 +1016,4 @@ Byunghyun Jang,University of Mississippi,http://www.olemiss.edu/people/bjang,NOS
 Byungjoo Lee,Yonsei University,https://esports.yonsei.ac.kr/Professor-2,b9we1fYAAAAJ,0009-0003-1547-9923
 Bárbara Poblete,Universidad de Chile,https://www.dcc.uchile.cl/barbara_poblete,eZBFWGEAAAAJ,0000-0000-0000-0000
 Béchir Ktari,Université Laval,http://www2.ift.ulaval.ca/~ktari,NOSCHOLARPAGE,0009-0009-7633-9901
+

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -1484,7 +1484,6 @@ Cosmin Munteanu,University of Toronto,http://www.cs.utoronto.ca/~mcosmin,sblCo1I
 Costantino Grana,Univ. of Modena and Reggio Emilia,https://personale.unimore.it/rubrica/dettaglio/cgrana,MBy-kecAAAAJ,0000-0002-4792-2358
 Costas Busch,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=KBUSCH,VxzBbI0AAAAJ,0000-0002-4381-4333
 Costas Courcoubetis,CUHK (SZ),https://sds.cuhk.edu.cn/en/teacher/473,_vDxlTUAAAAJ,0000-0000-0000-0000
-Costas J. Spanos,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/spanos.html,90TaOdoAAAAJ,0000-0000-0000-0000
 Costas Lambrinoudakis,University of Piraeus,https://www.ds.unipi.gr/en/faculty/clam-en,D-mfQXsAAAAJ,0000-0003-3101-5347
 Costas Patsakis,University of Piraeus,https://www.cs.unipi.gr/kpatsak,wkHmlysAAAAJ,0000-0000-0000-0000
 Costas S. Iliopoulos,King's College London,https://www.kcl.ac.uk/people/costas-iliopoulos,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -1598,3 +1597,4 @@ César Torres 0001,University of Texas at Arlington,http://cearto.com,9CJbh1MAAA
 Çagdas D. Önal,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/cdo.html,3symmLYAAAAJ,0000-0000-0000-0000
 Çaglar Gülçehre,EPFL,https://people.epfl.ch/caglar.gulcehre?lang=en,7hwJ2ckAAAAJ,0009-0003-4124-1687
 Çigdem Aslay,Aarhus University,https://pure.au.dk/portal/da/persons/cigdem-aslay(921b00ac-c233-4813-be49-89852a83f6bc).html,aVRi34QAAAAJ,0000-0002-5556-8977
+

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -1439,7 +1439,6 @@ Connie White,University of Southern Mississippi,https://www.usm.edu/computing,NO
 Conor J. Houghton,University of Bristol,https://conorhoughton.github.io,VoP4kDQAAAAJ,0000-0000-0000-0000
 Conrad Watt,Nanyang Technological University,https://conrad-watt.github.io,SVU1RU8AAAAJ,0000-0002-0596-877X
 Conrado R. Ruiz Jr.,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742689520&command=GETPROFILE,y91psfsAAAAJ,0000-0002-0956-7201
-Constance J. Chang-Hasnain,Univ. of California - Berkeley,https://www.eecs.berkeley.edu/Faculty/Homepages/chang-hasnain.html,O2HSABIAAAAJ,0000-0000-0000-0000
 Constandinos X. Mavromoustakis,University of Nicosia,https://www.unic.ac.cy/mavromoustakis-constandinos,b095UrEAAAAJ,0000-0000-0000-0000
 Constantin A. Rothkopf,TU Darmstadt,https://www.pip.tu-darmstadt.de/members_pip/publications.en.jsp,dCcMzGsAAAAJ,0000-0002-5636-0801
 Constantin Catalin Dragan,University of Surrey,https://www.surrey.ac.uk/people/constantin-catalin-dragan,h6Xk78UAAAAJ,0000-0002-4033-9880
@@ -1597,4 +1596,5 @@ César Torres 0001,University of Texas at Arlington,http://cearto.com,9CJbh1MAAA
 Çagdas D. Önal,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/cdo.html,3symmLYAAAAJ,0000-0000-0000-0000
 Çaglar Gülçehre,EPFL,https://people.epfl.ch/caglar.gulcehre?lang=en,7hwJ2ckAAAAJ,0009-0003-4124-1687
 Çigdem Aslay,Aarhus University,https://pure.au.dk/portal/da/persons/cigdem-aslay(921b00ac-c233-4813-be49-89852a83f6bc).html,aVRi34QAAAAJ,0000-0002-5556-8977
+
 

--- a/csrankings-e.csv
+++ b/csrankings-e.csv
@@ -269,7 +269,6 @@ Eli Bozorgzadeh,Univ. of California - Irvine,https://www.ics.uci.edu/~eli,ogE3q4
 Eli T. Brown,DePaul University,https://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=1311,8zeXprkAAAAJ,0009-0005-2894-2432
 Eli Tilevich,Virginia Tech,http://www.cs.vt.edu/~tilevich,t4OSUfgAAAAJ,0000-0003-2415-6926
 Eli Upfal,Brown University,https://cs.brown.edu/people/eli,O_7MVDIAAAAJ,0000-0002-9321-9460
-Eli Yablonovitch,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/yablonovitch.html,4wqIUjMAAAAJ,0000-0000-0000-0000
 Eliana Colunga,University of Colorado Boulder,http://psych.colorado.edu/~colunga,NOSCHOLARPAGE,0000-0003-2818-9389
 Eliane Martins,UNICAMP,http://www.ic.unicamp.br/~eliane,yrq9S_4AAAAJ,0000-0000-0000-0000
 Eliane Stampfer,University of Utah,https://eliane-s-wiese.owlstown.net,hvEjrewAAAAJ,0000-0000-0000-0000
@@ -832,4 +831,5 @@ Ezio Bartocci,TU Wien,http://www.eziobartocci.com,EeK43rAAAAAJ,0000-0002-8004-66
 Éric Schost,University of Waterloo,https://cs.uwaterloo.ca/~eschost,qWXMDWkAAAAJ,0000-0000-0000-0000
 Éric Tanter,Universidad de Chile,https://pleiad.cl/people/etanter,d0LISE4AAAAJ,0000-0002-7359-890X
 Éva Tardos,Cornell University,http://www.cs.cornell.edu/~eva,h6jljQQAAAAJ,0000-0002-2978-1475
+
 

--- a/csrankings-e.csv
+++ b/csrankings-e.csv
@@ -204,7 +204,6 @@ El-Ghazil Talbi,CRIStAL,https://www.cristal.univ-lille.fr/profil/talbi,hoQmzocAA
 Ela Claridge,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/claridge-ela.aspx,oMP44BAAAAAJ,0000-0000-0000-0000
 Ela Kumar,IGDTUW,https://www.igdtuw.ac.in/computerScience.php?name=ElaKumar,piLQnM8AAAAJ,0000-0000-0000-0000
 Elad Aigner-Horev,Ariel University,http://www.elad-horev.org,4-mES5gAAAAJ,0000-0000-0000-0000
-Elad Alon,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/elad.html,ktlHDnQAAAAJ,0000-0000-0000-0000
 Elad Hazan,Princeton University,https://www.cs.princeton.edu/~ehazan,LnhCGNMAAAAJ,0000-0002-1566-3216
 Elad Horev,Ariel University,http://www.elad-horev.org,4-mES5gAAAAJ,0000-0002-9207-0596
 Elad Michael Schiller,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/elad-schiller.aspx,NOSCHOLARPAGE,0000-0003-3258-3696
@@ -831,5 +830,6 @@ Ezio Bartocci,TU Wien,http://www.eziobartocci.com,EeK43rAAAAAJ,0000-0002-8004-66
 Éric Schost,University of Waterloo,https://cs.uwaterloo.ca/~eschost,qWXMDWkAAAAJ,0000-0000-0000-0000
 Éric Tanter,Universidad de Chile,https://pleiad.cl/people/etanter,d0LISE4AAAAJ,0000-0002-7359-890X
 Éva Tardos,Cornell University,http://www.cs.cornell.edu/~eva,h6jljQQAAAAJ,0000-0002-2978-1475
+
 
 

--- a/csrankings-e.csv
+++ b/csrankings-e.csv
@@ -116,9 +116,7 @@ Eduardo da Veiga Beltrame,MBZUAI,https://mbzuai.ac.ae/study/faculty/eduardo-belt
 Eduardo del Castillo-Sánchez,EPFL,https://people.epfl.ch/eduardo.sanchez,NOSCHOLARPAGE,0000-0000-0000-0000
 Eduardo do Valle Simões,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/simoes,acJCV0AAAAAJ,0000-0000-0000-0000
 Edward A. Hirsch,Ariel University,https://edwardahirsch.github.io/edwardahirsch/index.html,p_CnQm0AAAAJ,0000-0000-0000-0000
-Edward A. Lee,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/lee.html,IJgXsgwAAAAJ,0000-0002-5663-0584
 Edward Anstead,Goldsmiths University of London,https://www.gold.ac.uk/computing/people/anstead-edward,by96CrcAAAAJ,0000-0000-0000-0000
-Edward Ashford Lee,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/lee.html,IJgXsgwAAAAJ,0000-0000-0000-0000
 Edward C. Keedwell,University of Exeter,http://emps.exeter.ac.uk/computer-science/staff/eckeedwe,lApWCPUAAAAJ,0000-0000-0000-0000
 Edward Chien,Boston University,https://cs-people.bu.edu/edchien,YZ1HFYIAAAAJ,0000-0001-5084-7638
 Edward Choi,KAIST,https://mp2893.com,GUlGIPkAAAAJ,0000-0000-0000-0000
@@ -834,3 +832,4 @@ Ezio Bartocci,TU Wien,http://www.eziobartocci.com,EeK43rAAAAAJ,0000-0002-8004-66
 Éric Schost,University of Waterloo,https://cs.uwaterloo.ca/~eschost,qWXMDWkAAAAJ,0000-0000-0000-0000
 Éric Tanter,Universidad de Chile,https://pleiad.cl/people/etanter,d0LISE4AAAAJ,0000-0002-7359-890X
 Éva Tardos,Cornell University,http://www.cs.cornell.edu/~eva,h6jljQQAAAAJ,0000-0002-2978-1475
+

--- a/csrankings-e.csv
+++ b/csrankings-e.csv
@@ -501,7 +501,6 @@ Erhard Plödereder,University of Stuttgart,http://www.iste.uni-stuttgart.de/ps/t
 Erhard Rahm,University of Leipzig,https://dbs.uni-leipzig.de/personen/rahm.html,N9wi5soAAAAJ,0000-0002-2665-1114
 Erhardt Barth,University of Lübeck,https://www.inb.uni-luebeck.de/mitarbeiter/mitarbeiter/professoren/erhardt-barth.html,YX3ympsAAAAJ,0000-0000-0000-0000
 Erhu Feng,Shanghai Jiao Tong University,https://ipads.se.sjtu.edu.cn/pub/members/erhu_feng,e_no1Q0AAAAJ,0009-0006-5957-3024
-Eric A. Brewer,Univ. of California - Berkeley,https://www.cs.berkeley.edu/~brewer,BbzYzsgAAAAJ,0000-0003-0250-9268
 Eric A. Hansen,Mississippi State University,http://web.cse.msstate.edu/~hansen,9PEURssAAAAJ,0000-0000-0000-0000
 Eric Allender,Rutgers University,http://www.cs.rutgers.edu/~allender,dQwv9e4AAAAJ,0000-0002-0650-028X
 Eric Andre Martin,UNSW,https://www.engineering.unsw.edu.au/computer-science-engineering/staff/eric-martin,dgTxZiUAAAAJ,0000-0000-0000-0000
@@ -830,6 +829,7 @@ Ezio Bartocci,TU Wien,http://www.eziobartocci.com,EeK43rAAAAAJ,0000-0002-8004-66
 Éric Schost,University of Waterloo,https://cs.uwaterloo.ca/~eschost,qWXMDWkAAAAJ,0000-0000-0000-0000
 Éric Tanter,Universidad de Chile,https://pleiad.cl/people/etanter,d0LISE4AAAAJ,0000-0002-7359-890X
 Éva Tardos,Cornell University,http://www.cs.cornell.edu/~eva,h6jljQQAAAAJ,0000-0002-2978-1475
+
 
 
 

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -253,7 +253,6 @@ George B. Purdy,University of Cincinnati,https://etd.ohiolink.edu/!etd.send_file
 George Bebis,University of Nevada,https://www.cse.unr.edu/~bebis,-uRoVEUAAAAJ,0009-0000-6222-5967
 George Berg,University at Albany - SUNY,https://www.albany.edu/ceas/george-berg.php,NOSCHOLARPAGE,0000-0002-2503-638X
 George Buchanan 0001,University of Melbourne,https://findanexpert.unimelb.edu.au/display/person793596,HPbkM6YAAAAJ,0000-0001-9044-6644
-George C. Necula,Univ. of California - Berkeley,http://www.cs.berkeley.edu/~necula,_fiHvDAAAAAJ,0000-0000-0000-0000
 George C. Polyzos,AUEB,http://niovi.aueb.gr/~gcp,y-Mxxa0AAAAJ,0000-0003-0030-4808
 George Candea,EPFL,http://dslab.epfl.ch/people/candea,Yd-SGH8AAAAJ,0009-0002-8107-6535
 George Christodoulou 0001,University of Liverpool,https://cgi.csc.liv.ac.uk/~gchristo,QRIaADsAAAAJ,0000-0002-9623-7461
@@ -1058,3 +1057,4 @@ Günther R. Raidl,TU Wien,https://www.ac.tuwien.ac.at/people/raidl,NOSCHOLARPAGE
 Günther Ruhe,University of Calgary,http://ruhe.cpsc.ucalgary.ca,5nL_z0oAAAAJ,0000-0000-0000-0000
 Günther Schatter,Bauhaus University Weimar,https://www.uni-weimar.de/de/medien/professuren/medieninformatik/vernetzte-medien/personen/apl-prof-dr-guenther-schatter,NOSCHOLARPAGE,0000-0000-0000-0000
 Günther Specht,University of Innsbruck,https://dbis-informatik.uibk.ac.at/specht,Csj85-oAAAAJ,0000-0000-0000-0000
+

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -254,7 +254,6 @@ James D. Herbsleb,Carnegie Mellon University,http://herbsleb.org,NOSCHOLARPAGE,0
 James D. Hollan,Univ. of California - San Diego,http://hci.ucsd.edu/hollan,LOFYnLkAAAAJ,0000-0000-0000-0000
 James David Laird,University of Bath,http://www.bath.ac.uk/comp-sci/contacts/academics/james_laird,_Gi9Hl4AAAAJ,0000-0000-0000-0000
 James Davis 0001,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~davis,BDYIAe4AAAAJ,0000-0002-1413-2616
-James Demmel,Univ. of California - Berkeley,https://www.cs.berkeley.edu/~demmel,NOSCHOLARPAGE,0000-0002-0550-5476
 James Dunham,Southern Methodist University,https://www.smu.edu/Lyle/Departments/CSE/People/Faculty/DunhamJames,s2VQbjwAAAAJ,0000-0000-0000-0000
 James E. Davis,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~davis,BDYIAe4AAAAJ,0000-0000-0000-0000
 James E. Gain,University of Cape Town,https://people.cs.uct.ac.za/~jgain,ZN802qkAAAAJ,0000-0000-0000-0000
@@ -357,7 +356,6 @@ James W. Mickens,Harvard University,http://mickens.seas.harvard.edu,7m5-SfEAAAAJ
 James Waldo,Harvard University,https://www.seas.harvard.edu/directory/waldo,A6y_bqkAAAAJ,0009-0009-0852-5390
 James Wang,Clemson University,https://people.cs.clemson.edu/~jzwang,JVEaAlEAAAAJ,0000-0000-0000-0000
 James Weimer,Vanderbilt University,https://jamesweimer.net,IeuLakwAAAAJ,0000-0001-8167-9163
-James Weldon Demmel,Univ. of California - Berkeley,https://www.cs.berkeley.edu/~demmel,NOSCHOLARPAGE,0000-0000-0000-0000
 James Westall,Clemson University,https://people.cs.clemson.edu/~westall/homepage.html,NOSCHOLARPAGE,0000-0000-0000-0000
 James Won-Ki Hong,POSTECH,http://dpnm.postech.ac.kr/~jwkhong,xmjM_WoAAAAJ,0000-0003-2853-7734
 James Worrell 0001,University of Oxford,http://www.cs.ox.ac.uk/james.worrell,oFZmiioAAAAJ,0000-0001-8151-2443
@@ -1340,7 +1338,6 @@ Jim Canning,University of Massachusetts Lowell,https://www.uml.edu/Honors/People
 Jim Carter,University of Saskatchewan,http://artsandscience.usask.ca/profile/JCarter,v_YyMagAAAAJ,0000-0000-0000-0000
 Jim Davies,University of Oxford,http://www.cs.ox.ac.uk/jim.davies,b8iAzGAAAAAJ,0000-0003-4664-6862
 Jim Davis,Ohio State University,http://web.cse.ohio-state.edu/~jwdavis,Jd6nw80AAAAJ,0000-0000-0000-0000
-Jim Demmel,Univ. of California - Berkeley,https://www.cs.berkeley.edu/~demmel,NOSCHOLARPAGE,0000-0000-0000-0000
 Jim Dowling,KTH Royal Inst. of Technology,https://www.kth.se/profile/jdowling,MnSM1RMAAAAJ,0000-0002-9484-6714
 Jim Greer,University of Saskatchewan,https://teaching.usask.ca/about/staff/jim-greer.php,gQg14r8AAAAJ,0000-0000-0000-0000
 Jim Griffioen,University of Kentucky,http://protocols.netlab.uky.edu/~griff,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -2833,4 +2830,5 @@ Jürgen Steimle,Saarland University,https://hci.cs.uni-saarland.de/people/juerge
 Jürgen Teich,University of Erlangen–Nuremberg,https://www.cs12.tf.fau.de/person/juergen-teich,Hj3eizAAAAAJ,0000-0001-6285-5862
 Jürgen W. Hesser,Heidelberg University,http://medphyssrv1.medma.uni-heidelberg.de/cms,NOSCHOLARPAGE,0000-0000-0000-0000
 Jürgen Ziegler 0001,University of Duisburg-Essen,https://interactivesystems.info/team/juergen-ziegler,UD-ha3YAAAAJ,0000-0001-9603-5272
+
 

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -737,7 +737,6 @@ Jeffrey A. Bilmes,University of Washington,https://people.ece.uw.edu/bilmes,L9Qu
 Jeffrey A. Fessler,University of Michigan,https://web.eecs.umich.edu/~fessler,J5f4Gq8AAAAJ,0000-0000-0000-0000
 Jeffrey A. Miller,University of Southern California,https://pressroom.usc.edu/jeffrey-miller,VYYLUPoAAAAJ,0000-0000-0000-0000
 Jeffrey A. Weiss,University of Utah,https://www.sci.utah.edu/people/weiss.html,YtFi-KkAAAAJ,0000-0000-0000-0000
-Jeffrey Bokor,Univ. of California - Berkeley,http://people.eecs.berkeley.edu/~jbokor,ylSEuoIAAAAJ,0000-0002-4541-0156
 Jeffrey C. Carver,The University of Alabama,http://carver.cs.ua.edu,qGe7nJ0AAAAJ,0000-0000-0000-0000
 Jeffrey C. Dill,Ohio University,https://www.ohio.edu/engineering/about/people/profiles.cfm?profile=dill,NOSCHOLARPAGE,0000-0000-0000-0000
 Jeffrey C. Trinkle,Lehigh University,http://www.cse.lehigh.edu/~trink,Dl0vAp8AAAAJ,0000-0000-0000-0000
@@ -2829,6 +2828,7 @@ Jürgen Steimle,Saarland University,https://hci.cs.uni-saarland.de/people/juerge
 Jürgen Teich,University of Erlangen–Nuremberg,https://www.cs12.tf.fau.de/person/juergen-teich,Hj3eizAAAAAJ,0000-0001-6285-5862
 Jürgen W. Hesser,Heidelberg University,http://medphyssrv1.medma.uni-heidelberg.de/cms,NOSCHOLARPAGE,0000-0000-0000-0000
 Jürgen Ziegler 0001,University of Duisburg-Essen,https://interactivesystems.info/team/juergen-ziegler,UD-ha3YAAAAJ,0000-0001-9603-5272
+
 
 
 

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -2158,7 +2158,6 @@ Joseph Kee-Yin Ng,Hong Kong Baptist University,http://www.comp.hkbu.edu.hk/~jng,
 Joseph Keshet,Technion,https://keshet.net.technion.ac.il,GoWgJ1AAAAAJ,0000-0003-2332-5783
 Joseph Khoury,Louisiana State University,https://www.lsu.edu/eng/cse/people/faculty/khoury.php,pupjXigAAAAJ,0000-0002-6219-2875
 Joseph L. Gabbard,Virginia Tech,https://me.vt.edu/people/faculty/gabbard-joseph.html,fHHHBRoAAAAJ,0000-0002-7488-676X
-Joseph M. Hellerstein,Univ. of California - Berkeley,http://citris-uc.org/person/professor-joseph-hellerstein,uFJi3IUAAAAJ,0000-0002-7712-4306
 Joseph Maguire,University of Glasgow,http://www.josephmaguire.co.uk,NOSCHOLARPAGE,0000-0000-0000-0000
 Joseph Malloch,Dalhousie University,https://www.dal.ca/faculty/computerscience/faculty-staff/joseph-malloch.html,iQa0leoAAAAJ,0000-0001-9684-2269
 Joseph Mihaljevic,Northern Arizona University,https://nau.edu/siccs/faculty,pRvNhbAAAAAJ,0000-0003-2320-5773
@@ -2834,3 +2833,4 @@ Jürgen Steimle,Saarland University,https://hci.cs.uni-saarland.de/people/juerge
 Jürgen Teich,University of Erlangen–Nuremberg,https://www.cs12.tf.fau.de/person/juergen-teich,Hj3eizAAAAAJ,0000-0001-6285-5862
 Jürgen W. Hesser,Heidelberg University,http://medphyssrv1.medma.uni-heidelberg.de/cms,NOSCHOLARPAGE,0000-0000-0000-0000
 Jürgen Ziegler 0001,University of Duisburg-Essen,https://interactivesystems.info/team/juergen-ziegler,UD-ha3YAAAAJ,0000-0001-9603-5272
+

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -418,7 +418,6 @@ Jan Kybic,Czech Technical University,http://cmp.felk.cvut.cz/~kybic,QwIATDoAAAAJ
 Jan Kyncl,Charles University,https://kam.mff.cuni.cz/~kyncl,08jlpUUAAAAJ,0000-0003-4908-4703
 Jan Lellmann,University of Lübeck,https://www.mic.uni-luebeck.de/people/jan-lellmann.html,AyjlTxMAAAAJ,0000-0000-0000-0000
 Jan M. Allbeck,George Mason University,https://people.cs.gmu.edu/~jallbeck,GF-eRaMAAAAJ,0000-0000-0000-0000
-Jan M. Rabaey,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/rabaey.html,GP64q_kAAAAJ,0000-0000-0000-0000
 Jan Maas,IST Austria,https://ist.ac.at/research/research-groups/maas-group,Cm3vCpUAAAAJ,0000-0000-0000-0000
 Jan Madey,University of Warsaw,http://www.eunis.org/organization/jan-madey-bio,NOSCHOLARPAGE,0000-0000-0000-0000
 Jan Madsen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE,0000-0002-5098-8454
@@ -2830,5 +2829,6 @@ Jürgen Steimle,Saarland University,https://hci.cs.uni-saarland.de/people/juerge
 Jürgen Teich,University of Erlangen–Nuremberg,https://www.cs12.tf.fau.de/person/juergen-teich,Hj3eizAAAAAJ,0000-0001-6285-5862
 Jürgen W. Hesser,Heidelberg University,http://medphyssrv1.medma.uni-heidelberg.de/cms,NOSCHOLARPAGE,0000-0000-0000-0000
 Jürgen Ziegler 0001,University of Duisburg-Essen,https://interactivesystems.info/team/juergen-ziegler,UD-ha3YAAAAJ,0000-0001-9603-5272
+
 
 

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -1058,7 +1058,6 @@ Kurt Driessens,Maastricht University,https://www.maastrichtuniversity.nl/kurt.dr
 Kurt E. Oughstun,University of Vermont,http://www.cems.uvm.edu/~oughstun,lmYBo-oAAAAJ,0000-0000-0000-0000
 Kurt Geihs,University of Kassel,http://www.uni-kassel.de/eecs/fachgebiete/vs/team/kge-detail-page/person/578-Kurt-Geihs.html,JsrZG2YAAAAJ,0000-0001-9833-6108
 Kurt Jensen,Aarhus University,http://pure.au.dk/portal/en/persons/kurt-jensen(40695a62-b356-4d94-b437-4db0be203bdc).html,OLXJpH8AAAAJ,0000-0000-0000-0000
-Kurt Keutzer,Univ. of California - Berkeley,https://people.eecs.berkeley.edu/~keutzer,IzaagZkAAAAJ,0000-0000-0000-0000
 Kurt Luther,Virginia Tech,https://www.kurtluther.com,b8cNEHwAAAAJ,0000-0003-1809-6269
 Kurt Mehlhorn [INF],Max Planck Society,https://www.mpi-inf.mpg.de/~mehlhorn,28CWXPUAAAAJ,0000-0000-0000-0000
 Kurt Nørmark,Aalborg University,http://people.cs.aau.dk/~normark,5L7St-cAAAAJ,0000-0000-0000-0000
@@ -1133,3 +1132,4 @@ Kyungwoo Song,Yonsei University,https://mlai.yonsei.ac.kr,HWxRii4AAAAJ,0000-0003
 Kyuseok Shim,Seoul National University,http://kdd.snu.ac.kr/~shim,3Y254i4AAAAJ,0000-0001-8818-0963
 Kôiti Hasida,University of Tokyo,http://www.i.u-tokyo.ac.jp/edu/course/ice/members_e.shtml,d3CnvP8AAAAJ,0000-0000-0000-0000
 Kübra Kalkan,Özyeğin University,https://faculty.ozyegin.edu.tr/kubrakalkan,xE0INEMAAAAJ,0000-0000-0000-0000
+

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -1911,7 +1911,7 @@ Michael Horn 0001,Northwestern University,http://tidal.northwestern.edu,_yO5SYkA
 Michael Horsch,University of Saskatchewan,http://artsandscience.usask.ca/profile/MHorsch,NOSCHOLARPAGE,0000-0000-0000-0000
 Michael Huth 0001,Imperial College London,http://www.doc.ic.ac.uk/~mrh,ZBlUaIAAAAAJ,0000-0001-9229-3055
 Michael Hübner,Brandenburg Univ. of Technology,https://www.b-tu.de/en/fg-technische-informatik/team/professor,0U6y9RoAAAAJ,0000-0000-0000-0000
-Michael I. Jordan,Univ. of California - Berkeley,http://www.cs.berkeley.edu/~jordan,yxUduqMAAAAJ,0000-0001-8935-817X
+Michael I. Jordan,INRIA,http://www.cs.berkeley.edu/~jordan,yxUduqMAAAAJ,0000-0001-8935-817X
 Michael I. Mandel,CUNY,http://www.brooklyn.cuny.edu/web/academics/faculty/faculty_profile.jsp?faculty=1264,0v1-axgAAAAJ,0000-0000-0000-0000
 Michael I. Miga,Vanderbilt University,https://migalab.org,q2ThJtAAAAAJ,0000-0000-0000-0000
 Michael I. Miller,Johns Hopkins University,https://www.bme.jhu.edu/people/faculty/michael-i-miller,Ui8pnoIAAAAJ,0000-0000-0000-0000
@@ -3046,3 +3046,4 @@ Máté Lengyel,University of Cambridge,https://www.eng.cam.ac.uk/profiles/ml468,
 Mélanie Bouroche,Trinity College Dublin,https://www.scss.tcd.ie/Melanie.Bouroche,cuVe_vQAAAAJ,0000-0002-5039-0815
 Mücahid Kutlu,TOBB ETÜ,https://www.etu.edu.tr/en/bolum/computer-engineering/akademik-kadro?l=1#mucahid-kutlu,9pxldM0AAAAJ,0000-0002-5660-4992
 m. c. schraefel,University of Southampton,https://www.ecs.soton.ac.uk/people/sign,nAtF6UMAAAAJ,0000-0002-9061-7957
+

--- a/csrankings-n.csv
+++ b/csrankings-n.csv
@@ -617,7 +617,7 @@ Nikos Papanikolopoulos,University of Minnesota,http://www-users.cs.umn.edu/~npap
 Nikos Tzevelekos,Queen Mary University of London,https://www.tzevelekos.org,OsFtuawAAAAJ,0000-0001-8509-8059
 Nikos Vasilakis,Brown University,https://nikos.vasilak.is,yt3UwhMAAAAJ,0000-0001-7347-298X
 Niladri Chatterjee,IIT Delhi,https://web.iitd.ac.in/~niladri,_wvFRaMAAAAJ,0000-0000-0000-0000
-Nilah Ioannidis,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/nilah.html,uNNLZxYAAAAJ,0000-0000-0000-0000
+Nilah Ioannidis,Univ. of California - Santa Cruz,https://www2.eecs.berkeley.edu/Faculty/Homepages/nilah.html,uNNLZxYAAAAJ,0000-0000-0000-0000
 Nilanjan Banerjee,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~nilanb,ElJBmvgAAAAJ,0000-0000-0000-0000
 Nilanjan Chakraborty,Stony Brook University,https://www.cs.stonybrook.edu/people/faculty/NilanjanChakraborty,Y4XkdPQAAAAJ,0000-0000-0000-0000
 Nilanjan Ray,University of Alberta,https://webdocs.cs.ualberta.ca/~nray1,E3wuLqAAAAAJ,0000-0000-0000-0000
@@ -832,3 +832,4 @@ Nurit Haspel,University of Massachusetts Boston,http://www.cs.umb.edu/~nurith,xT
 Nutan Limaye,IT University of Copenhagen,https://itu.dk/~nuli,r8r6g-0AAAAJ,0000-0002-0238-1674
 Nysret Musliu,TU Wien,https://informatics.tuwien.ac.at/people/nysret-musliu,35owm6EAAAAJ,0000-0002-3992-8637
 Næhyuck Chang,KAIST,http://www.cad4x.kaist.ac.kr/professor,w0uiMd4AAAAJ,0000-0000-0000-0000
+

--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -764,7 +764,6 @@ Peter King,University of Manitoba,http://www.cs.umanitoba.ca/~prking,jENQurUAAAA
 Peter Kling,University of Hamburg,https://www.inf.uni-hamburg.de/en/inst/ab/tea/people/kling.html,YWvcp6AAAAAJ,0000-0003-0000-8689
 Peter Knees,TU Wien,https://informatics.tuwien.ac.at/people/peter-knees,MtyaO2cAAAAJ,0000-0003-3906-1292
 Peter Komisarczuk,Royal Holloway Univ. of London,https://pure.royalholloway.ac.uk/en/persons/peter-komisarczuk,NOSCHOLARPAGE,0000-0000-0000-0000
-Peter L. Bartlett,Univ. of California - Berkeley,http://www.stat.berkeley.edu/~bartlett,UPVvV6kAAAAJ,0000-0002-8760-3140
 Peter Lammich,University of Twente,https://people.utwente.nl/p.lammich,2eWIPzwAAAAJ,0000-0003-3576-0504
 Peter Langendörfer,Brandenburg Univ. of Technology,https://www.b-tu.de/fg-sicherheit-in-pervasiven-systemen/team/professor,giUyxgYAAAAJ,0000-0000-0000-0000
 Peter Liggesmeyer,TU Kaiserslautern,https://seda.informatik.uni-kl.de/staff-members/prof-liggesmeyer,mztSTlYAAAAJ,0000-0000-0000-0000
@@ -1280,3 +1279,4 @@ Puwei Wang,Renmin University of China,http://iir.ruc.edu.cn/~pwwang,NOSCHOLARPAG
 Pádraig Cunningham,University College Dublin,https://people.ucd.ie/padraig.cunningham,HqGgUVAAAAAJ,0000-0002-3499-0810
 Pável Calado,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist14497,7Udj_YAAAAAJ,0000-0001-6478-229X
 Péter Gács,Boston University,http://www.cs.bu.edu/~gacs,vNCcKo0AAAAJ,0000-0000-0000-0000
+

--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -786,7 +786,6 @@ Richard Khoury,Université Laval,http://www2.ift.ulaval.ca/~rikho,PgyHf0oAAAAJ,0
 Richard Lenz,University of Erlangen–Nuremberg,https://www.cs6.tf.fau.de/lehrstuhl/personen/richard-lenz,pN7nt2gAAAAJ,0000-0000-0000-0000
 Richard M. Everson,University of Exeter,http://emps.exeter.ac.uk/computer-science/staff/reverson,2XJDEWUAAAAJ,0000-0000-0000-0000
 Richard M. Jiang 0001,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/people/richard-jiang,NuyoNc4AAAAJ,0000-0000-0000-0000
-Richard M. Karp,Univ. of California - Berkeley,https://www.eecs.berkeley.edu/Faculty/Homepages/karp.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Richard M. Mortier,University of Cambridge,http://mort.io,9LJgRFAAAAAJ,0000-0000-0000-0000
 Richard M. Murray,California Inst. of Technology,https://www.bbe.caltech.edu/people/richard-m-murray,NOSCHOLARPAGE,0000-0002-5785-7481
 Richard M. Stern,Carnegie Mellon University,http://www.cs.cmu.edu/~rms,ffUu1PcAAAAJ,0000-0000-0000-0000
@@ -1625,6 +1624,7 @@ Rüdiger L. Urbanke,EPFL,https://people.epfl.ch/rudiger.urbanke,vFWw1NoAAAAJ,000
 Rüdiger Reischuk,University of Lübeck,http://www.tcs.uni-luebeck.de/mitarbeiter/reischuk,NOSCHOLARPAGE,0000-0000-0000-0000
 Rüdiger Schack,Royal Holloway Univ. of London,https://pure.royalholloway.ac.uk/portal/en/persons/ruediger-schack,tjusX-4AAAAJ,0000-0000-0000-0000
 Rüdiger Westermann,TU Munich,https://wwwcg.in.tum.de/group/persons/westermann.html,a8YUuWwAAAAJ,0000-0002-3394-0731
+
 
 
 

--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -1337,7 +1337,6 @@ Ronald P. A. Petrick,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/r
 Ronald Parr,Duke University,https://users.cs.duke.edu/~parr,b-GJ3QIAAAAJ,0000-0000-0000-0000
 Ronald Poppe,Utrecht University,https://www.uu.nl/staff/RWPoppe,khmLnVIAAAAJ,0000-0002-0843-7878
 Ronald Rosenfeld,Carnegie Mellon University,http://www.cs.cmu.edu/~roni,ct3WjtoAAAAJ,0000-0002-3274-5862
-Ronald S. Fearing,Univ. of California - Berkeley,https://robotics.eecs.berkeley.edu/~ronf,mx9gMZ4AAAAJ,0000-0001-6242-5379
 Ronald Vullo,Rochester Inst. of Technology,http://ist.rit.edu/~rpv,NOSCHOLARPAGE,0000-0000-0000-0000
 Ronald W. Poppe,Utrecht University,https://www.uu.nl/staff/RWPoppe,khmLnVIAAAAJ,0000-0000-0000-0000
 Ronald de Haan,University of Amsterdam,https://staff.science.uva.nl/r.dehaan,r_PMdJEAAAAJ,0000-0000-0000-0000
@@ -1629,3 +1628,4 @@ Rüdiger L. Urbanke,EPFL,https://people.epfl.ch/rudiger.urbanke,vFWw1NoAAAAJ,000
 Rüdiger Reischuk,University of Lübeck,http://www.tcs.uni-luebeck.de/mitarbeiter/reischuk,NOSCHOLARPAGE,0000-0000-0000-0000
 Rüdiger Schack,Royal Holloway Univ. of London,https://pure.royalholloway.ac.uk/portal/en/persons/ruediger-schack,tjusX-4AAAAJ,0000-0000-0000-0000
 Rüdiger Westermann,TU Munich,https://wwwcg.in.tum.de/group/persons/westermann.html,a8YUuWwAAAAJ,0000-0002-3394-0731
+

--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -382,8 +382,6 @@ Randi Karlsen,UiT The Arctic Univ. of Norway,https://uit.no/ansatte/randi.karlse
 Randy Avent,North Carolina State University,https://www.csc.ncsu.edu/people/rkavent,NOSCHOLARPAGE,0000-0000-0000-0000
 Randy E. Ellis,Queen’s University,http://www.cs.queensu.ca/~ellis,u97Fg9IAAAAJ,0000-0000-0000-0000
 Randy Goebel,University of Alberta,https://webdocs.cs.ualberta.ca/~goebel,fTgRyn4AAAAJ,0000-0000-0000-0000
-Randy H. Katz,Univ. of California - Berkeley,http://bnrg.eecs.berkeley.edu/~randy,PkfChMgAAAAJ,0000-0000-0000-0000
-Randy Howard Katz,Univ. of California - Berkeley,http://bnrg.eecs.berkeley.edu/~randy,PkfChMgAAAAJ,0000-0000-0000-0000
 Randy K. Smith,The University of Alabama,http://cs.ua.edu/people/rsmith,NOSCHOLARPAGE,0000-0000-0000-0000
 Randy Klaassen,University of Twente,https://research.utwente.nl/en/persons/8cabe314-4f70-43ea-9a19-54f393958c94,9t0KJpQAAAAJ,0000-0000-0000-0000
 Ranendu Ghosh,DAIICT,http://www.daiict.ac.in/daiict/people/faculty.html,BDnMnJkAAAAJ,0000-0000-0000-0000
@@ -1628,4 +1626,5 @@ Rüdiger L. Urbanke,EPFL,https://people.epfl.ch/rudiger.urbanke,vFWw1NoAAAAJ,000
 Rüdiger Reischuk,University of Lübeck,http://www.tcs.uni-luebeck.de/mitarbeiter/reischuk,NOSCHOLARPAGE,0000-0000-0000-0000
 Rüdiger Schack,Royal Holloway Univ. of London,https://pure.royalholloway.ac.uk/portal/en/persons/ruediger-schack,tjusX-4AAAAJ,0000-0000-0000-0000
 Rüdiger Westermann,TU Munich,https://wwwcg.in.tum.de/group/persons/westermann.html,a8YUuWwAAAAJ,0000-0002-3394-0731
+
 

--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -982,7 +982,6 @@ Robert Ian Davis,University of York,https://www-users.cs.york.ac.uk/~robdavis,xj
 Robert Irving Soare,University of Chicago,http://people.cs.uchicago.edu/~soare,NOSCHOLARPAGE,0000-0000-0000-0000
 Robert J. Brunner,Univ. of Illinois at Urbana-Champaign,http://www.astro.illinois.edu/people/bigdog,tL8qoFQAAAAJ,0000-0000-0000-0000
 Robert J. Fornaro,North Carolina State University,https://www.csc.ncsu.edu/people/fornaro,NOSCHOLARPAGE,0000-0000-0000-0000
-Robert J. Full,Univ. of California - Berkeley,https://ib.berkeley.edu/people/faculty/fullr,82eHqZYAAAAJ,0000-0000-0000-0000
 Robert J. Gaizauskas,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/rob-gaizauskas,HY8ATOgAAAAJ,0000-0002-3356-5126
 Robert J. Hammell,Towson University,https://www.towson.edu/fcsm/departments/computerinfosci/facultystaff/rhammell.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Robert J. Hammell II,Towson University,https://www.towson.edu/fcsm/departments/computerinfosci/facultystaff/rhammell.html,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -1626,5 +1625,6 @@ Rüdiger L. Urbanke,EPFL,https://people.epfl.ch/rudiger.urbanke,vFWw1NoAAAAJ,000
 Rüdiger Reischuk,University of Lübeck,http://www.tcs.uni-luebeck.de/mitarbeiter/reischuk,NOSCHOLARPAGE,0000-0000-0000-0000
 Rüdiger Schack,Royal Holloway Univ. of London,https://pure.royalholloway.ac.uk/portal/en/persons/ruediger-schack,tjusX-4AAAAJ,0000-0000-0000-0000
 Rüdiger Westermann,TU Munich,https://wwwcg.in.tum.de/group/persons/westermann.html,a8YUuWwAAAAJ,0000-0002-3394-0731
+
 
 

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -600,7 +600,6 @@ Scott Ruoti,University of Tennessee,https://isrl.byu.edu/researchers/scott-ruoti
 Scott S. L. Piao,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/people/scott-piao,qSTTL6MAAAAJ,0000-0000-0000-0000
 Scott Sanner,University of Toronto,https://d3m.mie.utoronto.ca/members/ssanner,kB8UPNIAAAAJ,0000-0001-7984-8394
 Scott Schaefer,Texas A&M University,http://faculty.cs.tamu.edu/schaefer,tIgxLTUAAAAJ,0000-0002-0988-1452
-Scott Shenker,Univ. of California - Berkeley,https://www.eecs.berkeley.edu/Faculty/Homepages/shenker.html,GUAoEcAAAAAJ,0000-0002-1357-7533
 Scott Songlin Piao,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/people/scott-piao,qSTTL6MAAAAJ,0000-0000-0000-0000
 Scott T. Leutenegger,University of Denver,http://www.cs.du.edu/~leut,UDOTNC0AAAAJ,0000-0000-0000-0000
 Scott. D. Goodwin,University of Windsor,http://www.uwindsor.ca/science/computerscience/1036/dr-scott-goodwin,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -2754,3 +2753,4 @@ Søren Ingvor Olsen,University of Copenhagen,http://diku.dk/english/staff/?pure=
 Søren Kimmer Schou Gregersen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE,0000-0003-3469-2271
 Søren Knudsen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/soeren-knudsen(2575c800-642d-4984-9c56-41601cf07a26).html,DT6JUdcAAAAJ,0000-0002-8306-1102
 Søren Lauesen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/soeren-lauesen(ea6d10cf-6bb5-4414-8966-f1ed2591f794).html,NOSCHOLARPAGE,0000-0000-0000-0000
+

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -814,8 +814,6 @@ Seth Lewis Gilbert,National University of Singapore,http://www.comp.nus.edu.sg/~
 Seth Pettie,University of Michigan,http://web.eecs.umich.edu/~pettie,ao_EFbUAAAAJ,0000-0002-2610-1630
 Seth Poulsen,Utah State University,https://www.usu.edu/cs/directory/faculty/poulsen-seth,yoEvwpsAAAAJ,0000-0001-6284-9972
 Seth R. Flaxman,University of Oxford,https://www.cs.ox.ac.uk/people/seth.flaxman,Wnxq0mgAAAAJ,0000-0000-0000-0000
-Seth R. Sanders,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/sanders.html,Qb7xQQ0AAAAJ,0000-0000-0000-0000
-Seth Sanders,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/sanders.html,Qb7xQQ0AAAAJ,0000-0000-0000-0000
 Sethu Vijayakumar,University of Edinburgh,http://homepages.inf.ed.ac.uk/svijayak,JdRs1sQAAAAJ,0000-0000-0000-0000
 Sethuraman Panchanathan,Arizona State University,https://search.asu.edu/profile/88253,GKTKZ8kAAAAJ,0000-0002-8769-6340
 Seulbae Kim,POSTECH,https://seulbae-security.github.io,ZCUVl9AAAAAJ,0000-0001-9990-7953
@@ -2753,4 +2751,5 @@ Søren Ingvor Olsen,University of Copenhagen,http://diku.dk/english/staff/?pure=
 Søren Kimmer Schou Gregersen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE,0000-0003-3469-2271
 Søren Knudsen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/soeren-knudsen(2575c800-642d-4984-9c56-41601cf07a26).html,DT6JUdcAAAAJ,0000-0002-8306-1102
 Søren Lauesen,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/soeren-lauesen(ea6d10cf-6bb5-4414-8966-f1ed2591f794).html,NOSCHOLARPAGE,0000-0000-0000-0000
+
 

--- a/csrankings-t.csv
+++ b/csrankings-t.csv
@@ -1107,7 +1107,6 @@ Tse-Hsun Chen,Concordia University,http://petertsehsun.github.io,gUBD7x0AAAAJ,00
 Tse-Hsun Peter Chen,Concordia University,http://petertsehsun.github.io,gUBD7x0AAAAJ,0000-0003-4027-0905
 Tsi-Ui Ik,National Chiao Tung University,http://people.cs.nctu.edu.tw/~yi,NOSCHOLARPAGE,0000-0001-6432-9161
 Tsu-Han Chen,Cornell University,https://www.ece.cornell.edu/people/profile.cfm?netid=tc345,NOSCHOLARPAGE,0000-0000-0000-0000
-Tsu-Jae King Liu,Univ. of California - Berkeley,https://www.eecs.berkeley.edu/~tking,lMUmE_UAAAAJ,0000-0000-0000-0000
 Tsuhan Chen,National University of Singapore,http://www.nus.edu.sg/about/management/chen-tsuhan,syCMBRIAAAAJ,0000-0003-3951-7931
 Tsui-Wei Weng,Univ. of California - San Diego,https://lilyweng.github.io,v8GM4xoAAAAJ,0000-0000-0000-0000
 Tsung-Chi Lin,NJIT,https://www.lintsungchi.com,9gCMg9cAAAAJ,0000-0000-0000-0000
@@ -1165,3 +1164,4 @@ Tzu-Chien Hsiao,National Chiao Tung University,https://sites.google.com/site/lab
 Tzu-Mao Li,Univ. of California - San Diego,https://people.csail.mit.edu/tzumao,Y7MCOdYAAAAJ,0000-0001-5443-470X
 Tõnu Tamme,University of Tartu,http://www.ut.ee/en/tonu-tamme,076eOUoAAAAJ,0000-0000-0000-0000
 Tülay Adali,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~adali,KgjUnawAAAAJ,0000-0000-0000-0000
+

--- a/csrankings-v.csv
+++ b/csrankings-v.csv
@@ -471,14 +471,12 @@ Vladimir I. Zadorozhny,University of Pittsburgh,http://www.pitt.edu/~viz,fv1GAB8
 Vladimir Kolesnikov,Georgia Institute of Technology,https://www.scs.gatech.edu/people/vladimir-kolesnikov,1vwuDM4AAAAJ,0000-0002-0211-1244
 Vladimir Kolmogorov,IST Austria,http://pub.ist.ac.at/~vnk,BBGlIGQAAAAJ,0000-0002-7625-8986
 Vladimir Makarenkov,Université du Québec à Montréal,http://www.info2.uqam.ca/~makarenkov_v/site_web/index.html,tP0i83IAAAAJ,0000-0003-3753-5925
-Vladimir Marko Stojanovic,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/vlada.html,rsGmH38AAAAJ,0000-0000-0000-0000
 Vladimir Naumovich Vapnik,Columbia University,http://datascience.columbia.edu/vladimir-vapnik,NOSCHOLARPAGE,0000-0000-0000-0000
 Vladimir Oliveira Di Iorio,Universidade Federal de Viçosa,http://www.dpi.ufv.br/~vladimir,NOSCHOLARPAGE,0000-0000-0000-0000
 Vladimir Pavlovic 0001,Rutgers University,http://seqam.rutgers.edu,NOSCHOLARPAGE,0000-0003-3979-1236
 Vladimir Reinharz,Université du Québec à Montréal,https://cbe.uqam.ca,5wAUH3MAAAAJ,0000-0001-8481-1094
 Vladimir Rokhlin,Yale University,http://cpsc.yale.edu/people/vladimir-rokhlin,Cy4eJqMAAAAJ,0000-0000-0000-0000
 Vladimir Stankovic 0002,City University of London,https://www.city.ac.uk/people/academics/vladimir-stankovic,jYvo0GQAAAAJ,0000-0000-0000-0000
-Vladimir Stojanovic,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/vlada.html,rsGmH38AAAAJ,0000-0001-7233-6863
 Vladimir V. Podolskii,Tufts University,https://facultyprofiles.tufts.edu/vladimir-podolskii,56S9XEsAAAAJ,0000-0001-7154-138X
 Vladimir Vapnik,Columbia University,http://datascience.columbia.edu/vladimir-vapnik,NOSCHOLARPAGE,0000-0000-0000-0000
 Vladimir Vlassov,KTH Royal Inst. of Technology,https://www.kth.se/profile/vladv,X2AfiyAAAAAJ,0000-0002-6779-7435
@@ -532,4 +530,5 @@ Víctor A. Braberman,University of Buenos Aires,http://lafhis.dc.uba.ar/en/~vbra
 Víctor Gutiérrez-Basulto,Cardiff University,https://users.cs.cf.ac.uk/GutierrezBasultoV,L2eFo5IAAAAJ,
 Vít Jelínek,Charles University,https://iuuk.mff.cuni.cz/~jelinek,yD9a43oAAAAJ,0000-0003-4831-4079
 Vítek Jelínek,Charles University,https://iuuk.mff.cuni.cz/~jelinek,yD9a43oAAAAJ,0000-0000-0000-0000
+
 

--- a/csrankings-v.csv
+++ b/csrankings-v.csv
@@ -453,7 +453,7 @@ Vivek Nallur,University College Dublin,https://people.ucd.ie/vivek.nallur,TeqJsj
 Vivek Sarin,Texas A&M University,http://faculty.cs.tamu.edu/sarin,4vLOo4wAAAAJ,0000-0000-0000-0000
 Vivek Sarkar,Georgia Institute of Technology,http://vsarkar.cc.gatech.edu,XjeIqxYAAAAJ,0000-0002-3433-8830
 Vivek Srikumar,University of Utah,http://svivek.com,TsTUfOIAAAAJ,0000-0003-0419-6568
-Vivek Subramanian,Univ. of California - Berkeley,https://people.eecs.berkeley.edu/~viveks,j-KcbbAAAAAJ,0000-0000-0000-0000
+Vivek Subramanian,EPFL,https://people.epfl.ch/vivek.subramanian?lang=en,j-KcbbAAAAAJ,0000-0000-0000-0000
 Viviane Moreira Orengo,UFRGS,http://www.inf.ufrgs.br/~viviane,-l5-OIQAAAAJ,0000-0000-0000-0000
 Viviane P. Moreira,UFRGS,http://www.inf.ufrgs.br/~viviane,-l5-OIQAAAAJ,0000-0000-0000-0000
 Viviane Pereira Moreira,UFRGS,http://www.inf.ufrgs.br/~viviane,-l5-OIQAAAAJ,0000-0000-0000-0000
@@ -532,3 +532,4 @@ Víctor A. Braberman,University of Buenos Aires,http://lafhis.dc.uba.ar/en/~vbra
 Víctor Gutiérrez-Basulto,Cardiff University,https://users.cs.cf.ac.uk/GutierrezBasultoV,L2eFo5IAAAAJ,
 Vít Jelínek,Charles University,https://iuuk.mff.cuni.cz/~jelinek,yD9a43oAAAAJ,0000-0003-4831-4079
 Vítek Jelínek,Charles University,https://iuuk.mff.cuni.cz/~jelinek,yD9a43oAAAAJ,0000-0000-0000-0000
+

--- a/old/emeritus.csv
+++ b/old/emeritus.csv
@@ -28,9 +28,11 @@ Amiram Yehudai,Tel Aviv University,http://www.cs.tau.ac.il/~amiramy,NOSCHOLARPAG
 Amos Fiat,Tel Aviv University,http://www.cs.tau.ac.il/~fiat,0MzVIUsAAAAJ,0000-0002-5748-9519
 Andrew Klapper,University of Kentucky,https://www.engr.uky.edu/directory/klapper-andrew,nn3Fx0cAAAAJ,0000-0002-6267-089X
 Aristides A. G. Requicha,University of Southern California,http://ee.usc.edu/faculty_staff/faculty_directory/requicha.htm,NOSCHOLARPAGE,0000-0000-0000-0000
+Avideh Zakhor,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/zakhor.html,XV8QLVQAAAAJ,0000-0003-4770-6353
 Barbara G. Ryder,Virginia Tech,http://people.cs.vt.edu/ryder,OdWimfcAAAAJ,0000-0000-0000-0000
 Benjamin Kuipers,University of Michigan,http://web.eecs.umich.edu/~kuipers,H1XVLwsAAAAJ,0000-0000-0000-0000
 Bernd Hamann,Univ. of California - Davis,http://graphics.cs.ucdavis.edu/~hamann,aNRlTa8AAAAJ,0000-0000-0000-0000
+Bernhard E. Boser,Univ. of California - Berkeley,https://people.eecs.berkeley.edu/~boser,NHIpV98AAAAJ
 Berthold K. P. Horn,Massachusetts Inst. of Technology,http://people.csail.mit.edu/bkph,NOSCHOLARPAGE,0000-0000-0000-0000
 Berthold Klaus Paul Horn,Massachusetts Inst. of Technology,http://people.csail.mit.edu/bkph,NOSCHOLARPAGE,0000-0000-0000-0000
 Biswanath Mukherjee,Univ. of California - Davis,http://networks.cs.ucdavis.edu/~mukherje,ytXtLjkAAAAJ,0000-0000-0000-0000
@@ -41,6 +43,8 @@ Chris Clifton,Purdue University,https://www.cs.purdue.edu/people/clifton,C_cWJIk
 Christopher W. Clifton,Purdue University,https://www.cs.purdue.edu/people/clifton,C_cWJIkAAAAJ,0000-0000-0000-0000
 Chuck Hansen,University of Utah,https://www.cs.utah.edu/~hansen,UqyaAQQAAAAJ,0000-0000-0000-0000
 Concettina Guerra,Georgia Institute of Technology,http://www.cc.gatech.edu/~guerra,NOSCHOLARPAGE,0000-0000-0000-0000
+Constance J. Chang-Hasnain,Univ. of California - Berkeley,https://www.eecs.berkeley.edu/Faculty/Homepages/chang-hasnain.html,O2HSABIAAAAJ,0000-0000-0000-0000
+Costas J. Spanos,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/spanos.html,90TaOdoAAAAJ,0000-0000-0000-0000
 Dan Gusfield,Univ. of California - Davis,http://www.cs.ucdavis.edu/~gusfield,VoAHydgAAAAJ,0000-0000-0000-0000
 Dana Angluin,Yale University,http://cpsc.yale.edu/people/dana-angluin,bxi6JXYAAAAJ,0000-0000-0000-0000
 Dana S. Scott,Carnegie Mellon University,http://www.cs.cmu.edu/~scott,EsIyIQsAAAAJ,0000-0000-0000-0000
@@ -65,11 +69,14 @@ Donna J. Cox,Univ. of Illinois at Urbana-Champaign,http://avl.ncsa.illinois.edu/
 Ed Lazowska,University of Washington,http://www.cs.washington.edu/people/faculty/lazowska,NhY4TT4AAAAJ,0000-0003-0645-8787
 Edmund H. Durfee,University of Michigan,http://ai.eecs.umich.edu/people/durfee,NOSCHOLARPAGE,0000-0002-1045-3690
 Edward A. Fox,Virginia Tech,https://fox.cs.vt.edu/foxinfo.html,uDwy_JgAAAAJ,0000-0003-1447-6870
+Edward A. Lee,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/lee.html,IJgXsgwAAAAJ,0000-0002-5663-0584
 Edward Alan Fox,Virginia Tech,https://fox.cs.vt.edu/foxinfo.html,uDwy_JgAAAAJ,0000-0000-0000-0000
+Edward Ashford Lee,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/lee.html,IJgXsgwAAAAJ,0000-0000-0000-0000
 Edward D. Lazowska,University of Washington,http://www.cs.washington.edu/people/faculty/lazowska,NhY4TT4AAAAJ,0000-0003-0645-8787
 Edward W. Felten,Princeton University,https://www.cs.princeton.edu/~felten,watx0IAAAAAJ,0009-0002-2235-4814
 Elaine Cohen,University of Utah,https://www.cs.utah.edu/~cohen,6lNd480AAAAJ,0000-0000-0000-0000
 Eli Gafni,Univ. of California - Los Angeles,http://www.cs.ucla.edu/~eli,pX-NLrYAAAAJ,0009-0008-6799-2784
+Eli Yablonovitch,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/yablonovitch.html,4wqIUjMAAAAJ,0000-0000-0000-0000
 Eliezer M. Gafni,Univ. of California - Los Angeles,http://www.cs.ucla.edu/~eli,pX-NLrYAAAAJ,0000-0000-0000-0000
 Eliot Moss,Univ. of Massachusetts Amherst,https://people.cs.umass.edu/~moss,yYtaDFUAAAAJ,0000-0001-6637-3641
 Elisha Sacks,Purdue University,https://www.cs.purdue.edu/people/eps,NOSCHOLARPAGE,0009-0002-6955-2754
@@ -101,15 +108,22 @@ Jack Mostow,Carnegie Mellon University,http://www.cs.cmu.edu/~mostow,P0Mv6pIAAAA
 Jack Tumblin,Northwestern University,http://www.cs.northwestern.edu/~jet,NOSCHOLARPAGE,0000-0000-0000-0000
 James A. Reggia,Univ. of Maryland - College Park,https://www.cs.umd.edu/~reggia,NOSCHOLARPAGE,0000-0000-0000-0000
 James D. Foley,Georgia Institute of Technology,http://www.cc.gatech.edu/fac/Jim.Foley/foley.html,GmcChLIAAAAJ,0000-0000-0000-0000
+James Demmel,Univ. of California - Berkeley,https://www.cs.berkeley.edu/~demmel,NOSCHOLARPAGE,0000-0002-0550-5476
 James F. Kurose,Univ. of Massachusetts Amherst,http://www-net.cs.umass.edu/personnel/kurose.html,ogj8ppAAAAAJ,0000-0000-0000-0000
 James Foley 0001,Georgia Institute of Technology,http://www.cc.gatech.edu/fac/Jim.Foley/foley.html,GmcChLIAAAAJ,0000-0000-0000-0000
 James H. Cross,Auburn University,http://www.eng.auburn.edu/~cross,qOHTo_oAAAAJ,0000-0000-0000-0000
 James H. Cross II,Auburn University,http://www.eng.auburn.edu/~cross,qOHTo_oAAAAJ,0000-0000-0000-0000
 James R. Larus,EPFL,https://people.epfl.ch/james.larus,xWZTGPUAAAAJ,0000-0002-5820-2524
+James Weldon Demmel,Univ. of California - Berkeley,https://www.cs.berkeley.edu/~demmel,NOSCHOLARPAGE,0000-0000-0000-0000
 Jan Allebach,Purdue University,https://engineering.purdue.edu/ECE/People/ptProfile?resource_id=3043,NOSCHOLARPAGE,0000-0000-0000-0000
+Jan M. Rabaey,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/rabaey.html,GP64q_kAAAAJ,0000-0000-0000-0000
 Jan van den Berg,TU Delft,https://www.tudelft.nl/en/tpm/about-the-faculty/departments/engineering-systems-and-services/people/professors-emeriti/profdrir-j-jan-van-den-berg,p8-kZTAAAAAJ,0000-0000-0000-0000
 Janet L. Kolodner,Georgia Institute of Technology,https://home.cc.gatech.edu/jlk,NOSCHOLARPAGE,0000-0003-3858-4470
 Jayadev Misra,University of Texas at Austin,http://www.cs.utexas.edu/~misra,NOSCHOLARPAGE,0000-0000-0000-0000
+Jean C. Walrand,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/walrand.html,rPU7fz0AAAAJ
+Jean Camille Walrand,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/walrand.html,rPU7fz0AAAAJ
+Jeffrey Bokor,Univ. of California - Berkeley,http://people.eecs.berkeley.edu/~jbokor,ylSEuoIAAAAJ,0000-0002-4541-0156
+Jim Demmel,Univ. of California - Berkeley,https://www.cs.berkeley.edu/~demmel,NOSCHOLARPAGE,0000-0000-0000-0000
 Jim Foley 0001,Georgia Institute of Technology,http://www.cc.gatech.edu/fac/Jim.Foley/foley.html,GmcChLIAAAAJ,0000-0000-0000-0000
 Jim Kurose,Univ. of Massachusetts Amherst,http://www-net.cs.umass.edu/personnel/kurose.html,ogj8ppAAAAAJ,0000-0000-0000-0000
 Jim R. Larus,EPFL,https://people.epfl.ch/james.larus,xWZTGPUAAAAJ,0000-0000-0000-0000
@@ -128,6 +142,7 @@ John R. Kender,Columbia University,http://www.cs.columbia.edu/~jrk,RBuoCYEAAAAJ,
 Jonathan Turner,Washington University in St. Louis,http://www.arl.wustl.edu/~jst,Cgx9W6UAAAAJ,0000-0000-0000-0000
 Joseph J. DiStefano III,Univ. of California - Los Angeles,http://www.cs.ucla.edu/joseph-distefano-iii,NOSCHOLARPAGE,0000-0000-0000-0000
 Joseph L. Zachary,University of Utah,https://www.cs.utah.edu/~zachary,hOCBMzIAAAAJ,0000-0000-0000-0000
+Joseph M. Hellerstein,Univ. of California - Berkeley,http://citris-uc.org/person/professor-joseph-hellerstein,uFJi3IUAAAAJ,0000-0002-7712-4306
 Judea Pearl,Univ. of California - Los Angeles,http://bayes.cs.ucla.edu/jp_home.html,bAipNH8AAAAJ,0000-0000-0000-0000
 K. Mani Chandy,California Inst. of Technology,https://www.eas.caltech.edu/people/mani,_e1E9DQAAAAJ,0000-0000-0000-0000
 Kai H. Chang,Auburn University,http://www.eng.auburn.edu/~kchang,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -139,6 +154,7 @@ Kendra Cooper,University of Texas at Dallas,https://www.utdallas.edu/~kcooper,mw
 Kendra M. L. Cooper,University of Texas at Dallas,https://www.utdallas.edu/~kcooper,mwSaet0AAAAJ,0000-0000-0000-0000
 Kenneth Salisbury,Stanford University,https://med.stanford.edu/profiles/john-salisbury,FmrDR68AAAAJ,0000-0000-0000-0000
 Kok-Ming Leung,New York University,http://engineering.nyu.edu/people/kok-ming-leung,NOSCHOLARPAGE,0000-0000-0000-0000
+Kurt Keutzer,Univ. of California - Berkeley,https://people.eecs.berkeley.edu/~keutzer,IzaagZkAAAAJ,0000-0000-0000-0000
 Larry A. Finkelstein,Northeastern University,http://www.ccis.northeastern.edu/people/larry-finkelstein,I4iKZSkAAAAJ,0000-0000-0000-0000
 Larry Davis 0001,Univ. of Maryland - College Park,http://www.umiacs.umd.edu/~lsd,lc0ARagAAAAJ,0000-0000-0000-0000
 Larry S. Davis,Univ. of Maryland - College Park,http://www.umiacs.umd.edu/~lsd,lc0ARagAAAAJ,0000-0000-0000-0000
@@ -188,6 +204,7 @@ Pat Hanrahan,Stanford University,https://graphics.stanford.edu/~hanrahan,RzEnQmg
 Patrick M. Hanrahan,Stanford University,https://graphics.stanford.edu/~hanrahan,RzEnQmgAAAAJ,0000-0000-0000-0000
 Paul Ammann,George Mason University,https://people.cs.gmu.edu/~pammann,-j0V55IAAAAJ,0009-0002-8470-2917
 Peter K. Allen,Columbia University,http://www.cs.columbia.edu/~allen,BDxQ5soAAAAJ,0000-0000-0000-0000
+Peter L. Bartlett,Univ. of California - Berkeley,http://www.stat.berkeley.edu/~bartlett,UPVvV6kAAAAJ,0000-0002-8760-3140
 Peter Scheuermann,Northwestern University,http://www.ece.northwestern.edu/~peters,nvKQ7JQAAAAJ,0000-0000-0000-0000
 Phyllis G. Frankl,New York University,http://engineering.nyu.edu/people/phyllis-frankl,XE683E8AAAAJ,0000-0000-0000-0000
 Prem Devanbu,Univ. of California - Davis,https://web.cs.ucdavis.edu/~devanbu/,tQ5vbOAAAAAJ,0000-0000-0000-0000
@@ -197,6 +214,8 @@ Ralph Grishman,New York University,http://cs.nyu.edu/grishman,blwKAkUAAAAJ,0000-
 Ramesh C. Jain,Univ. of California - Irvine,https://ngs.ics.uci.edu,wOYUPpwAAAAJ,0000-0000-0000-0000
 Ramesh Jain,Univ. of California - Irvine,https://ngs.ics.uci.edu,wOYUPpwAAAAJ,0000-0000-0000-0000
 Randal E. Bryant,Carnegie Mellon University,http://www.cs.cmu.edu/~bryant,AFgYa68AAAAJ,0000-0001-5024-6613
+Randy H. Katz,Univ. of California - Berkeley,http://bnrg.eecs.berkeley.edu/~randy,PkfChMgAAAAJ,0000-0000-0000-0000
+Randy Howard Katz,Univ. of California - Berkeley,http://bnrg.eecs.berkeley.edu/~randy,PkfChMgAAAAJ,0000-0000-0000-0000
 Ratan K. Ghosh,IIT Kanpur,http://www.iitk.ac.in/new/dr-r-k-ghosh,UNULIi0AAAAJ,0000-0000-0000-0000
 Red Whittaker,Carnegie Mellon University,http://www.ri.cmu.edu/person.html?person_id=339,ouKJUyEAAAAJ,0000-0000-0000-0000
 Richard Anderson 0001,University of Washington,http://www.cs.washington.edu/people/faculty/anderson,uLsDDUMAAAAJ,0000-0002-7283-7219
@@ -209,11 +228,13 @@ Richard Furuta,Texas A&M University,http://www.csdl.tamu.edu/~furuta,vygtLDcAAAA
 Richard J. Anderson 0001,University of Washington,http://www.cs.washington.edu/people/faculty/anderson,uLsDDUMAAAAJ,0000-0000-0000-0000
 Richard J. Cole,New York University,http://cs.nyu.edu/cole,p2ttvlEAAAAJ,0000-0000-0000-0000
 Richard M. Fujimoto,Georgia Institute of Technology,http://www.cc.gatech.edu/~fujimoto,q1bkP7AAAAAJ,0000-0000-0000-0000
+Richard M. Karp,Univ. of California - Berkeley,https://www.eecs.berkeley.edu/Faculty/Homepages/karp.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Richard N. Taylor,Univ. of California - Irvine,https://www.ics.uci.edu/~taylor,h9t7KCcAAAAJ,0000-0000-0000-0000
 Richard Rasala,Northeastern University,http://www.ccs.neu.edu/home/rasala,NOSCHOLARPAGE,0000-0000-0000-0000
 Richard Taylor 0001,Univ. of California - Irvine,https://www.ics.uci.edu/~taylor,h9t7KCcAAAAJ,0000-0000-0000-0000
 Robert E. Kraut,Carnegie Mellon University,http://kraut.hciresearch.org,HKGYvu4AAAAJ,0000-0002-8554-2137
 Robert F. Murphy,Carnegie Mellon University,http://murphylab.web.cmu.edu,qQLlBH4AAAAJ,0000-0003-0358-901X
+Robert J. Full,Univ. of California - Berkeley,https://ib.berkeley.edu/people/faculty/fullr,82eHqZYAAAAJ,0000-0000-0000-0000
 Robert J. Vanderbei,Princeton University,https://vanderbei.princeton.edu,3mXqzKcAAAAJ,0000-0000-0000-0000
 Robert Kraut,Carnegie Mellon University,http://kraut.hciresearch.org,HKGYvu4AAAAJ,0000-0000-0000-0000
 Robert L. Constable,Cornell University,http://www.cs.cornell.edu/home/rc,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -228,12 +249,16 @@ Ronald A. Olsson,Univ. of California - Davis,http://www.cs.ucdavis.edu/~olsson,N
 Ronald Baecker,University of Toronto,http://ron.taglab.ca/,-X6Rj5EAAAAJ,0000-0000-0000-0000
 Ronald C. Arkin,Georgia Institute of Technology,http://www.cc.gatech.edu/home/arkin,WSN7T_YAAAAJ,0000-0000-0000-0000
 Ronald Craig Arkin,Georgia Institute of Technology,http://www.cc.gatech.edu/home/arkin,WSN7T_YAAAAJ,0000-0000-0000-0000
+Ronald S. Fearing,Univ. of California - Berkeley,https://robotics.eecs.berkeley.edu/~ronf,mx9gMZ4AAAAJ,0000-0001-6242-5379
 Roy H. Campbell,Univ. of Illinois at Urbana-Champaign,http://cs.illinois.edu/directory/profile/rhc,2ftJYXMAAAAJ,0000-0000-0000-0000
 Ruzena Bajcsy,University of Pennsylvania,https://www.grasp.upenn.edu/people/ruzena-bajcsy,NOSCHOLARPAGE,0000-0000-0000-0000
 Ruzena Bajcsyová,University of Pennsylvania,https://www.grasp.upenn.edu/people/ruzena-bajcsy,NOSCHOLARPAGE,0000-0000-0000-0000
 Sam Kamin,Univ. of Illinois at Urbana-Champaign,https://kamin.cs.illinois.edu,NOSCHOLARPAGE,0000-0000-0000-0000
 Samuel N. Kamin,Univ. of Illinois at Urbana-Champaign,http://loome.cs.uiuc.edu/kamin,NOSCHOLARPAGE,0000-0000-0000-0000
 Samuel S. Wagstaff Jr.,Purdue University,https://www.cs.purdue.edu/people/ssw,NOSCHOLARPAGE,0000-0000-0000-0000
+Scott Shenker,Univ. of California - Berkeley,https://www.eecs.berkeley.edu/Faculty/Homepages/shenker.html,GUAoEcAAAAAJ,0000-0002-1357-7533
+Seth R. Sanders,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/sanders.html,Qb7xQQ0AAAAJ,0000-0000-0000-0000
+Seth Sanders,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/sanders.html,Qb7xQQ0AAAAJ,0000-0000-0000-0000
 Sheila A. Greibach,Univ. of California - Los Angeles,http://www.cs.ucla.edu/sheila-greibach,NOSCHOLARPAGE,0000-0000-0000-0000
 Sheila Adele Greibach,Univ. of California - Los Angeles,http://www.cs.ucla.edu/sheila-greibach,NOSCHOLARPAGE,0000-0000-0000-0000
 Sheila Carlyle-Greibach,Univ. of California - Los Angeles,http://www.cs.ucla.edu/sheila-greibach,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -274,3 +299,4 @@ Yehezkel Yeshurun,Tel Aviv University,https://english.tau.ac.il/profile/hezy,NOS
 Yehuda Afek,Tel Aviv University,http://www.cs.tau.ac.il/~afek,pYasE5oAAAAJ,0000-0000-0000-0000
 Yu Hen Hu,University of Wisconsin - Madison,https://directory.engr.wisc.edu/ece/Faculty/Hu_Yu-hen,5CAjat0AAAAJ,0000-0000-0000-0000
 Zvi M. Kedem,New York University,http://cs.nyu.edu/kedem,NOSCHOLARPAGE,0000-0000-0000-0000
+

--- a/old/industry.csv
+++ b/old/industry.csv
@@ -22,6 +22,7 @@ Aman Parnami,IIIT Delhi,https://www.iiitd.ac.in/aman,PI30hN8AAAAJ,Ohilo,0000-000
 Amarjeet Singh 0001,IIIT Delhi,https://www.iiitd.edu.in/~amarjeet/,Yipk0X4AAAAJ,Zenatix Solutions,0000-0000-0000-0000
 Anand Seetharam,Binghamton University,https://www.binghamton.edu/cs/people/aseetharam.html,gA5qFUYAAAAJ,TBD,0000-0000-0000-0000
 Ananya Kumar,University of Wisconsin - Madison,https://ananyakumar.wordpress.com,x6EeqjUAAAAJ,Meta,0000-0000-0000-0000
+Anca D. Dragan,Univ. of California - Berkeley,http://www.eecs.berkeley.edu/~anca,UgHB5oAAAAAJ,Google DeepMind,0000-0000-0000-0000
 Andrea Tagliasacchi,University of Victoria,https://ai.google/research/people/106392/,1RmD-YsAAAAJ,Google AI,0000-0002-2209-7187
 Andrea Vedaldi,University of Oxford,http://www.robots.ox.ac.uk/~vedaldi/,bRT7t28AAAAJ,Facebook,0000-0003-1374-2858
 Andrew W. Moore 0001,Carnegie Mellon University,http://www.cs.cmu.edu/~awm,PbfkKLcAAAAJ,Google,0000-0000-0000-0000
@@ -89,6 +90,7 @@ Donald Kossmann,ETH Zurich,https://www.systems.ethz.ch,NOSCHOLARPAGE,Microsoft R
 Edwin B. Olson,University of Michigan,https://april.eecs.umich.edu/people/ebolson,GwtVjKYAAAAJ,TBD,0000-0000-0000-0000
 Edwin Olson,University of Michigan,https://april.eecs.umich.edu/people/ebolson,GwtVjKYAAAAJ,TBD,0000-0000-0000-0000
 Edwin V. Bonilla,UNSW,http://ebonilla.github.io,uDLRZQMAAAAJ,TBD,0000-0002-9904-2408
+Elad Alon,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/elad.html,ktlHDnQAAAAJ,Blue Cheetah Analog Design,0000-0000-0000-0000
 Emanuel Todorov,University of Washington,http://homes.cs.washington.edu/~todorov,QCBdB7AAAAAJ,Roboti LLC,0000-0000-0000-0000
 Emerson R. Murphy-Hill,North Carolina State University,https://people.engr.ncsu.edu/ermurph3,9Kk7PNQAAAAJ,Google,0000-0003-3921-9416
 Emery D. Berger,Univ. of Massachusetts Amherst,https://emeryberger.com,RaHaArkAAAAJ,Amazon,0000-0002-3222-3271
@@ -97,6 +99,7 @@ Emina Torlak,University of Washington,http://homes.cs.washington.edu/~emina,rFpe
 Emo Todorov,University of Washington,http://homes.cs.washington.edu/~todorov,QCBdB7AAAAAJ,Roboti LLC,0000-0000-0000-0000
 Engin Ipek,University of Rochester,http://www.cs.rochester.edu/~ipek/Home.html,Lka71pAAAAAJ,Qualcomm,0000-0003-2809-5809
 Erhan Mengusoglu,Hacettepe University,http://cs.hacettepe.edu.tr/files/erhan_mengusoglu_CVa.pdf,CRHfLuoAAAAJ,IBM,0000-0000-0000-0000
+Eric A. Brewer,Univ. of California - Berkeley,https://www.cs.berkeley.edu/~brewer,BbzYzsgAAAAJ,Google,0000-0003-0250-9268
 Eric C. Price,University of Texas at Austin,https://www.cs.utexas.edu/~ecprice,UiKzYNMAAAAJ,Microsoft Research,0000-0000-0000-0000
 Eric Osterweil,George Mason University,https://people.cs.gmu.edu/~eoster/,Jw1ccPYAAAAJ,Verisign,0000-0003-1446-5602
 Eric Price 0001,University of Texas at Austin,https://www.cs.utexas.edu/~ecprice,UiKzYNMAAAAJ,Microsoft Research,0000-0000-0000-0000
@@ -108,6 +111,7 @@ Fei Sha,University of Southern California,https://www.feisha.org/,HDHOS0QAAAAJ,G
 Feifei Li 0001,University of Utah,https://www.cs.utah.edu/~lifeifei,qPDhlWkAAAAJ,Alibaba,0009-0003-0770-5775
 Francesco Zappa Nardelli,Ecole Normale Superieure,http://www.di.ens.fr/~zappa,pp1KBVQAAAAJ,Facebook,0000-0000-0000-0000
 G. Edward Suh,Cornell University,http://www.csl.cornell.edu/~suh,NOSCHOLARPAGE,Nvidia,0000-0001-6409-9888
+George C. Necula,Univ. of California - Berkeley,http://www.cs.berkeley.edu/~necula,_fiHvDAAAAAJ,Google,0000-0000-0000-0000
 George Danezis,University College London,http://www0.cs.ucl.ac.uk/staff/G.Danezis,LCNVGpcAAAAJ,Facebook,0000-0002-8923-4860
 Georgios Gousios,TU Delft,https://gousios.gr,-NI5S50AAAAJ,Facebook,0000-0002-8495-7939
 Gerome Miklau,Univ. of Massachusetts Amherst,http://people.cs.umass.edu/~miklau,mlafJ6wAAAAJ,Tumult Labs,0000-0000-0000-0000
@@ -313,12 +317,15 @@ Thore Graepel,University College London,http://www0.cs.ucl.ac.uk/people/T.Graepe
 Tim Kraska,Massachusetts Inst. of Technology,http://cs.brown.edu/~kraskat,biuxbRsAAAAJ,Amazon,0009-0003-2414-2759
 Tobin Isaac,Georgia Institute of Technology,http://triquadtethex.org,SpDPpqgAAAAJ,Argonne National Laboratory,0000-0002-2628-3585
 Tony Jebara,Columbia University,http://www.cs.columbia.edu/~jebara,Dn_qYK8AAAAJ,Spotify,0000-0003-0314-3376
+Tsu-Jae King Liu,Univ. of California - Berkeley,https://www.eecs.berkeley.edu/~tking,lMUmE_UAAAAJ,NAE,0000-0000-0000-0000
 Tyler N. Allen,UNC - Charlotte,https://webpages.charlotte.edu/~tallen93,oRL0c28AAAAJ,NVIDIA,0000-0002-0253-372X
 Tyson Condie,Univ. of California - Los Angeles,http://clash.cs.ucla.edu,7SdcAiEAAAAJ,TBD,0000-0000-0000-0000
 V. Benjamin Livshits,Imperial College London,http://www.imperial.ac.uk/computing/people/alphabetical/academic-staff/,jaITaUcAAAAJ,Brave,0000-0000-0000-0000
 Victor Shoup,New York University,http://www.shoup.net,H4cQsHAAAAAJ,DFINITY,0009-0003-6996-5660
 Vipul Goyal,Carnegie Mellon University,https://www.cs.cmu.edu/~goyal,BYLsgysAAAAJ,NTT Research,0000-0000-0000-0000
 Vittorio Ferrari,University of Edinburgh,http://homepages.inf.ed.ac.uk/vferrari,4QvYJ00AAAAJ,Google,0000-0000-0000-0000
+Vladimir Marko Stojanovic,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/vlada.html,rsGmH38AAAAJ,Ayar Labs,0000-0000-0000-0000
+Vladimir Stojanovic,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/vlada.html,rsGmH38AAAAJ,Ayar Labs,0000-0001-7233-6863
 Wang Chiew Tan,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~tan,sOY-wjkAAAAJ,,0000-0000-0000-0000
 Wang-Chiew Tan,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~tan,sOY-wjkAAAAJ,Facebook AI,0000-0000-0000-0000
 Warren B. Powell,Princeton University,http://castlelab.princeton.edu/wbpbio.html,vDw80QEAAAAJ,Optimal Dynamics,0000-0000-0000-0000
@@ -350,3 +357,4 @@ Zhenhui Li,Pennsylvania State University,https://faculty.ist.psu.edu/jessieli,r0
 Zia Khan,Univ. of Maryland - College Park,https://www.cs.umd.edu/~zia,gJkhFkgAAAAJ,TBD,0000-0000-0000-0000
 Zihan Zhou 0001,Pennsylvania State University,https://faculty.ist.psu.edu/zzhou/Home.html,vEcgp3AAAAAJ,Manycore Tech Inc.,0000-0002-1697-2168
 Zvonimir Rakamaric,University of Utah,http://www.zvonimir.info,Ui1q1jkAAAAJ,Amazon Web Services,0000-0000-0000-0000
+


### PR DESCRIPTION
Resolves the changes from #10038 by @andrewcrotty (rebased and conflict-resolved).

## Changes
- **Homepage updates**: Alvin Cheung, Aditya Parameswaran
- **Affiliation changes**: Michael I. Jordan → INRIA, Nilah Ioannidis → UC Santa Cruz, Vivek Subramanian → EPFL, Bernd Sturmfels → Max Planck
- **Emeritus moves**: ~25 faculty including Karp, Demmel, Katz, Shenker, Bartlett, Hellerstein, Keutzer, Rabaey, and others
- **Industry moves**: Dragan → DeepMind, Brewer → Google, Necula → Google, Alon → Blue Cheetah, Stojanovic → Ayar Labs, King Liu → NAE

Original PR: #10038