### PR TITLE
Update Stony Brook University

### DIFF
--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -309,7 +309,7 @@ Hans-Ulrich Prokosch,University of Erlangen–Nuremberg,https://www.imi.med.fau.
 Hans-Werner Gellersen,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/people/hans-gellersen,wmpvU_YAAAAJ,0000-0003-2233-2121
 Hans-Werner Güsgen,Massey University,http://seat.massey.ac.nz/h.w.guesgen,QwXZ99YAAAAJ,0000-0000-0000-0000
 Hans-Wolfgang Loidl,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/hans-wolfgang-loidl.htm,lwb1Va0AAAAJ,0000-0001-6318-1732
-Hansen Andrew Schwartz,Stony Brook University,http://www3.cs.stonybrook.edu/~has,Na16PsUAAAAJ,0000-0000-0000-0000
+Hansen Andrew Schwartz,Vanderbilt University,https://haschwartz.com,Na16PsUAAAAJ,0000-0000-0000-0000
 Hansenclever F. Bassani,UFPE,https://www.cin.ufpe.br/~hfb,s14pJ00AAAAJ,0000-0000-0000-0000
 Hansenclever de F. Bassani,UFPE,https://www.cin.ufpe.br/~hfb,s14pJ00AAAAJ,0000-0000-0000-0000
 Hanseok Ko,Korea University,http://ispl.korea.ac.kr,G9v28v4AAAAJ,0000-0002-8744-4514

--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -953,7 +953,6 @@ Robert E. Tarjan,Princeton University,https://www.cs.princeton.edu/~ret,lazJixIA
 Robert E. Webber,Western University,http://www.csd.uwo.ca/~webber,A4nm80EAAAAJ,0000-0000-0000-0000
 Robert Elsässer,University of Salzburg,https://algorithms.cosy.sbg.ac.at/group/robert-elsaesser.html,WIY8ymUAAAAJ,0000-0002-5766-8103
 Robert Endre Tarjan,Princeton University,https://www.cs.princeton.edu/~ret,lazJixIAAAAJ,0000-0000-0000-0000
-Robert F. Kelly,Stony Brook University,https://www.cs.stonybrook.edu/people/faculty/RobertKelly,M6IXlpgAAAAJ,0000-0000-0000-0000
 Robert Feldt,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/robert-feldt.aspx,VemqkeEAAAAJ,0000-0002-5179-4205
 Robert G. Crawford,Queen’s University,http://research.cs.queensu.ca/home/rgc,EQ-mkaAAAAAJ,0000-0000-0000-0000
 Robert G. Maunder,University of Southampton,https://www.ecs.soton.ac.uk/people/rgm1y07,IpSIFzkAAAAJ,0000-0000-0000-0000
@@ -1624,7 +1623,4 @@ Rüdiger L. Urbanke,EPFL,https://people.epfl.ch/rudiger.urbanke,vFWw1NoAAAAJ,000
 Rüdiger Reischuk,University of Lübeck,http://www.tcs.uni-luebeck.de/mitarbeiter/reischuk,NOSCHOLARPAGE,0000-0000-0000-0000
 Rüdiger Schack,Royal Holloway Univ. of London,https://pure.royalholloway.ac.uk/portal/en/persons/ruediger-schack,tjusX-4AAAAJ,0000-0000-0000-0000
 Rüdiger Westermann,TU Munich,https://wwwcg.in.tum.de/group/persons/westermann.html,a8YUuWwAAAAJ,0000-0002-3394-0731
-
-
-
 


### PR DESCRIPTION
Resolves the changes from #10735 by @andrewcrotty (rebased and conflict-resolved).

## Changes
- **Hansen Andrew Schwartz**: Stony Brook → Vanderbilt University (new homepage)
- **Robert F. Kelly**: Removed from Stony Brook

Original PR: #10735