### PR TITLE
Update Muhammad Awais → Awais Rauf (Queen's University Belfast)

### DIFF
--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -2660,6 +2660,7 @@ Avrim Blum,TTI Chicago,https://home.ttic.edu/~avrim,Jlv4MR4AAAAJ,0000-0003-2450-
 Awad H. Khalil,American University in Cairo,https://www.aucegypt.edu/fac/awadkhalil,NOSCHOLARPAGE,0000-0000-0000-0000
 Awais Aziz Shah,University of Glasgow,https://www.gla.ac.uk/schools/computing/staff/awaisazizshah,0ZWrFbgAAAAJ,0000-0000-0000-0000
 Awais Rashid,University of Bristol,https://research-information.bris.ac.uk/en/persons/awais-rashid,pI5g2hIAAAAJ,0000-0002-0109-1341
+Awais Rauf,Queen's University Belfast,https://pure.qub.ac.uk/en/persons/awais-rauf/,bA-9t1cAAAAJ,0000-0003-2407-7865
 Awdren Fontão,UFMS,https://awdren.github.io,BfesYF0AAAAJ,0000-0000-0000-0000
 Aws Albarghouthi,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~aws,CUbC2zYAAAAJ,0000-0003-4577-175X
 Axel Hahn,University of Oldenburg,https://uol.de/sao/personen/prof-dr-ing-axel-hahn,0XGwMHkAAAAJ,0000-0003-2240-5351

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -2896,7 +2896,6 @@ Muhammad Ali Babar 0001,Adelaide University,http://www.adelaide.edu.au/directory
 Muhammad Ali Babar Abbasi,Queen's University Belfast,https://pure.qub.ac.uk/en/persons/muhammad-ali-babar-abbasi,56muy2AAAAAJ,0000-0002-1283-4614
 Muhammad Ali Gulzar,Virginia Tech,http://people.cs.vt.edu/~gulzar,k9M-nccAAAAJ,0000-0002-8007-8662
 Muhammad Asif Hossain Khan,University of Dhaka,https://du.ac.bd/body/faculty_details/CSE/1771,MxsRecMAAAAJ,0000-0003-3313-6812
-Muhammad Awais,Queen's University Belfast,https://pure.qub.ac.uk/en/persons/muhammad-awais,bA-9t1cAAAAJ,0000-0000-0000-0000
 Muhammad Awais 0001,University of Surrey,https://www.surrey.ac.uk/people/muhammad-awais,X_oK7kQAAAAJ,0000-0002-1122-0709
 Muhammad Fahim,Queen's University Belfast,https://pure.qub.ac.uk/en/persons/muhammad-fahim,HFp8hzMAAAAJ,0000-0001-6259-5458
 Muhammad Fareed Zaffar,LUMS,https://lums.edu.pk/lums_employee/422,NOSCHOLARPAGE,0000-0000-0000-0000


### PR DESCRIPTION
## Summary
Updating faculty entry for **Muhammad Awais** → **Awais Rauf** at Queen's University Belfast.

Entry moved from `csrankings-m.csv` to `csrankings-a.csv` due to name change. Updated homepage and ORCID.

Submitted by @awaisrauf via [CSRankings form](https://csrankings.org/submit/).

Closes #10907

## Changes
**Old:**
```
Muhammad Awais,Queen's University Belfast,https://pure.qub.ac.uk/en/persons/muhammad-awais,bA-9t1cAAAAJ,0000-0000-0000-0000
```

**New:**
```
Awais Rauf,Queen's University Belfast,https://pure.qub.ac.uk/en/persons/awais-rauf/,bA-9t1cAAAAJ,0000-0003-2407-7865
```

**Note:** Entry moved from `csrankings-m.csv` to `csrankings-a.csv` due to name change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)