### PR TITLE
Add 125 faculty from Manipal Academy of Higher Education

### DIFF
--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -52,6 +52,7 @@ Aamir Cheema,Monash University,https://research.monash.edu/en/persons/aamir-chee
 Aamir Saeed Malik,Brno University of Technology,https://www.fit.vut.cz/person/malik,wgdxIH0AAAAJ,0000-0000-0000-0000
 Aanjhan Ranganathan,Northeastern University,https://www.aanjhan.com,Jid_EAkAAAAJ,0000-0003-0464-5861
 Aapo Hyvärinen,University of Helsinki,https://www.cs.helsinki.fi/u/ahyvarin,UnrY-40AAAAJ,0000-0000-0000-0000
+Aarabhi Putty,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr--aarabhi-putty---department-of-computer-science---engg---mit-/_jcr_content.html,Gdb3sjoAAAAJ,0000-0002-7646-8262
 Aarne Ranta,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/aarne-ranta.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Aaron Bernstein,New York University,https://wp.nyu.edu/tandonschoolofengineering-aaronbernstein,N94spO0AAAAJ,0000-0002-7599-2679
 Aaron C. Courville,University of Montreal,https://aaroncourville.wordpress.com,km6CP8cAAAAJ,0000-0001-6223-0301
@@ -142,6 +143,7 @@ Abhijit S. Pandya,Florida Atlantic University,http://pire.fiu.edu/faculty/Dr_Pan
 Abhijnan Chakraborty,IIT Kharagpur,https://cse.iitkgp.ac.in/~abhijnan,21oQO9oAAAAJ,0000-0003-0908-1639
 Abhik Roychoudhury,National University of Singapore,https://www.comp.nus.edu.sg/~abhik,UxFWSJIAAAAJ,0000-0002-7127-1137
 Abhilash Jindal,IIT Delhi,http://abhilash-jindal.com,_af8suQAAAAJ,0000-0000-0000-0000
+Abhilash K. Pai,Manipal Academy of Higher Education,https://sites.google.com/site/abhilashkpai,WIsqsnsAAAAJ,0000-0001-7218-0475
 Abhinav Bhatele,Univ. of Maryland - College Park,http://www.cs.umd.edu/~bhatele,3x65qtwAAAAJ,0000-0003-3069-3701
 Abhinav Dhall,IIT Ropar,http://www.iitrpr.ac.in/cse/abhinavdhall,ypusncAAAAAJ,0000-0000-0000-0000
 Abhinav Gupta 0001,Carnegie Mellon University,http://www.cs.cmu.edu/~abhinavg,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -259,6 +261,7 @@ Adam Wierman,California Inst. of Technology,https://adamwierman.com,4OvOdSgAAAAJ
 Adam Wolisz,TU Berlin,https://www.tkn.tu-berlin.de/menue/team/wolisz/parameter/de,Gq8gWX4AAAAJ,0000-0000-0000-0000
 Adams Wai-Kin Kong,Nanyang Technological University,https://www3.ntu.edu.sg/home/adamskong,NOSCHOLARPAGE,0000-0002-9728-9511
 Adarsh Barik,IIT Delhi,https://adarsh-barik.github.io,GJt7n0oAAAAJ,0000-0000-0000-0000
+Adarsh Rag S,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/Dr-Adarsh-Rag-S/_jcr_content.html,7PJLdIsAAAAJ,0000-0002-1680-6055
 Adarsh S. Sethi,University of Delaware,https://www.eecis.udel.edu/~sethi,NOSCHOLARPAGE,0000-0000-0000-0000
 Adarshpal S. Sethi,University of Delaware,https://www.eecis.udel.edu/~sethi,NOSCHOLARPAGE,0000-0000-0000-0000
 Adel Abusitta,Polytechnique Montreal,https://www.polymtl.ca/expertises/en/abusitta-adel,BiKkFU8AAAAJ,0000-0000-0000-0000
@@ -385,6 +388,7 @@ Agustín Fernández,Polytechnic Univ. of Catalonia,http://engineering.academicke
 Agustín Gravano,University of Buenos Aires,http://habla.dc.uba.ar/gravano,GrKOwHIAAAAJ,0000-0000-0000-0000
 Ah-Hwee Tan,Singapore Management University,https://sis.smu.edu.sg/faculty/profile/165181/TAN-Ah-Hwee,G0hdDqYAAAAJ,0000-0003-0378-4069
 Ahad N. Zehmakan,Australian National University,https://comp.anu.edu.au/people/ahad-zehmakan,bB3qVuEAAAAJ,0000-0002-8569-6347
+Ahamed Shafeeq B. M.,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/ahamed-shafeeq-bm/_jcr_content.html,FvPxOJcAAAAJ,0000-0001-6555-6980
 Aharon Bar-Hillel,Ben-Gurion University of the Negev,https://sites.google.com/site/aharonbarhillel,x4GlT3IAAAAJ,0000-0002-7303-0687
 Ahmad Akbari,IUST,http://ce.iust.ac.ir/page.php?slct_pg_id=6537&sid=14&slc_lang=en,pCil4_cAAAAJ,0000-0000-0000-0000
 Ahmad Akbari Azirani,IUST,http://ce.iust.ac.ir/page.php?slct_pg_id=6537&sid=14&slc_lang=en,pCil4_cAAAAJ,0000-0002-0387-1616
@@ -477,6 +481,7 @@ Ajit Rajwade 0001,IIT Bombay,https://www.cse.iitb.ac.in/~ajitvr,CkTW7PwAAAAJ,000
 Ajit V. Rajwade 0001,IIT Bombay,https://www.cse.iitb.ac.in/~ajitvr,CkTW7PwAAAAJ,0000-0000-0000-0000
 Ajita Rattani,University of North Texas,https://computerscience.engineering.unt.edu/people/faculty/ajita-rattani,9esyU2EAAAAJ,0000-0000-0000-0000
 Ajitha Rajan,University of Edinburgh,http://homepages.inf.ed.ac.uk/arajan,Y8ROiBEAAAAJ,0000-0003-3765-3075
+Ajitha Shenoy K. B,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/ajitha-shenoy-k-b/_jcr_content.html,9Crzx8QAAAAJ,0000-0003-3995-1826
 Ajmal Mian,University of Western Australia,http://staffhome.ecm.uwa.edu.au/~00053650,X589yaIAAAAJ,0000-0002-5206-3842
 Ajmal S. Mian,University of Western Australia,http://staffhome.ecm.uwa.edu.au/~00053650,X589yaIAAAAJ,0000-0002-5206-3842
 Ajmal Saeed Mian,University of Western Australia,http://staffhome.ecm.uwa.edu.au/~00053650,X589yaIAAAAJ,0000-0002-5206-3842
@@ -1454,6 +1459,7 @@ Anca D. Jurcut,University College Dublin,https://people.ucd.ie/anca.jurcut,rzHu7
 Anca Delia Jurcut,University College Dublin,https://people.ucd.ie/anca.jurcut,rzHu7gYAAAAJ,0000-0000-0000-0000
 Anca Jurcut,University College Dublin,https://people.ucd.ie/anca.jurcut,rzHu7gYAAAAJ,0000-0000-0000-0000
 Anca L. Ralescu,University of Cincinnati,http://uc.academia.edu/AncaRalescu,eFiFA9cAAAAJ,0000-0000-0000-0000
+Ancilla J. Pinto,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/ancilla-juliet-pinto/_jcr_content.html,rRAnhqgAAAAJ,0000-0000-0000-0000
 Anders Andersen,UiT The Arctic Univ. of Norway,https://uit.no/ansatte/anders.andersen,InL6bSoAAAAJ,0000-0000-0000-0000
 Anders B. Dahl,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE,0000-0002-0068-8170
 Anders Berglund,Uppsala University,http://www.it.uu.se/katalog/andersb,F9TIbzAAAAAJ,0000-0002-0393-3530
@@ -1674,6 +1680,7 @@ Andrew Horner,HKUST,http://www.cse.ust.hk/faculty/horner,NOSCHOLARPAGE,0000-0000
 Andrew Howes,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/academic-staff/howes-andrew.aspx,iswtssoAAAAJ,0000-0003-4251-1127
 Andrew Ian Coles,King's College London,https://www.kcl.ac.uk/people/andrew-coles,EMiUE40AAAAJ,0000-0000-0000-0000
 Andrew Ireland,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/andrew-ireland.htm,LQpzXygAAAAJ,0009-0004-3530-9996
+Andrew J. 0001,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/Dr-Andrew-J/_jcr_content.html,4td6IKQAAAAJ,0000-0003-3592-6543
 Andrew J. Davison,Imperial College London,https://www.doc.ic.ac.uk/~ajd,SNQFnBEAAAAJ,0000-0002-3784-099X
 Andrew J. McAllister,University of New Brunswick,http://www.cs.unb.ca/~andrewm,d1yVDNgAAAAJ,0000-0000-0000-0000
 Andrew J. Parkes,University of Nottingham,https://www.nottingham.ac.uk/computerscience/people/andrew.parkes,G0yAJAwAAAAJ,0000-0000-0000-0000
@@ -1937,6 +1944,7 @@ Anish Mathuria,DAIICT,http://intranet.daiict.ac.in/~anish_mathuria,l3CE25YAAAAJ,
 Anisoara Calinescu,University of Oxford,http://www.cs.ox.ac.uk/people/ani.calinescu,aCljaCYAAAAJ,0000-0000-0000-0000
 Anisur Rahaman Molla,ISI Kolkata,https://sites.google.com/site/mollaanisurrahaman,JSIMGn0AAAAJ,0000-0002-1537-3462
 Anita Raja,CUNY,https://anraja.commons.gc.cuny.edu,rDo_DcgAAAAJ,0000-0000-0000-0000
+Anita S. Kini,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/anitha-kini/_jcr_content.html,ituKe9MAAAAJ,0000-0002-7823-7142
 Anita Sarma,Oregon State University,http://eecs.oregonstate.edu/people/sarma-anita,O4TGxGMAAAAJ,0000-0002-1859-1692
 Anita Wasilewska,Stony Brook University,http://www3.cs.stonybrook.edu/~anita,NOSCHOLARPAGE,0000-0000-0000-0000
 Anitha Gollamudi,University of Massachusetts Lowell,https://scholar.harvard.edu/anithag,6cLC6vYAAAAJ,0000-0002-0861-1418
@@ -2056,6 +2064,7 @@ Annie Liang,Northwestern University,https://www.anniehliang.com,gquS0PUAAAAJ,000
 Annie S. Wu,University of Central Florida,http://www.cs.ucf.edu/~aswu,Gona8sYAAAAJ,0000-0000-0000-0000
 Annika Hinze,University of Waikato,http://www.cms.waikato.ac.nz/people/hinze,01QXWU8AAAAJ,0000-0002-7383-1134
 Annika Marie Hinze,University of Waikato,http://www.cms.waikato.ac.nz/people/hinze,01QXWU8AAAAJ,0000-0000-0000-0000
+Anoop Benet Nirmala,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/AnoopBN.html,YN6dNyoAAAAJ,0000-0002-6082-391X
 Anoop M. Namboodiri,IIIT Hyderabad,http://iiit.ac.in/~anoop,mpI3sbYAAAAJ,0000-0000-0000-0000
 Anoop Sarkar,Simon Fraser University,http://www.cs.sfu.ca/~anoop,KhJJchQAAAAJ,0000-0000-0000-0000
 Anowarul Kabir,University of South Florida,https://www.usf.edu/ai-cybersecurity-computing/people/faculty/anowarul_kabir.aspx,6vjzN7EAAAAJ,0000-0001-8060-2084
@@ -2229,6 +2238,7 @@ Anuj Pathania,University of Amsterdam,https://staff.fnwi.uva.nl/a.pathania,oHJOy
 Anuja T. Dharmarathne,Monash University,https://research.monash.edu/en/persons/anuja-thimali-dharmaratne,QToD1sYAAAAJ,0000-0000-0000-0000
 Anujan Varma,Univ. of California - Santa Cruz,https://www.soe.ucsc.edu/people/varma,z9lI9VIAAAAJ,0000-0000-0000-0000
 Anup Basu,University of Alberta,https://webdocs.cs.ualberta.ca/~anup,x8Nn-jQAAAAJ,0000-0000-0000-0000
+Anup Bhat,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr-anup--bhat-b--department-of-computer-science---engg---mit--ma/_jcr_content.html,NOSCHOLARPAGE,0000-0002-9910-6758
 Anup Bhattacharya,NISER,https://sites.google.com/site/anupbtcs,giCNz6AAAAAJ,0000-0000-0000-0000
 Anup Kumar,University of Louisville,http://louisville.edu/speed/people/faculty/kumarAnup,NOSCHOLARPAGE,0000-0000-0000-0000
 Anup Rao 0001,University of Washington,http://homes.cs.washington.edu/~anuprao,T2U5sGIAAAAJ,0000-0002-6449-9547
@@ -2247,6 +2257,7 @@ Anurag Khandelwal,Yale University,http://anuragkhandelwal.com,LlfHFqUAAAAJ,0000-
 Anurag Mittal,IIT Madras,http://www.cse.iitm.ac.in/~amittal,mB9AZSAAAAAJ,0000-0000-0000-0000
 Anurag Srivastava 0001,West Virginia University,https://directory.statler.wvu.edu/faculty-staff-directory/anurag-srivastava,_GtNYPMAAAAJ,0000-0000-0000-0000
 Anuran Makur,Purdue University,https://www.cs.purdue.edu/homes/amakur,NOSCHOLARPAGE,0000-0000-0000-0000
+Anusha Hegde,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/anusha-hegde/_jcr_content.html,-togicsAAAAJ,0000-0002-2862-4187
 Anusha I. Withana,University of Sydney,https://sydney.edu.au/engineering/people/anusha.withana,y17ckyIAAAAJ,0000-0001-6587-1278
 Anusha Indrajith Withana,University of Sydney,https://sydney.edu.au/engineering/people/anusha.withana,y17ckyIAAAAJ,0000-0000-0000-0000
 Anwar Ghammam,University of Michigan-Dearborn,https://anwarghammam.github.io,J4NPGMkAAAAJ,0000-0000-0000-0000
@@ -2292,6 +2303,7 @@ Aravind Srinivasan,Univ. of Maryland - College Park,https://www.cs.umd.edu/~srin
 Aravindan Vijayaraghavan,Northwestern University,http://www.eecs.northwestern.edu/~aravindv,tokXOxkAAAAJ,0000-0001-9734-3779
 Arcangelo Castiglione,University of Salerno,https://docenti.unisa.it/026260/home,Uh1YyVYAAAAJ,0000-0002-7991-2410
 Archan Misra,Singapore Management University,https://www.smu.edu.sg/faculty/profile/9632/Archan-MISRA,a0YC5VAAAAAJ,0000-0003-1212-1769
+Archana Praveen Kumar,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/archana-praveen-kumar/_jcr_content.html,zrTypBIAAAAJ,0000-0002-7671-6633
 Archit Somani,Shiv Nadar University,https://www.snu.edu.in/schools/school-of-engineering/faculty/archit-somani,NkEQdrYAAAAJ,0000-0000-0000-0000
 Archontis Politis,Tampere University,https://www.tuni.fi/en/archontis-politis,DuCqB3sAAAAJ,0000-0002-0595-2356
 Arcot Sowmya,UNSW,http://www.cse.unsw.edu.au/~sowmya,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -2413,6 +2425,7 @@ Aron Laszka,Pennsylvania State University,https://aronlaszka.com,ckHkkjgAAAAJ,00
 Aroor Dinesh Dileep,IIT Mandi,http://faculty.iitmandi.ac.in/~addileep,NOSCHOLARPAGE,0000-0000-0000-0000
 Arosha K. Bandara,Open University UK,http://stem.open.ac.uk/people/akb235,eYWisq0AAAAJ,0000-0001-8974-0555
 Arpan Gujarati,University of British Columbia,https://arpangujarati.github.io,0ZLNSwQAAAAJ,0000-0000-0000-0000
+Arpan Mandal,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr--arpan-mandal---department-of-computer-science---engg---mit--/_jcr_content.html,3Bpdm_QAAAAJ,0000-0001-8376-429X
 Arpan Mukhopadhyay,University of Warwick,https://warwick.ac.uk/fac/sci/dcs/people/arpan_mukhopadhyay,bmPxFagAAAAJ,0000-0002-0634-1389
 Arpit Agarwal,IIT Bombay,https://agarpit.github.io,bjrtXOcAAAAJ,0000-0000-0000-0000
 Arpit Gupta,Univ. of California - Santa Barbara,https://sites.cs.ucsb.edu/~arpitgupta,lc3R9-wAAAAJ,0000-0002-6378-7440
@@ -2445,6 +2458,7 @@ Arturo Azcorra,IMDEA Networks Institute,https://networks.imdea.org/team/imdea-ne
 Arturo Azcorra Saloña,IMDEA Networks Institute,https://networks.imdea.org/team/imdea-networks-team/people/arturo-azcorra,pui4ym6mQiwC,0000-0000-0000-0000
 Arturo Caronongan,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742735361&command=GETPROFILE,XfZmeCYAAAAJ,0000-0000-0000-0000
 Arturo P. Caronongan III,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742735361&command=GETPROFILE,XfZmeCYAAAAJ,0000-0000-0000-0000
+Arul Elango,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr--g--arul-elango--school-of-computer-engineering---mit--manipa/_jcr_content.html,qnXhFxgAAAAJ,0000-0002-7517-8757
 Arun Abraham Ross,Michigan State University,http://www.cse.msu.edu/~rossarun,7IiUQDkAAAAJ,0000-0000-0000-0000
 Arun Balaji Buduru,IIIT Delhi,http://www.iiitd.ac.in/arunb,sSZczN4AAAAJ,0000-0000-0000-0000
 Arun Chauhan 0002,BITS Pilani,http://www.bits-pilani.ac.in/pilani/arunchauhan/profile,noo17fcAAAAJ,0000-0000-0000-0000
@@ -2494,6 +2508,7 @@ Asaf Cidon,Columbia University,https://www.asafcidon.com,yKzSdygAAAAJ,0009-0007-
 Asaf Levin,Technion,https://web.iem.technion.ac.il/en/people/userprofile/levinas.html,cRDZAZoAAAAJ,0000-0001-7935-6218
 Asaf Shabtai,Ben-Gurion University of the Negev,http://www.ise.bgu.ac.il/engineering/PersonalWebSite1main.aspx?id=VrjseMur,k-J7GfgAAAAJ,0000-0003-0630-4059
 Asanobu Kitamoto,National Inst. of Informatics,http://agora.ex.nii.ac.jp/~kitamoto,TZG-qp0AAAAJ,0000-0002-1517-7795
+Ashalatha Nayak,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/ashalatha-nayak/_jcr_content.html,QTphu14AAAAJ,0000-0001-7888-6516
 Ashery Mbilinyi,University of Victoria,https://www.uvic.ca/ecs/computerscience/people/faculty/profiles/mbilinyi-ashery.php,w8xN7z8AAAAJ,0009-0009-1372-9072
 Ashikur Rahman,BUET,http://ashikur.buet.ac.bd,obaBwx4AAAAJ,0000-0000-0000-0000
 Ashique Rupam Mahmood,University of Alberta,https://armahmood.github.io,YwB8XM4AAAAJ,0000-0000-0000-0000
@@ -2646,6 +2661,7 @@ Avi Silberschatz,Yale University,http://www.cs.yale.edu/~avi,-YvgZDEAAAAJ,0000-0
 Aviad Rubinstein,Stanford University,https://cs.stanford.edu/~aviad,ZTsHfNAAAAAJ,0000-0002-6900-8612
 Aviezri S. Fraenkel,Weizmann Institute of Science,https://www.weizmann.ac.il/pages/search/people?language=english&single=1&person_id=3774,NOSCHOLARPAGE,0000-0000-0000-0000
 Avigdor Gal,Technion,https://agp.iem.technion.ac.il/avigal,APs1p2oAAAAJ,0000-0002-7028-661X
+Avik Bose,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/AvikBose/_jcr_content.html,uPCk3gUAAAAJ,0000-0002-4592-4632
 Avinash Gautam,BITS Pilani,http://universe.bits-pilani.ac.in/pilani/avinash/profile,V6-4CfQAAAAJ,0000-0000-0000-0000
 Avinash Karanth,Ohio University,http://oucsace.cs.ohiou.edu/~avinashk,NOSCHOLARPAGE,0000-0002-9472-4637
 Avinash Karanth Kodi,Ohio University,http://oucsace.cs.ohiou.edu/~avinashk,NOSCHOLARPAGE,0000-0000-0000-0000

--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -1,12 +1,16 @@
 name,affiliation,homepage,scholarid,orcid
 B. Aditya Prakash,Georgia Institute of Technology,http://www.cc.gatech.edu/~badityap,C-NftTgAAAAJ,0000-0002-3252-455X
+B. Ashutosh Holla,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/ashutosh-holla-b-/_jcr_content.html,0S83U1sAAAAJ,0009-0009-7995-4213
+B. Ashwath Rao,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/ashwath-rao/_jcr_content.html,bJA8hZQAAAAJ,0000-0001-8528-1646
 B. B. Amberker,National Inst. of Tech. Warangal,https://wsdc.nitw.ac.in/facultynew/facultyprofile/id/16334,Nf686AUAAAAJ,0000-0000-0000-0000
 B. Berk Üstündag,Istanbul Technical University,http://akademi.itu.edu.tr/bustundag,JJY3eIEAAAAJ,0000-0000-0000-0000
 B. Chandrasekaran 0002,VU Amsterdam,https://balakrishnanc.github.io,wDjUEMMAAAAJ,0000-0000-0000-0000
 B. David Saunders,University of Delaware,https://www.eecis.udel.edu/~saunders,U-0PM_cAAAAJ,0000-0000-0000-0000
 B. G. Kim,University of Massachusetts Lowell,http://www.cs.uml.edu/~kim,ujXxdMIAAAAJ,0000-0000-0000-0000
 B. John Oommen,Carleton University,http://www.scs.carleton.ca/~oommen,E5TiDR4AAAAJ,0000-0002-5105-1575
+B. P. Swathi,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/swathi-b-p/_jcr_content.html,o17gPAgAAAAJ,0000-0002-6708-6385
 B. Prabhakaran 0001,University of Texas at Dallas,http://www.utdallas.edu/~praba,4yki88YAAAAJ,0000-0000-0000-0000
+B. Priya Kamath,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/priya-kamath-b/_jcr_content.html,NOSCHOLARPAGE,0000-0002-5471-8822
 B. R. Badrinath,Rutgers University,http://www.cs.rutgers.edu/~badri,ZuCDNqwAAAAJ,0000-0000-0000-0000
 B. S. Manjunath,Univ. of California - Santa Barbara,https://vision.ece.ucsb.edu/people/bs-manjunath,wRYM4qgAAAAJ,0000-0000-0000-0000
 B. Srivathsan,CMI,http://www.cmi.ac.in/~sri,2SMNivQAAAAJ,0000-0003-2666-0691
@@ -185,6 +189,7 @@ Bastian Rieck,University of Fribourg,https://bastian.rieck.me,La7zuKQAAAAJ,0000-
 Bastin Tony Roy Savarimuthu,University of Otago,https://www.otago.ac.nz/school-of-computing/our-people/tony-savarimuthu,0__bwK0AAAAJ,0000-0003-3213-6319
 Battista Biggio,University of Cagliari,https://battistabiggio.github.io,OoUIOYwAAAAJ,0000-0001-7752-509X
 Bayu Anggorojati,Monash University Indonesia,https://www.monash.edu/indonesia/about/academic-staff/bayu-anggorojati,c_9_R7wAAAAJ,0000-0003-4580-1162
+Bayyapu Neelima,Manipal Academy of Higher Education,https://bayyapu.github.io,_TPjGvcAAAAJ,0000-0002-7201-2217
 Beat D. Brüderlin,TU Ilmenau,https://www.tu-ilmenau.de/gdv/mitarbeiter/prof-beat-bruederlin,NOSCHOLARPAGE,0000-0000-0000-0000
 Beata Konikowska,IPI PAN,https://ipipan.waw.pl/instytut/pracownicy/beata-konikowska,EIJSiIIAAAAJ,0000-0001-8188-8344
 Beata Stahre,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/beata-wastberg.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -478,6 +483,7 @@ Bhiksha Ramakrishnan,Carnegie Mellon University,https://www.cs.cmu.edu/directory
 Bhojan Anand,National University of Singapore,http://www.comp.nus.edu.sg/~bhojan,FDxsgEgAAAAJ,0000-0001-8105-1739
 Bhubaneswar Mishra,New York University,https://cs.nyu.edu/mishra,kXVBr20AAAAJ,0000-0000-0000-0000
 Bhujanga Chakrabarti,Victoria University of Wellington,http://sms.victoria.ac.nz/Main/BhujangaChakrabarti,3VT_IZEAAAAJ,0000-0000-0000-0000
+Bhukya Padma,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr--bhukya-padma---department-of-computer-science---engg---mit--/_jcr_content.html,2xFVxNsAAAAJ,0000-0002-5490-035X
 Bhuvan Urgaonkar,Pennsylvania State University,http://www.cse.psu.edu/~buu1,ZoI6hPwAAAAJ,0000-0003-3495-6345
 Bhuvana Krishnaswamy,University of Wisconsin - Madison,https://uwconnect.ece.wisc.edu,1Hn1s1sAAAAJ,0009-0005-6057-8159
 Bhuwan Dhingra,Duke University,http://www.cs.cmu.edu/~bdhingra,SLISZFAAAAAJ,0000-0002-6874-9515

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -1,5 +1,6 @@
 name,affiliation,homepage,scholarid,orcid
 C. Aiswarya,CMI,http://www.cmi.ac.in/~aiswarya,NLwqvCwAAAAJ,0000-0002-4878-7581
+C. B. Chandrakala,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/chandrakala-cb/_jcr_content.html,n4Gi7qkAAAAJ,0000-0003-3818-0679
 C. Barry Jay,University of Technology Sydney,https://www.uts.edu.au/staff/barry.jay,Ml9nDYQAAAAJ,0000-0000-0000-0000
 C. Carvalho de Souza,UNICAMP,http://www.ic.unicamp.br/~cid,t_w8cAkAAAAJ,0000-0000-0000-0000
 C. Chandra Sekhar,IIT Madras,https://www.iitm.ac.in/info/fac/cchandra,rO5ZgW4AAAAJ,0000-0000-0000-0000
@@ -630,6 +631,7 @@ Chester Rebeiro,IIT Madras,http://www.cse.iitm.ac.in/~chester,ctxSQrwAAAAJ,0000-
 Chetan Arora 0001,IIT Delhi,https://www.cse.iitd.ac.in/~chetan,Q8cTLNMAAAAJ,0000-0000-0000-0000
 Chetan Arora 0002,Monash University,https://research.monash.edu/en/persons/chetan-arora,YQVqgWwAAAAJ,0000-0003-1466-7386
 Chetan D. Parikh,IIIT Bangalore,http://www.iiitb.ac.in/faculty_page.php?name=ChetanParikh,S1edNtAAAAAJ,0000-0000-0000-0000
+Chetana Pujari,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/chetana-pujari/_jcr_content.html,45yWeBUAAAAJ,0000-0001-6717-5567
 Chethan Kamath,IIT Bombay,https://www.cse.iitb.ac.in/~ckamath,NOSCHOLARPAGE,0009-0006-6812-7317
 Chi Jin 0001,Princeton University,https://sites.google.com/view/cjin/home,GINhGvwAAAAJ,0000-0002-2865-5610
 Chi-Keung Tang,HKUST,http://www.cse.ust.hk/~cktang,EWfpM74AAAAJ,0000-0001-6495-3685

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -1,6 +1,7 @@
 name,affiliation,homepage,scholarid,orcid
 D. C. Douglas Hung,NJIT,http://cs.njit.edu/people/hung.php,NOSCHOLARPAGE,0000-0000-0000-0000
 D. Caleb Rucker,University of Tennessee,https://mabe.utk.edu/people/d-caleb-rucker,swKSAGAAAAAJ,0000-0001-7181-1933
+D. Cenitta,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/d-cenitta/_jcr_content.html,949MilMAAAAJ,0000-0003-3715-6941
 D. Ellis Hershkowitz,Brown University,https://dhershko.github.io,JR_KR7MAAAAJ,0000-0003-0862-3715
 D. F. Wong,Chinese University of Hong Kong,https://www.erg.cuhk.edu.hk/erg/DeanMessage,WPhoQiUAAAAJ,0000-0000-0000-0000
 D. F. Wong 0001,Chinese University of Hong Kong,https://www.erg.cuhk.edu.hk/erg/DeanMessage,WPhoQiUAAAAJ,0000-0001-8274-9688
@@ -13,6 +14,7 @@ D. M. H. Walker,Texas A&M University,http://faculty.cse.tamu.edu/walker,NOSCHOLA
 D. Manivannan 0001,University of Kentucky,https://www.cs.uky.edu/~manivann,NOSCHOLARPAGE,0000-0001-9895-3085
 D. Martin Swany,Indiana University,https://www.soic.indiana.edu/all-people/profile.html?profile_id=307,NOSCHOLARPAGE,0000-0001-8028-1161
 D. Medhi,Univ. of Missouri - Kansas City,http://sce2.umkc.edu/csee/dmedhi,17e2M2AAAAAJ,0000-0000-0000-0000
+D. N. Sindhura,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/sindhura-d-n/_jcr_content.html,Ydg4EroAAAAJ,0000-0001-9358-9165
 D. Scott McCrickard,Virginia Tech,http://people.cs.vt.edu/~mccricks,jQNt6RwAAAAJ,0000-0001-9839-7146
 D. T. Huynh,University of Texas at Dallas,http://www.utdallas.edu/~huynh,LLcgKtUAAAAJ,0000-0000-0000-0000
 D. Turgay Altilar,Istanbul Technical University,http://web.itu.edu.tr/altilar,wknEy5IAAAAJ,0000-0000-0000-0000
@@ -505,6 +507,7 @@ Daryl H. Hepting,University of Regina,http://www.cs.uregina.ca/People/Profiles/D
 Daryl Johnson,Rochester Inst. of Technology,https://www.rit.edu/gccis/daryl-johnson,RFV02_UAAAAJ,0000-0002-1505-703X
 Darío Correal,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/dcorreal/es/inicio,Bo4lXDAtq9QC,0000-0000-0000-0000
 Darío Ernesto Correal Torres,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/dcorreal/es/inicio,Bo4lXDAtq9QC,0000-0000-0000-0000
+Dasharathraj K. Shetty,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dasharathraj-k-shetty/_jcr_content.html,Qxk16b4AAAAJ,0000-0002-5021-4029
 Dave (Jing) Tian,Purdue University,https://davejingtian.org,xtclQ8AAAAAJ,0000-0002-7506-9593
 Dave Andersen,Carnegie Mellon University,https://www.cs.cmu.edu/~dga,wUArfPgAAAAJ,0000-0000-0000-0000
 Dave Bull 0001,University of Bristol,https://david-bull.github.io,WraDXlkAAAAJ,0000-0000-0000-0000
@@ -941,6 +944,7 @@ Deepak Mishra 0001,IIT Jodhpur,https://sites.google.com/iitj.ac.in/dmishra,-rOCu
 Deepak N. Subramani,IISc Bangalore,https://cds.iisc.ac.in/faculty/deepakns,d-V0TTwAAAAJ,0000-0000-0000-0000
 Deepak P 0001,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=d.padmanabhan,YC60F-YAAAAJ,0000-0002-1336-2356
 Deepak Padmanabhan 0001,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=d.padmanabhan,YC60F-YAAAAJ,0000-0002-1336-2356
+Deepak Parashar,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr--deepak-parashar----department-of-computer-science---engg---m/_jcr_content.html,1GgE92cAAAAJ,0000-0002-4189-4560
 Deepak Pathak,Carnegie Mellon University,https://people.eecs.berkeley.edu/~pathak,AEsPCAUAAAAJ,0000-0003-2496-0690
 Deepak Puthal,UAEU,https://deepakputhal.github.io,-USAlD8AAAAJ,0000-0000-0000-0000
 Deepak Rajendraprasad,IIT Palakkad,https://www.iitpkd.ac.in/people/deepak,2tTBXwoAAAAJ,0000-0001-9101-8967
@@ -1142,6 +1146,7 @@ Diana Freed,Brown University,https://dfreed.me,H92ND5sAAAAJ,0000-0001-5262-4147
 Diana Inkpen,University of Ottawa,http://www.site.uottawa.ca/~diana,66pwIBcAAAAJ,0000-0002-0202-2444
 Diana Keen,University of Chicago,http://people.cs.uchicago.edu/~dmfranklin,gG5PRvgAAAAJ,0000-0000-0000-0000
 Diana Marculescu,University of Texas at Austin,https://www.ece.utexas.edu/people/faculty/diana-marculescu,MRHzTAIAAAAJ,0000-0002-5734-4221
+Diana Olivia,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/diana-olivia/_jcr_content.html,r8qIdp4AAAAJ,0000-0003-2934-2090
 Diana S. Bental,Heriot-Watt University,https://researchportal.hw.ac.uk/en/persons/diana-bental,NOSCHOLARPAGE,0000-0000-0000-0000
 Diana Suleimenova,Brunel University London,https://www.brunel.ac.uk/people/diana-suleimenova1,6RXWkscAAAAJ,0000-0003-4474-0943
 Diana Wilson,Trinity College Dublin,https://www.tcd.ie/research/profiles/?profile=diwilson,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -1291,6 +1296,7 @@ Dina Duhovny,Hebrew University of Jerusalem,http://www.huji.ac.il/dataj/controll
 Dina Katabi,Massachusetts Inst. of Technology,http://people.csail.mit.edu/dina,nst5fHgAAAAJ,0000-0000-0000-0000
 Dina Schneidman-Duhovny,Hebrew University of Jerusalem,http://www.huji.ac.il/dataj/controller/ihoker/MOP-STAFF_LINK?sno=70741876&Save_t=,NOSCHOLARPAGE,0000-0000-0000-0000
 Dina Sokol,CUNY,http://www.sci.brooklyn.cuny.edu/~sokol,-2ePFEwAAAAJ,0000-0003-2478-2636
+Dinesh Acharya U.,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dinesh-acharya-u/_jcr_content.html,ekWnLPQAAAAJ,0000-0002-0304-4725
 Dinesh Babu J.,IIIT Bangalore,http://www.iiitb.ac.in/faculty_page.php?name=DineshBabuJayagopi,tVEF11EAAAAJ,0000-0000-0000-0000
 Dinesh Babu Jayagopi,IIIT Bangalore,http://www.iiitb.ac.in/faculty_page.php?name=DineshBabuJayagopi,tVEF11EAAAAJ,0000-0000-0000-0000
 Dinesh Bharadia,Univ. of California - San Diego,https://web.eng.ucsd.edu/~dineshb,5SjaXJsAAAAJ,0000-0002-3518-4722
@@ -1370,6 +1376,7 @@ Divesh Aggarwal,National University of Singapore,https://sites.google.com/site/d
 Divy Agrawal,Univ. of California - Santa Barbara,https://www.cs.ucsb.edu/~agrawal,XcaEg-cAAAAJ,0000-0002-0215-9539
 Divya Padmanabhan,IIT Goa,https://www.iitgoa.ac.in/faculty_page.php?id=130,1sqb7gwAAAAJ,0000-0000-0000-0000
 Divya Ramesh,UNC - Charlotte,https://cci.charlotte.edu/people/divya-ramesh,WQ8nlAQAAAAJ,0000-0002-9989-5435
+Divya Rao,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/divya-rao/_jcr_content.html,c2vLQ10AAAAJ,0000-0001-8370-4959
 Divya Ravi,University of Amsterdam,https://cci-research.nl/author/divya-ravi,lSanMWUAAAAJ,0000-0000-0000-0000
 Divyakant Agrawal,Univ. of California - Santa Barbara,https://www.cs.ucsb.edu/~agrawal,XcaEg-cAAAAJ,0000-0002-0215-9539
 Dixin Tang,University of Texas at Austin,https://dx-tang.github.io,yrIA9oUAAAAJ,0000-0002-3316-6651

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -5,6 +5,7 @@ G. Elisabeta Marai,University of Illinois at Chicago,https://www.evl.uic.edu/mar
 G. Katsaros,IST Austria,https://ist.ac.at/research/research-groups/katsaros-group,NOSCHOLARPAGE,0000-0000-0000-0000
 G. N. Srinivasa Prasanna,IIIT Bangalore,http://www.iiitb.ac.in/faculty_page.php?name=GNSrinivasaPrasanna,NOSCHOLARPAGE,0000-0000-0000-0000
 G. P. S. Raghava,IIIT Delhi,http://webs.iiitd.edu.in/raghava,XK5GUiYAAAAJ,0000-0002-8902-2876
+G. Poornalatha,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/poornalatha-g/_jcr_content.html,znl8ITYAAAAJ,0000-0001-9620-5526
 G. Ramakrishna,IIT Tirupati,https://iittp.ac.in/dr-g-ramakrishna,NOSCHOLARPAGE,0000-0002-7554-0349
 G. Sivakumar,IIT Bombay,https://www.cse.iitb.ac.in/~siva,gqHcbCkAAAAJ,0000-0000-0000-0000
 G. Srinivasa Raghavan 0001,IIIT Bangalore,http://www.iiitb.ac.in/faculty_page.php?name=GSrinivasaraghavan,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -590,7 +591,9 @@ Giovanni Simonini,Univ. of Modena and Reggio Emilia,https://personale.unimore.it
 Giovanni V. Comarela,Universidade Federal de Viçosa,http://www.dpi.ufv.br/~gcom,onfmt40AAAAJ,0000-0000-0000-0000
 Giovanni Vigna,Univ. of California - Santa Barbara,https://www.cs.ucsb.edu/~vigna,2eM6GocAAAAJ,0000-0002-3422-5369
 Giri Narasimhan,Florida International University,http://www.cs.fiu.edu/~giri,Q9PwPo8AAAAJ,0000-0003-0535-4871
+Giridhar N. Shakarad,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/giridhar-n-shakarad/_jcr_content.html,NOSCHOLARPAGE,0000-0003-4870-2039
 Girija Limaye,BITS Pilani-Goa,https://sites.google.com/view/girijalimaye,UNrK3hEAAAAJ,0009-0000-6241-6720
+Girija V. Attigeri,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/girija-attegeri/_jcr_content.html,pRIA3K8AAAAJ,0000-0002-0899-5781
 Girish Varma,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/girish.varma,YLlRCu4AAAAJ,0000-0000-0000-0000
 Gisele L. Pappa,UFMG,http://homepages.dcc.ufmg.br/~glpappa,C_0ZLuYAAAAJ,0000-0000-0000-0000
 Gisele Lobo Pappa,UFMG,http://homepages.dcc.ufmg.br/~glpappa,C_0ZLuYAAAAJ,0000-0000-0000-0000
@@ -650,6 +653,7 @@ Gobinda G. Chowdhury,University of Strathclyde,https://pureportal.strath.ac.uk/e
 Godmar Back,Virginia Tech,https://people.cs.vt.edu/~gback,WUb-KZ0AAAAJ,0000-0000-0000-0000
 Godmar V. Back,Virginia Tech,https://people.cs.vt.edu/~gback,WUb-KZ0AAAAJ,0000-0000-0000-0000
 Goetz Botterweck,Trinity College Dublin,https://www.scss.tcd.ie/personnel/botterwg,xsIAZAkAAAAJ,0000-0002-5556-1660
+Gogulamudi Pradeep Reddy,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/PradeepReddy/_jcr_content.html,Zc9aCrIAAAAJ,0000-0002-5624-5547
 Gokarna Sharma,Kent State University,http://www.cs.kent.edu/~sharma,PnmtA3wAAAAJ,0000-0002-4930-4609
 Gokhan Bilgin,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/gokhanb?lang=en,xOtyJygAAAAJ,0000-0002-5532-477X
 Gokila Dorai,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=GDORAI,VME6RWsAAAAJ,0000-0001-5825-7034
@@ -695,9 +699,11 @@ Gottfried Vossen,University of Münster,https://www.wi.uni-muenster.de/departmen
 Gouhei Tanaka,University of Tokyo,http://www.sat.t.u-tokyo.ac.jp/~gouhei,NOSCHOLARPAGE,0000-0002-6223-4406
 Gourab Ghoshal,University of Rochester,http://gghoshal.pas.rochester.edu,_CNYi6MAAAAJ,0000-0001-7593-5626
 Gourab Sen Gupta,Massey University,http://seat.massey.ac.nz/g.sengupta,NOSCHOLARPAGE,0000-0000-0000-0000
+Gouranga Mandal,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr--gouranga-mandal---department-of-computer-science---engg---mi0/_jcr_content.html,aT8601cAAAAJ,0000-0002-7749-290X
 Gouri Ginde,University of Calgary,https://shaktilab.org,pf18racAAAAJ,0000-0001-7519-3503
 Gourinath Banda,IIT Indore,http://cse.iiti.ac.in/faculty.html,k5nOs00AAAAJ,0000-0000-0000-0000
 Goutam Paul 0001,ISI Kolkata,https://www.isical.ac.in/~goutam.paul,PbIhVccAAAAJ,0000-0000-0000-0000
+Govardhan Hegde,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/govardhan-hegde-k/_jcr_content.html,-DoUpLYAAAAJ,0000-0002-8741-8965
 Govindarajulu Regeti,IIIT Hyderabad,https://iiit.ac.in/people/faculty/gregeti,TvcR9REAAAAJ,0000-0000-0000-0000
 Gowtham Atluri,University of Cincinnati,http://homepages.uc.edu/~atlurigm,tpfik0wAAAAJ,0000-0001-5619-6688
 Gowtham Kaki,University of Colorado Boulder,https://gowthamk.github.io,d3JzmN4AAAAJ,0000-0002-4189-3189

--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -2,6 +2,7 @@ name,affiliation,homepage,scholarid,orcid
 H. Altay Güvenir,Bilkent University,http://www.cs.bilkent.edu.tr/~guvenir,zRvIRVUAAAAJ,0000-0000-0000-0000
 H. Andrew Schwartz,Vanderbilt University,https://haschwartz.com,Na16PsUAAAAJ,0000-0000-0000-0000
 H. Andrés Neyem,UC Chile,http://www.andresneyem.cl,xPEdf1wAAAAJ,0000-0000-0000-0000
+H. Anitha,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/anitha-h/_jcr_content.html,8f9mZtQAAAAJ,0000-0001-5898-4442
 H. Birkan Yilmaz 0001,Boğaziçi University,https://sites.google.com/site/birkanyilmazacademic,Eg_wBXUAAAAJ,0000-0000-0000-0000
 H. Dieter Rombach,TU Kaiserslautern,http://wwwagse.informatik.uni-kl.de/staff/rombach,OpsrHLAAAAAJ,0000-0000-0000-0000
 H. F. Ting,University of Hong Kong,https://i.cs.hku.hk/~hfting,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -416,6 +417,7 @@ Harish Chaandar Ravichandar,Georgia Institute of Technology,https://www.cc.gatec
 Harish G. Ramaswamy,IIT Madras,https://sites.google.com/site/harishguruprasad,NOSCHOLARPAGE,0000-0000-0000-0000
 Harish Guruprasad Ramaswamy,IIT Madras,https://sites.google.com/site/harishguruprasad,NOSCHOLARPAGE,0000-0000-0000-0000
 Harish Ravichandar,Georgia Institute of Technology,https://www.cc.gatech.edu/people/harish-ravichandar,d2HP6SMAAAAJ,0000-0002-6635-2637
+Harish Sheeranalli Venkatarama,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/harish-sv/_jcr_content.html,zIGEeWMAAAAJ,0000-0002-7264-7538
 Harjinder Rahanu,Middlesex University,https://www.mdx.ac.uk/about-us/our-people/staff-directory/profile/rahanu-harjinder,NOSCHOLARPAGE,0000-0000-0000-0000
 Harkeerat Kaur,IIT Jammu,https://www.iitjammu.ac.in/computer_science_engineering/faculty-list/~harkeeratkaur,Mt1kwb0AAAAJ,0000-0000-0000-0000
 Harley D. Eades III,Augusta University,https://metatheorem.org,Nbb0YZEAAAAJ,0000-0000-0000-0000
@@ -443,6 +445,7 @@ Harry S. Delugach,University of Alabama - Huntsville,https://www.uah.edu/science
 Harry Shomer,University of Texas at Arlington,https://www.uta.edu/academics/faculty/profile?user=harry.shomer,_6eE2vsAAAAJ,0000-0001-5081-1870
 Harry Xu 0001,Univ. of California - Los Angeles,http://www.cs.ucla.edu/~harryxu,DS6rCasAAAAJ,0000-0003-4737-2146
 Harsh Beohar,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/harsh-beohar,b1C8fogAAAAJ,0000-0000-0000-0000
+Harsh Nagar,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/harsh-nagar---department-of-computer-science---engg---mit--manip/_jcr_content.html,4gTqs8kAAAAJ,0009-0005-9167-7168
 Harsha Chenji,Ohio University,http://ace.eecs.ohiou.edu/~chenji,DdiZCHoAAAAJ,0000-0003-3272-7020
 Harsha V. Madhyastha,University of Southern California,https://www.harsha.usc.edu,kxDm9EsAAAAJ,0000-0002-7978-9643
 Harshavardhan Chenji,Ohio University,http://ace.eecs.ohiou.edu/~chenji,DdiZCHoAAAAJ,0000-0000-0000-0000

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -6,12 +6,15 @@ K. Gopinath,Plaksha University,https://plaksha.edu.in/faculty-details/dr-k-gopin
 K. Harald Gjermundrød,University of Nicosia,https://www.unic.ac.cy/gjermundrod-harald,sRPAAHcAAAAJ,0000-0000-0000-0000
 K. Hari Babu 0001,BITS Pilani,http://www.bits-pilani.ac.in/pilani/khari/profile,E-yshlwAAAAJ,0000-0000-0000-0000
 K. Haribabu 0001,BITS Pilani,http://www.bits-pilani.ac.in/pilani/khari/profile,E-yshlwAAAAJ,0000-0000-0000-0000
+K. Jyothi Upadhya,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/jyothi-upadhya-k/_jcr_content.html,NOSCHOLARPAGE,0000-0002-4997-7918
 K. K. Ramakrishnan,Univ. of California - Riverside,http://www.cs.ucr.edu/~kk,Da-s1FQAAAAJ,0000-0003-1849-5155
 K. Lakshmanan 0001,IIT (BHU) Varanasi,http://www.iitbhu.ac.in/cse/index.php/people/faculty.html,K2Q4ZxkAAAAJ,0000-0000-0000-0000
 K. M. George,Oklahoma State University,https://www.cs.okstate.edu/~kmg,NOSCHOLARPAGE,0000-0002-7391-2444
 K. Madhava Krishna,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/mkrishna,QDuPGHwAAAAJ,0000-0001-7846-7901
+K. N. Manjunath,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/ManjunathKN/_jcr_content.html,jm2sgbMAAAAJ,0000-0001-8239-4047
 K. Narayan Kumar,CMI,http://www.cmi.ac.in/~kumar,iREqKFwAAAAJ,0000-0003-0504-7302
 K. R. Seeja,IGDTUW,https://www.igdtuw.ac.in/computerScience.php?name=KRSeeja,BL4-9QUAAAAJ,0000-0000-0000-0000
+K. Raghurama Holla,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/raghurama-holla/_jcr_content.html,GtSpk8QAAAAJ,0000-0001-5265-9120
 K. Ramesh 0009,National Inst. of Tech. Warangal,https://wsdc.nitw.ac.in/facultynew/facultyprofile/id/16339,NOSCHOLARPAGE,0000-0002-8531-5401
 K. Rüdiger Reischuk,University of Lübeck,http://www.tcs.uni-luebeck.de/mitarbeiter/reischuk,NOSCHOLARPAGE,0000-0000-0000-0000
 K. S. Rajan,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/rajan,00_zU7QAAAAJ,0000-0000-0000-0000
@@ -142,6 +145,7 @@ Kamal Lodaya,IMSc,http://www.imsc.res.in/%7Ekamal,NOSCHOLARPAGE,0000-0000-0000-0
 Kamal Mansur Jambi,King Abdulaziz University,http://www.kau.edu.sa/CVEn.aspx?Site_ID=0001480&Lng=EN,NOSCHOLARPAGE,0000-0000-0000-0000
 Kamal Sarkar,Jadavpur University,http://jaduniv.edu.in/profile.php?uid=662,2KnBEMEAAAAJ,0000-0002-0689-3976
 Kamalakar Karlapalem,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/kamal,bEZqpLsAAAAJ,0000-0000-0000-0000
+Kamaraj Kanagaraj,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr--kamaraj-k---department-of-computer-science---engg---mit--man/_jcr_content.html,ClvckT4AAAAJ,0000-0002-2761-0138
 Kambiz Ghazinour,Kent State University,https://www.kent.edu/cs/profile/kambiz-ghazinour,S5Dabo0AAAAJ,0000-0002-6816-2968
 Kamer Kaya,Sabancı University,http://people.sabanciuniv.edu/kaya,cFJGW7gAAAAJ,0000-0000-0000-0000
 Kamesh Madduri,Pennsylvania State University,http://www.cse.psu.edu/~kxm85,bYI7VMwAAAAJ,0000-0003-4344-0957
@@ -921,6 +925,7 @@ Koustuv Saha,Univ. of Illinois at Urbana-Champaign,https://koustuv.com,tipePDkAA
 Kouta Minamizawa,Keio University,http://embodiedmedia.org/member/kouta-minamizawa,gxCL2_wAAAAJ,0000-0002-6303-5791
 Kovila P. L. Coopamootoo,King's College London,https://www.kcl.ac.uk/people/kovila-coopamootoo,yg0HAJoAAAAJ,0000-0000-0000-0000
 Koya Narumi,Keio University,https://narumi.me,vCMXaGoAAAAJ,0000-0001-5830-3942
+Kranthi Kumar Lella,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr--lella-kranthi-kumar---school-of-computer-engineering---mit--/_jcr_content.html,5olV0NoAAAAJ,0000-0001-7736-5321
 Krasimir Angelov,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/krasimir-angelov.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Krikamol Muandet,CISPA Helmholtz Center,http://www.krikamol.org,E2z5uYsAAAAJ,0000-0002-4182-5282
 Kris Bubendorfer,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/KrisBubendorfer,PufVt-8AAAAJ,0000-0003-4315-8337
@@ -942,13 +947,16 @@ Krishna Narayanan 0001,Texas A&M University,http://krishnanarayanan.wikidot.com,
 Krishna P. Gummadi [SWS],Max Planck Society,https://www.mpi-sws.org/~gummadi,Bz3APTsAAAAJ,0000-0000-0000-0000
 Krishna P. Miyapuram,IIT Gandhinagar,http://cogs.iitgn.ac.in/people/faculty/krishna-miyapuram,R20YmxkAAAAJ,0000-0000-0000-0000
 Krishna Pillutla,IIT Madras,https://krishnap25.github.io,xUUEAG4AAAAJ,0000-0000-0000-0000
+Krishna Prakasha,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/krishna-prakasha-a/_jcr_content.html,OGL1JBQAAAAJ,0000-0001-7797-1399
 Krishna Prasad Miyapuram,IIT Gandhinagar,http://cogs.iitgn.ac.in/people/faculty/krishna-miyapuram,R20YmxkAAAAJ,0000-0000-0000-0000
 Krishna R. Narayanan,Texas A&M University,http://krishnanarayanan.wikidot.com,oDivxXQAAAAJ,0000-0000-0000-0000
 Krishna Reddy Polepalli,IIIT Hyderabad,http://faculty.iiit.ac.in/~pkreddy,XIgl8kUAAAAJ,0000-0000-0000-0000
 Krishna V. Palem,Rice University,http://www.cs.rice.edu/~kvp1,TW6dnZUAAAAJ,0000-0000-0000-0000
 Krishnaiyan Thulasiraman,University of Oklahoma,http://www.ou.edu/coe/cs/people/thulasi,NOSCHOLARPAGE,0000-0000-0000-0000
+Krishnamoorthi Makkithaya,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/krishnamoorthi-makkithaya/_jcr_content.html,bxvTd6sAAAAJ,0000-0002-7919-8886
 Krishnamoorthy Dinesh 0001,IIT Palakkad,https://kdinesh.bitbucket.io,kgIdFfUAAAAJ,0000-0000-0000-0000
 Krishnamoorthy Sivakumar,Washington State University,http://www.eecs.wsu.edu/~siva,bEic8SsAAAAJ,0000-0000-0000-0000
+Krishnaraj Chadaga,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/mr--krishnaraj-chadaga---department-of-computer-science---engg--/_jcr_content.html,zpNqzEgAAAAJ,0000-0002-9459-8423
 Krishnendu Chakrabarty,Arizona State University,https://search.asu.edu/profile/4669916,R_VPUyEAAAAJ,0000-0003-4475-6435
 Krishnendu Chatterjee,IST Austria,http://pub.ist.ac.at/~kchatterjee,1kaW8bwAAAAJ,0000-0002-4561-241X
 Krishnendu Mukhopadhyaya,ISI Kolkata,https://www.isical.ac.in/~krishnendu,NtcJrBwAAAAJ,0000-0000-0000-0000

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -20,6 +20,7 @@ M. Fatih Demirci,TOBB ETÜ,http://mfdemirci.etu.edu.tr,qShOHtsAAAAJ,0000-0000-00
 M. Frans Kaashoek,Massachusetts Inst. of Technology,https://pdos.csail.mit.edu/archive/kaashoek,NOSCHOLARPAGE,0000-0001-7098-586X
 M. Furkan Kiraç,Özyeğin University,http://www.fkirac.net,kdJBxv8AAAAJ,0000-0000-0000-0000
 M. G. J. van den Brand,TU Eindhoven,http://www.win.tue.nl/~mvdbrand,CZt-AsoAAAAJ,0000-0000-0000-0000
+M. Geetha 0002,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/geetha-m/_jcr_content.html,GQDzmRsAAAAJ,0000-0002-6150-7601
 M. Gopi,Univ. of California - Irvine,http://www.ics.uci.edu/~gopi,DI8bU-0AAAAJ,0000-0000-0000-0000
 M. Gopi 0001,Univ. of California - Irvine,http://www.ics.uci.edu/~gopi,DI8bU-0AAAAJ,0000-0003-2326-8029
 M. H. Samadzadeh,Oklahoma State University,http://cs.okstate.edu/faculty.html,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -29,13 +30,16 @@ M. Kaykobad,BUET,http://kaykobad.buet.ac.bd,3rYfNBIAAAAJ,0000-0000-0000-0000
 M. Kemal Sönmez,OHSU,http://www.ohsu.edu/xd/education/schools/school-of-medicine/departments/basic-science-departments/csee/csee-people/sonmez.cfm,NOSCHOLARPAGE,0000-0000-0000-0000
 M. L. Chaudhry,Royal Military College of Canada,https://www.rmc-cmr.ca/en/mathematics-and-computer-science/dr-mohan-chaudhry,NOSCHOLARPAGE,0000-0000-0000-0000
 M. L. Chaudhry 0001,Royal Military College of Canada,https://www.rmc-cmr.ca/en/mathematics-and-computer-science/dr-mohan-chaudhry,NOSCHOLARPAGE,0000-0000-0000-0000
+M. M. Manohara Pai,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/manohara-mm-pai/_jcr_content.html,Zr3-m3IAAAAJ,0000-0003-2164-2945
 M. Masadeh Bani Yassein,JUST,http://www.just.edu.jo/eportfolio/Pages/Default.aspx?email=masadeh,E8muBrkAAAAJ,0000-0000-0000-0000
 M. Mondal Ananda,Florida International University,https://www.cis.fiu.edu/faculty-staff/mondal-ananda,NOSCHOLARPAGE,0000-0000-0000-0000
 M. Mustafa Rafique,Rochester Inst. of Technology,https://cs.rit.edu/~mrafique,utSvhGEAAAAJ,0000-0002-5034-2880
 M. Narasimha Murty,IISc Bangalore,http://www.csa.iisc.ac.in/~mnm,VQZTmpcAAAAJ,0000-0000-0000-0000
 M. Osama Alhalabi,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/osama_halabi.php,jYUTRTcAAAAJ,0000-0002-2052-0500
 M. Praveen,CMI,http://www.cmi.ac.in/~praveenm,xDgt2Z8AAAAJ,0000-0000-0000-0000
+M. Ramakrishna 0002,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/ramakrishna-m/_jcr_content.html,Bn_4MosAAAAJ,0000-0001-8270-8675
 M. Ravinder,IGDTUW,https://www.igdtuw.ac.in/computerScience.php?name=ravinderm,H8QKaLoAAAAJ,0000-0000-0000-0000
+M. Raviraja Holla,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/RavirajaHollaM/_jcr_content.html,cU18X00AAAAJ,0000-0003-1627-552X
 M. Reha Civanlar,Özyeğin University,https://cs.ozyegin.edu.tr/en/rehacivanlar,6yMIP8AAAAAJ,0000-0000-0000-0000
 M. Remzi Sanver,Université Paris Dauphine,https://sanver.bilgi.edu.tr,gY8NSNoAAAAJ,0000-0000-0000-0000
 M. S. Ramanujan 0001,University of Warwick,https://warwick.ac.uk/fac/sci/dcs/people/ramanujan_sridharan,XMuyXpEAAAAJ,0000-0002-2116-6048
@@ -232,6 +236,7 @@ Malte Schwarzkopf,Brown University,http://www.malteschwarzkopf.de,Lf1hSacAAAAJ,0
 Malu Zhang,UESTC,https://www.scse.uestc.edu.cn/info/1081/12350.htm,NOSCHOLARPAGE,0000-0002-2345-0974
 Malvin Gattinger,University of Amsterdam,https://malv.in,6_WdCF4AAAAJ,0000-0000-0000-0000
 Malvina Nissim,University of Groningen,https://malvinanissim.github.io,hnTpEOAAAAAJ,0000-0000-0000-0000
+Mamatha Balachandra,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/mamatha-balachandra/_jcr_content.html,mct_H0kAAAAJ,0000-0003-2201-8730
 Mamoun A. Awad,UAEU,https://faculty.uaeu.ac.ae/mamoun_awad,XqhZPf0AAAAJ,0000-0000-0000-0000
 Mamtaj Akter,New York Tech,https://site.nyit.edu/bio/Mamtaj.Akter,31Pq3u0AAAAJ,0000-0002-5692-9252
 Man Ho Allen Au,The Hong Kong Polytechnic Univ.,https://web.comp.polyu.edu.hk/mhaau,3OC-_bQAAAAJ,0000-0000-0000-0000
@@ -295,7 +300,10 @@ Manish Singh 0002,IIT Hyderabad,https://www.iith.ac.in/~msingh,I1jX5vgAAAAJ,0000
 Manisha Padala,IIT Gandhinagar,https://sites.google.com/view/manishapadala/home,xV1WKDkAAAAJ,0000-0000-0000-0000
 Manja Marz,Friedrich Schiller University Jena,http://www.rna.uni-jena.de,NOSCHOLARPAGE,0000-0003-4783-8823
 Manjubala Bisi,National Inst. of Tech. Warangal,https://wsdc.nitw.ac.in/facultynew/facultyprofile/id/16858,CEiwpuYAAAAJ,0000-0000-0000-0000
+Manjula C. Belavagi,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/manjula-c-belavagi/_jcr_content.html,4b3JVBYAAAAJ,0000-0002-3243-1310
 Manjula Sandirigama,University of Peradeniya,https://people.ce.pdn.ac.lk/staff/academic/manjula-sandirigama,qpmlrL0AAAAJ,0000-0000-0000-0000
+Manjula Shenoy K,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/manjula-shenoy-k/_jcr_content.html,y2OvIiwAAAAJ,0000-0002-7835-1156
+Manjunath Hegde,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/manjunath-hegde/_jcr_content.html,4geA59wAAAAJ,0000-0002-4264-9532
 Manjunath V. Joshi,DAIICT,http://www.daiict.ac.in/daiict/people/faculty.html,iDqnnKkAAAAJ,0000-0000-0000-0000
 Manling Li,Northwestern University,https://limanling.github.io,6U4SXnUAAAAJ,0000-0002-5543-3343
 Manmohan Chandraker,Univ. of California - San Diego,http://cseweb.ucsd.edu/~mkchandraker,oPFCNk4AAAAJ,0000-0003-4683-2454
@@ -310,6 +318,7 @@ Manoj Mishra,NISER,https://www.niser.ac.in/users/manojmishra,NOSCHOLARPAGE,0000-
 Manoj Misra,IIT Roorkee,https://iitr.ac.in/~CSE/Manoj_Mishra,NOSCHOLARPAGE,0000-0000-0000-0000
 Manoj Prabhakaran 0001,IIT Bombay,https://www.cse.iitb.ac.in/~mp,FANRIhwAAAAJ,0000-0000-0000-0000
 Manoj Singh Gaur,IIT Jammu,https://www.iitjammu.ac.in/computer_science_engineering/faculty-list/~manojsinghgaur,NOSCHOLARPAGE,0000-0000-0000-0000
+Manoj T.,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr--manoj-t---department-of-computer-science---engg---mit--manip0/_jcr_content.html,fTlZ070AAAAJ,0000-0002-5472-2418
 Manolis G. H. Katevenis,University of Crete,http://users.ics.forth.gr/~kateveni,E2-GshsAAAAJ,0000-0000-0000-0000
 Manolis Katevenis,University of Crete,http://users.ics.forth.gr/~kateveni,E2-GshsAAAAJ,0009-0008-5437-4709
 Manolis Kellis,Massachusetts Inst. of Technology,http://mit.edu/manoli,lsYXBx8AAAAJ,0000-0001-7113-9630
@@ -1565,6 +1574,7 @@ Maya Ramanath,IIT Delhi,http://www.cse.iitd.ac.in/~ramanath,y6BXzxIAAAAJ,0000-00
 Maya Çakmak,University of Washington,http://www.mayacakmak.com,sPlonWcAAAAJ,0000-0000-0000-0000
 Mayank Goel,Carnegie Mellon University,https://www.hcii.cmu.edu/people/mayank-goel,nxqrff8AAAAJ,0000-0003-1237-7545
 Mayank Goswami 0001,CUNY,https://boole.cs.qc.cuny.edu/mgoswami,NOSCHOLARPAGE,0000-0000-0000-0000
+Mayank Patel 0001,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr--mayankkumar-lalabhai-patel---school-of-computer-engineering-/_jcr_content.html,vGxMDbAAAAAJ,0000-0002-7804-4017
 Mayank Singh 0001,IIT Gandhinagar,https://iitgn.ac.in/faculty/cse/fac-mayank,U2NUj90AAAAJ,0000-0001-8757-2623
 Mayank Varia,Boston University,https://www.bu.edu/cds-faculty/profile/mayank-varia,lneZSfIAAAAJ,0000-0002-7460-3272
 Mayank Vatsa,IIT Jodhpur,http://home.iitj.ac.in/~mvatsa,-DAxp-cAAAAJ,0000-0001-5952-2274
@@ -1572,6 +1582,7 @@ Maycon Leone Maciel Peixoto,Federal University of Bahia,https://computacao.ufba.
 Mayra Donaji Barrera Machuca,University of Calgary,https://profiles.ucalgary.ca/mayra-barrera-machuca,z0eIn9IAAAAJ,0000-0002-8057-7103
 Mays F. Al-Naday,University of Essex,https://www.essex.ac.uk/people/alned81405/mays-al-naday,aOlKyJ0AAAAJ,0000-0000-0000-0000
 Mayumi Bono,National Inst. of Informatics,http://research.nii.ac.jp/~bono/ja,NOSCHOLARPAGE,0000-0001-7910-5187
+Mayur Anand Pandya,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/mr--mayur-pandya---school-of-computer-engineering---mit--manipal/_jcr_content.html,NOSCHOLARPAGE,0000-0001-5044-4521
 Mayur Naik,University of Pennsylvania,http://www.cis.upenn.edu/~mhnaik,fmsV6nEAAAAJ,0000-0003-1348-8618
 Mazen Al Borno,University of Colorado - Denver,https://cse.ucdenver.edu/mazen-alborno,-we9aNIAAAAJ,0000-0002-4460-1719
 Maziar Ghorbani,Brunel University London,https://www.brunel.ac.uk/people/maziar-ghorbani1,vDTAWxIAAAAJ,0000-0000-0000-0000
@@ -2977,6 +2988,7 @@ Murtuza Jadliwala,University of Texas at San Antonio,http://www.cs.utsa.edu/~jad
 Murugesan Venkatapathi,IISc Bangalore,https://cds.iisc.ac.in/faculty/murugesh,NOSCHOLARPAGE,0000-0000-0000-0000
 Mury Thian,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=m.thian,8ny-HR8AAAAJ,0000-0000-0000-0000
 Musard Balliu,KTH Royal Inst. of Technology,http://www.csc.kth.se/~musard,aTUgj08AAAAJ,0000-0001-6005-5992
+Musica Supriya,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/MusicaSupriya/_jcr_content.html,5R8ag2kAAAAJ,0000-0002-4611-229X
 Muslum Ozgur Ozmen,Arizona State University,https://search.asu.edu/profile/5143759,MSBT_V4AAAAJ,0000-0000-0000-0000
 Mustafa A. Mustafa,University of Manchester,https://research.manchester.ac.uk/en/persons/mustafa.mustafa,lP0z5wEAAAAJ,0000-0002-8772-8023
 Mustafa Bilgic 0001,Illinois Institute of Technology,https://science.iit.edu/people/faculty/mustafa-bilgic,bOM9qN8AAAAJ,0000-0001-5123-9992

--- a/csrankings-n.csv
+++ b/csrankings-n.csv
@@ -2,6 +2,8 @@ name,affiliation,homepage,scholarid,orcid
 N. A. Snooke,Aberystwyth University,https://www.aber.ac.uk/en/cs/staff-profiles/listing/profile/nns,NOSCHOLARPAGE,0000-0000-0000-0000
 N. Asokan,University of Waterloo,https://cs.uwaterloo.ca/about/people/n-asokan,0MqQ8AgAAAAJ,0000-0002-5093-9871
 N. Balakrishnan 0001,IISc Bangalore,https://www.serc.iisc.ac.in/faculty/prof-n-balakrishnan,NOSCHOLARPAGE,0000-0000-0000-0000
+N. D. Adesh,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/AdeshND/_jcr_content.html,CMvgY44AAAAJ,0000-0002-9750-113X
+N. Gopalakrishna Kini,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/gopalakrishna-n-kini/_jcr_content.html,8tz0vAQAAAAJ,0000-0002-9293-7460
 N. Hari Narayanan,Auburn University,http://www.eng.auburn.edu/~naraynh,6YytJ4MAAAAJ,0000-0000-0000-0000
 N. M. Mosharaf Kabir Chowdhury,University of Michigan,http://www.mosharaf.com,Dzh5C9EAAAAJ,0000-0000-0000-0000
 N. R. Aravind,IIT Hyderabad,http://www.iith.ac.in/~aravind,5547vIcAAAAJ,0000-0000-0000-0000
@@ -56,6 +58,7 @@ Nafise Sadat Moosavi,University of Sheffield,https://www.sheffield.ac.uk/dcs/peo
 Naftali Tishby,Hebrew University of Jerusalem,http://www.cs.huji.ac.il/~tishby,NOSCHOLARPAGE,0000-0000-0000-0000
 Naftaly H. Minsky,Rutgers University,https://www.cs.rutgers.edu/~minsky,VLgJXtQAAAAJ,0000-0000-0000-0000
 Naftaly Minsky,Rutgers University,https://www.cs.rutgers.edu/~minsky,VLgJXtQAAAAJ,0000-0000-0000-0000
+Nagaraj Naik,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr--nagaraj-naik---department-of-computer-science---engg---mit--/_jcr_content.html,uYcX1bsAAAAJ,0000-0001-7031-9787
 Nagarajan Prabakar,Florida International University,http://www.cis.fiu.edu/~prabakar,UcK0B78AAAAJ,0000-0000-0000-0000
 Naghmeh Karimi,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/people/faculty/naghmeh-karimi,M-Z7bAIAAAAJ,0000-0002-5825-6637
 Nagiza F. Samatova,North Carolina State University,https://www.csc.ncsu.edu/people/nfsamato,vukA8JAAAAAJ,0000-0000-0000-0000
@@ -701,6 +704,7 @@ Nisansala Yatapanage,Australian National University,https://comp.anu.edu.au/peop
 Nisar R. Ahmed,University of Colorado Boulder,https://cohrint.info,HA3R65IAAAAJ,0000-0002-7555-5671
 Nisar Razzi Ahmed,University of Colorado Boulder,https://cohrint.info,HA3R65IAAAAJ,0000-0000-0000-0000
 Nisarg Shah 0001,University of Toronto,http://www.cs.toronto.edu/~nisarg,GCvk26UAAAAJ,0000-0002-0946-3402
+Nisha P. Shetty,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/nisha-p-shetty/_jcr_content.html,o4fHE34AAAAJ,0000-0002-4738-4713
 Nisha Panwar,Augusta University,https://sites.google.com/view/panwar,0dhq-70AAAAJ,0000-0002-7179-5213
 Nishad Kothari,IIT Madras,https://sites.google.com/view/nishadkothari,qnp2XGoAAAAJ,0000-0000-0000-0000
 Nishant A. Mehta,University of Victoria,http://web.uvic.ca/~nmehta,YGeqVQkAAAAJ,0000-0002-9639-0124

--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -1,4 +1,6 @@
 name,affiliation,homepage,scholarid,orcid
+P. B. Shanthi,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/pb-shanthi/_jcr_content.html,WVwqrWwAAAAJ,0000-0003-3276-7073
+P. C. Siddalingaswamy,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/siddhalinga-swamy-p-c/_jcr_content.html,BfnSN3sAAAAJ,0000-0002-7597-7591
 P. David Stotts,University of North Carolina,http://www.cs.unc.edu/~stotts,NOSCHOLARPAGE,0000-0000-0000-0000
 P. Deepak 0001,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=d.padmanabhan,YC60F-YAAAAJ,0000-0000-0000-0000
 P. J. Narayanan,IIIT Hyderabad,https://www.iiit.ac.in/~pjn,3HKjt_IAAAAJ,0000-0002-7164-4917
@@ -10,6 +12,7 @@ P. Krishna Reddy,IIIT Hyderabad,http://faculty.iiit.ac.in/~pkreddy,XIgl8kUAAAAJ,
 P. L. Kilpatrick,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=p.kilpatrick,OlitxFsAAAAJ,0000-0000-0000-0000
 P. Madhusudan,Univ. of Illinois at Urbana-Champaign,http://madhu.cs.illinois.edu,V828uG8AAAAJ,0000-0002-9782-721X
 P. P. Chakrabarti,IIT Kharagpur,http://cse.iitkgp.ac.in/~ppchak,yq-ekN8AAAAJ,0000-0000-0000-0000
+P. P. Jashma Suresh,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/jashma-suresh-pp/_jcr_content.html,XAG68zMAAAAJ,0000-0003-4565-991X
 P. Patrick van der Smagt,TU Munich,https://brml.org/people/smagt,5ybzvbsAAAAJ,0000-0003-4418-4916
 P. Radha Krishna 0001,National Inst. of Tech. Warangal,https://wsdc.nitw.ac.in/facultynew/facultyprofile/id/16934,JFzGHMIAAAAJ,0000-0000-0000-0000
 P. Roberto Oliveira,UFRJ,http://www.cos.ufrj.br/index.php/pt-BR/pessoas/details/18/1045-poliveir,55Or75UAAAAJ,0000-0000-0000-0000
@@ -103,6 +106,7 @@ Pang-Ning Tan,Michigan State University,http://www.cse.msu.edu/~ptan,xNs4D2QAAAA
 Pangfeng Liu,National Taiwan University,https://sites.google.com/view/pangfengliu/home,24KEj7kAAAAJ,0000-0002-5466-9960
 Pankaj Jalote,IIIT Delhi,https://www.iiitd.edu.in/~jalote,NOSCHOLARPAGE,0000-0000-0000-0000
 Pankaj K. Agarwal,Duke University,https://users.cs.duke.edu/~pankaj,xe0eVksAAAAJ,0000-0002-9439-181X
+Pankaj Kumar 0007,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/pankaj-kumar/_jcr_content.html,fhRWHsIAAAAJ,0000-0003-2824-0551
 Pankaj Kumar Agarwal,Duke University,https://users.cs.duke.edu/~pankaj,xe0eVksAAAAJ,0000-0000-0000-0000
 Panlong Yang,USTC,http://cs.ustc.edu.cn/szdw/bdjs/201707/t20170705_279933.html,sst3cxoAAAAJ,0000-0003-1057-2793
 Panos Constantopoulos,AUEB,https://uregister-ldap.aueb.gr/en/faculty/constantopoulos-panos,EAagfCoAAAAJ,0000-0001-6149-441X
@@ -503,6 +507,7 @@ Pavol Hell,Simon Fraser University,http://www.cs.sfu.ca/~pavol,8KDwlbEAAAAJ,0000
 Pawan Goyal,IIT Kharagpur,http://cse.iitkgp.ac.in/~pawang,F14FHsIAAAAJ,0000-0000-0000-0000
 Pawan Goyal 0002,IIT Kharagpur,http://cse.iitkgp.ac.in/~pawang,F14FHsIAAAAJ,0000-0002-9414-8166
 Pawan Kumar 0001,IIIT Hyderabad,https://faculty.iiit.ac.in/~pawan.kumar,MrtcNxQAAAAJ,0000-0000-0000-0000
+Pawan S. Jogi,Manipal Academy of Higher Education,https://sites.google.com/view/pawan-s-j/home,RGzx9_4AAAAJ,0000-0002-2560-9213
 Pawel A. Dmochowski,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/PawelDmochowski,i1WBCpoAAAAJ,0000-0000-0000-0000
 Pawel Andrzej Herman,KTH Royal Inst. of Technology,https://www.kth.se/profile/paherman,usAxvpcAAAAJ,0000-0001-6553-823X
 Pawel Gawrychowski,University of Wroclaw,http://www.ii.uni.wroc.pl/~gawry,m-B6e-YAAAAJ,0000-0002-6993-5440
@@ -1129,6 +1134,7 @@ Pontus Johnson,KTH Royal Inst. of Technology,https://www.kth.se/profile/pontusj,
 Pontus Saito Stenetorp,University College London,https://iris.ucl.ac.uk/iris/browse/profile?upi=PLEPS00,NOSCHOLARPAGE,0000-0000-0000-0000
 Pooja Malik,Shiv Nadar University,https://www.snu.edu.in/schools/school-of-engineering/faculty/pooja-malik,NOSCHOLARPAGE,0000-0000-0000-0000
 Poonam Goyal,BITS Pilani,http://www.bits-pilani.ac.in/pilani/poonam/profile,YHN0TYMAAAAJ,0000-0000-0000-0000
+Poornima Panduranga Kundapur,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/poornima-panduranga-kundapur/_jcr_content.html,4prLSkMAAAAJ,0000-0002-8271-524X
 Poorvi L. Vora,George Washington University,https://www.seas.gwu.edu/~poorvi,NOSCHOLARPAGE,0000-0000-0000-0000
 Pooya Farshim,Durham University,https://farshim.github.io,w_Pjc6MAAAAJ,0000-0003-2746-3585
 Pooya Hatami,Ohio State University,https://pooyahatami.org,VNJ9di0AAAAJ,0000-0001-7928-8008
@@ -1167,7 +1173,9 @@ Pradip Kumar Sharma,University of Aberdeen,https://www.abdn.ac.uk/people/pradip.
 Pradipta Maji,ISI Kolkata,https://www.isical.ac.in/~pmaji,RtOqKr0AAAAJ,0000-0002-8288-8917
 Prahladh Harsha,Tata Inst. of Fundamental Research,http://www.tcs.tifr.res.in/~prahladh,PTv2p1AAAAAJ,0000-0002-2739-5642
 Prajakta Nimbhorkar,CMI,http://www.cmi.ac.in/~prajakta,hDBz3EUAAAAJ,0000-0002-7601-9555
+Prajna Paramita Pradhan,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr--prajna-paramita-pradhan---department-of-computer-science---e/_jcr_content.html,0gB0ImMAAAAJ,0000-0002-2210-5028
 Prakash Ishwar,Boston University,https://www.bu.edu/eng/profile/prakash-ishwar,RYvdtGcAAAAJ,0000-0002-2621-1549
+Prakash K. Aithal,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/prakash-kalingrao-aithal/_jcr_content.html,jACptsMAAAAJ,0000-0002-4304-9512
 Prakash Murali,University of Cambridge,https://www.cst.cam.ac.uk/people/pm830,2J0X_aIAAAAJ,0000-0000-0000-0000
 Prakash Panangaden,McGill University,http://www.cs.mcgill.ca/~prakash,IROzEKQAAAAJ,0000-0000-0000-0000
 Prakash Ramanan,Wichita State University,https://www.wichita.edu/profiles/academics/engineering/SoC/Ramanan-Prakash.php,ADVpR-gAAAAJ,0000-0000-0000-0000
@@ -1223,6 +1231,7 @@ Pravesh Kothari,Princeton University,http://praveshkkothari.org,07qshUgAAAAJ,000
 Predrag Radivojac,Northeastern University,https://www.ccis.northeastern.edu/people/predrag-radivojac,ugj0at8AAAAJ,0000-0002-6769-0793
 Preetam Ghosh,Virginia Commonwealth University,https://egr.vcu.edu/directory/preetamghosh,S30uT7YAAAAJ,0000-0000-0000-0000
 Preetha Chatterjee,Drexel University,https://sites.udel.edu/preethac,5i170moAAAAJ,0000-0003-3057-7807
+Preetham Kumar,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/preetham-kumar/_jcr_content.html,S8rapA8AAAAJ,0000-0002-0736-7687
 Preethi Jyothi,IIT Bombay,https://www.cse.iitb.ac.in/~pjyothi,QN_uhu8AAAAJ,0000-0000-0000-0000
 Preeti Malakar,IIT Kanpur,https://www.cse.iitk.ac.in/users/pmalakar,7HlDLQMAAAAJ,0000-0000-0000-0000
 Preeti Mudliar,IIIT Bangalore,http://www.iiitb.ac.in/faculty_page.php?name=PreetiMudliar,NOSCHOLARPAGE,0000-0002-7125-6674

--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -22,6 +22,7 @@ R. Mukundan 0001,University of Canterbury,http://www.cosc.canterbury.ac.nz/mukun
 R. Padmavathy,National Inst. of Tech. Warangal,https://wsdc.nitw.ac.in/facultynew/facultyprofile/id/16345,QVuSh6EAAAAJ,0000-0000-0000-0000
 R. Ramanujam,IMSc,http://www.imsc.res.in/~jam,NOSCHOLARPAGE,0000-0000-0000-0000
 R. Rodrey Howell,Kansas State University,http://people.cs.ksu.edu/~rhowell,NOSCHOLARPAGE,0000-0000-0000-0000
+R. Roopalakshmi,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/roopalakshmi-r---department-of-computer-science-and-engineering-/_jcr_content.html,NOSCHOLARPAGE,0000-0001-7931-4608
 R. Ryan Williams,Massachusetts Inst. of Technology,https://people.csail.mit.edu/rrw,Wp38QQYAAAAJ,0000-0003-2326-2233
 R. S. Lazic,University of Warwick,https://warwick.ac.uk/fac/sci/dcs/people/ranko_lazic/biography,yGOk7boAAAAJ,0000-0000-0000-0000
 R. S. Meir,Technion,https://ronmeir.net.technion.ac.il,r3NAa9oAAAAJ,0000-0000-0000-0000
@@ -65,8 +66,12 @@ Rada Y. Chirkova,North Carolina State University,https://www.csc.ncsu.edu/people
 Rade Kutil,University of Salzburg,https://www.cosy.sbg.ac.at/~rkutil,NOSCHOLARPAGE,0000-0000-0000-0000
 Radek Pelánek,Masaryk University,https://www.muni.cz/en/people/4297,Q5pgzoUAAAAJ,0000-0001-8877-4729
 Radha Jagadeesan,DePaul University,http://reed.cs.depaul.edu/rjagadeesan,zh0DETsAAAAJ,0000-0000-0000-0000
+Radha Krishna Reddy Pallavali,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr--radha-krishna-reddy-p---department-of-computer-science---eng/_jcr_content.html,zlU2IHUAAAAJ,0000-0002-9651-3294
 Radha Venkatagiri,Georgetown University,https://gufaculty360.georgetown.edu/s/contact/0031Q00002cs4FTQAY/radha-venkatagiri,R4KY_noAAAAJ,0000-0000-0000-0000
+Radhakrishna Bhat,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/radhakrishna-bhat/_jcr_content.html,j7oPyBAAAAAJ,0000-0002-2309-0745
 Radhakrishnan Venkatesh Babu,IISc Bangalore,https://cds.iisc.ac.in/faculty/venky,cVg7HrEAAAAJ,0000-0000-0000-0000
+Radhika Kamath,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/radhika-kamath/_jcr_content.html,16mmcL0AAAAJ,0000-0002-9353-409X
+Radhika M. Pai,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/radhika-m-pai/_jcr_content.html,4gHteBAAAAAJ,0000-0002-0916-0495
 Radhika Mamidi,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/radhikamamidi,DsIpZR0AAAAJ,0000-0000-0000-0000
 Radhika Mittal,Univ. of Illinois at Urbana-Champaign,http://radhikam.web.illinois.edu,96mJbhwAAAAJ,0000-0003-4082-7865
 Radhika Nagpal,Princeton University,http://www.radhikanagpal.org,a3ZGDsoAAAAJ,0000-0001-9756-0167
@@ -130,12 +135,15 @@ Ragesh Jaiswal,IIT Delhi,http://www.cse.iitd.ernet.in/~rjaiswal,hrbj92oAAAAJ,000
 Raghav Sampangi,Dalhousie University,https://www.dal.ca/academics/programs/graduate/computer-science/graduate-life/current-students/raghav-sampangi.html,x_Cy69EAAAAJ,0000-0000-0000-0000
 Raghava Mutharaju,IIIT Delhi,https://www.iiitd.ac.in/raghavam,69pEM_YAAAAJ,0000-0000-0000-0000
 Raghavan Komondoor,IISc Bangalore,http://www.csa.iisc.ac.in/~raghavan,fZq9W2cAAAAJ,0000-0000-0000-0000
+Raghavendra Achar,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/RaghavendraAchar/_jcr_content.html,NOSCHOLARPAGE,0000-0003-2646-0606
+Raghavendra Ganiga,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/raghavendra-ganiga/_jcr_content.html,8jdkvp4AAAAJ,0000-0003-4748-6733
 Raghavendra Kanakagiri,IIT Tirupati,https://raghavendrak.github.io,7udEeZcAAAAJ,0000-0002-5561-2421
 Raghavendra Pradyumna Pothukuchi,University of North Carolina,https://www.cs.unc.edu/~raghav,WXYEFn4AAAAJ,0000-0003-0109-7417
 Raghavendra Selvan,University of Copenhagen,https://raghavian.github.io,R9VBQ54AAAAJ,0000-0003-4302-0207
 Raghu Machiraju,Ohio State University,http://web.cse.ohio-state.edu/~raghu,HHialjcAAAAJ,0000-0000-0000-0000
 Raghu Meka,Univ. of California - Los Angeles,http://www.raghumeka.org,xuDZ9-sAAAAJ,0009-0004-7676-2762
 Raghu Reddy,IIIT Hyderabad,http://faculty.iiit.ac.in/~raghu.reddy,NOSCHOLARPAGE,0000-0000-0000-0000
+Raghu Thekke Veedu,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr--raghu-thekke-veedu---department-of-computer-science---engg--/_jcr_content.html,HGPnY_EAAAAJ,0000-0003-4748-6733
 Raghunath Tewari,IIT Kanpur,http://www.cse.iitk.ac.in/users/rtewari,Ks3QdEUAAAAJ,0000-0000-0000-0000
 Raghuvansh Saxena,Tata Inst. of Fundamental Research,https://www.tcs.tifr.res.in/web/people/faculty,NOSCHOLARPAGE,0000-0000-0000-0000
 Ragib Hasan,University of Alabama - Birmingham,http://ua-birmingham.academia.edu/RagibHasan,2R1w6xwAAAAJ,0000-0000-0000-0000
@@ -200,6 +208,7 @@ Rajalakshmi Nandakumar [Tech],Cornell University,https://tech.cornell.edu/people
 Rajalida Lipikorn,Chulalongkorn University,http://www.math.sc.chula.ac.th/en/profile/rajalida.l,NOSCHOLARPAGE,0000-0000-0000-0000
 Rajasekhar Anguluri,Univ. of Maryland - Baltimore County,https://www.csee.umbc.edu/rajasekhar-anguluri,GH4f3-sAAAAJ,0000-0000-0000-0000
 Rajasekhar Inkulu,IIT Guwahati,http://www.iitg.ernet.in/rinkulu,NOSCHOLARPAGE,0000-0000-0000-0000
+Rajashree Krishna,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/rajashree-krishna/_jcr_content.html,ro9JY3AAAAAJ,0000-0003-1924-039X
 Rajat Kumar De,ISI Kolkata,https://www.isical.ac.in/~rajat,gM9LAI0AAAAJ,0000-0000-0000-0000
 Rajat Mittal 0001,IIT Kanpur,http://www.cse.iitk.ac.in/users/rmittal,gK5DF9QAAAAJ,0000-0000-0000-0000
 Rajat Moona,IIT Kanpur,http://www.cse.iitk.ac.in/users/moona,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -219,12 +228,14 @@ Rajendra Mitharwal,DAIICT,http://faculty.daiict.ac.in/rmitharwal,NOSCHOLARPAGE,0
 Rajendra V. Boppana,University of Texas at San Antonio,http://www.cs.utsa.edu/faculty/boppana,bNOQrU0AAAAJ,0000-0000-0000-0000
 Rajesh Balan,Singapore Management University,https://apollo.smu.edu.sg,U1jLrJcAAAAJ,0000-0001-6289-9902
 Rajesh Chitnis,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/academic-staff/chitnis-rajesh.aspx,u4oLgMAAAAAJ,0000-0002-6098-7770
+Rajesh Gopakumar,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/rajesh-gopakumar/_jcr_content.html,GQSljqsAAAAJ,0000-0002-4252-9178
 Rajesh Gupta 0001,Univ. of California - San Diego,http://mesl.ucsd.edu/gupta,I1w51gUAAAAJ,0000-0002-6489-7633
 Rajesh Hemant Chitnis,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/chitnis-rajesh.aspx,u4oLgMAAAAAJ,0000-0002-6098-7770
 Rajesh K. Gupta 0001,Univ. of California - San Diego,http://mesl.ucsd.edu/gupta,I1w51gUAAAAJ,0000-0002-6489-7633
 Rajesh Krishna Balan,Singapore Management University,https://apollo.smu.edu.sg,U1jLrJcAAAAJ,0000-0001-6289-9902
 Rajesh Kumar 0012,BITS Pilani-Goa,https://beta.bits-pilani.ac.in/faculty-overview/?faculty=rajesh-kumar-3,ZZFnM2gAAAAJ,0000-0000-0000-0000
 Rajesh Kumar Mundotiya,IIT Bhilai,https://rajeshkmmundotiya.wixsite.com/home,jp3MgBAAAAAJ,0000-0000-0000-0000
+Rajesh Mahadeva,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr--rajesh-mahadeva---department-of-computer-science---engg---mi/_jcr_content.html,m_BdM2IAAAAJ,0000-0001-8952-7172
 Rajesh P. N. Rao,University of Washington,https://homes.cs.washington.edu/~rao,02nHF0gAAAAJ,0000-0003-0682-8952
 Rajesh Ranganath,New York University,https://cims.nyu.edu/~rajeshr,kddKBCsAAAAJ,0000-0000-0000-0000
 Rajesh Sharma 0002,Plaksha University,https://plaksha.edu.in/faculty-details/rajesh-sharma,GKegbo0AAAAJ,0000-0000-0000-0000
@@ -352,6 +363,7 @@ Ramprasad S. Joshi,BITS Pilani-Goa,https://universe.bits-pilani.ac.in/goa/rsj/pr
 Ramprasad Saptharishi,Tata Inst. of Fundamental Research,http://www.tcs.tifr.res.in/~ramprasad,NOSCHOLARPAGE,0000-0002-7485-3220
 Ramtin Zand,University of South Carolina,https://sc.edu/study/colleges_schools/engineering_and_computing/faculty-staff/zand.php,JyzaowcAAAAJ,0000-0002-1786-1152
 Ramviyas Parasuraman,University of Georgia,https://cobweb.cs.uga.edu/~ramviyas,gmhcslQAAAAJ,0000-0001-5451-8209
+Ramya D. Shetty,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/RamyaShetty/_jcr_content.html,NOSCHOLARPAGE,0000-0003-3530-0102
 Ramya Korlakai Vinayak,University of Wisconsin - Madison,https://ramyakv.github.io,-dDKMgoAAAAJ,0000-0003-0248-9551
 Ramyaa,New Mexico Tech,https://www.cs.nmt.edu/~ramyaa,NOSCHOLARPAGE,0000-0000-0000-0000
 Ramyaa Ramyaa,New Mexico Tech,https://www.cs.nmt.edu/~ramyaa,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -390,6 +402,7 @@ Ranga Rao Venkatesha Prasad,TU Delft,http://homepage.tudelft.nl/w5p50,9RVkIfsAAA
 Rangachar Kasturi,University of South Florida,http://www.cse.usf.edu/~r1k,EFB9ZuwAAAAJ,0000-0000-0000-0000
 Rangarao Venkatesha Prasad,TU Delft,http://homepage.tudelft.nl/w5p50,9RVkIfsAAAAJ,0000-0000-0000-0000
 Ranggi Hwang,UNIST,https://sites.google.com/view/unist-cocolab,X6GMiFIAAAAJ,0000-0003-2343-586X
+Rani Oomman Panicker,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr--rani-oomman-panicker---department-of-computer-science---engg/_jcr_content.html,PMxQvNQAAAAJ,0000-0001-9083-8840
 Ranita Biswas,IIT Roorkee,http://faculty.iitr.ac.in/~ranitafcs,x2obmAYAAAAJ,0000-0000-0000-0000
 Ranjay A. Krishna,University of Washington,http://www.ranjaykrishna.com/index.html,IcqahyAAAAAJ,0000-0000-0000-0000
 Ranjay Krishna,University of Washington,http://www.ranjaykrishna.com/index.html,IcqahyAAAAAJ,0000-0001-8784-2531
@@ -422,6 +435,7 @@ Rashid Rashid,Massey University,http://www.massey.ac.nz/massey/expertise/profile
 Rashina Hoda,Monash University,https://research.monash.edu/en/persons/rashina-hoda,WrNBfzwAAAAJ,0000-0001-5147-8096
 Rashmi Dutta Baruah,IIT Guwahati,https://www.iitg.ernet.in/r.duttabaruah,pSiO0xoAAAAJ,0000-0000-0000-0000
 Rashmi Jha,University of Cincinnati,https://researchdirectory.uc.edu/p/jhari,NOSCHOLARPAGE,0000-0002-2656-5945
+Rashmi Naveen Raj,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/rashmi-naveen-raj/_jcr_content.html,heRm3gsAAAAJ,0000-0002-7683-4955
 Rashmi Ranjan Rout,National Inst. of Tech. Warangal,https://wsdc.nitw.ac.in/facultynew/facultyprofile/id/16336,SQTBOa8AAAAJ,0000-0000-0000-0000
 Rashmi Vinayak,Carnegie Mellon University,http://www.cs.cmu.edu/~rvinayak,gUO59T8AAAAJ,0000-0002-2227-7460
 Rasiah Loganantharaj,Univ. of Louisiana - Lafayette,http://louisiana.academia.edu/RasiahLoganantharaj,avhN-IMAAAAJ,0000-0000-0000-0000
@@ -624,6 +638,7 @@ Renjie Zhao,Johns Hopkins University,https://renjiezhao.github.io,2IrtUS4AAAAJ,0
 Rens Bod,University of Amsterdam,https://www.uva.nl/profiel/b/o/l.w.m.bod/l.w.m.bod.html,LRKlkaAAAAAJ,0000-0000-0000-0000
 Renu M. Rameshan,IIT Mandi,http://faculty.iitmandi.ac.in/research/publications/Author/renumr.php,NOSCHOLARPAGE,0000-0000-0000-0000
 Renu Rameshan,IIT Mandi,http://faculty.iitmandi.ac.in/research/publications/Author/renumr.php,NOSCHOLARPAGE,0000-0000-0000-0000
+Renuka A. 0001,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/renuka-a/_jcr_content.html,xPCPaSUAAAAJ,0000-0001-6511-9780
 Renwei Dian,Hunan University,https://sites.google.com/view/publication-code-renweidian/homepage,EoTrH5UAAAAJ,0000-0001-9197-6292
 Renzhe Xu,SUFE,https://windxrz.github.io,NnppITIAAAAJ,0000-0001-8418-0034
 René Just,University of Washington,https://homes.cs.washington.edu/~rjust,Y_KtQ8kAAAAJ,0000-0002-5982-275X
@@ -1221,6 +1236,7 @@ Rohan Chandra,University of Virginia,https://engineering.virginia.edu/faculty/ro
 Rohan Padhye,Carnegie Mellon University,https://rohan.padhye.org,XI03UxYAAAAJ,0000-0003-4939-033X
 Rohan Paul,IIT Delhi,https://www.cse.iitd.ac.in/~rohanpaul,Cgp-L2UAAAAJ,0000-0000-0000-0000
 Rohini K. Srihari,University at Buffalo,https://cse.buffalo.edu/~rohini,Uttu9kkAAAAJ,0000-0000-0000-0000
+Rohini R. Rao,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/rohini-r-rao/_jcr_content.html,s2-TY6EAAAAJ,0000-0002-6940-3858
 Rohit Babbar,Aalto University,https://research.aalto.fi/en/persons/rohit-babbar,QsqvuGsAAAAJ,0000-0002-3787-8971
 Rohit Chadha,University of Missouri,https://engineering.missouri.edu/faculty/rohit-chadha,NC5SnUcAAAAJ,0000-0002-1674-1650
 Rohit Gurjar,IIT Bombay,https://www.cse.iitb.ac.in/~rgurjar,dtbKJVUAAAAJ,0000-0002-8623-0872
@@ -1375,6 +1391,7 @@ Ronitt Rubinfeld,Massachusetts Inst. of Technology,http://people.csail.mit.edu/r
 Ronnie E. S. Santos,University of Calgary,https://www.drdesouzasantos.ca,wYfnBrYAAAAJ,0000-0000-0000-0000
 Ronny Meir,Technion,https://ronmeir.net.technion.ac.il,r3NAa9oAAAAJ,0000-0000-0000-0000
 Roopa Vishwanathan,New Mexico State University,https://www.cs.nmsu.edu/~roopa,o6jDwowAAAAJ,0000-0000-0000-0000
+Roopashri Shetty,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/roopashri-shetty/_jcr_content.html,rh58Ol0AAAAJ,0000-0003-4145-620X
 Roope Raisamo,Tampere University,https://www.tuni.fi/en/roope-raisamo,KJr447YAAAAJ,0000-0003-3276-7866
 Roozbeh Jafari,Texas A&M University,http://jafari.tamu.edu/rjafari,ZKg1UKwAAAAJ,0000-0002-6358-0458
 Roque Marín,University of Murcia,http://perseo.inf.um.es/~roque,1UhXRsUAAAAJ,0000-0000-0000-0000
@@ -1401,6 +1418,7 @@ Roseli A. F. Romero,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/rafrance,pdtTa-
 Roseli A. Francelin Romero,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/rafrance,pdtTa-8AAAAJ,0000-0000-0000-0000
 Roseli Aparecida Francelin Romero,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/rafrance,pdtTa-8AAAAJ,0000-0000-0000-0000
 Roshan Ayyalasomayajula,University at Buffalo,https://cse.buffalo.edu/~roshana,j1BjHf0AAAAJ,0000-0000-0000-0000
+Roshan David Jathanna,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/roshan-david-jathanna/_jcr_content.html,b83AZP8AAAAJ,0000-0002-4080-7621
 Roshan Dharshana Yapa,University of Peradeniya,https://sci.pdn.ac.lk/scs/staff/Roshan-Yapa,hfEXzKYAAAAJ,0000-0000-0000-0000
 Roshan G. Ragel,University of Peradeniya,https://people.ce.pdn.ac.lk/staff/academic/roshan-ragel,UTYj8usAAAAJ,0000-0002-4511-2335
 Roshan L. Peiris,Rochester Inst. of Technology,https://www.rit.edu/directory/rxpics-roshan-peiris,cVEUHIIAAAAJ,0000-0002-4191-3565

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -9,9 +9,12 @@ S. C. Mukhopadhyay,Massey University,http://www.massey.ac.nz/massey/expertise/pr
 S. Dov Gordon,George Mason University,https://people.cs.gmu.edu/~gordon,wS_5894AAAAJ,0009-0001-6490-1786
 S. E. M. O'Keefe,University of York,https://www-users.cs.york.ac.uk/~sok,QL1JHlUAAAAJ,0000-0000-0000-0000
 S. Hamed Hassani,University of Pennsylvania,https://www.seas.upenn.edu/~hassani,M9V6y-0AAAAJ,0000-0000-0000-0000
+S. Hemalatha 0001,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/hemalatha-s/_jcr_content.html,Ur85FNEAAAAJ,0000-0002-1826-0738
 S. J. Creese,University of Oxford,http://www.cs.ox.ac.uk/sadie.creese,hZ3DmHkAAAAJ,0000-0000-0000-0000
 S. J. Overbeek,Utrecht University,http://www.sietseoverbeek.nl,JEmkfmsAAAAJ,0000-0000-0000-0000
+S. J. Pawan,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr--pawan-s-jogi---department-of-computer-science---engg---mit--/_jcr_content.html,RGzx9_4AAAAJ,0000-0002-2560-9213
 S. J. Wright,Monash University,http://monash.edu/research/explore/en/persons/steven-wright(40be3258-c026-4e34-a74d-08837c38344b).html,icJpxpMAAAAJ,0000-0000-0000-0000
+S. Kaliraj,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr-kaliraj-s/_jcr_content.html,hwIDoJsAAAAJ,0000-0003-4212-8427
 S. Krishna 0004,IIT Bombay,https://www.cse.iitb.ac.in/~krishnas,14JlaZsAAAAJ,0000-0003-0925-398X
 S. Lakshmivarahan,University of Oklahoma,http://www.ou.edu/coe/cs/people/varahan,NOSCHOLARPAGE,0000-0000-0000-0000
 S. M. Rezaul Hasan,Massey University,http://www.massey.ac.nz/~smhasan,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -19,6 +22,7 @@ S. M. Shahriar Nirjon,University of North Carolina,http://cs.unc.edu/~nirjon,CsG
 S. Manoharan,University of Auckland,https://unidirectory.auckland.ac.nz/profile/s-manoharan,55FwvisAAAAJ,0000-0000-0000-0000
 S. Masoud Sadjadi,Florida International University,http://www.cis.fiu.edu/~sadjadi,qmkC7FQAAAAJ,0000-0000-0000-0000
 S. Matthew Weinberg,Princeton University,https://www.cs.princeton.edu/~smattw,CBUpEcQAAAAJ,0000-0001-7744-795X
+S. N. Muralikrishna,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/muralikrishna-sn/_jcr_content.html,CRP1To4AAAAJ,0000-0002-5657-4439
 S. P. Luttik,TU Eindhoven,http://www.win.tue.nl/~luttik,mwYLD4QAAAAJ,0000-0000-0000-0000
 S. P. Suresh,CMI,http://www.cmi.ac.in/~spsuresh,S0fWcAoAAAAJ,0000-0000-0000-0000
 S. Prahallad Kishore,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/kishore,3-8i_54AAAAJ,0000-0000-0000-0000
@@ -181,6 +185,7 @@ Samarjit Chakraborty,University of North Carolina,https://www.cs.unc.edu/~samarj
 Sambuddho Chakravarty,IIIT Delhi,https://www.iiitd.ac.in/sambuddho,8CJgHUIAAAAJ,0000-0000-0000-0000
 Sameem Abdul Kareem,University of Malaya,https://umexpert.um.edu.my/sameem,Rl2ebS4AAAAJ,0000-0000-0000-0000
 Sameem Binti Abdul Kareem,University of Malaya,https://umexpert.um.edu.my/sameem,Rl2ebS4AAAAJ,0000-0000-0000-0000
+Sameena Pathan,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/SameenaBP/_jcr_content.html,ndNLcQ0AAAAJ,0000-0002-9867-4382
 Sameer G. Kulkarni,IIT Gandhinagar,https://iitgn.ac.in/faculty/cse/sameer,CnPfKYUAAAAJ,0000-0000-0000-0000
 Sameer Patil,University of Utah,https://www.sameerpatil.com,JGEniHoAAAAJ,0000-0002-8214-0765
 Samer Al-Kiswany,University of Waterloo,https://cs.uwaterloo.ca/~alkiswan,t7n06tsAAAAJ,0000-0002-6429-9983
@@ -260,6 +265,7 @@ Sander M. Bohte,CWI,http://homepages.cwi.nl/~sbohte,zHlebkUAAAAJ,0000-0000-0000-
 Sander M. Bohté,CWI,http://homepages.cwi.nl/~sbohte,zHlebkUAAAAJ,0000-0000-0000-0000
 Sandesh Kamath,BITS Pilani-Goa,https://ksandeshk.github.io,xyp5MusAAAAJ,0000-0000-0000-0000
 Sandhya Dwarkadas,University of Virginia,https://engineering.virginia.edu/faculty/sandhya-dwarkadas,L1pb8GUAAAAJ,0000-0003-2631-8191
+Sandhya Parasnath Dubey,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/sandhya-dubey/_jcr_content.html,N1Y2zPsAAAAJ,0000-0002-8350-2676
 Sandhya Saisubramanian,Oregon State University,https://www.sandhyasai.com,pUWf24gAAAAJ,0000-0000-0000-0000
 Sandip Chakraborty 0001,IIT Kharagpur,http://cse.iitkgp.ac.in/~sandipc,pQ6C8YAAAAAJ,0000-0003-3531-968X
 Sandip Das 0001,ISI Kolkata,https://www.isical.ac.in/~sandipdas,nb68w1cAAAAJ,0000-0000-0000-0000
@@ -352,6 +358,7 @@ Sanjay Rajopadhye,Colorado State University,http://www.cs.colostate.edu/~svr,fYO
 Sanjay Ranka,University of Florida,https://www.cise.ufl.edu/people/faculty/ranka,j7WSgbwAAAAJ,0000-0003-4886-1988
 Sanjay Rawat 0001,University of Bristol,http://www.bristol.ac.uk/engineering/people/sanjay-rawat/index.html,9T1aL3wAAAAJ,0000-0003-0875-7924
 Sanjay Shakkottai,University of Texas at Austin,https://sites.google.com/view/sanjay-shakkottai/home,NOSCHOLARPAGE,0000-0002-4325-9050
+Sanjay Singh 0002,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/sanjay-singh/_jcr_content.html,VBj6NyUAAAAJ,0000-0001-7212-5919
 Sanjay Srivastava,DAIICT,http://intranet.daiict.ac.in/~sanjay_srivastava,VpSSqi0AAAAJ,0000-0000-0000-0000
 Sanjay V. Rajopadhye,Colorado State University,http://www.cs.colostate.edu/~svr,fYOdJ-oAAAAJ,0000-0002-4246-6066
 Sanjaya Kumar Panda,National Inst. of Tech. Warangal,https://wsdc.nitw.ac.in/facultynew/facultyprofile/id/17027,Amtx7OIAAAAJ,0000-0000-0000-0000
@@ -387,6 +394,8 @@ Sanshuai Cui,City University of Macau,https://fds.cityu.edu.mo/en/members/284,sR
 Sansiri Tanachutiwat,KMUTNB,https://tggs.kmutnb.ac.th/dr-sansiri-tanachutiwa,EDs4YooAAAAJ,0000-0000-0000-0000
 Santanu Chaudhury,IIT Jodhpur,https://web.iitd.ac.in/~santanuc,V6NJi4kAAAAJ,0000-0000-0000-0000
 Santanu Kumar Dash 0001,Royal Holloway Univ. of London,https://pure.royalholloway.ac.uk/en/persons/santanu-dash,aNI6aTkAAAAJ,0000-0002-5674-8531
+Santhosh Kamath,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/santhosh-kamath/_jcr_content.html,1JciSa8AAAAJ,0000-0002-1956-1727
+Santhosha Rao,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/santhosha-rao/_jcr_content.html,NOSCHOLARPAGE,0000-0001-9511-3048
 Santhoshini Velusamy,University of Waterloo,https://uwaterloo.ca/computer-science/contacts/santhoshini-velusamy,GpxRFs4AAAAJ,0000-0002-0294-5425
 Santi Ontañón,Drexel University,http://drexel.edu/cci/contact/Faculty/Ontanon-Santiago,aS-DrOwAAAAJ,0000-0000-0000-0000
 Santi Ontañón Villar,Drexel University,http://drexel.edu/cci/contact/Faculty/Ontanon-Santiago,aS-DrOwAAAAJ,0000-0000-0000-0000
@@ -530,6 +539,7 @@ Satwik Patnaik,University of Delaware,https://sites.google.com/udel.edu/satwikpa
 Satya Ranjan Dash,KIIT Bhubaneswar,https://ksca.kiit.ac.in/profiles/satya-ranjan-dash,3aLkeUYAAAAJ,0000-0000-0000-0000
 Satyadev Nandakumar,IIT Kanpur,http://www.cse.iitk.ac.in/users/satyadev,lMAxggwAAAAJ,0000-0000-0000-0000
 Satyajayant Misra,New Mexico State University,http://www.cs.nmsu.edu/~misra,KJPGePAAAAAJ,0000-0000-0000-0000
+Satyajit Mahapatra,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/satyajit-mahapatra/_jcr_content.html,cJan4cgAAAAJ,0000-0002-5516-6978
 Satyajit Thakor,IIT Mandi,http://faculty.iitmandi.ac.in/~satyajit,B4gJ7CoAAAAJ,0000-0000-0000-0000
 Satyanath Bhat,IIT Goa,https://www.iitgoa.ac.in/faculty_page.php?id=112,YDBDyLIAAAAJ,0000-0000-0000-0000
 Saugata Basu,Purdue University,https://www.math.purdue.edu/~sbasu,8i0lYbAAAAAJ,0000-0002-2441-0915
@@ -962,6 +972,7 @@ Shangwei Guo,Chongqing University,https://guoshangwei.github.io,wQrVkBYAAAAJ,000
 Shangwei Lin 0001,Nanyang Technological University,http://www.ntu.edu.sg/home/shang-wei.lin,sCbkO2oAAAAJ,0000-0002-9726-3434
 Shanika A. Karunasekera,University of Melbourne,http://findanexpert.unimelb.edu.au/display/person18115,WG0tRVcAAAAJ,0000-0000-0000-0000
 Shanika Karunasekera,University of Melbourne,http://findanexpert.unimelb.edu.au/display/person18115,WG0tRVcAAAAJ,0000-0001-7080-5064
+Shankar Biradar,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/ShankarBiradar/_jcr_content.html,00abV08AAAAJ,0000-0003-4869-5860
 Shankar K. Ghosh,Shiv Nadar University,https://www.snu.edu.in/schools/school-of-engineering/faculty/shankar-kumar-ghosh,ck5tZy0AAAAJ,0000-0000-0000-0000
 Shankar Kumar Ghosh,Shiv Nadar University,https://www.snu.edu.in/schools/school-of-engineering/faculty/shankar-kumar-ghosh,ck5tZy0AAAAJ,0000-0000-0000-0000
 Shankar S. Sastry,Univ. of California - Berkeley,http://robotics.eecs.berkeley.edu/~sastry,KgZxzjsAAAAJ,0000-0000-0000-0000
@@ -1041,6 +1052,7 @@ Shaull Almagor,Technion,https://shaull.cswp.cs.technion.ac.il,kpOkLNsAAAAJ,0000-
 Shaun J. Canavan,University of South Florida,http://www.cse.usf.edu/~scanavan,zayQB-oAAAAJ,0000-0002-1538-476X
 Shaun K. Kane,University of Colorado Boulder,http://shaunkane.info,v564lDgAAAAJ,0000-0002-0276-9417
 Shaun Wallace,University of Rhode Island,https://shaunwallace.org,wyeu9MkAAAAJ,0000-0001-5297-1659
+Shavantrevva Bilakeri,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/Shavantrevva-Sangappa-Bilakeri/_jcr_content.html,gV47yBMAAAAJ,0000-0002-5347-1485
 Shawn D. Newsam,Univ. of California - Merced,https://faculty.ucmerced.edu/snewsam/index.html,pQZX0mEAAAAJ,0000-0001-6803-5291
 Shawn Newsam,Univ. of California - Merced,https://faculty.ucmerced.edu/snewsam/index.html,pQZX0mEAAAAJ,0000-0000-0000-0000
 Shawn Ostermann,Ohio University,http://oucsace.cs.ohiou.edu/~osterman/Homepage.html,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -1245,6 +1257,7 @@ Shiva Darian,New Mexico State University,https://smdarian.github.io,HWqnD8IAAAAJ
 Shiva Nejati 0001,University of Ottawa,https://shnejati.github.io,Cem5xUsAAAAJ,0000-0002-0281-8231
 Shivakant Mishra,University of Colorado Boulder,https://www.cs.colorado.edu/~mishras,0RMteS0AAAAJ,0000-0000-0000-0000
 Shivani Agarwal 0001,University of Pennsylvania,https://directory.seas.upenn.edu/shivani-agarwal,Q4ErnU4AAAAJ,0000-0000-0000-0000
+Shivaprasad Gundibail,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/shivaprasad-g/_jcr_content.html,NOSCHOLARPAGE,0000-0003-4986-5593
 Shivaram Kalyanakrishnan,IIT Bombay,https://www.cse.iitb.ac.in/~shivaram,YZkeEqAAAAAJ,0000-0000-0000-0000
 Shivaram Venkataraman,University of Wisconsin - Madison,http://shivaram.org,5LLV29oAAAAJ,0000-0001-9575-7935
 Shivashankar B. Nair,IIT Guwahati,https://www.iitg.ernet.in/sbnair,wfeT0bYAAAAJ,0000-0000-0000-0000
@@ -1295,6 +1308,7 @@ Shqiponja Ahmetaj,TU Wien,https://informatics.tuwien.ac.at/people/shqiponja-ahme
 Shravan Narayan,University of Texas at Austin,https://shravanrn.com,ZLFLzJ8AAAAJ,0000-0002-0065-6611
 Shravan R. Narayan,University of Texas at Austin,https://shravanrn.com,ZLFLzJ8AAAAJ,0000-0000-0000-0000
 Shree K. Nayar,Columbia University,http://www.cs.columbia.edu/~nayar,Yj7KQmQAAAAJ,0000-0002-6452-6998
+Shreenidhi H. Bhat,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/ShreenidhiBhat/_jcr_content.html,vHsBeQ4AAAAJ,0000-0002-2185-0608
 Shreyas Pai,IIT Madras,https://shreyaspai.com,yP41zOIAAAAJ,0000-0003-2409-7807
 Shri Narayanan,University of Southern California,http://sail.usc.edu/people/shri.php,8EDHmYkAAAAJ,0000-0000-0000-0000
 Shrideep Pallickara,Colorado State University,http://www.cs.colostate.edu/~shrideep,yjFpPkYAAAAJ,0000-0000-0000-0000
@@ -1414,7 +1428,9 @@ Shweta Shinde,ETH Zurich,https://n.ethz.ch/~sshivaji,KYumLGkAAAAJ,0000-0003-0415
 Shweta Yadav 0001,University of Illinois at Chicago,https://shwetanlp.github.io,dMK8VBkAAAAJ,0000-0003-0001-4464
 Shwetak N. Patel,University of Washington,http://abstract.cs.washington.edu/~shwetak,z4S5rC0AAAAJ,0000-0002-6300-4389
 Shwetak Patel,University of Washington,http://abstract.cs.washington.edu/~shwetak,z4S5rC0AAAAJ,0000-0000-0000-0000
+Shwetha Rai,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/shwetha-rai/_jcr_content.html,quyQq_EAAAAJ,0000-0002-5714-2611
 Shyam Gollakota,University of Washington,https://homes.cs.washington.edu/~gshyam,w_HJY2MAAAAJ,0000-0000-0000-0000
+Shyam Karanth,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/shyam-subraya-karanth/_jcr_content.html,ogANrVQAAAAJ,0000-0003-3232-4213
 Shyamapada Mukherjee,National Inst. of Tech. Silchar,http://cs.nits.ac.in/shyama,qGuy8goAAAAJ,0000-0000-0000-0000
 Shyamnath Gollakota,University of Washington,https://homes.cs.washington.edu/~gshyam,w_HJY2MAAAAJ,0000-0002-9863-3054
 Shyamosree Pal,National Inst. of Tech. Silchar,http://cs.nits.ac.in/spal,lpybqSwAAAAJ,0000-0000-0000-0000
@@ -1641,6 +1657,7 @@ Sivaram Ambikasaran,IIT Madras,https://sivaramambikasaran.com/CV,h2hgRJoAAAAJ,00
 Sivaramakrishnan Lakshmivarahan,University of Oklahoma,http://www.ou.edu/coe/cs/people/varahan,NOSCHOLARPAGE,0000-0000-0000-0000
 Sivaraman Balakrishnan,Carnegie Mellon University,http://www.stat.cmu.edu/~siva,o7yFQXUAAAAJ,0000-0000-0000-0000
 Sivaraman K. Anirudh,New York University,https://cs.nyu.edu/~anirudh,z9em5msAAAAJ,0000-0000-0000-0000
+Sivaselvan N,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/siva-selvan-n/_jcr_content.html,gQrRkm4AAAAJ,0000-0002-5014-5991
 Siwei Feng,Soochow University,http://web.suda.edu.cn/fsw,_7xkHz8AAAAJ,0000-0000-0000-0000
 Siwei Lyu,University at Buffalo,https://cse.buffalo.edu/~siweilyu,wefAEM4AAAAJ,0000-0000-0000-0000
 Siwei Ma,Peking University,http://idm.pku.edu.cn/staff/masiwei/masiwei.htm,y3YqlaUAAAAJ,0000-0000-0000-0000
@@ -1663,6 +1680,7 @@ Slinger Jansen,Utrecht University,https://www.slingerjansen.nl,e13z2YAAAAJ,0000-
 Slobodan Mitrovic,Univ. of California - Davis,https://web.cs.ucdavis.edu/~mitrovic,O62Q1t0AAAAJ,0009-0003-9269-4379
 Slobodan Vucetic,Temple University,http://www.dabi.temple.edu/~vucetic,eG-C3JIAAAAJ,0000-0001-5884-6293
 Smita Krishnaswamy,Yale University,https://medicine.yale.edu/genetics/people/smita_krishnaswamy.profile,l2Pr9m8AAAAJ,0000-0000-0000-0000
+Smitha N. Pai,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/smitha-n-pai0/_jcr_content.html,NOSCHOLARPAGE,0000-0002-3258-2688
 Smruti R. Sarangi,IIT Delhi,http://www.cse.iitd.ac.in/~srsarangi,-5JfCRsAAAAJ,0000-0002-1657-8523
 Smruti Ranjan Sarangi,IIT Delhi,http://www.cse.iitd.ac.in/~srsarangi,-5JfCRsAAAAJ,0000-0000-0000-0000
 Smruti Sarangi,IIT Delhi,http://www.cse.iitd.ac.in/~srsarangi,-5JfCRsAAAAJ,0000-0000-0000-0000
@@ -1807,6 +1825,7 @@ Soumya Dutta,IIT Kanpur,https://soumyadutta-cse.github.io,7CGMUB8AAAAJ,0000-0001
 Soumya K. Ghosh,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ,0000-0000-0000-0000
 Soumya K. Ghosh 0001,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ,0000-0000-0000-0000
 Soumya Kanti Ghosh 0001,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ,0000-0000-0000-0000
+Soumya Nandan Mishra,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/mr--soumya-nandan-mishra----school-of-computer-engineering---mit/_jcr_content.html,uZaW9DwAAAAJ,0000-0002-4115-3498
 Soumya Ray,Case Western Reserve University,http://engr.case.edu/ray_soumya,T3Wxu_AAAAAJ,0000-0002-7497-3281
 Soumyabrata Dev,University College Dublin,https://people.ucd.ie/soumyabrata.dev,_akXw8IAAAAJ,0000-0000-0000-0000
 Soumyajit Dey,IIT Kharagpur,http://cse.iitkgp.ac.in/~soumya,XJI3nYIAAAAJ,0000-0001-9329-6389
@@ -1865,6 +1884,7 @@ Srijita Das 0001,University of Michigan-Dearborn,https://sites.google.com/view/s
 Srikant Srinivasan,Plaksha University,https://plaksha.edu.in/faculty-details/dr-srikant-srinivasan,-fftoxoAAAAJ,0000-0000-0000-0000
 Srikanta Bedathur,IIT Delhi,https://www.cse.iitd.ac.in/~srikanta,ngfF2oAAAAAJ,0000-0002-3949-2175
 Srikanta J. Bedathur,IIT Delhi,https://www.cse.iitd.ac.in/~srikanta,ngfF2oAAAAAJ,0000-0000-0000-0000
+Srikanth Prabhu,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/SrikanthPrabhu/_jcr_content.html,iNwLHREAAAAJ,0000-0002-3826-1084
 Srikanth Srinivasan 0001,University of Copenhagen,https://di.ku.dk/english/staff/vip/researchers_ac/?pure=en/persons/792011,uJzmr8YAAAAJ,0000-0001-6491-124X
 Srikanth V. Krishnamurthy,Univ. of California - Riverside,http://www.cs.ucr.edu/~krish,x8UnxSoAAAAJ,0000-0002-6533-4381
 Srikanthan Thambipillai,Nanyang Technological University,http://research.ntu.edu.sg/expertise/academicprofile/Pages/StaffProfile.aspx?ST_EMAILID=ASTSRIKAN,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -2366,6 +2386,7 @@ Subhasis Bhattacharjee,IIT Jammu,https://www.iitjammu.ac.in/computer_science_eng
 Subhasis Ray,Plaksha University,https://plaksha.edu.in/faculty-details/dr-subhasis-ray,V7pOJVgAAAAJ,0000-0000-0000-0000
 Subhasish Mazumdar,New Mexico Tech,https://nmt.edu/academics/compsci/faculty/smazumdar.php,NOSCHOLARPAGE,0000-0000-0000-0000
 Subhasish Mitra,Stanford University,https://web.stanford.edu/~subh,SCdhzWoAAAAJ,0000-0002-5572-5194
+Subhrajit Barick,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/SubhrajitBarick/_jcr_content.html,0H2nwXIAAAAJ,0000-0002-8763-2427
 Subhransu Maji,Univ. of Massachusetts Amherst,http://people.cs.umass.edu/~smaji,l7Qx0zAAAAAJ,0000-0002-3869-9334
 Subidh Ali,IIT Bhilai,https://www.iitbhilai.ac.in/index.php?pid=subidh,BdDCoeEAAAAJ,0000-0000-0000-0000
 Subodh Kumar 0001,IIT Delhi,http://www.cse.iitd.ac.in/~subodh,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -2379,8 +2400,10 @@ Subrata Dasgupta,Univ. of Louisiana - Lafayette,https://louisiana.edu/about-us/a
 Subrota K. Mondal,MUST,https://fie.must.edu.mo/id-1444/person/view/id-441.html,tLKruz8AAAAJ,0000-0000-0000-0000
 Sucha Supittayapornpong,VISTEC,https://vistec.ist/faculty-member/sucha,NOSCHOLARPAGE,0000-0000-0000-0000
 Suchada Siripant,Chulalongkorn University,http://pioneer.netserv.chula.ac.th/~ssuchada,NOSCHOLARPAGE,0000-0000-0000-0000
+Sucharitha Shetty,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/sucharitha-shetty/_jcr_content.html,FuNX6CoAAAAJ,0000-0003-3809-8309
 Suchendra M. Bhandarkar,University of Georgia,http://cobweb.cs.uga.edu/~suchi,WjrtwJgAAAAJ,0000-0000-0000-0000
 Sucheta Soundarajan,Syracuse University,http://eng-cs.syr.edu/our-departments/electrical-engineering-and-computer-science/people/faculty,Li0F9VAAAAAJ,0000-0000-0000-0000
+Sucheta V. Kolekar,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/sucheta-kolekar/_jcr_content.html,okqYYHUAAAAJ,0000-0003-2642-6088
 Suchetana Chakraborty,IIT Jodhpur,http://home.iitj.ac.in/~suchetana,sLnKodYAAAAJ,0000-0000-0000-0000
 Suchi Kumari,Shiv Nadar University,https://www.snu.edu.in/schools/school-of-engineering/faculty/suchi-kumari,x1f7bxoAAAAJ,0000-0000-0000-0000
 Suchi Saria,Johns Hopkins University,https://suchisaria.jhu.edu,FZLHMv8AAAAJ,0000-0000-0000-0000
@@ -2481,6 +2504,7 @@ Sumit K. Pandey,IIT Jammu,https://www.iitjammu.ac.in/computer_science_engineerin
 Sumit Kalra,IIT Jodhpur,http://home.iitj.ac.in/~sumitk,Uqmo9kIAAAAJ,0000-0000-0000-0000
 Sumit Kumar Jha,University of Florida,https://cise.ufl.edu/~sumit.jha,3kJbs98AAAAJ,0000-0000-0000-0000
 Sumita Mishra,Rochester Inst. of Technology,http://csec.rit.edu/~smishra,WdVZoP4AAAAJ,0000-0002-7093-631X
+Sumith N,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/SumitN/_jcr_content.html,Al-4upIAAAAJ,0000-0003-0791-7092
 Sumitra M. Mukherjee,Nova Southeastern University,https://cec.nova.edu/faculty/mukherjee.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Sumitra Mukherjee,Nova Southeastern University,https://cec.nova.edu/faculty/mukherjee.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Sumon Biswas,Case Western Reserve University,https://sumonbis.github.io,SD5GRJ4AAAAJ,0000-0001-7074-1953
@@ -2691,6 +2715,7 @@ Swaroop Joshi,BITS Pilani-Goa,https://swaroopjoshi.in,iibndPYAAAAJ,0000-0003-453
 Swarun Kumar,Carnegie Mellon University,https://swarunkumar.com,WfaqxlgAAAAJ,0000-0002-5398-5347
 Swastik Brahma,University of Cincinnati,https://researchdirectory.uc.edu/p/brahmask,E7yV38gAAAAJ,0000-0000-0000-0000
 Swastik Kopparty,University of Toronto,https://www.math.toronto.edu/swastik,NOSCHOLARPAGE,0000-0003-2704-8808
+Swathi Prabhu,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/SwathiPrabhu/_jcr_content.html,qdBPT9sAAAAJ,0009-0004-0470-0028
 Swati Jaiswal,VNIT Nagpur,https://vnit.ac.in/engineering/cse/dr-swati-jaiswal,nsswjtsAAAAJ,0000-0000-0000-0000
 Swati Mishra 0006,McMaster University,https://swati-mishra.com,NOSCHOLARPAGE,0000-0000-0000-0000
 Swen Jacobs,CISPA Helmholtz Center,https://www.react.uni-saarland.de/people/jacobs.html,pofIiPIAAAAJ,0000-0002-9051-4050

--- a/csrankings-t.csv
+++ b/csrankings-t.csv
@@ -14,6 +14,8 @@ T. Patrick Martin,Queen’s University,http://www.cs.queensu.ca/home/martin,KgIp
 T. Ramakrishnudu,National Inst. of Tech. Warangal,https://wsdc.nitw.ac.in/facultynew/facultyprofile/id/16344,oscHBicAAAAJ,0000-0000-0000-0000
 T. S. E. Maibaum,McMaster University,http://www.cas.mcmaster.ca/~maibaum,NOSCHOLARPAGE,0000-0000-0000-0000
 T. S. Eugene Ng,Rice University,https://www.cs.rice.edu/~eugeneng,P07ZE9sAAAAJ,0000-0003-2954-0767
+T. S. Sangeetha,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/sangeetha-ts/_jcr_content.html,X2worqkAAAAJ,0000-0002-2129-7873
+T. Sujithra,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/dr-t-sujithra----department-of-computer-science---engg---mit--ma/_jcr_content.html,CJGaFr4AAAAJ,0000-0000-0000-0000
 T. V. Prabhakar,IIT Kanpur,http://www.cse.iitk.ac.in/users/tvp,vWvglUgAAAAJ,0000-0000-0000-0000
 T. Venkatesh,IIT Guwahati,http://www.iitg.ernet.in/t.venkat,yxogbeoAAAAJ,0000-0000-0000-0000
 T. Yung Kong,CUNY,http://www.gc.cuny.edu/Page-Elements/Academics-Research-Centers-Initiatives/Doctoral-Programs/Computer-Science/Faculty-Bios/T-Yung-Kong,Hbb5UBgAAAAJ,0000-0000-0000-0000
@@ -155,6 +157,7 @@ Tanmay Tulsidas Verlekar,BITS Pilani-Goa,https://www.bits-pilani.ac.in/goa/tanma
 Tanmoy Chakraborty 0002,IIT Delhi,https://tanmoychak.com,C5S9JnIAAAAJ,0000-0002-0210-0369
 Tanmoy Kundu 0001,IIIT Delhi,https://tanmoy1040.wixsite.com/researchprofile,uaR6OVIAAAAJ,0000-0002-3076-0145
 Tanu Malik,DePaul University,http://www.cdm.depaul.edu/Faculty-and-Staff/Pages/faculty-info.aspx?fid=1328,ZvYwdsUAAAAJ,0000-0000-0000-0000
+Tanuja Shailesh,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/tanuja-shailesh/_jcr_content.html,NOSCHOLARPAGE,0000-0003-4916-3807
 Tanushree Mitra,University of Washington,http://faculty.washington.edu/tmitra,5q_BkVAAAAAJ,0000-0002-9507-6192
 Tanya Goyal,Cornell University,https://tagoyal.github.io,w72MSFoAAAAJ,0000-0000-0000-0000
 Tanya Plotkin,Bar-Ilan University,http://cs.biu.ac.il/en/node/648,NOSCHOLARPAGE,0000-0000-0000-0000

--- a/csrankings-v.csv
+++ b/csrankings-v.csv
@@ -1,4 +1,5 @@
 name,affiliation,homepage,scholarid,orcid
+V. G. Narendra,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/narendra-vg/_jcr_content.html,pya2ShwAAAAJ,0000-0002-6259-0056
 V. G. Vovk,Royal Holloway Univ. of London,https://pure.royalholloway.ac.uk/portal/en/persons/vladimir-vovk_74ed8b21-d9d7-4ab6-8dbf-6f177b91b945.html,GJE29ekAAAAJ,0000-0000-0000-0000
 V. John Mathews,Oregon State University,http://eecs.oregonstate.edu/people/mathews-v-john,NOSCHOLARPAGE,0000-0000-0000-0000
 V. K. Prasanna Kumar,University of Southern California,http://ceng.usc.edu/~prasanna,4FQXSP8AAAAJ,0000-0000-0000-0000
@@ -152,6 +153,7 @@ Vedrana Andersen Dahl,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE,0000-
 Veeky Baths,BITS Pilani-Goa,https://www.bits-pilani.ac.in/goa/veeky-baths,s84fzIoAAAAJ,0000-0001-9980-5738
 Veelasha Moonsamy,Ruhr-University Bochum,https://www.veelasha.org,lMDHW00AAAAJ,0000-0000-0000-0000
 Veena Goswami,KIIT Bhubaneswar,https://ksca.kiit.ac.in/profiles/veena-goswami,tJHsyCMAAAAJ,0000-0000-0000-0000
+Veena Mayya,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/veena-mayya/_jcr_content.html,Ox2h-7AAAAAJ,0000-0002-8091-5053
 Veezhinathan Kamakoti,IIT Madras,http://rise.cse.iitm.ac.in/people/faculty/kama/kama.html,n_Ck-8UAAAAJ,0000-0000-0000-0000
 Veikko Surakka,Tampere University,https://www.tuni.fi/en/veikko-surakka,7h-zuycAAAAJ,0000-0003-3986-0713
 Veit Hagenmeyer,Karlsruhe Inst. of Technology,https://www.iai.kit.edu/Ansprechpersonen_1213.php,VQ70NaMAAAAJ,0000-0000-0000-0000
@@ -174,6 +176,7 @@ Venkataramana Badarla,IIT Tirupati,https://iittp.ac.in/dr-venkata-ramana-badarla
 Venkatesan Guruswami,Univ. of California - Berkeley,https://people.eecs.berkeley.edu/~venkatg,Es6jE1kAAAAJ,0000-0001-7926-3396
 Venkatesh Akella,Univ. of California - Davis,https://www.ece.ucdavis.edu/~akella,onJXki0AAAAJ,0000-0000-0000-0000
 Venkatesh Babu Radhakrishnan,IISc Bangalore,https://cds.iisc.ac.in/faculty/venky,cVg7HrEAAAAJ,0000-0002-1926-1804
+Venkatesh Bhandage,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/Venkatesh-Bhandage/_jcr_content.html,3RfaOrAAAAAJ,0000-0002-9503-8196
 Venkatesh Choppella,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/choppell,fGj4T74AAAAJ,0000-0000-0000-0000
 Venkatesh Prasad Ranganath,Kansas State University,http://people.cis.ksu.edu/~rvprasad,efsT3ykAAAAJ,0000-0001-7684-6086
 Venkatesh Raman 0001,IMSc,http://www.imsc.res.in/~vraman,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -254,7 +257,9 @@ Victoria Kostina,California Inst. of Technology,http://vkostina.caltech.edu,TooJ
 Victoria Stodden,University of Southern California,https://stodden.net,LWw60SgAAAAJ,0000-0000-0000-0000
 Victoria Yao,Rice University,https://profiles.rice.edu/faculty/vicky-yao,egBVVA8AAAAJ,0000-0000-0000-0000
 Vida Dujmovic,University of Ottawa,http://cglab.ca/~vida,NOSCHOLARPAGE,0000-0000-0000-0000
+Vidhya V.,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/vidhya-v/_jcr_content.html,pu9wkNcAAAAJ,0000-0002-8111-723X
 Vidya Muthukumar,Georgia Institute of Technology,https://vmuthukumar.ece.gatech.edu,NOSCHOLARPAGE,0000-0000-0000-0000
+Vidya Rao,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/vidya-rao/_jcr_content.html,XEAeSVcAAAAJ,0000-0001-7282-7726
 Viera Rozinajová,Kempelen Institute - KInIT,https://kinit.sk/member/viera-rozinajova,Kv2JpV0AAAAJ,0000-0000-0000-0000
 Viet Tung Hoang,Florida State University,http://www.cs.fsu.edu/~tvhoang,ggcCMuIAAAAJ,0000-0003-3092-6405
 Viggo Kann,KTH Royal Inst. of Technology,http://www.csc.kth.se/~viggo,4Fexy5ml2cMC,0000-0000-0000-0000
@@ -455,6 +460,7 @@ Vivek Sarin,Texas A&M University,http://faculty.cs.tamu.edu/sarin,4vLOo4wAAAAJ,0
 Vivek Sarkar,Georgia Institute of Technology,http://vsarkar.cc.gatech.edu,XjeIqxYAAAAJ,0000-0002-3433-8830
 Vivek Srikumar,University of Utah,http://svivek.com,TsTUfOIAAAAJ,0000-0003-0419-6568
 Vivek Subramanian,EPFL,https://people.epfl.ch/vivek.subramanian?lang=en,j-KcbbAAAAAJ,0000-0000-0000-0000
+Vivekananda Bhat K.,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/vivekananda-k-bhat/_jcr_content.html,SqCsL8EAAAAJ,0000-0003-3411-9221
 Viviane Moreira Orengo,UFRGS,http://www.inf.ufrgs.br/~viviane,-l5-OIQAAAAJ,0000-0000-0000-0000
 Viviane P. Moreira,UFRGS,http://www.inf.ufrgs.br/~viviane,-l5-OIQAAAAJ,0000-0000-0000-0000
 Viviane Pereira Moreira,UFRGS,http://www.inf.ufrgs.br/~viviane,-l5-OIQAAAAJ,0000-0000-0000-0000

--- a/orcid.csv
+++ b/orcid.csv
@@ -31552,3 +31552,126 @@ wanchun Jiang,0000-0000-0000-0000
 Øystein Nytrø,0000-0000-0000-0000
 Øyvind Hanssen,0000-0000-0000-0000
 Ümit V. Çatalyürek,0000-0002-5625-3758
+Anup Bhat,0000-0002-9910-6758
+Arpan Mandal,0000-0001-8376-429X
+S. J. Pawan,0000-0002-2560-9213
+Pawan S. Jogi,0000-0002-2560-9213
+Aarabhi Putty,0000-0002-7646-8262
+Abhilash K. Pai,0000-0001-7218-0475
+Adarsh Rag S,0000-0002-1680-6055
+N. D. Adesh,0000-0002-9750-113X
+Ahamed Shafeeq B. M.,0000-0001-6555-6980
+Ajitha Shenoy K. B,0000-0003-3995-1826
+Andrew J. 0001,0000-0003-3592-6543
+Anita S. Kini,0000-0002-7823-7142
+H. Anitha,0000-0001-5898-4442
+Anoop Benet Nirmala,0000-0002-6082-391X
+Archana Praveen Kumar,0000-0002-7671-6633
+B. Ashutosh Holla,0009-0009-7995-4213
+B. Ashwath Rao,0000-0001-8528-1646
+Avik Bose,0000-0002-4592-4632
+Bhukya Padma,0000-0002-5490-035X
+C. B. Chandrakala,0000-0003-3818-0679
+Chetana Pujari,0000-0001-6717-5567
+D. Cenitta,0000-0003-3715-6941
+Dasharathraj K. Shetty,0000-0002-5021-4029
+Deepak Parashar,0000-0002-4189-4560
+Diana Olivia,0000-0003-2934-2090
+Divya Rao,0000-0001-8370-4959
+Ashalatha Nayak,0000-0001-7888-6516
+N. Gopalakrishna Kini,0000-0002-9293-7460
+M. Geetha 0002,0000-0002-6150-7601
+Dinesh Acharya U.,0000-0002-0304-4725
+Harish Sheeranalli Venkatarama,0000-0002-7264-7538
+S. Hemalatha 0001,0000-0002-1826-0738
+Mamatha Balachandra,0000-0003-2201-8730
+K. N. Manjunath,0000-0001-8239-4047
+Srikanth Prabhu,0000-0002-3826-1084
+R. Roopalakshmi,0000-0001-7931-4608
+Radhika Kamath,0000-0002-9353-409X
+P. B. Shanthi,0000-0003-3276-7073
+Vivekananda Bhat K.,0000-0003-3411-9221
+Arul Elango,0000-0002-7517-8757
+Giridhar N. Shakarad,0000-0003-4870-2039
+Girija V. Attigeri,0000-0002-0899-5781
+Gouranga Mandal,0000-0002-7749-290X
+Govardhan Hegde,0000-0002-8741-8965
+K. Jyothi Upadhya,0000-0002-4997-7918
+P. P. Jashma Suresh,0000-0003-4565-991X
+Harsh Nagar,0009-0005-9167-7168
+Kamaraj Kanagaraj,0000-0002-2761-0138
+S. Kaliraj,0000-0003-4212-8427
+Shyam Karanth,0000-0003-3232-4213
+Krishna Prakasha,0000-0001-7797-1399
+Kranthi Kumar Lella,0000-0001-7736-5321
+Krishnaraj Chadaga,0000-0002-9459-8423
+Krishnamoorthi Makkithaya,0000-0002-7919-8886
+Manjula Shenoy K,0000-0002-7835-1156
+M. M. Manohara Pai,0000-0003-2164-2945
+Manjunath Hegde,0000-0002-4264-9532
+Manjula C. Belavagi,0000-0002-3243-1310
+Manoj T.,0000-0002-5472-2418
+Mayank Patel 0001,0000-0002-7804-4017
+Anusha Hegde,0000-0002-2862-4187
+Mayur Anand Pandya,0000-0001-5044-4521
+B. P. Swathi,0000-0002-6708-6385
+T. S. Sangeetha,0000-0002-2129-7873
+S. N. Muralikrishna,0000-0002-5657-4439
+Musica Supriya,0000-0002-4611-229X
+Sivaselvan N,0000-0002-5014-5991
+Bayyapu Neelima,0000-0002-7201-2217
+V. G. Narendra,0000-0002-6259-0056
+Nagaraj Naik,0000-0001-7031-9787
+Nisha P. Shetty,0000-0002-4738-4713
+P. C. Siddalingaswamy,0000-0002-7597-7591
+Pankaj Kumar 0007,0000-0003-2824-0551
+G. Poornalatha,0000-0001-9620-5526
+Prakash K. Aithal,0000-0002-4304-9512
+Prajna Paramita Pradhan,0000-0002-2210-5028
+Poornima Panduranga Kundapur,0000-0002-8271-524X
+Preetham Kumar,0000-0002-0736-7687
+B. Priya Kamath,0000-0002-5471-8822
+Radha Krishna Reddy Pallavali,0000-0002-9651-3294
+Raghavendra Achar,0000-0003-2646-0606
+Radhika M. Pai,0000-0002-0916-0495
+Radhakrishna Bhat,0000-0002-2309-0745
+Raghavendra Ganiga,0000-0003-4748-6733
+Raghu Thekke Veedu,0000-0003-4748-6733
+K. Raghurama Holla,0000-0001-5265-9120
+Rajashree Krishna,0000-0003-1924-039X
+Ramya D. Shetty,0000-0003-3530-0102
+M. Ramakrishna 0002,0000-0001-8270-8675
+Rajesh Gopakumar,0000-0002-4252-9178
+Rajesh Mahadeva,0000-0001-8952-7172
+Rani Oomman Panicker,0000-0001-9083-8840
+Rohini R. Rao,0000-0002-6940-3858
+Renuka A. 0001,0000-0001-6511-9780
+M. Raviraja Holla,0000-0003-1627-552X
+Rashmi Naveen Raj,0000-0002-7683-4955
+Roopashri Shetty,0000-0003-4145-620X
+Roshan David Jathanna,0000-0002-4080-7621
+Soumya Nandan Mishra,0000-0002-4115-3498
+Sanjay Singh 0002,0000-0001-7212-5919
+Sandhya Parasnath Dubey,0000-0002-8350-2676
+Sameena Pathan,0000-0002-9867-4382
+Santhosh Kamath,0000-0002-1956-1727
+Santhosha Rao,0000-0001-9511-3048
+Satyajit Mahapatra,0000-0002-5516-6978
+Shavantrevva Bilakeri,0000-0002-5347-1485
+Shankar Biradar,0000-0003-4869-5860
+Shivaprasad Gundibail,0000-0003-4986-5593
+Shreenidhi H. Bhat,0000-0002-2185-0608
+Shwetha Rai,0000-0002-5714-2611
+D. N. Sindhura,0000-0001-9358-9165
+Sucharitha Shetty,0000-0003-3809-8309
+Subhrajit Barick,0000-0002-8763-2427
+Smitha N. Pai,0000-0002-3258-2688
+Sucheta V. Kolekar,0000-0003-2642-6088
+Tanuja Shailesh,0000-0003-4916-3807
+Swathi Prabhu,0009-0004-0470-0028
+Sumith N,0000-0003-0791-7092
+Veena Mayya,0000-0002-8091-5053
+Venkatesh Bhandage,0000-0002-9503-8196
+Vidya Rao,0000-0001-7282-7726
+Vidhya V.,0000-0002-8111-723X
+Gogulamudi Pradeep Reddy,0000-0002-5624-5547


### PR DESCRIPTION
## Summary
Adding 125 faculty entries from **Manipal Academy of Higher Education**.

**Note:** This PR was created manually because the [batch submission form](https://csrankings.org/submit/) does not work for large submissions. The form generates a GitHub Issue URL with the entire payload encoded in the query string, and for 125 entries this produced a ~63,000 character URL — far exceeding the browser/GitHub URL length limit. The resulting URL simply fails to load. The form may need a fix for large batch submissions.

## Details
- **Institution:** Manipal Academy of Higher Education (already in `institutions.csv`)
- **Files changed:** `csrankings-{a,b,c,d,g,h,k,m,n,p,r,s,t,v}.csv` and `orcid.csv`
- **Entries:** 125 new faculty members with DBLP names, homepages, Google Scholar IDs, and ORCIDs

## Eligibility Confirmation
- [X] Full-time, tenure-track faculty
- [X] Can solely advise CS PhD students
- [X] In a CS department (School of Computer Engineering)
- [X] Names match DBLP exactly
- [X] Homepage URLs provided for all entries