### PR TITLE
Update faculty affiliations and fix duplicates

### DIFF
--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -23,7 +23,6 @@ C. R. Ramakrishnan 0001,Stony Brook University,http://www3.cs.stonybrook.edu/~cr
 C. R. Subramanian 0001,IMSc,http://www.imsc.res.in/~crs,A_WrLWsAAAAJ,0000-0000-0000-0000
 C. Ravindranath Chowdary,IIT (BHU) Varanasi,http://www.old.iitbhu.ac.in/cse/index.php/people/faculty/36.html,wWbOB0UAAAAJ,0000-0000-0000-0000
 C. Seshadhri 0001,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~sesh,NOSCHOLARPAGE,0000-0003-2163-3555
-C. Siva Ram Murthy,IIT Hyderabad,http://www.cse.iitm.ac.in/~murthy,VjJFBjcAAAAJ,0000-0000-0000-0000
 C. V. Jawahar,IIIT Hyderabad,https://www.iiit.ac.in/~jawahar,U9dH-DoAAAAJ,0000-0001-6767-7057
 C. Y. Roger Chen,Syracuse University,https://eng-cs.syr.edu/our-departments/electrical-engineering-and-computer-science/people/?peopleid=2970,NOSCHOLARPAGE,0000-0000-0000-0000
 C.-C. Jay Kuo,University of Southern California,http://mcl.usc.edu,81d60okAAAAJ,0000-0001-9474-5035
@@ -501,7 +500,6 @@ Chaya Ganesh,IISc Bangalore,https://www.csa.iisc.ac.in/~chaya,b_NnjeQAAAAJ,0000-
 Chaya Keller,Ariel University,https://www.ariel.ac.il/wp/chaya-keller,EMx7NAz8RZAC,0000-0001-6400-3946
 Chayakorn Netramai,KMUTNB,https://tggs.kmutnb.ac.th/asst-prof-dr-ing-chayakorn-netramai,mGzsTX4AAAAJ,0000-0000-0000-0000
 Che-Rung Lee,National Tsing Hua University,http://www.cs.nthu.edu.tw/~cherung,FoJPzwUAAAAJ,0000-0000-0000-0000
-Chebiyyam Siva Ram Murthy,IIT Hyderabad,http://www.cse.iitm.ac.in/~murthy,VjJFBjcAAAAJ,0000-0000-0000-0000
 Chee K. Yap,New York University,http://cs.nyu.edu/yap,NOSCHOLARPAGE,0000-0000-0000-0000
 Chee Keong Kwoh 0001,Nanyang Technological University,http://www.ntu.edu.sg/home/asckkwoh,jVn0wDMAAAAJ,0000-0000-0000-0000
 Chee Keong Tan,Monash University Malaysia,https://research.monash.edu/en/persons/tan-chee-keong,hlGeZ4MAAAAJ,0000-0001-5551-1017

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -23,7 +23,7 @@ C. R. Ramakrishnan 0001,Stony Brook University,http://www3.cs.stonybrook.edu/~cr
 C. R. Subramanian 0001,IMSc,http://www.imsc.res.in/~crs,A_WrLWsAAAAJ,0000-0000-0000-0000
 C. Ravindranath Chowdary,IIT (BHU) Varanasi,http://www.old.iitbhu.ac.in/cse/index.php/people/faculty/36.html,wWbOB0UAAAAJ,0000-0000-0000-0000
 C. Seshadhri 0001,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~sesh,NOSCHOLARPAGE,0000-0003-2163-3555
-C. Siva Ram Murthy,IIT Madras,http://www.cse.iitm.ac.in/~murthy,VjJFBjcAAAAJ,0000-0000-0000-0000
+C. Siva Ram Murthy,IIT Hyderabad,http://www.cse.iitm.ac.in/~murthy,VjJFBjcAAAAJ,0000-0000-0000-0000
 C. V. Jawahar,IIIT Hyderabad,https://www.iiit.ac.in/~jawahar,U9dH-DoAAAAJ,0000-0001-6767-7057
 C. Y. Roger Chen,Syracuse University,https://eng-cs.syr.edu/our-departments/electrical-engineering-and-computer-science/people/?peopleid=2970,NOSCHOLARPAGE,0000-0000-0000-0000
 C.-C. Jay Kuo,University of Southern California,http://mcl.usc.edu,81d60okAAAAJ,0000-0001-9474-5035
@@ -501,7 +501,7 @@ Chaya Ganesh,IISc Bangalore,https://www.csa.iisc.ac.in/~chaya,b_NnjeQAAAAJ,0000-
 Chaya Keller,Ariel University,https://www.ariel.ac.il/wp/chaya-keller,EMx7NAz8RZAC,0000-0001-6400-3946
 Chayakorn Netramai,KMUTNB,https://tggs.kmutnb.ac.th/asst-prof-dr-ing-chayakorn-netramai,mGzsTX4AAAAJ,0000-0000-0000-0000
 Che-Rung Lee,National Tsing Hua University,http://www.cs.nthu.edu.tw/~cherung,FoJPzwUAAAAJ,0000-0000-0000-0000
-Chebiyyam Siva Ram Murthy,IIT Madras,http://www.cse.iitm.ac.in/~murthy,VjJFBjcAAAAJ,0000-0000-0000-0000
+Chebiyyam Siva Ram Murthy,IIT Hyderabad,http://www.cse.iitm.ac.in/~murthy,VjJFBjcAAAAJ,0000-0000-0000-0000
 Chee K. Yap,New York University,http://cs.nyu.edu/yap,NOSCHOLARPAGE,0000-0000-0000-0000
 Chee Keong Kwoh 0001,Nanyang Technological University,http://www.ntu.edu.sg/home/asckkwoh,jVn0wDMAAAAJ,0000-0000-0000-0000
 Chee Keong Tan,Monash University Malaysia,https://research.monash.edu/en/persons/tan-chee-keong,hlGeZ4MAAAAJ,0000-0001-5551-1017

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -945,7 +945,6 @@ Krishna Murthy Jatavallabhula,Johns Hopkins University,https://krrish94.github.i
 Krishna Narayanan 0001,Texas A&M University,http://krishnanarayanan.wikidot.com,oDivxXQAAAAJ,0000-0000-0000-0000
 Krishna P. Gummadi [SWS],Max Planck Society,https://www.mpi-sws.org/~gummadi,Bz3APTsAAAAJ,0000-0000-0000-0000
 Krishna P. Miyapuram,IIT Gandhinagar,http://cogs.iitgn.ac.in/people/faculty/krishna-miyapuram,R20YmxkAAAAJ,0000-0000-0000-0000
-Krishna Prasad Miyapuram,IIT Gandhinagar,http://cogs.iitgn.ac.in/people/faculty/krishna-miyapuram,R20YmxkAAAAJ,0000-0000-0000-0000
 Krishna Pillutla,IIT Madras,https://krishnap25.github.io,xUUEAG4AAAAJ,0000-0000-0000-0000
 Krishna Prakasha,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/krishna-prakasha-a/_jcr_content.html,OGL1JBQAAAAJ,0000-0001-7797-1399
 Krishna R. Narayanan,Texas A&M University,http://krishnanarayanan.wikidot.com,oDivxXQAAAAJ,0000-0000-0000-0000

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -945,6 +945,7 @@ Krishna Murthy Jatavallabhula,Johns Hopkins University,https://krrish94.github.i
 Krishna Narayanan 0001,Texas A&M University,http://krishnanarayanan.wikidot.com,oDivxXQAAAAJ,0000-0000-0000-0000
 Krishna P. Gummadi [SWS],Max Planck Society,https://www.mpi-sws.org/~gummadi,Bz3APTsAAAAJ,0000-0000-0000-0000
 Krishna P. Miyapuram,IIT Gandhinagar,http://cogs.iitgn.ac.in/people/faculty/krishna-miyapuram,R20YmxkAAAAJ,0000-0000-0000-0000
+Krishna Prasad Miyapuram,IIT Gandhinagar,http://cogs.iitgn.ac.in/people/faculty/krishna-miyapuram,R20YmxkAAAAJ,0000-0000-0000-0000
 Krishna Pillutla,IIT Madras,https://krishnap25.github.io,xUUEAG4AAAAJ,0000-0000-0000-0000
 Krishna Prakasha,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/krishna-prakasha-a/_jcr_content.html,OGL1JBQAAAAJ,0000-0001-7797-1399
 Krishna R. Narayanan,Texas A&M University,http://krishnanarayanan.wikidot.com,oDivxXQAAAAJ,0000-0000-0000-0000

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -1007,7 +1007,7 @@ Krzysztof R. Apt,University of Warsaw,http://www.bokus.com/bok/9780521866286/con
 Krzysztof Rzadca,University of Warsaw,http://www.mimuw.edu.pl/~krzadca,ctiDQxUAAAAJ,0000-0002-4176-853X
 Krzysztof Stencel,University of Warsaw,http://uw.academia.edu/KrzysztofStencel,393Ddr0AAAAJ,0000-0000-0000-0000
 Krzysztof Z. Gajos,Harvard University,http://www.eecs.harvard.edu/~kgajos,MnnERiQAAAAJ,0000-0002-1897-9048
-Kshitij Gajjar,IIIT Hyderabad,https://www.tcs.tifr.res.in/~kshitij,2AO5VAsAAAAJ,0000-0003-0890-199X
+Kshitij Gajjar,IIIT Hyderabad,https://sites.google.com/view/kshitijgajjar/,2AO5VAsAAAAJ,0000-0003-0890-199X
 Ku-Jin Kim,Kyungpook National University,http://bh.knu.ac.kr/~kujinkim,yD2zLvYAAAAJ,0000-0000-0000-0000
 Kuan Cheng,Peking University,https://sites.google.com/site/ckkcdh/home,cHneZMEAAAAJ,0000-0000-0000-0000
 Kuan Fang,Cornell University,https://kuanfang.github.io,BZBkjNYAAAAJ,0000-0000-0000-0000

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -263,7 +263,7 @@ Karsten Schmidt 0004,University of Rostock,https://theo.informatik.uni-rostock.d
 Karsten Weihe,TU Darmstadt,https://www.informatik.tu-darmstadt.de/fb20/organisation_fb20/professuren_und_gruppenleitungen/fb20professuren_und_gruppenleitungen_detailseite_32832.en.jsp,ElDbbP8AAAAJ,0000-0003-3039-8454
 Karsten Wolf,University of Rostock,https://theo.informatik.uni-rostock.de/theo-team/karsten-wolf,1OleyYgAAAAJ,0000-0000-0000-0000
 Karsten Øster Lundqvist,Victoria University of Wellington,https://ecs.victoria.ac.nz/Main/KarstenLundqvist,aLfZJJQAAAAJ,0000-0000-0000-0000
-Karteek Sreenivasaiah,University of Liverpool,http://www.iith.ac.in/~karteek,NOSCHOLARPAGE,0000-0001-7396-3383
+Karteek Sreenivasaiah,University of Liverpool,https://www.liverpool.ac.uk/people/karteek-sreenivasaiah,NOSCHOLARPAGE,0000-0001-7396-3383
 Karthekeyan Chandrasekaran,Univ. of Illinois at Urbana-Champaign,http://karthik.ise.illinois.edu,MD0uui4AAAAJ,0000-0002-3421-7238
 Karthik C. S. 0001,Rutgers University,https://cskarthikcs.github.io,PS2LQKYAAAAJ,0000-0001-9105-364X
 Karthik Dantu,University at Buffalo,https://cse.buffalo.edu/~kdantu,aOO2tOwAAAAJ,0000-0002-7497-6722

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -1008,7 +1008,7 @@ Krzysztof R. Apt,University of Warsaw,http://www.bokus.com/bok/9780521866286/con
 Krzysztof Rzadca,University of Warsaw,http://www.mimuw.edu.pl/~krzadca,ctiDQxUAAAAJ,0000-0002-4176-853X
 Krzysztof Stencel,University of Warsaw,http://uw.academia.edu/KrzysztofStencel,393Ddr0AAAAJ,0000-0000-0000-0000
 Krzysztof Z. Gajos,Harvard University,http://www.eecs.harvard.edu/~kgajos,MnnERiQAAAAJ,0000-0002-1897-9048
-Kshitij Gajjar,IIT Jodhpur,https://www.tcs.tifr.res.in/~kshitij,2AO5VAsAAAAJ,0000-0003-0890-199X
+Kshitij Gajjar,IIIT Hyderabad,https://www.tcs.tifr.res.in/~kshitij,2AO5VAsAAAAJ,0000-0003-0890-199X
 Ku-Jin Kim,Kyungpook National University,http://bh.knu.ac.kr/~kujinkim,yD2zLvYAAAAJ,0000-0000-0000-0000
 Kuan Cheng,Peking University,https://sites.google.com/site/ckkcdh/home,cHneZMEAAAAJ,0000-0000-0000-0000
 Kuan Fang,Cornell University,https://kuanfang.github.io,BZBkjNYAAAAJ,0000-0000-0000-0000

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -947,7 +947,6 @@ Krishna P. Gummadi [SWS],Max Planck Society,https://www.mpi-sws.org/~gummadi,Bz3
 Krishna P. Miyapuram,IIT Gandhinagar,http://cogs.iitgn.ac.in/people/faculty/krishna-miyapuram,R20YmxkAAAAJ,0000-0000-0000-0000
 Krishna Pillutla,IIT Madras,https://krishnap25.github.io,xUUEAG4AAAAJ,0000-0000-0000-0000
 Krishna Prakasha,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/krishna-prakasha-a/_jcr_content.html,OGL1JBQAAAAJ,0000-0001-7797-1399
-Krishna Prasad Miyapuram,IIT Gandhinagar,http://cogs.iitgn.ac.in/people/faculty/krishna-miyapuram,R20YmxkAAAAJ,0000-0000-0000-0000
 Krishna R. Narayanan,Texas A&M University,http://krishnanarayanan.wikidot.com,oDivxXQAAAAJ,0000-0000-0000-0000
 Krishna Reddy Polepalli,IIIT Hyderabad,http://faculty.iiit.ac.in/~pkreddy,XIgl8kUAAAAJ,0000-0000-0000-0000
 Krishna V. Palem,Rice University,http://www.cs.rice.edu/~kvp1,TW6dnZUAAAAJ,0000-0000-0000-0000

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -263,7 +263,7 @@ Karsten Schmidt 0004,University of Rostock,https://theo.informatik.uni-rostock.d
 Karsten Weihe,TU Darmstadt,https://www.informatik.tu-darmstadt.de/fb20/organisation_fb20/professuren_und_gruppenleitungen/fb20professuren_und_gruppenleitungen_detailseite_32832.en.jsp,ElDbbP8AAAAJ,0000-0003-3039-8454
 Karsten Wolf,University of Rostock,https://theo.informatik.uni-rostock.de/theo-team/karsten-wolf,1OleyYgAAAAJ,0000-0000-0000-0000
 Karsten Øster Lundqvist,Victoria University of Wellington,https://ecs.victoria.ac.nz/Main/KarstenLundqvist,aLfZJJQAAAAJ,0000-0000-0000-0000
-Karteek Sreenivasaiah,IIT Hyderabad,http://www.iith.ac.in/~karteek,NOSCHOLARPAGE,0000-0001-7396-3383
+Karteek Sreenivasaiah,University of Liverpool,http://www.iith.ac.in/~karteek,NOSCHOLARPAGE,0000-0001-7396-3383
 Karthekeyan Chandrasekaran,Univ. of Illinois at Urbana-Champaign,http://karthik.ise.illinois.edu,MD0uui4AAAAJ,0000-0002-3421-7238
 Karthik C. S. 0001,Rutgers University,https://cskarthikcs.github.io,PS2LQKYAAAAJ,0000-0001-9105-364X
 Karthik Dantu,University at Buffalo,https://cse.buffalo.edu/~kdantu,aOO2tOwAAAAJ,0000-0002-7497-6722

--- a/csrankings-l.csv
+++ b/csrankings-l.csv
@@ -183,7 +183,7 @@ Laurie Williams,North Carolina State University,http://collaboration.csc.ncsu.ed
 Lauritz Thamsen,University of Glasgow,https://www.gla.ac.uk/schools/computing/staff/lauritzthamsen,yOXcVswAAAAJ,0000-0003-3755-1503
 Lav R. Varshney,Stony Brook University,https://ai.stonybrook.edu/people/faculty/lav-r-varshney,JIJGu30AAAAJ,0000-0003-2798-5308
 Lavika Goel,BITS Pilani,http://www.bits-pilani.ac.in/pilani/lavikagoel/profile,S9hsnNoAAAAJ,0000-0000-0000-0000
-Lawqueen Kanesh,IIT Jodhpur,https://sites.google.com/view/lawqueenkanesh/home,WD1JUOEAAAAJ,0000-0000-0000-0000
+Lawqueen Kanesh,IIT Indore,https://sites.google.com/view/lawqueenkanesh/home,WD1JUOEAAAAJ,0000-0000-0000-0000
 Lawrence B. Holder,Washington State University,http://www.eecs.wsu.edu/~holder,SjPX43QAAAAJ,0000-0000-0000-0000
 Lawrence Birnbaum,Northwestern University,http://www.mccormick.northwestern.edu/research-faculty/directory/profiles/birnbaum-larry.html,vxmUoXEAAAAJ,0000-0000-0000-0000
 Lawrence Carin,Duke University,https://ece.duke.edu/people/lawrence-carin,yuxwFscAAAAJ,0000-0001-6277-7948

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -2880,7 +2880,7 @@ Mostafa Mehdipour-Ghazi,University of Copenhagen,https://di.ku.dk/english/staff/
 Mostafa Milani,Western University,https://www.csd.uwo.ca/~mmilani7,4KeuWDYAAAAJ,0000-0002-3386-7079
 Motonobu Kanagawa,EURECOM,https://sites.google.com/site/motonobukanagawa,9G-g30IAAAAJ,0000-0002-3948-8053
 Motoshi Saeki,Tokyo Institute of Technology,http://www.se.cs.titech.ac.jp,NOSCHOLARPAGE,0009-0009-7352-1951
-Moumita Patra,IIT Guwahati,https://www.iiit.ac.in/people/faculty/moumita.patra,BIGZy7sAAAAJ,0000-0000-0000-0000
+Moumita Patra,IIT Guwahati,https://patramoumita88.wixsite.com/moumita,BIGZy7sAAAAJ,0000-0000-0000-0000
 Mounir Boukadoum,Université du Québec à Montréal,https://professeurs.uqam.ca/professeur/boukadoum.mounir,tjMtB4AAAAJ,0000-0002-4894-2350
 Mounir Ghogho,Mohammed VI Polytechnic University,https://cc.um6p.ma/people/Mounir.GHOGHO,aIXHNpAAAAAJ,0000-0002-0055-7867
 Mounir Hamdi,HKUST,http://www.cs.ust.hk/~hamdi,QBietV4AAAAJ,0000-0000-0000-0000

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -2880,7 +2880,7 @@ Mostafa Mehdipour-Ghazi,University of Copenhagen,https://di.ku.dk/english/staff/
 Mostafa Milani,Western University,https://www.csd.uwo.ca/~mmilani7,4KeuWDYAAAAJ,0000-0002-3386-7079
 Motonobu Kanagawa,EURECOM,https://sites.google.com/site/motonobukanagawa,9G-g30IAAAAJ,0000-0002-3948-8053
 Motoshi Saeki,Tokyo Institute of Technology,http://www.se.cs.titech.ac.jp,NOSCHOLARPAGE,0009-0009-7352-1951
-Moumita Patra,IIT Guwahati,https://patramoumita88.wixsite.com/moumita,BIGZy7sAAAAJ,0000-0000-0000-0000
+Moumita Patra,IIT Guwahati,https://patramoumita88.wixsite.com/moumita,HcqyHeQAAAAJ,0000-0000-0000-0000
 Mounir Boukadoum,Université du Québec à Montréal,https://professeurs.uqam.ca/professeur/boukadoum.mounir,tjMtB4AAAAJ,0000-0002-4894-2350
 Mounir Ghogho,Mohammed VI Polytechnic University,https://cc.um6p.ma/people/Mounir.GHOGHO,aIXHNpAAAAAJ,0000-0002-0055-7867
 Mounir Hamdi,HKUST,http://www.cs.ust.hk/~hamdi,QBietV4AAAAJ,0000-0000-0000-0000

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -2880,7 +2880,7 @@ Mostafa Mehdipour-Ghazi,University of Copenhagen,https://di.ku.dk/english/staff/
 Mostafa Milani,Western University,https://www.csd.uwo.ca/~mmilani7,4KeuWDYAAAAJ,0000-0002-3386-7079
 Motonobu Kanagawa,EURECOM,https://sites.google.com/site/motonobukanagawa,9G-g30IAAAAJ,0000-0002-3948-8053
 Motoshi Saeki,Tokyo Institute of Technology,http://www.se.cs.titech.ac.jp,NOSCHOLARPAGE,0009-0009-7352-1951
-Moumita Patra,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/moumita.patra,BIGZy7sAAAAJ,0000-0000-0000-0000
+Moumita Patra,IIT Guwahati,https://www.iiit.ac.in/people/faculty/moumita.patra,BIGZy7sAAAAJ,0000-0000-0000-0000
 Mounir Boukadoum,Université du Québec à Montréal,https://professeurs.uqam.ca/professeur/boukadoum.mounir,tjMtB4AAAAJ,0000-0002-4894-2350
 Mounir Ghogho,Mohammed VI Polytechnic University,https://cc.um6p.ma/people/Mounir.GHOGHO,aIXHNpAAAAAJ,0000-0002-0055-7867
 Mounir Hamdi,HKUST,http://www.cs.ust.hk/~hamdi,QBietV4AAAAJ,0000-0000-0000-0000

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -254,7 +254,7 @@ Sandeep Kumar 0002,IIT Delhi,https://sites.google.com/view/sandeepkr/home,lycMMW
 Sandeep Kumar Shukla,IIT Kanpur,http://www.cse.iitk.ac.in/users/sandeeps,SKqctYsAAAAJ,0000-0001-5525-7426
 Sandeep Manjanna,Plaksha University,https://plaksha.edu.in/faculty-details/dr-sandeep-manjanna,FkRY-OcAAAAJ,0000-0000-0000-0000
 Sandeep Neema,Vanderbilt University,https://engineering.vanderbilt.edu/bio/?pid=sandeep-neema,OhUZTZ0AAAAJ,0000-0002-9781-3619
-Sandeep Sen,Ashoka University,http://www.cse.iitd.ac.in/~ssen,GK7JUpkAAAAJ,0000-0000-0000-0000
+Sandeep Sen,Ashoka University,https://www.ashoka.edu.in/profile/sandeep-sen/,GK7JUpkAAAAJ,0000-0000-0000-0000
 Sandeep Silwal,University of Wisconsin - Madison,https://sandeepsilwal.com,MnDnUvcAAAAJ,0000-0000-0000-0000
 Sander Bakkes,Utrecht University,http://sander.landofsand.com,R4OXfi4AAAAJ,0000-0000-0000-0000
 Sander C. J. Bakkes,Utrecht University,http://sander.landofsand.com,R4OXfi4AAAAJ,0000-0000-0000-0000

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -245,8 +245,7 @@ Sanchuan Chen,Auburn University,https://schuan.github.io,mWLdekkAAAAJ,0009-0002-
 Sanda M. Harabagiu,University of Texas at Dallas,http://www.utdallas.edu/~sanda,fkyBx9EAAAAJ,0000-0002-8186-1501
 Sandareka Wickramanayake,University of Moratuwa,https://sandareka.github.io,6mlKqLgAAAAJ,0000-0000-0000-0000
 Sandeep Chandran,IIT Palakkad,https://www.iitpkd.ac.in/people/sandeepchandran,NOSCHOLARPAGE,0000-0001-7110-5668
-Sandeep Juneja,Ashoka University,http://www.tcs.tifr.res.in/~sandeepj,Tfgv6VgAAAAJ,0000-0000-0000-0000
-Sandeep K. Juneja,Ashoka University,http://www.tcs.tifr.res.in/~sandeepj,Tfgv6VgAAAAJ,0000-0000-0000-0000
+Sandeep Juneja 0001,Ashoka University,https://sandeep-juneja.github.io/,Tfgv6VgAAAAJ,0000-0000-0000-0000
 Sandeep K. S. Gupta,Arizona State University,https://cidse.engineering.asu.edu/directory/gupta-sandeep,U9bcQkMAAAAJ,0000-0000-0000-0000
 Sandeep K. Shukla,IIT Kanpur,http://www.cse.iitk.ac.in/users/sandeeps,SKqctYsAAAAJ,0000-0001-5525-7426
 Sandeep Kaur Kuttal,North Carolina State University,https://www.csc.ncsu.edu/people/skuttal,RNfafUcAAAAJ,0000-0002-2610-5308

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -2723,7 +2723,7 @@ Swen Jacobs,CISPA Helmholtz Center,https://www.react.uni-saarland.de/people/jaco
 Sweta Mishra,Shiv Nadar University,https://www.snu.edu.in/schools/school-of-engineering/faculty/sweta-mishra,nqSP0nIAAAAJ,0000-0000-0000-0000
 Syamantak Das,IIIT Delhi,http://faculty.iiitd.ac.in/~syamantak,7nBU-20AAAAJ,0000-0000-0000-0000
 Sye Loong Keoh,University of Glasgow,http://www.dcs.gla.ac.uk/~sye,wS5aZWwAAAAJ,0000-0000-0000-0000
-Syed Azeemuddin,Pennsylvania State University,https://www.iiit.ac.in/people/faculty/azeemuddin,6FjRZ_MAAAAJ,0000-0000-0000-0000
+Syed Azeemuddin,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/azeemuddin,6FjRZ_MAAAAJ,0000-0000-0000-0000
 Syed Ishtiaque Ahmed,University of Toronto,http://web.cs.toronto.edu/news/events/dcsl_mar28.htm,Ji2o32AAAAAJ,0000-0003-2452-0687
 Syed Islam,University of Tennessee,http://www.eecs.utk.edu/people/faculty/sislam,Q2JWrRkAAAAJ,0000-0000-0000-0000
 Syed M. S. Islam,University of Western Australia,http://www.ecm.uwa.edu.au/contact/profiles?type=profile&dn=cn%3DSyed%20Islam%2Cou%3DSchool%20of%20Computer%20Science%20and%20Software%20Engineering%2Cou%3DFaculty%20of%20Engineering%5C2C%20Computing%20and%20Mathematics%2Cou%3DFaculties%2Co%3DThe%20University%20of%20Western%20Australia,2oSH1wgAAAAJ,0000-0000-0000-0000

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -255,7 +255,7 @@ Sandeep Kumar 0002,IIT Delhi,https://sites.google.com/view/sandeepkr/home,lycMMW
 Sandeep Kumar Shukla,IIT Kanpur,http://www.cse.iitk.ac.in/users/sandeeps,SKqctYsAAAAJ,0000-0001-5525-7426
 Sandeep Manjanna,Plaksha University,https://plaksha.edu.in/faculty-details/dr-sandeep-manjanna,FkRY-OcAAAAJ,0000-0000-0000-0000
 Sandeep Neema,Vanderbilt University,https://engineering.vanderbilt.edu/bio/?pid=sandeep-neema,OhUZTZ0AAAAJ,0000-0002-9781-3619
-Sandeep Sen,IIT Delhi,http://www.cse.iitd.ac.in/~ssen,GK7JUpkAAAAJ,0000-0000-0000-0000
+Sandeep Sen,Ashoka University,http://www.cse.iitd.ac.in/~ssen,GK7JUpkAAAAJ,0000-0000-0000-0000
 Sandeep Silwal,University of Wisconsin - Madison,https://sandeepsilwal.com,MnDnUvcAAAAJ,0000-0000-0000-0000
 Sander Bakkes,Utrecht University,http://sander.landofsand.com,R4OXfi4AAAAJ,0000-0000-0000-0000
 Sander C. J. Bakkes,Utrecht University,http://sander.landofsand.com,R4OXfi4AAAAJ,0000-0000-0000-0000

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -2723,7 +2723,7 @@ Swen Jacobs,CISPA Helmholtz Center,https://www.react.uni-saarland.de/people/jaco
 Sweta Mishra,Shiv Nadar University,https://www.snu.edu.in/schools/school-of-engineering/faculty/sweta-mishra,nqSP0nIAAAAJ,0000-0000-0000-0000
 Syamantak Das,IIIT Delhi,http://faculty.iiitd.ac.in/~syamantak,7nBU-20AAAAJ,0000-0000-0000-0000
 Sye Loong Keoh,University of Glasgow,http://www.dcs.gla.ac.uk/~sye,wS5aZWwAAAAJ,0000-0000-0000-0000
-Syed Azeemuddin,Pennsylvania State University,https://behrend.psu.edu/person/azeemuddin-syed,6FjRZ_MAAAAJ,0000-0000-0000-0000
+Syed Azeemuddin,Pennsylvania State University,https://www.iiit.ac.in/people/faculty/azeemuddin,6FjRZ_MAAAAJ,0000-0000-0000-0000
 Syed Ishtiaque Ahmed,University of Toronto,http://web.cs.toronto.edu/news/events/dcsl_mar28.htm,Ji2o32AAAAAJ,0000-0003-2452-0687
 Syed Islam,University of Tennessee,http://www.eecs.utk.edu/people/faculty/sislam,Q2JWrRkAAAAJ,0000-0000-0000-0000
 Syed M. S. Islam,University of Western Australia,http://www.ecm.uwa.edu.au/contact/profiles?type=profile&dn=cn%3DSyed%20Islam%2Cou%3DSchool%20of%20Computer%20Science%20and%20Software%20Engineering%2Cou%3DFaculty%20of%20Engineering%5C2C%20Computing%20and%20Mathematics%2Cou%3DFaculties%2Co%3DThe%20University%20of%20Western%20Australia,2oSH1wgAAAAJ,0000-0000-0000-0000

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -2723,7 +2723,7 @@ Swen Jacobs,CISPA Helmholtz Center,https://www.react.uni-saarland.de/people/jaco
 Sweta Mishra,Shiv Nadar University,https://www.snu.edu.in/schools/school-of-engineering/faculty/sweta-mishra,nqSP0nIAAAAJ,0000-0000-0000-0000
 Syamantak Das,IIIT Delhi,http://faculty.iiitd.ac.in/~syamantak,7nBU-20AAAAJ,0000-0000-0000-0000
 Sye Loong Keoh,University of Glasgow,http://www.dcs.gla.ac.uk/~sye,wS5aZWwAAAAJ,0000-0000-0000-0000
-Syed Azeemuddin,Pennsylvania State University,https://www.iiit.ac.in/people/faculty/azeemuddin,6FjRZ_MAAAAJ,0000-0000-0000-0000
+Syed Azeemuddin,Pennsylvania State University,https://behrend.psu.edu/person/azeemuddin-syed,6FjRZ_MAAAAJ,0000-0000-0000-0000
 Syed Ishtiaque Ahmed,University of Toronto,http://web.cs.toronto.edu/news/events/dcsl_mar28.htm,Ji2o32AAAAAJ,0000-0003-2452-0687
 Syed Islam,University of Tennessee,http://www.eecs.utk.edu/people/faculty/sislam,Q2JWrRkAAAAJ,0000-0000-0000-0000
 Syed M. S. Islam,University of Western Australia,http://www.ecm.uwa.edu.au/contact/profiles?type=profile&dn=cn%3DSyed%20Islam%2Cou%3DSchool%20of%20Computer%20Science%20and%20Software%20Engineering%2Cou%3DFaculty%20of%20Engineering%5C2C%20Computing%20and%20Mathematics%2Cou%3DFaculties%2Co%3DThe%20University%20of%20Western%20Australia,2oSH1wgAAAAJ,0000-0000-0000-0000

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -486,7 +486,7 @@ Sarita V. Adve,Univ. of Illinois at Urbana-Champaign,http://rsim.cs.illinois.edu
 Sarma B. K. Vrudhula,Arizona State University,https://search.asu.edu/profile/761142,2UF8gNsAAAAJ,0000-0001-9278-2959
 Sarmistha Neogy,Jadavpur University,http://jaduniv.edu.in/profile.php?uid=873,ync_fv8AAAAJ,0000-0000-0000-0000
 Saroj K. Biswas 0001,National Inst. of Tech. Silchar,http://cs.nits.ac.in/saroj,KHQrZawAAAAJ,0000-0000-0000-0000
-Saroj Kaushik,IIT Delhi,http://www.cse.iitd.ernet.in/~saroj,NOSCHOLARPAGE,0000-0000-0000-0000
+Saroj Kaushik,Shiv Nadar University,http://www.cse.iitd.ernet.in/~saroj,NOSCHOLARPAGE,0000-0000-0000-0000
 Saroj Kumar Biswas,National Inst. of Tech. Silchar,http://cs.nits.ac.in/saroj,KHQrZawAAAAJ,0000-0000-0000-0000
 Sartaj K. Sahni,University of Florida,http://www.cise.ufl.edu/~sahni,gMQWxE0AAAAJ,0000-0000-0000-0000
 Sartaj Sahni,University of Florida,http://www.cise.ufl.edu/~sahni,gMQWxE0AAAAJ,0000-0000-0000-0000

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -245,8 +245,8 @@ Sanchuan Chen,Auburn University,https://schuan.github.io,mWLdekkAAAAJ,0009-0002-
 Sanda M. Harabagiu,University of Texas at Dallas,http://www.utdallas.edu/~sanda,fkyBx9EAAAAJ,0000-0002-8186-1501
 Sandareka Wickramanayake,University of Moratuwa,https://sandareka.github.io,6mlKqLgAAAAJ,0000-0000-0000-0000
 Sandeep Chandran,IIT Palakkad,https://www.iitpkd.ac.in/people/sandeepchandran,NOSCHOLARPAGE,0000-0001-7110-5668
-Sandeep Juneja,Tata Inst. of Fundamental Research,http://www.tcs.tifr.res.in/~sandeepj,Tfgv6VgAAAAJ,0000-0000-0000-0000
-Sandeep K. Juneja,Tata Inst. of Fundamental Research,http://www.tcs.tifr.res.in/~sandeepj,Tfgv6VgAAAAJ,0000-0000-0000-0000
+Sandeep Juneja,Ashoka University,http://www.tcs.tifr.res.in/~sandeepj,Tfgv6VgAAAAJ,0000-0000-0000-0000
+Sandeep K. Juneja,Ashoka University,http://www.tcs.tifr.res.in/~sandeepj,Tfgv6VgAAAAJ,0000-0000-0000-0000
 Sandeep K. S. Gupta,Arizona State University,https://cidse.engineering.asu.edu/directory/gupta-sandeep,U9bcQkMAAAAJ,0000-0000-0000-0000
 Sandeep K. Shukla,IIT Kanpur,http://www.cse.iitk.ac.in/users/sandeeps,SKqctYsAAAAJ,0000-0001-5525-7426
 Sandeep Kaur Kuttal,North Carolina State University,https://www.csc.ncsu.edu/people/skuttal,RNfafUcAAAAJ,0000-0002-2610-5308

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -2724,7 +2724,7 @@ Swen Jacobs,CISPA Helmholtz Center,https://www.react.uni-saarland.de/people/jaco
 Sweta Mishra,Shiv Nadar University,https://www.snu.edu.in/schools/school-of-engineering/faculty/sweta-mishra,nqSP0nIAAAAJ,0000-0000-0000-0000
 Syamantak Das,IIIT Delhi,http://faculty.iiitd.ac.in/~syamantak,7nBU-20AAAAJ,0000-0000-0000-0000
 Sye Loong Keoh,University of Glasgow,http://www.dcs.gla.ac.uk/~sye,wS5aZWwAAAAJ,0000-0000-0000-0000
-Syed Azeemuddin,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/azeemuddin,6FjRZ_MAAAAJ,0000-0000-0000-0000
+Syed Azeemuddin,Pennsylvania State University,https://www.iiit.ac.in/people/faculty/azeemuddin,6FjRZ_MAAAAJ,0000-0000-0000-0000
 Syed Ishtiaque Ahmed,University of Toronto,http://web.cs.toronto.edu/news/events/dcsl_mar28.htm,Ji2o32AAAAAJ,0000-0003-2452-0687
 Syed Islam,University of Tennessee,http://www.eecs.utk.edu/people/faculty/sislam,Q2JWrRkAAAAJ,0000-0000-0000-0000
 Syed M. S. Islam,University of Western Australia,http://www.ecm.uwa.edu.au/contact/profiles?type=profile&dn=cn%3DSyed%20Islam%2Cou%3DSchool%20of%20Computer%20Science%20and%20Software%20Engineering%2Cou%3DFaculty%20of%20Engineering%5C2C%20Computing%20and%20Mathematics%2Cou%3DFaculties%2Co%3DThe%20University%20of%20Western%20Australia,2oSH1wgAAAAJ,0000-0000-0000-0000

--- a/old/emeritus.csv
+++ b/old/emeritus.csv
@@ -299,3 +299,5 @@ Yehezkel Yeshurun,Tel Aviv University,https://english.tau.ac.il/profile/hezy,NOS
 Yehuda Afek,Tel Aviv University,http://www.cs.tau.ac.il/~afek,pYasE5oAAAAJ,0000-0000-0000-0000
 Yu Hen Hu,University of Wisconsin - Madison,https://directory.engr.wisc.edu/ece/Faculty/Hu_Yu-hen,5CAjat0AAAAJ,0000-0000-0000-0000
 Zvi M. Kedem,New York University,http://cs.nyu.edu/kedem,NOSCHOLARPAGE,0000-0000-0000-0000
+C. Siva Ram Murthy,IIT Hyderabad,http://www.cse.iitm.ac.in/~murthy,VjJFBjcAAAAJ,0000-0000-0000-0000
+Chebiyyam Siva Ram Murthy,IIT Hyderabad,http://www.cse.iitm.ac.in/~murthy,VjJFBjcAAAAJ,0000-0000-0000-0000

--- a/old/emeritus.csv
+++ b/old/emeritus.csv
@@ -37,8 +37,10 @@ Berthold K. P. Horn,Massachusetts Inst. of Technology,http://people.csail.mit.ed
 Berthold Klaus Paul Horn,Massachusetts Inst. of Technology,http://people.csail.mit.edu/bkph,NOSCHOLARPAGE,0000-0000-0000-0000
 Biswanath Mukherjee,Univ. of California - Davis,http://networks.cs.ucdavis.edu/~mukherje,ytXtLjkAAAAJ,0000-0000-0000-0000
 Bradley J. Lucier,Purdue University,https://www.math.purdue.edu/~lucier,sVRNOg0AAAAJ,0000-0000-0000-0000
+C. Siva Ram Murthy,IIT Hyderabad,https://iith.ac.in/cse/murthy/,VjJFBjcAAAAJ,0000-0000-0000-0000
 Carlo Zaniolo,Univ. of California - Los Angeles,http://www.cs.ucla.edu/~zaniolo,f8FjAtMAAAAJ,0000-0000-0000-0000
 Charles D. Hansen,University of Utah,https://www.cs.utah.edu/~hansen,UqyaAQQAAAAJ,0000-0002-8480-2152
+Chebiyyam Siva Ram Murthy,IIT Hyderabad,https://iith.ac.in/cse/murthy/,VjJFBjcAAAAJ,0000-0000-0000-0000
 Chris Clifton,Purdue University,https://www.cs.purdue.edu/people/clifton,C_cWJIkAAAAJ,0000-0000-0000-0000
 Christopher W. Clifton,Purdue University,https://www.cs.purdue.edu/people/clifton,C_cWJIkAAAAJ,0000-0000-0000-0000
 Chuck Hansen,University of Utah,https://www.cs.utah.edu/~hansen,UqyaAQQAAAAJ,0000-0000-0000-0000
@@ -299,5 +301,3 @@ Yehezkel Yeshurun,Tel Aviv University,https://english.tau.ac.il/profile/hezy,NOS
 Yehuda Afek,Tel Aviv University,http://www.cs.tau.ac.il/~afek,pYasE5oAAAAJ,0000-0000-0000-0000
 Yu Hen Hu,University of Wisconsin - Madison,https://directory.engr.wisc.edu/ece/Faculty/Hu_Yu-hen,5CAjat0AAAAJ,0000-0000-0000-0000
 Zvi M. Kedem,New York University,http://cs.nyu.edu/kedem,NOSCHOLARPAGE,0000-0000-0000-0000
-C. Siva Ram Murthy,IIT Hyderabad,http://www.cse.iitm.ac.in/~murthy,VjJFBjcAAAAJ,0000-0000-0000-0000
-Chebiyyam Siva Ram Murthy,IIT Hyderabad,http://www.cse.iitm.ac.in/~murthy,VjJFBjcAAAAJ,0000-0000-0000-0000


### PR DESCRIPTION
## Summary

Update faculty affiliations across Indian institutions based on cross-referencing CSRankings data with current departmental websites. Also removes a duplicate entry and moves an emeritus professor to `old/emeritus.csv`.

## Changes

### Faculty Moves (8 people)

| Faculty | From | To | Source |
|---------|------|----|--------|
| Lawqueen Kanesh | IIT Jodhpur | IIT Indore | IITJ website |
| Kshitij Gajjar | IIT Jodhpur | IIIT Hyderabad | IIITH website |
| Sandeep Juneja (+ alias Sandeep K. Juneja) | TIFR | Ashoka University | TIFR website |
| Karteek Sreenivasaiah | IIT Hyderabad | University of Liverpool | IITH website |
| Sandeep Sen | IIT Delhi | Ashoka University | IITD website (listed as former) |
| Saroj Kaushik | IIT Delhi | Shiv Nadar University | IITD website (listed as former) |
| Moumita Patra | IIIT Hyderabad | IIT Guwahati | IIITH website |
| Syed Azeemuddin | IIIT Hyderabad | Pennsylvania State University | IIITH website |

### Duplicate Removal (1)

| Entry Removed | Kept | Institution |
|---------------|------|-------------|
| Krishna Prasad Miyapuram | Krishna P. Miyapuram | IIT Gandhinagar |

Same Google Scholar ID and homepage. Alias already exists in `dblp-aliases.csv`.

### Emeritus (1)

| Faculty | From | Moved To |
|---------|------|----------|
| C. Siva Ram Murthy (+ alias Chebiyyam Siva Ram Murthy) | IIT Madras | IIT Hyderabad → `old/emeritus.csv` |

Affiliation updated to IIT Hyderabad (current institution) and moved to emeritus list per IITM website (former faculty, left Jun 2025).

## Files Changed

- `csrankings-c.csv` — Removed C. Siva Ram Murthy entries (moved to emeritus)
- `csrankings-k.csv` — Karteek Sreenivasaiah, Kshitij Gajjar moves; Krishna Prasad Miyapuram duplicate removal
- `csrankings-l.csv` — Lawqueen Kanesh move
- `csrankings-m.csv` — Moumita Patra move
- `csrankings-s.csv` — Sandeep Juneja, Sandeep Sen, Saroj Kaushik, Syed Azeemuddin moves
- `old/emeritus.csv` — Added C. Siva Ram Murthy entries