### PR TITLE
Update University of York faculty

### DIFF
--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -603,8 +603,6 @@ Javier Andreu-Perez,University of Essex,https://www.essex.ac.uk/people/andre0940
 Javier Andréu Pérez,University of Essex,https://www.essex.ac.uk/people/andre09407/javier-andreu-perez,1m4DHQQAAAAJ,0000-0000-0000-0000
 Javier Andréu-Pérez,University of Essex,https://www.essex.ac.uk/people/andre09407/javier-andreu-perez,1m4DHQQAAAAJ,0000-0000-0000-0000
 Javier Cuenca,University of Murcia,http://ditec.um.es/%7Ejaviercm/index_english.html,VfJyirIAAAAJ,0000-0000-0000-0000
-Javier Cámara 0001,University of York,http://www.javicamara.com,iMMncw8AAAAJ,0000-0000-0000-0000
-Javier Cámara Moreno,University of York,http://www.javicamara.com,iMMncw8AAAAJ,0000-0000-0000-0000
 Javier Esparza,TU Munich,https://www7.in.tum.de/people/detail/index.php?id=people.detail&arg=33,c9qgPSYAAAAJ,0000-0001-9862-4919
 Javier Guerrero,Washington State University,https://foundation.wsu.edu/2013/04/12/solar-car-donation-accelerates-renewables-education,ntHlYjcAAAAJ,0000-0000-0000-0000
 Javier L. Marenco,University of Buenos Aires,https://www.dc.uba.ar/rrhh/profesores/marenco,NOSCHOLARPAGE,0000-0000-0000-0000

--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -1148,6 +1148,7 @@ Posco Tso,Loughborough University,https://www.lboro.ac.uk/departments/compsci/st
 Poul G. Hjorth,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE,0000-0000-0000-0000
 Pourang Irani,University of British Columbia,https://cmps.ok.ubc.ca/about/contact/pourang-irani,hiMVhagAAAAJ,0000-0002-7716-9280
 Pourang P. Irani,University of British Columbia,https://cmps.ok.ubc.ca/about/contact/pourang-irani,hiMVhagAAAAJ,0000-0000-0000-0000
+Pourya Shamsolmoali,University of York,https://www.cs.york.ac.uk/people/pshams,SGNlMswAAAAJ,0000-0002-0263-1661
 Prabal Dutta,Univ. of California - Berkeley,https://people.eecs.berkeley.edu/~prabal,H790-zwAAAAJ,0000-0003-4106-9138
 Prabal K. Dutta,Univ. of California - Berkeley,https://people.eecs.berkeley.edu/~prabal,H790-zwAAAAJ,0000-0000-0000-0000
 Prabhakar Ragde,University of Waterloo,https://cs.uwaterloo.ca/~plragde,NOSCHOLARPAGE,0000-0000-0000-0000

--- a/csrankings-t.csv
+++ b/csrankings-t.csv
@@ -733,7 +733,6 @@ Tim Muller,University of Nottingham,https://www.nottingham.ac.uk/computerscience
 Tim Newman,University of Alabama - Huntsville,http://www.cs.uah.edu/~tnewman,KkN7DMIAAAAJ,0000-0000-0000-0000
 Tim Oates 0001,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/people/faculty/tim-oates,NOSCHOLARPAGE,0000-0000-0000-0000
 Tim Ophelders,TU Eindhoven,https://tophelde.win.tue.nl,ZuCEOPMAAAAJ,0000-0000-0000-0000
-Tim P. Kelly,University of York,https:/www-users.cs.york.ac.uk/~tpk,cNeDb_8AAAAJ,0000-0000-0000-0000
 Tim Robert Merritt,Aalborg University,http://www.ixd.net,RBhmAmkAAAAJ,0000-0002-7851-7339
 Tim Roughgarden,Columbia University,http://timroughgarden.org,0lcJYs8AAAAJ,0000-0002-7163-8306
 Tim Sherwood,Univ. of California - Santa Barbara,https://www.cs.ucsb.edu/~sherwood,nLuHfy4AAAAJ,0000-0000-0000-0000


### PR DESCRIPTION
## Summary
- Remove **Tim P. Kelly** (no longer faculty at University of York)
- Remove **Javier Cámara 0001** / **Javier Cámara Moreno** (no longer faculty at University of York)
- Add **Pourya Shamsolmoali** (new faculty at University of York)
  - Homepage: https://www.cs.york.ac.uk/people/pshams
  - DBLP: https://dblp.org/pid/154/8477
  - Google Scholar: https://scholar.google.com/citations?user=SGNlMswAAAAJ
  - ORCID: 0000-0002-0263-1661

## Checklist
- [x] Non-anonymous account with full name
- [x] Descriptive PR title
- [x] One PR per institution
- [x] Only modified `csrankings-[a-z].csv` files
- [x] Did not use Excel
- [x] New entry in alphabetical order
- [x] No spaces after commas, no missing fields
- [x] Homepage verified
- [x] Google Scholar ID is alphanumeric only
- [x] Name matches DBLP entry exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)