### PR TITLE
Add 8 faculty from Nankai University (consolidated)

### DIFF
--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -1,4 +1,5 @@
 name,affiliation,homepage,scholarid,orcid
+"Boyang ""Albert"" Li",Nanyang Technological University,http://boyangli.org,QwL4z2UAAAAJ,0000-0002-6230-2376
 B. Aditya Prakash,Georgia Institute of Technology,http://www.cc.gatech.edu/~badityap,C-NftTgAAAAJ,0000-0002-3252-455X
 B. Ashutosh Holla,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/ashutosh-holla-b-/_jcr_content.html,0S83U1sAAAAJ,0009-0009-7995-4213
 B. Ashwath Rao,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/ashwath-rao/_jcr_content.html,bJA8hZQAAAAJ,0000-0001-8528-1646
@@ -58,8 +59,8 @@ Balaji Parthasarathy,IIIT Bangalore,http://citapp.iiitb.ac.in/staff-members/bala
 Balaji Prabhakar,Stanford University,http://web.stanford.edu/~balaji,TyPF9V4AAAAJ,0009-0006-3106-8720
 Balaji Raghavachari,University of Texas at Dallas,https://www.utdallas.edu/~rbk,NOSCHOLARPAGE,0000-0000-0000-0000
 Balakrishnan Chandrasekaran 0002,VU Amsterdam,https://balakrishnanc.github.io,wDjUEMMAAAAJ,0000-0002-5582-1223
-Balakrishnan Prabhakaran,University of Texas at Dallas,http://www.utdallas.edu/~praba,4yki88YAAAAJ,0000-0000-0000-0000
 Balakrishnan Prabhakaran 0001,University of Texas at Dallas,http://www.utdallas.edu/~praba,4yki88YAAAAJ,0000-0000-0000-0000
+Balakrishnan Prabhakaran,University of Texas at Dallas,http://www.utdallas.edu/~praba,4yki88YAAAAJ,0000-0000-0000-0000
 Balaprakasa Rao Killi,National Inst. of Tech. Warangal,https://wsdc.nitw.ac.in/facultynew/facultyprofile/id/17028,zpYxy98AAAAJ,0000-0000-0000-0000
 Balaraman Ravindran,IIT Madras,http://www.cse.iitm.ac.in/~ravi,nGUcGrYAAAAJ,0000-0002-5364-7639
 Balasubramaniam Srinivasan,Monash University,http://monash.edu/research/explore/en/persons/balasubramaniam-srinivasan(6a75b48c-6276-4090-90c9-0d784c16c78d).html,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -192,8 +193,8 @@ Bayu Anggorojati,Monash University Indonesia,https://www.monash.edu/indonesia/ab
 Bayyapu Neelima,Manipal Academy of Higher Education,https://bayyapu.github.io,_TPjGvcAAAAJ,0000-0002-7201-2217
 Beat D. Brüderlin,TU Ilmenau,https://www.tu-ilmenau.de/gdv/mitarbeiter/prof-beat-bruederlin,NOSCHOLARPAGE,0000-0000-0000-0000
 Beata Konikowska,IPI PAN,https://ipipan.waw.pl/instytut/pracownicy/beata-konikowska,EIJSiIIAAAAJ,0000-0001-8188-8344
-Beata Stahre,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/beata-wastberg.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Beata Stahre Wästberg,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/beata-wastberg.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
+Beata Stahre,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/beata-wastberg.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Beate Bollig,TU Dortmund,https://ls2-www.cs.tu-dortmund.de/grav/de/grav_files/people/bollig,NOSCHOLARPAGE,0000-0000-0000-0000
 Beatrice M. Ombuki,Brock University,http://www.cosc.brocku.ca/~bombuki,NOSCHOLARPAGE,0000-0000-0000-0000
 Beatrice M. Ombuki-Berman,Brock University,http://www.cosc.brocku.ca/~bombuki,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -225,8 +226,8 @@ Beiyu Lin,University of Oklahoma,https://beiyulincs.github.io,hou6waAAAAAJ,0000-
 Beki Grinter,Georgia Institute of Technology,http://www.cc.gatech.edu/~beki/Beki.html,PNalJ58AAAAJ,0000-0000-0000-0000
 Bela Gipp,University of Göttingen,https://gipplab.org,No2ot2YAAAAJ,0000-0001-6522-3019
 Belgin Ergenc,Izmir Institute of Technology,http://ceng.iyte.edu.tr/people/belgin-ergenc,e00LSrIAAAAJ,0000-0001-6193-9853
-Belgin Ergenç,Izmir Institute of Technology,http://ceng.iyte.edu.tr/people/belgin-ergenc,e00LSrIAAAAJ,0000-0000-0000-0000
 Belgin Ergenç Bostanoglu,Izmir Institute of Technology,http://ceng.iyte.edu.tr/people/belgin-ergenc,e00LSrIAAAAJ,0000-0000-0000-0000
+Belgin Ergenç,Izmir Institute of Technology,http://ceng.iyte.edu.tr/people/belgin-ergenc,e00LSrIAAAAJ,0000-0000-0000-0000
 Belgin Ozakar,Izmir Institute of Technology,http://ceng.iyte.edu.tr/people/belgin-ergenc,e00LSrIAAAAJ,0000-0000-0000-0000
 Bella Bose,Oregon State University,http://eecs.oregonstate.edu/people/bose-bella,NOSCHOLARPAGE,0009-0009-4992-3184
 Belén Masiá,Universidad de Zaragoza,http://webdiis.unizar.es/~bmasia,d10sXc8AAAAJ,0000-0003-0060-7278
@@ -469,8 +470,8 @@ Bharat M. Deshpande,BITS Pilani-Goa,https://www.bits-pilani.ac.in/goa/bmd/Profil
 Bharath Hariharan,Cornell University,http://home.bharathh.info,TpglobcAAAAJ,0000-0002-2309-4703
 Bhargab B. Bhattacharya,IIT Kharagpur,https://www.isical.ac.in/~bhargab,udxFQnwAAAAJ,0000-0002-5890-2483
 Bhargav Narayanan,Rutgers University,https://sites.math.rutgers.edu/~narayanan,LRN9H2sAAAAJ,0000-0000-0000-0000
-Bharti,University of Delhi,http://people.du.ac.in/~bharti,4OuoFtAAAAAJ,0000-0000-0000-0000
 Bharti Rana,University of Delhi,http://people.du.ac.in/~bharti,4OuoFtAAAAAJ,0000-0000-0000-0000
+Bharti,University of Delhi,http://people.du.ac.in/~bharti,4OuoFtAAAAAJ,0000-0000-0000-0000
 Bhaskar DasGupta,University of Illinois at Chicago,https://www.cs.uic.edu/~dasgupta,V6ddZSkAAAAJ,0000-0000-0000-0000
 Bhaskar Krishnamachari,University of Southern California,http://ceng.usc.edu/~bkrishna,JHJozAYAAAAJ,0000-0002-9994-9931
 Bhaskar Mukhoty,IIT Delhi,https://sites.google.com/view/bhaskar-mukhoty,lJglnOQAAAAJ,0000-0002-8594-980X
@@ -550,6 +551,7 @@ Bin Liu 0001,Tsinghua University,http://s-router.cs.tsinghua.edu.cn/~liubin,NOSC
 Bin Luo 0003,Nanjing University,https://cs.nju.edu.cn/58/1c/c2639a153628/page.htm,NOSCHOLARPAGE,0000-0002-7609-4838
 Bin Ma 0002,University of Waterloo,https://cs.uwaterloo.ca/~binma,f-eL6DYAAAAJ,0000-0000-0000-0000
 Bin Mu,Tongji University,https://sse.tongji.edu.cn/Data/View/2814,NOSCHOLARPAGE,0000-0000-0000-0000
+Bin Pan,Nankai University,https://nankai.teacher.360eol.com/teacherBasic/preview?teacherId=5595,NOSCHOLARPAGE,0000-0001-7513-6533
 Bin Ren 0002,College of William and Mary,https://www.cs.wm.edu/~bren,9Uqwy4UAAAAJ,0000-0002-4116-5237
 Bin Sheng 0001,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/PeopleDetail.aspx?id=81,unORJQ8AAAAJ,0000-0001-8678-2784
 Bin Wang 0004,Chinese Academy of Sciences,http://people.ucas.ac.cn/~wangbin,tDajnHEAAAAJ,0000-0001-7577-229X
@@ -669,8 +671,8 @@ Bo Dai 0001,Georgia Institute of Technology,https://bo-dai.github.io,TIKl_foAAAA
 Bo Dai 0002,University of Hong Kong,https://datascience.hku.hk/people/bo-dai,KNWTvgEAAAAJ,0000-0000-0000-0000
 Bo Dai 0006,UESTC,https://www.scse.uestc.edu.cn/info/1081/11208.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Bo Du 0001,Wuhan University,https://cs.whu.edu.cn/info/1019/2892.htm,Shy1gnMAAAAJ,0000-0002-0059-8458
-Bo Fang,University of Texas at Arlington,https://www.uta.edu/academics/faculty/profile?user=bo.fang,50k_hl8AAAAJ,0000-0000-0000-0000
 Bo Fang 0002,University of Texas at Arlington,https://www.uta.edu/academics/faculty/profile?user=bo.fang,50k_hl8AAAAJ,0000-0001-9721-3982
+Bo Fang,University of Texas at Arlington,https://www.uta.edu/academics/faculty/profile?user=bo.fang,50k_hl8AAAAJ,0000-0000-0000-0000
 Bo Friis Nielsen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE,0000-0000-0000-0000
 Bo Han 0001,George Mason University,https://bohan00.github.io,BhRa314AAAAJ,0000-0001-7042-3322
 Bo Han 0003,Hong Kong Baptist University,https://bhanml.github.io,nTNjqHwAAAAJ,0000-0002-9226-0461
@@ -797,7 +799,6 @@ Bowen Weng,Iowa State University,https://www.cs.iastate.edu/people/bowen-weng-0,
 Bowen Xu,North Carolina State University,https://www.bowenxu.me,tLWbczIAAAAJ,0000-0002-1006-8493
 Boxin Shi,Peking University,http://www.shiboxin.com,K1LjZxcAAAAJ,0000-0001-6749-0364
 Boyana Norris,University of Oregon,https://ix.cs.uoregon.edu/~norris,prJFPwUAAAAJ,0000-0001-5811-9731
-"Boyang ""Albert"" Li",Nanyang Technological University,http://boyangli.org,QwL4z2UAAAAJ,0000-0002-6230-2376
 Boyang Li 0001,Nanyang Technological University,http://boyangli.org,QwL4z2UAAAAJ,0000-0002-6230-2376
 Boyang Wang,University of Cincinnati,https://researchdirectory.uc.edu/p/wang2ba,bKUDk2AAAAAJ,0000-0001-8973-2328
 Boyu Wang,Western University,https://sites.google.com/site/borriewang/home?authuser=0,qAZM5KcAAAAJ,0000-0002-7413-4162

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -4,8 +4,8 @@ C. B. Chandrakala,Manipal Academy of Higher Education,https://www.manipal.edu/mi
 C. Barry Jay,University of Technology Sydney,https://www.uts.edu.au/staff/barry.jay,Ml9nDYQAAAAJ,0000-0000-0000-0000
 C. Carvalho de Souza,UNICAMP,http://www.ic.unicamp.br/~cid,t_w8cAkAAAAJ,0000-0000-0000-0000
 C. Chandra Sekhar,IIT Madras,https://www.iitm.ac.in/info/fac/cchandra,rO5ZgW4AAAAJ,0000-0000-0000-0000
-C. David Page,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~dpage,aNh0te8AAAAJ,0000-0000-0000-0000
 C. David Page Jr.,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~dpage,aNh0te8AAAAJ,0000-0000-0000-0000
+C. David Page,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~dpage,aNh0te8AAAAJ,0000-0000-0000-0000
 C. Edward Chow,UCCS,http://www.cs.uccs.edu/~chow,xLIQ4PYAAAAJ,0000-0000-0000-0000
 C. Estelle Smith,Colorado School of Mines,https://estellesmithphd.com,1YmwfXoAAAAJ,0000-0002-4981-7105
 C. Greg Plaxton,University of Texas at Austin,https://www.cs.utexas.edu/users/plaxton,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -26,9 +26,9 @@ C. V. Jawahar,IIIT Hyderabad,https://www.iiit.ac.in/~jawahar,U9dH-DoAAAAJ,0000-0
 C. Y. Roger Chen,Syracuse University,https://eng-cs.syr.edu/our-departments/electrical-engineering-and-computer-science/people/?peopleid=2970,NOSCHOLARPAGE,0000-0000-0000-0000
 C.-C. Jay Kuo,University of Southern California,http://mcl.usc.edu,81d60okAAAAJ,0000-0001-9474-5035
 C.-H. Luke Ong,Nanyang Technological University,https://dr.ntu.edu.sg/entities/person/Luke-Ong,gNFel3QAAAAJ,0000-0001-7509-680X
-Caetano Traina,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/caetano,h2ivd3AAAAAJ,0000-0002-6625-6047
 Caetano Traina Jr.,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/caetano,h2ivd3AAAAAJ,0000-0002-6625-6047
 Caetano Traina Júnior,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/caetano,h2ivd3AAAAAJ,0000-0000-0000-0000
+Caetano Traina,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/caetano,h2ivd3AAAAAJ,0000-0002-6625-6047
 Cagatay Turkay,City University of London,https://www.city.ac.uk/people/academics/cagatay-turkay#profile=overview,ho0I_1kAAAAJ,0000-0001-6788-251X
 Cagdas D. Onal,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/cdo.html,3symmLYAAAAJ,0000-0000-0000-0000
 Cagdas Denizel Onal,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/cdo.html,3symmLYAAAAJ,0000-0000-0000-0000
@@ -81,8 +81,8 @@ Carey L. Williamson,University of Calgary,http://www.cpsc.ucalgary.ca/~carey,NOS
 Carey Williamson,University of Calgary,http://www.cpsc.ucalgary.ca/~carey,NOSCHOLARPAGE,0000-0000-0000-0000
 Carina Alves 0001,UFPE,https://www.cin.ufpe.br/~cfa,qrsfaXoAAAAJ,0000-0000-0000-0000
 Carina F. Alves,UFPE,https://www.cin.ufpe.br/~cfa,qrsfaXoAAAAJ,0000-0000-0000-0000
-Carina Frota,UFPE,https://www.cin.ufpe.br/~cfa,qrsfaXoAAAAJ,0000-0000-0000-0000
 Carina Frota Alves,UFPE,https://www.cin.ufpe.br/~cfa,qrsfaXoAAAAJ,0000-0000-0000-0000
+Carina Frota,UFPE,https://www.cin.ufpe.br/~cfa,qrsfaXoAAAAJ,0000-0000-0000-0000
 Carl A. Gunter,Univ. of Illinois at Urbana-Champaign,http://web.engr.illinois.edu/~cgunter,3S5qpXsAAAAJ,0000-0000-0000-0000
 Carl A. Gutwin,University of Saskatchewan,https://www.cs.usask.ca/faculty/gutwin,ZWsIEYcAAAAJ,0000-0000-0000-0000
 Carl DiSalvo,Georgia Institute of Technology,https://www.carldisalvo.com,YR1EmaAAAAAJ,0000-0002-7344-8741
@@ -142,8 +142,8 @@ Carlos Caleiro,Universidade de Lisboa,http://sqig.math.ist.utl.pt/ccal,YnVAMh4AA
 Carlos Camarao de Figueiredo,UFMG,http://homepages.dcc.ufmg.br/~camarao,2LRi77IAAAAJ,0000-0000-0000-0000
 Carlos Camarão 0001,UFMG,http://homepages.dcc.ufmg.br/~camarao,2LRi77IAAAAJ,0000-0000-0000-0000
 Carlos Cid,Simula UiB,https://www.simula.no/people/carlos,yfL0oMkAAAAJ,0000-0001-5761-8694
-Carlos Dafonte,University of A Coruña,https://pdi.udc.es/en/File/Pdi/9K9AF,plU2iAkAAAAJ,0000-0000-0000-0000
 Carlos Dafonte Vázquez,University of A Coruña,https://pdi.udc.es/en/File/Pdi/9K9AF,plU2iAkAAAAJ,0000-0000-0000-0000
+Carlos Dafonte,University of A Coruña,https://pdi.udc.es/en/File/Pdi/9K9AF,plU2iAkAAAAJ,0000-0000-0000-0000
 Carlos Duarte,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/caduarte,I7hcyJgAAAAJ,0000-0003-1370-5379
 Carlos E. Ferreira,USP,http://www.ime.usp.br/~cef,cp2Bft4AAAAJ,0000-0000-0000-0000
 Carlos Eduardo Ferreira,USP,http://www.ime.usp.br/~cef,cp2Bft4AAAAJ,0000-0003-4804-5788
@@ -360,13 +360,14 @@ Changhee Joo,Korea University,https://rain.korea.ac.kr/members/professor,ZTvziRo
 Changhee Jung,Purdue University,https://www.cs.purdue.edu/homes/chjung,_sIzYHAAAAAJ,0000-0002-6422-6549
 Changhee Lee,Korea University,https://sites.google.com/view/actionable-intelligence,kSvJTg4AAAAJ,0000-0000-0000-0000
 Changho Suh,KAIST,https://sites.google.com/site/changhosuh,B1guGw8AAAAJ,0000-0002-3101-4291
-Changhun Kim,Korea University,http://kucg.korea.ac.kr/new/about/people.php,NOSCHOLARPAGE,0000-0000-0000-0000
 Changhun Kim 0001,Korea University,https://pure.korea.ac.kr/en/persons/chang-hun-kim,NOSCHOLARPAGE,0000-0000-0000-0000
+Changhun Kim,Korea University,http://kucg.korea.ac.kr/new/about/people.php,NOSCHOLARPAGE,0000-0000-0000-0000
 Changhyun Choi,University of Minnesota,https://choice.umn.edu/people,WOsQx6EAAAAJ,0000-0003-4715-3576
 Changick Kim,KAIST,https://cilabs.kaist.ac.kr/members/professor,ABH_2lcAAAAJ,0000-0001-9323-8488
 Changjian Chen,Hunan University,https://changjianchen.github.io,Q4pwU6sAAAAJ,0000-0003-2715-8839
 Changjian Li 0001,University of Edinburgh,https://enigma-li.github.io,aCgyQsQAAAAJ,0000-0003-0448-4957
 Changkun Jiang,Shenzhen University,https://csse.szu.edu.cn/en/pages/user/index?id=884,p8lulzsAAAAJ,0000-0000-0000-0000
+Changliang Zou,Nankai University,http://web.stat.nankai.edu.cn/chlzou,LPwSdmwAAAAJ,0009-0003-4726-6391
 Changliu Liu,Carnegie Mellon University,https://www.ri.cmu.edu/ri-faculty/changliu-liu,vvzAfOwAAAAJ,0000-0002-3767-5517
 Changqiao Xu,BUPT,https://teacher.bupt.edu.cn/cqxu,43GgIzkAAAAJ,0000-0000-0000-0000
 Changqing Li,Univ. of California - Merced,https://www.ucmerced.edu/content/changqing-li,hBTddCdYvMUC,0000-0000-0000-0000
@@ -445,8 +446,8 @@ Charles Anderson 0001,Colorado State University,http://www.cs.colostate.edu/~and
 Charles B. Owen,Michigan State University,http://www.cse.msu.edu/~cbowen,zBuDgD0AAAAJ,0009-0009-4255-4195
 Charles Border,Rochester Inst. of Technology,https://www.rit.edu/gccis/charlie-border,NOSCHOLARPAGE,0000-0000-0000-0000
 Charles Bouillaguet,CRIStAL,http://cristal.univ-lille.fr/~bouillag,5ov-TX4AAAAJ,0000-0001-9416-6244
-Charles C. Weems,Univ. of Massachusetts Amherst,https://people.cs.umass.edu/~weems,bkN-YUkAAAAJ,0000-0000-0000-0000
 Charles C. Weems Jr.,Univ. of Massachusetts Amherst,https://people.cs.umass.edu/~weems,bkN-YUkAAAAJ,0000-0000-0000-0000
+Charles C. Weems,Univ. of Massachusetts Amherst,https://people.cs.umass.edu/~weems,bkN-YUkAAAAJ,0000-0000-0000-0000
 Charles Dierbach,Towson University,https://www.towson.edu/fcsm/departments/computerinfosci/facultystaff/cdierbach.html,NOSCHOLARPAGE,0000-0002-3370-6291
 Charles E. Hughes,University of Central Florida,http://www.cs.ucf.edu/~ceh,pbb9CG4AAAAJ,0000-0002-2528-3380
 Charles E. Leiserson,Massachusetts Inst. of Technology,http://people.csail.mit.edu/cel,gWBoNCsAAAAJ,0000-0001-6386-5552
@@ -523,8 +524,8 @@ Chen Chen 0042,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/ac
 Chen Chen 0067,Shanghai Jiao Tong University,https://jhc.sjtu.edu.cn/~chen-chen,NOSCHOLARPAGE,0000-0001-9480-5632
 Chen Chen 0070,Florida International University,https://chen-chen.me,z--wnsUAAAAJ,0000-0001-7179-0861
 Chen Ding 0001,University of Rochester,http://www.cs.rochester.edu/~cding,SZuNhvQAAAAJ,0000-0003-4968-6659
-Chen Feng,Queen's University Belfast,https://pure.qub.ac.uk/en/persons/chen-feng,4VZhTYgAAAAJ,0000-0001-9199-559X
 Chen Feng 0002,New York University,https://engineering.nyu.edu/faculty/chen-feng,YeG8ZM0AAAAJ,0000-0003-3211-1576
+Chen Feng,Queen's University Belfast,https://pure.qub.ac.uk/en/persons/chen-feng,4VZhTYgAAAAJ,0000-0001-9199-559X
 Chen Greif,University of British Columbia,https://www.cs.ubc.ca/~greif,NOSCHOLARPAGE,0009-0006-4103-4364
 Chen Hajaj,Ariel University,https://www.ariel.ac.il/wp/chen-hajaj,Zy2cIskAAAAJ,0000-0001-9940-5654
 Chen Li 0001,Univ. of California - Irvine,https://chenli.ics.uci.edu,BRMbGhgAAAAJ,0000-0001-8015-6870
@@ -589,6 +590,7 @@ Chengqing Li,Hunan University,http://www.chengqingli.com,i4a0j8IAAAAJ,0000-0002-
 Chengqing Zong,Chinese Academy of Sciences,http://www.nlpr.ia.ac.cn/cip/english/zong.htm,l8lvKOQAAAAJ,0000-0002-9864-3818
 Chengrong Wu,Fudan University,http://www.cs.fudan.edu.cn/en/?page_id=2253,NOSCHOLARPAGE,0000-0000-0000-0000
 Chenguang Wang 0001,Washington University in St. Louis,https://cgraywang.github.io,hsZ2aj0AAAAJ,0000-0000-0000-0000
+Chengwei Liu,Nankai University,https://lcwj3.github.io/,96s3pKUAAAAJ,0000-0003-1175-2753
 Chengwen Luo 0001,Shenzhen University,https://luochengwen.bitbucket.io,DPW5Pj8AAAAJ,0000-0003-0293-0781
 Chengxiang Zhai,Univ. of Illinois at Urbana-Champaign,http://czhai.cs.illinois.edu,YU-baPIAAAAJ,0000-0002-6434-3702
 Chengying Huan,Nanjing University,https://huanchengying.github.io,8Dsw5EwAAAAJ,0000-0002-3154-3580
@@ -613,8 +615,8 @@ Chenren Xu,Peking University,http://soar.group/chenren,IFX5C-cAAAAJ,0000-0001-91
 Chenshu Wu,University of Hong Kong,https://cswu.me,q9llreMAAAAJ,0000-0002-9700-4627
 Chentao Wu,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/~wuct,RAs-wnEAAAAJ,0000-0002-6882-3754
 Chenxi Qiu,University of North Texas,https://computerscience.engineering.unt.edu/people/faculty/chenxi-qiu,Lj9jGZ8AAAAJ,0000-0002-3387-9758
-Chenxi Zhang,Tongji University,https://sse.tongji.edu.cn/Data/View/2825,NOSCHOLARPAGE,0000-0000-0000-0000
 Chenxi Zhang 0003,Xidian University,http://faculty.xidian.edu.cn/zhangchenxi/zh_CN/index.htm,Ds3dvEMAAAAJ,0009-0007-1432-9957
+Chenxi Zhang,Tongji University,https://sse.tongji.edu.cn/Data/View/2825,NOSCHOLARPAGE,0000-0000-0000-0000
 Chenxiong Qian,University of Hong Kong,https://i.cs.hku.hk/~cqian,AojtmP4AAAAJ,0000-0002-6201-6011
 Chenyan Xiong,Carnegie Mellon University,http://www.cs.cmu.edu/~cx,E9BaEBYAAAAJ,0000-0002-0392-4183
 Chenyang Lu 0001,Washington University in St. Louis,https://www.cs.wustl.edu/~lu,tCq7Wx0AAAAJ,0000-0003-1709-6769
@@ -752,8 +754,8 @@ Choonhwa Lee,Hanyang University,http://dcc.hanyang.ac.kr/members.htm,NOSCHOLARPA
 Chowdhury Farhan Ahmed,University of Dhaka,https://du.ac.bd/body/faculty_details/CSE/1770,0huuef0AAAAJ,0000-0002-6101-4591
 Chris Amato,Northeastern University,http://www.ccs.neu.edu/home/camato,-8-sD-sAAAAJ,0000-0000-0000-0000
 Chris Baber,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/academic-staff/baber-chris.aspx,MQ184fQAAAAJ,0000-0002-1830-2272
-Chris Bailey,University of York,https://www-users.cs.york.ac.uk/~chrisb,QQ_dWtcAAAAJ,0000-0000-0000-0000
 Chris Bailey 0002,University of York,https://www-users.cs.york.ac.uk/~chrisb,QQ_dWtcAAAAJ,0000-0000-0000-0000
+Chris Bailey,University of York,https://www-users.cs.york.ac.uk/~chrisb,QQ_dWtcAAAAJ,0000-0000-0000-0000
 Chris Bailey-Kellogg,Dartmouth College,http://www.cs.dartmouth.edu/~cbk,NOSCHOLARPAGE,0000-0003-1860-0912
 Chris Bartone,Ohio University,https://www.ohio.edu/engineering/about/people/profiles.cfm?profile=bartone,NOSCHOLARPAGE,0000-0000-0000-0000
 Chris Bevan,University of Bristol,http://www.chrisbevan.co.uk,oeU9peMAAAAJ,0000-0002-2823-420X
@@ -1243,8 +1245,8 @@ Chunyang Chen 0001,TU Munich,https://chunyang-chen.github.io,3tyGlPsAAAAJ,0000-0
 Chunyao Song,Nankai University,https://cc.nankai.edu.cn/2021/0323/c13620a549970/page.htm,8q8-yYcAAAAJ,0000-0002-5715-5092
 Chunyi Peng 0001,Purdue University,https://www.cs.purdue.edu/homes/chunyi,7QF1eF4AAAAJ,0000-0003-2945-4981
 Chunyu Lin,Beijing Jiaotong University,http://faculty.bjtu.edu.cn/8549,t8xkhscAAAAJ,0000-0003-2847-0349
-Chunyu Wang,Harbin Institute of Technology,http://homepage.hit.edu.cn/chunyu,1BBVb2wAAAAJ,0000-0001-6348-2455
 Chunyu Wang 0002,Harbin Institute of Technology,http://homepage.hit.edu.cn/chunyu,1BBVb2wAAAAJ,0000-0002-2965-9920
+Chunyu Wang,Harbin Institute of Technology,http://homepage.hit.edu.cn/chunyu,1BBVb2wAAAAJ,0000-0001-6348-2455
 Chunyu Wei,Renmin University of China,http://weicy15.github.io,qECtMnkAAAAJ,0000-0002-5802-5759
 Chuxu Zhang,University of Connecticut,https://chuxuzhang.github.io,ZbZ0l0oAAAAJ,0000-0002-8349-7926
 Chuyu Wang,Nanjing University,http://cs.nju.edu.cn/chuyu,yb3PUaoAAAAJ,0000-0002-1479-9023
@@ -1257,8 +1259,8 @@ Cicek Cavdar,KTH Royal Inst. of Technology,https://www.kth.se/profile/cavdar,9Dj
 Cid C. de Souza,UNICAMP,http://www.ic.unicamp.br/~cid,t_w8cAkAAAAJ,0000-0002-5945-0845
 Cid Carvalho de Souza,UNICAMP,http://www.ic.unicamp.br/~cid,t_w8cAkAAAAJ,0000-0000-0000-0000
 Cigdem Demir,Bilkent University,http://www.cs.bilkent.edu.tr/~gunduz,d1I0jcAAAAAJ,0000-0000-0000-0000
-Cigdem Gunduz,Bilkent University,http://www.cs.bilkent.edu.tr/~gunduz,d1I0jcAAAAAJ,0000-0000-0000-0000
 Cigdem Gunduz Demir,Bilkent University,http://www.cs.bilkent.edu.tr/~gunduz,d1I0jcAAAAAJ,0000-0000-0000-0000
+Cigdem Gunduz,Bilkent University,http://www.cs.bilkent.edu.tr/~gunduz,d1I0jcAAAAAJ,0000-0000-0000-0000
 Cigdem Sengul,Brunel University London,https://www.brunel.ac.uk/people/cigdem-sengul,dvmxdpEAAAAJ,0000-0002-6011-9690
 Cihan Tunc,University of North Texas,https://computerscience.engineering.unt.edu/people/faculty/cihan-tunc,b2Re4qYAAAAJ,0000-0001-5200-1097
 Cihang Xie,Univ. of California - Santa Cruz,https://cihangxie.github.io,X3vVZPcAAAAJ,0000-0003-1243-8045
@@ -1270,8 +1272,8 @@ Cindy Marling,Ohio University,http://oucsace.cs.ohiou.edu/~marling,zeBniq4AAAAJ,
 Cindy Rubio-González,Univ. of California - Davis,http://web.cs.ucdavis.edu/~rubio,AMeXAmQAAAAJ,0000-0002-0861-3763
 Cindy X. Chen,University of Massachusetts Lowell,http://www.cs.uml.edu/~cchen,dtaR0JYAAAAJ,0000-0000-0000-0000
 Cindy Xinmin Chen,University of Massachusetts Lowell,http://www.cs.uml.edu/~cchen,dtaR0JYAAAAJ,0000-0000-0000-0000
-Cindy Xiong,Georgia Institute of Technology,http://cyxiong.com,fFc3ezYAAAAJ,0000-0002-1451-4083
 Cindy Xiong Bearfield,Georgia Institute of Technology,http://cyxiong.com,fFc3ezYAAAAJ,0000-0002-1451-4083
+Cindy Xiong,Georgia Institute of Technology,http://cyxiong.com,fFc3ezYAAAAJ,0000-0002-1451-4083
 Cindy Ya Xiong,Georgia Institute of Technology,http://cyxiong.com,fFc3ezYAAAAJ,0000-0000-0000-0000
 Cinzia Cappiello,Politecnico di Milano,http://home.deib.polimi.it/cappiell,NOSCHOLARPAGE,0000-0001-6062-5174
 Claes Strannegård,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/claes-strannegard.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -1400,8 +1402,8 @@ Cláudio Rosito Jung,UFRGS,http://inf.ufrgs.br/~crjung,3hU1tEkAAAAJ,0000-0002-47
 Cláudio Sant'Anna,Federal University of Bahia,https://computacao.ufba.br/pt-br/claudio-nogueira-santanna,jJVb7rMAAAAJ,0000-0000-0000-0000
 Cláudio T. Silva,New York University,https://ctsilva.github.io,YIwiAAsAAAAJ,0000-0003-2452-2295
 Cláudio Teixeira Silva,New York University,https://ctsilva.github.io,YIwiAAsAAAAJ,0000-0000-0000-0000
-Cláudio Toledo,USP-ICMC,http://icmc.usp.br/pessoas?id=14662391,oiW7E1IAAAAJ,0000-0000-0000-0000
 Cláudio Toledo 0001,USP-ICMC,http://icmc.usp.br/pessoas?id=14662391,oiW7E1IAAAAJ,0000-0000-0000-0000
+Cláudio Toledo,USP-ICMC,http://icmc.usp.br/pessoas?id=14662391,oiW7E1IAAAAJ,0000-0000-0000-0000
 Clément Aubert,Augusta University,https://spots.augusta.edu/caubert,mV9zWOoAAAAJ,0000-0001-6346-3043
 Clément Ballabriga,CRIStAL,https://www.cristal.univ-lille.fr/profil/ballabri,NOSCHOLARPAGE,0000-0000-0000-0000
 Clément L. Canonne,University of Sydney,https://www.sydney.edu.au/engineering/about/our-people/academic-staff/clement-canonne.html,gjLr_FgAAAAJ,0000-0001-7153-5211

--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -48,8 +48,8 @@ Haggai Maron,Technion,https://haggaim.github.io,4v8uJrIAAAAJ,0009-0001-4088-6286
 Hagit Attiya,Technion,http://hagit.net.technion.ac.il,eoMK92MAAAAJ,0000-0002-8017-6457
 Hagit Hel-Or,University of Haifa,http://cs.haifa.ac.il/~hagit,GMM3-EUAAAAJ,0000-0001-8488-0380
 Hagit Shatkay,University of Delaware,https://www.eecis.udel.edu/~shatkay,NOSCHOLARPAGE,0000-0000-0000-0000
-Hagit Zabrodsky,University of Haifa,http://cs.haifa.ac.il/~hagit,GMM3-EUAAAAJ,0000-0000-0000-0000
 Hagit Zabrodsky Hel-Or,University of Haifa,http://cs.haifa.ac.il/~hagit,GMM3-EUAAAAJ,0000-0000-0000-0000
+Hagit Zabrodsky,University of Haifa,http://cs.haifa.ac.il/~hagit,GMM3-EUAAAAJ,0000-0000-0000-0000
 Hai (Helen) Li,Duke University,https://ece.duke.edu/people/hai-helen-li,E6Tpfq8AAAAJ,0000-0003-3228-6544
 Hai Dong,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/d/dong-dr-hai,ENWFU4gAAAAJ,0000-0002-7033-5688
 Hai Helen Li,Duke University,https://ece.duke.edu/people/hai-helen-li,E6Tpfq8AAAAJ,0000-0003-3228-6544
@@ -101,8 +101,8 @@ Hainan Zhang,Beihang University,https://zhanghainan.github.io,D22QG1557LgC,0000-
 Haining Fan,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/cs/4616/2017/20170303112105728431532/20170303112105728431532_.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Haining Zhang,Nankai University,https://cs.nankai.edu.cn/szdw/js/zhn.htm,NOSCHOLARPAGE,0009-0007-1320-3981
 Haipeng Cai,University at Buffalo,https://chapering.github.io,Ru4B_wkAAAAJ,0000-0002-5224-9970
-Haipeng Chen,College of William and Mary,https://haipeng-chen.github.io,YT-b72QAAAAJ,0000-0000-0000-0000
 Haipeng Chen 0002,Jilin University,https://ccst.jlu.edu.cn/info/1367/20675.htm,NOSCHOLARPAGE,0000-0002-9410-4120
+Haipeng Chen,College of William and Mary,https://haipeng-chen.github.io,YT-b72QAAAAJ,0000-0000-0000-0000
 Haipeng Dai 0001,Nanjing University,https://cs.nju.edu.cn/daihp,fb9R-QgAAAAJ,0000-0003-0545-8187
 Haipeng Luo,University of Southern California,https://haipeng-luo.net,ct2hw4UAAAAJ,0000-0001-8056-6271
 Haipeng Peng,BUPT,https://scss.bupt.edu.cn/info/1063/1188.htm,pZqxzFoAAAAJ,0000-0000-0000-0000
@@ -603,8 +603,8 @@ Helen Xu 0001,Georgia Institute of Technology,https://itshelenxu.github.io,ZcguQ
 Helen Yannakoudakis,King's College London,https://www.kcl.ac.uk/people/helen-yannakoudakis,B3WGvRsAAAAJ,0000-0000-0000-0000
 Helena Cristina da Gama Leitão,UFF,http://www2.ic.uff.br/~hcgl,NOSCHOLARPAGE,0000-0000-0000-0000
 Helena Galhardas,Universidade de Lisboa,http://web.ist.utl.pt/helena.galhardas,oBY_WrMAAAAJ,0000-0000-0000-0000
-Helena Holmström,Malmö University,https://mau.se/en/persons/helena.holmstrom.olsson,bjGw_5QAAAAJ,0000-0000-0000-0000
 Helena Holmström Olsson,Malmö University,https://mau.se/en/persons/helena.holmstrom.olsson,bjGw_5QAAAAJ,0000-0000-0000-0000
+Helena Holmström,Malmö University,https://mau.se/en/persons/helena.holmstrom.olsson,bjGw_5QAAAAJ,0000-0000-0000-0000
 Helena Karasti,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/helena-karasti(fdbd5c94-bf35-463a-ab70-1224809bbbf4).html,oEzi1K0AAAAJ,0000-0000-0000-0000
 Helena M. Mentis,Drexel University,https://drexel.edu/cci/about/directory/M/Mentis-Helena,_VdWyEcAAAAJ,0000-0002-0142-3529
 Helena Sarmento,Universidade de Lisboa,http://lisboa.academia.edu/HelenaSarmento,cn9nh7UAAAAJ,0000-0000-0000-0000
@@ -1140,6 +1140,7 @@ Hui Xue 0002,Southeast University,https://palm.seu.edu.cn/hxue,Cl4vVHAAAAAJ,0000
 Hui Yang 0001,Georgetown University,http://infosense.cs.georgetown.edu/grace,nafo_HAAAAAJ,0000-0001-6095-8358
 Hui Zhang 0005,University College London,http://mig.cs.ucl.ac.uk/index.php?n=People.GHZhang,Ii9_OYMAAAAJ,0000-0002-5426-2140
 Hui Zhao 0013,University of North Texas,http://www.cse.unt.edu/~huizhao,7DVxrRoAAAAJ,0000-0003-3683-4077
+Hui-Jia Li,Nankai University,https://my.nankai.edu.cn/stat/lhj/list.htm,f9TNAbUAAAAJ,0009-0001-1235-2818
 Huici Wu,BUPT,https://scss.bupt.edu.cn/info/1063/3985.htm,NccjAJkAAAAJ,0000-0000-0000-0000
 Huihuan Qian,CUHK (SZ),https://sse.cuhk.edu.cn/en/faculty/qianhuihuan,78SEQY4AAAAJ,0000-0000-0000-0000
 Huijia (Rachel) Lin,University of Washington,http://www.cs.ucsb.edu/~rachel.lin,h3gpLYAAAAAJ,0000-0000-0000-0000

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -1,4 +1,5 @@
 name,affiliation,homepage,scholarid,orcid
+"Jan ""Matt"" Pedersen",University of Nevada Las Vegas,http://www.egr.unlv.edu/~matt,Oh3z3nEAAAAJ,0000-0002-2800-5095
 J. A. dos Santos,UFMG,http://homepages.dcc.ufmg.br/~jefersson,wXQnnTUAAAAJ,0000-0000-0000-0000
 J. Alex Halderman,University of Michigan,https://jhalderm.com,h6yXnyEAAAAJ,0000-0002-9116-5390
 J. Andreas Bærentzen,DTU,https://people.compute.dtu.dk/janba,if2X4wkAAAAJ,0000-0003-2583-0660
@@ -109,8 +110,8 @@ Jacob W. Crandall,Brigham Young University,http://www.jacobcrandall.net,FHGBC58A
 Jacob White 0001,Massachusetts Inst. of Technology,http://www.rle.mit.edu/cpg/people_faculty.htm,4lpSV-8AAAAJ,0000-0000-0000-0000
 Jacob Whitehill,Worcester Polytechnic Institute,https://www.wpi.edu/academics/facultydir/200331.htm,PGyMqU0AAAAJ,0000-0000-0000-0000
 Jacob William Crandall,Brigham Young University,http://www.jacobcrandall.net,FHGBC58AAAAJ,0000-0000-0000-0000
-Jacobo Torán,University of Ulm,https://www.uni-ulm.de/toran1,9tCatQwAAAAJ,0000-0000-0000-0000
 Jacobo Torán Romero,University of Ulm,https://www.uni-ulm.de/toran1,9tCatQwAAAAJ,0000-0000-0000-0000
+Jacobo Torán,University of Ulm,https://www.uni-ulm.de/toran1,9tCatQwAAAAJ,0000-0000-0000-0000
 Jacobus E. van der Merwe,University of Utah,https://www.cs.utah.edu/~kobus,PEki4LgAAAAJ,0000-0000-0000-0000
 Jacopo Urbani,VU Amsterdam,http://www.jacopourbani.it,5o88MDIAAAAJ,0000-0002-0717-3559
 Jacqueline Christmas,University of Exeter,http://emps.exeter.ac.uk/computer-science/staff/jtc202,IQRq0CYAAAAJ,0000-0000-0000-0000
@@ -175,8 +176,8 @@ Jaideep Vaidya,Rutgers University,https://www.business.rutgers.edu/faculty/jaide
 Jaijeet Roychowdhury,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/jr.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Jaijeet S. Roychowdhury,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/jr.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Jaime Arguello,University of North Carolina,https://sils.unc.edu/people/faculty/profiles/Jaime-Arguello,q7foMK4AAAAJ,0000-0002-7645-0556
-Jaime Delgado,Polytechnic Univ. of Catalonia,http://ieeexplore.ieee.org/document/6214725/?section=abstract,RSDAEdAAAAAJ,0000-0000-0000-0000
 Jaime Delgado Merce,Polytechnic Univ. of Catalonia,http://ieeexplore.ieee.org/document/6214725/?section=abstract,RSDAEdAAAAAJ,0000-0000-0000-0000
+Jaime Delgado,Polytechnic Univ. of Catalonia,http://ieeexplore.ieee.org/document/6214725/?section=abstract,RSDAEdAAAAAJ,0000-0000-0000-0000
 Jaime Fernández Fisac,Princeton University,https://ece.princeton.edu/people/jaime-fernandez-fisac,HvjirogAAAAJ,0000-0000-0000-0000
 Jaime Navon,UC Chile,https://www.ing.uc.cl/academicos-e-investigadores/jaime-navon-cohen,NOSCHOLARPAGE,0000-0000-0000-0000
 Jaime Ruiz,University of Florida,https://www.jaimeruiz.com,K1O-ZPIAAAAJ,0000-0002-9139-6172
@@ -277,8 +278,8 @@ James H. Elder,York University,http://elderlab.yorku.ca/~elder,wSBFrb8AAAAJ,0000
 James H. Hill,IUPUI,http://sebox.cs.iupui.edu,NOSCHOLARPAGE,0000-0001-8336-9855
 James H. Martin,University of Colorado Boulder,http://www.cs.colorado.edu/~martin,ZVxO6IIAAAAJ,0000-0002-9654-3864
 James H. Moore,University of Pennsylvania,http://epistasis.org/jason-h-moore-phd,mE1Te78AAAAJ,0000-0000-0000-0000
-James H. Morris,Carnegie Mellon University,http://www.cs.cmu.edu/~jhm,Y9cRdbIAAAAJ,0000-0000-0000-0000
 James H. Morris Jr.,Carnegie Mellon University,http://www.cs.cmu.edu/~jhm,Y9cRdbIAAAAJ,0000-0000-0000-0000
+James H. Morris,Carnegie Mellon University,http://www.cs.cmu.edu/~jhm,Y9cRdbIAAAAJ,0000-0000-0000-0000
 James Harland,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/h/harland-associate-professor-james,46pt7TgAAAAJ,0000-0001-8640-5137
 James Harold Davenport,University of Bath,http://people.bath.ac.uk/masjhd,bxOyjTUAAAAJ,0000-0000-0000-0000
 James Hays,Georgia Institute of Technology,http://www.cc.gatech.edu/~hays,vjZrDKQAAAAJ,0000-0001-7016-4252
@@ -375,10 +376,9 @@ Jamie Twycross,University of Nottingham,https://www.nottingham.ac.uk/computersci
 Jamie Vicary,University of Cambridge,https://www.cl.cam.ac.uk/~jv258,9LG1IeMAAAAJ,0000-0002-0998-1701
 Jamilson Dantas,UFPE,https://sites.google.com/cin.ufpe.br/jamilsondantas,p-6fez4AAAAJ,0000-0000-0000-0000
 Jamuna Kanta Sing,Jadavpur University,https://jaduniv.irins.org/profile/57038,rf_-dsUAAAAJ,0000-0000-0000-0000
-"Jan ""Matt"" Pedersen",University of Nevada Las Vegas,http://www.egr.unlv.edu/~matt,Oh3z3nEAAAAJ,0000-0002-2800-5095
 Jan Arne Telle,University of Bergen,http://www.ii.uib.no/~telle,NOSCHOLARPAGE,0000-0000-0000-0000
-Jan B. Pedersen,University of Nevada Las Vegas,http://www.egr.unlv.edu/~matt,Oh3z3nEAAAAJ,0000-0000-0000-0000
 Jan B. Pedersen 0001,University of Nevada Las Vegas,http://www.egr.unlv.edu/~matt,Oh3z3nEAAAAJ,0000-0000-0000-0000
+Jan B. Pedersen,University of Nevada Las Vegas,http://www.egr.unlv.edu/~matt,Oh3z3nEAAAAJ,0000-0000-0000-0000
 Jan Baumbach,University of Hamburg,https://www.zbh.uni-hamburg.de/personen/csb/jbaumbach.html,PWV8xOoAAAAJ,0000-0002-0282-0462
 Jan Bender,RWTH Aachen University,https://www.animation.rwth-aachen.de,POEoFagAAAAJ,0000-0002-1908-4027
 Jan Beutel,University of Innsbruck,https://www.uibk.ac.at/informatik/forschung/professorinnen.html.de,LRkwAAAAJ,0000-0003-0879-2455
@@ -562,8 +562,8 @@ Jason Jue,University of Texas at Dallas,http://www.utdallas.edu/~jjue,8EDESdwAAA
 Jason L. Pacheco,University of Arizona,https://www2.cs.arizona.edu/~pachecoj,71ZEsnEAAAAJ,0000-0000-0000-0000
 Jason Leigh,University of Hawaii at Manoa,http://www2.hawaii.edu/~leighj,5KgriYAAAAAJ,0000-0001-7693-2814
 Jason Li 0006,Carnegie Mellon University,https://q3r.github.io,NOSCHOLARPAGE,0000-0003-3644-0879
-Jason Liu,Florida International University,http://www.cis.fiu.edu/~liux,l8b0bfcAAAAJ,0009-0007-6157-8841
 Jason Liu 0001,Florida International University,http://www.cis.fiu.edu/~liux,l8b0bfcAAAAJ,0000-0001-8222-4013
+Jason Liu,Florida International University,http://www.cis.fiu.edu/~liux,l8b0bfcAAAAJ,0009-0007-6157-8841
 Jason Lowe-Power,Univ. of California - Davis,https://faculty.engineering.ucdavis.edu/lowepower,7m7TYQsAAAAJ,0000-0002-8880-8703
 Jason M. Bindewald,Air Force Inst. of Technology,https://scholar.afit.edu/docs/21,NOSCHOLARPAGE,0000-0000-0000-0000
 Jason M. O'Kane,Texas A&M University,https://jokane.net,ETFTMZMAAAAJ,0000-0002-1536-4822
@@ -596,8 +596,8 @@ Javed A. Aslam,Northeastern University,http://www.ccs.neu.edu/home/jaa,-spRnaQAA
 Javed Khan,Kent State University,http://www.cs.kent.edu/~javed,NOSCHOLARPAGE,0000-0000-0000-0000
 Javen Shi,Adelaide University,https://cs.adelaide.edu.au/~javen,h6O9vYkAAAAJ,0000-0002-9126-2107
 Javid Taheri,Queen's University Belfast,https://pure.qub.ac.uk/en/persons/javid-taheri,QTNsnbAAAAAJ,0000-0001-9194-010X
-Javier Andrade,University of A Coruña,https://pdi.udc.es/en/File/Pdi/7379E,NOSCHOLARPAGE,0000-0000-0000-0000
 Javier Andrade Garda,University of A Coruña,https://pdi.udc.es/en/File/Pdi/7379E,NOSCHOLARPAGE,0000-0000-0000-0000
+Javier Andrade,University of A Coruña,https://pdi.udc.es/en/File/Pdi/7379E,NOSCHOLARPAGE,0000-0000-0000-0000
 Javier Andreu-Perez,University of Essex,https://www.essex.ac.uk/people/andre09407/javier-andreu-perez,1m4DHQQAAAAJ,0000-0002-7421-4808
 Javier Andréu Pérez,University of Essex,https://www.essex.ac.uk/people/andre09407/javier-andreu-perez,1m4DHQQAAAAJ,0000-0000-0000-0000
 Javier Andréu-Pérez,University of Essex,https://www.essex.ac.uk/people/andre09407/javier-andreu-perez,1m4DHQQAAAAJ,0000-0000-0000-0000
@@ -709,8 +709,8 @@ Jeff Clune,University of British Columbia,https://www.cs.ubc.ca/people/jeff-clun
 Jeff Dalton 0001,University of Edinburgh,http://www.inf.ed.ac.uk/people/staff/Jeff_Dalton.html,mgwLi-EAAAAJ,0000-0003-2422-8651
 Jeff Edmonds,York University,http://www.cs.yorku.ca/~jeff,AjD7zfgAAAAJ,0000-0003-4803-3365
 Jeff Erickson 0001,Univ. of Illinois at Urbana-Champaign,http://jeffe.cs.illinois.edu,02_kT4YAAAAJ,0000-0002-5253-2282
-Jeff Gray,The University of Alabama,http://gray.cs.ua.edu,83an8lYAAAAJ,0000-0003-0082-6753
 Jeff Gray 0001,The University of Alabama,http://gray.cs.ua.edu,83an8lYAAAAJ,0000-0003-0082-6753
+Jeff Gray,The University of Alabama,http://gray.cs.ua.edu,83an8lYAAAAJ,0000-0003-0082-6753
 Jeff Heflin,Lehigh University,http://www.cse.lehigh.edu/~heflin,IKKQHqkAAAAJ,0000-0002-7290-1495
 Jeff Huang 0001,Texas A&M University,https://parasol.tamu.edu/~jeff,UmrxW60AAAAJ,0000-0003-1393-0752
 Jeff Huang 0002,Brown University,http://jeffhuang.com,o8oJ6s4AAAAJ,0000-0002-3453-5666
@@ -901,8 +901,8 @@ Jerzy Tiuryn,University of Warsaw,https://www.mimuw.edu.pl/~tiuryn,1iFPnFwAAAAJ,
 Jerzy Tyszkiewicz,University of Warsaw,http://www.mimuw.edu.pl/~jty,5B5PToIAAAAJ,0000-0003-2858-3124
 Jerzy W. Grzymala-Busse,University of Kansas,http://people.eecs.ku.edu/~jerzy,NOSCHOLARPAGE,0000-0000-0000-0000
 Jerzy W. Jaromczyk,University of Kentucky,http://www.cs.uky.edu/~jurek,NOSCHOLARPAGE,0000-0000-0000-0000
-Jerónimo Castrillón,TU Dresden,https://cfaed.tu-dresden.de/ccc-about,Vez2G1kAAAAJ,0000-0002-5007-445X
 Jerónimo Castrillón Mazo,TU Dresden,https://cfaed.tu-dresden.de/ccc-about,Vez2G1kAAAAJ,0000-0000-0000-0000
+Jerónimo Castrillón,TU Dresden,https://cfaed.tu-dresden.de/ccc-about,Vez2G1kAAAAJ,0000-0002-5007-445X
 Jerônimo Grandi,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=JGRANDI,VOUOkLYAAAAJ,0000-0000-0000-0000
 Jes Frellsen,DTU,https://frellsen.org,Yj2sBWkAAAAJ,0000-0001-9224-1271
 Jesper Bengtson,IT University of Copenhagen,http://www.itu.dk/people/jebe,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -945,8 +945,8 @@ Jesús A. De Loera,Univ. of California - Davis,https://www.math.ucdavis.edu/~del
 Jesús Labarta,Polytechnic Univ. of Catalonia,https://www.bsc.es/labarta-mancho-jesus,6vj6TdsAAAAJ,0000-0002-7489-4727
 Jesús M. González-Barahona,Universidad Rey Juan Carlos,https://gsyc.urjc.es/jgb,vYIPWB0AAAAJ,0000-0000-0000-0000
 Jesús Martínez del Rincón,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=j.martinez-del-rincon,jEJdlX8AAAAJ,0000-0002-9574-4138
-Jesús Vilares,University of A Coruña,http://www.grupolys.org/~jvilares,fZHz0B0AAAAJ,0000-0000-0000-0000
 Jesús Vilares Ferro,University of A Coruña,http://www.grupolys.org/~jvilares,fZHz0B0AAAAJ,0000-0000-0000-0000
+Jesús Vilares,University of A Coruña,http://www.grupolys.org/~jvilares,fZHz0B0AAAAJ,0000-0000-0000-0000
 Jetty Kleijn,Leiden University,https://liacs.leidenuniv.nl/~kleijnhcm,NOSCHOLARPAGE,0000-0001-9506-4071
 Jevgenijs Vihrovs,University of Latvia,https://scholar.google.com/citations?user=3F4yQG4AAAAJ&hl=en,3F4yQG4AAAAJ,0000-0000-0000-0000
 Jey Han Lau,University of Melbourne,https://findanexpert.unimelb.edu.au/profile/385601-jey-han-lau,MFi65f4AAAAJ,0000-0002-1647-4628
@@ -984,8 +984,8 @@ Jia Yu 0001,Washington State University,https://jiayuasu.github.io,CHOjvFIAAAAJ,
 Jia Zou 0001,Arizona State University,https://sites.google.com/view/jiazou-web/home,7Dnxbj0AAAAJ,0000-0001-9849-0711
 Jia-Bin Huang 0001,Univ. of Maryland - College Park,https://jbhuang0604.github.io,pp848fYAAAAJ,0000-0002-0536-3658
 Jia-Fu Xu,Nanjing University,https://cs.nju.edu.cn/58/2b/c2639a153643/page.htm,NOSCHOLARPAGE,0000-0000-0000-0000
-Jia-Guang Sun,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2010/20101219095105462245998/20101219095105462245998_.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Jia-Guang Sun 0001,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2010/20101219095105462245998/20101219095105462245998_.html,NOSCHOLARPAGE,0009-0003-0179-317X
+Jia-Guang Sun,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2010/20101219095105462245998/20101219095105462245998_.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Jia-Huai You,University of Alberta,https://webdocs.cs.ualberta.ca/~you,NOSCHOLARPAGE,0000-0001-9372-4371
 Jia-Jie Xu 0001,Soochow University,http://jwsy.suda.edu.cn/69/bf/c9398a223679/page.htm,HYURJ-0AAAAJ,0000-0000-0000-0000
 Jia-Shung Wang,National Tsing Hua University,http://vc.cs.nthu.edu.tw/home/vc_html/member/jswang_e.html,NOSCHOLARPAGE,0000-0003-2157-6108
@@ -994,8 +994,8 @@ Jiachi Chen,Zhejiang University,https://person.zju.edu.cn/en/chenjiachi,FpdgEZMA
 Jiadi Yu,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/~jdyu,2e7_jEoAAAAJ,0000-0002-0207-9643
 Jiafeng Guo,Chinese Academy of Sciences,http://teacher.ucas.ac.cn/~0023936,nD0I3PUAAAAJ,0000-0002-9509-8674
 Jiafeng Zhou,University of Liverpool,https://liverpool.ac.uk/electrical-engineering-and-electronics/staff/jiafeng-zhou,NOSCHOLARPAGE,0000-0000-0000-0000
-Jiaguang Sun,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2010/20101219095105462245998/20101219095105462245998_.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Jiaguang Sun 0001,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2010/20101219095105462245998/20101219095105462245998_.html,NOSCHOLARPAGE,0000-0002-5884-7939
+Jiaguang Sun,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2010/20101219095105462245998/20101219095105462245998_.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Jiahai Yang,Tsinghua University,http://nmgroup.tsinghua.edu.cn/yang/index_en.htm,NOSCHOLARPAGE,0000-0001-6109-6737
 Jiaheng Liu,Nanjing University,https://is.nju.edu.cn/ljh/main.htm,yFI_RjUAAAAJ,0000-0000-0000-0000
 Jiaheng Lu,University of Helsinki,https://www.cs.helsinki.fi/u/jilu,EVNolAkAAAAJ,0000-0003-2067-454X
@@ -1096,8 +1096,8 @@ Jianfu Zhang 0003,Shanghai Jiao Tong University,http://www.qingyuan.sjtu.edu.cn/
 Jiang Hu,Texas A&M University,http://cesg.tamu.edu/faculty/jiang-hu,TWw91rQAAAAJ,0009-0005-8842-7811
 Jiang Liu 0001,SUSTech,https://faculty.sustech.edu.cn/liuj,NOSCHOLARPAGE,0000-0001-6281-6505
 Jiang Ming 0002,Tulane University,https://cs.tulane.edu/~jming,i4VFYKAAAAAJ,0000-0001-9682-0502
-Jiang Yu,Tsinghua University,https://sites.google.com/site/jiangyu198964/home,NOSCHOLARPAGE,0000-0000-0000-0000
 Jiang Yu Zheng,IUPUI,http://cs.iupui.edu/~jzheng,Gih-kpUAAAAJ,0000-0000-0000-0000
+Jiang Yu,Tsinghua University,https://sites.google.com/site/jiangyu198964/home,NOSCHOLARPAGE,0000-0000-0000-0000
 Jiangchuan Liu,Simon Fraser University,http://www.cs.sfu.ca/~jcliu,VU2Jw1YAAAAJ,0000-0001-6592-1984
 Jiangfan Yi,Peking University,http://eecs.pku.edu.cn/EN/People/Faculty/Detail/?ID=6016,NOSCHOLARPAGE,0000-0000-0000-0000
 Jiangfan Yu,CUHK (SZ),https://www.imlyu.com,2rMKEG0AAAAJ,0000-0002-7981-6744
@@ -1237,8 +1237,8 @@ Jiaxin Zhu,Chinese Academy of Sciences,http://www.tcse.cn/~zhujiaxin,2NTaUWsAAAA
 Jiaxing Song,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101224171300777933176/20101224171300777933176_.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Jiaxuan You,Univ. of Illinois at Urbana-Champaign,https://cs.stanford.edu/people/jiaxuan,NDbMl7oAAAAJ,0000-0003-1812-7598
 Jiaya Jia,HKUST,https://cse.hkust.edu.hk/admin/people/faculty/profile/jia,XPAkzTEAAAAJ,0000-0002-1246-553X
-Jiayi Huang,HKUST,https://jyhuang91.github.io,LAqRzrMAAAAJ,0000-0003-4011-6668
 Jiayi Huang 0001,HKUST,https://jyhuang91.github.io,LAqRzrMAAAAJ,0000-0003-4011-6668
+Jiayi Huang,HKUST,https://jyhuang91.github.io,LAqRzrMAAAAJ,0000-0003-4011-6668
 Jiayi Ma 0001,Wuhan University,http://eis.whu.edu.cn/ryDetail.shtml?rsh=00030884,73trMQkAAAAJ,0000-0003-3264-3265
 Jiayi Meng,University of Texas at Arlington,https://ranger.uta.edu/~jmeng,IlZs8_oAAAAJ,0000-0003-3091-8894
 Jiaying Liu 0001,Peking University,http://www.icst.pku.edu.cn/struct/people/liujiaying.html,NOSCHOLARPAGE,0000-0002-0468-9576
@@ -1357,8 +1357,8 @@ Jim Laird,University of Bath,http://www.bath.ac.uk/comp-sci/contacts/academics/j
 Jim Lathrop,Iowa State University,https://www.cs.iastate.edu/people/jim-lathrop,NOSCHOLARPAGE,0000-0000-0000-0000
 Jim Leone,Rochester Inst. of Technology,http://www.ist.rit.edu/~leone,ivIz4JYAAAAJ,0000-0000-0000-0000
 Jim Little 0001,University of British Columbia,http://www.cs.ubc.ca/~little,a0za4V8AAAAJ,0000-0000-0000-0000
-Jim Martin,Clemson University,https://people.cs.clemson.edu/~jmarty,66VE-3MAAAAJ,0000-0000-0000-0000
 Jim Martin 0001,Clemson University,https://people.cs.clemson.edu/~jmarty,66VE-3MAAAAJ,0000-0000-0000-0000
+Jim Martin,Clemson University,https://people.cs.clemson.edu/~jmarty,66VE-3MAAAAJ,0000-0000-0000-0000
 Jim McCann,Carnegie Mellon University,http://www.cs.cmu.edu/~jmccann,NOSCHOLARPAGE,0000-0000-0000-0000
 Jim Purtilo,Univ. of Maryland - College Park,https://seam.cs.umd.edu/purtilo,5-O2lzIAAAAJ,0000-0000-0000-0000
 Jim R. Davies,University of Oxford,http://www.cs.ox.ac.uk/jim.davies,w_UPj9YAAAAJ,0000-0000-0000-0000
@@ -1441,8 +1441,8 @@ Jing Ma 0002,Case Western Reserve University,https://jma712.github.io,VLElvX8AAA
 Jing Ma 0004,Hong Kong Baptist University,https://majingcuhk.github.io,78Jby0EAAAAJ,0000-0002-7464-8331
 Jing Ren 0003,Ontario Tech University,https://engineering.ontariotechu.ca/people/ecse/jing.ren.php,NOSCHOLARPAGE,0000-0000-0000-0000
 Jing Selena He,Old Dominion University,http://www.cs.odu.edu/~jhe,r4WtU2oAAAAJ,0000-0000-0000-0000
-Jing Sun,City University of Macau,https://fds.cityu.edu.mo/en/members/299,4XbYJisAAAAJ,0000-0000-0000-0000
 Jing Sun 0002,University of Auckland,https://www.cs.auckland.ac.nz/~jingsun,GUXAGAYAAAAJ,0000-0002-1979-6622
+Jing Sun,City University of Macau,https://fds.cityu.edu.mo/en/members/299,4XbYJisAAAAJ,0000-0000-0000-0000
 Jing Tang 0004,HKUST,https://sites.google.com/view/jtang,0S4cpyoAAAAJ,0000-0002-0785-707X
 Jing Wang 0055,Renmin University of China,http://info.ruc.edu.cn/jsky/szdw/ajxjgcx/jsjkxyjsx1/fjs2/c6cd7c6a13334e3da59f08920941bf56.htm,NOSCHOLARPAGE,0000-0003-3653-7013
 Jing Wu 0004,Cardiff University,https://www.cardiff.ac.uk/people/view/118177-wu-jing,ms46emIAAAAJ,0000-0001-5123-9861
@@ -1621,8 +1621,8 @@ Joachim Spoerhase,University of Liverpool,https://sites.google.com/view/joachim-
 Joachim Weickert,Saarland University,http://www.mia.uni-saarland.de/weickert/index.shtml,IWwCuGAAAAAJ,0000-0002-8494-0045
 Joachim von Hacht,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/joachim-hacht.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Joakim Lilliesköld,KTH Royal Inst. of Technology,https://www.kth.se/profile/joakiml,4ki0Nk4AAAAJ,0000-0003-0724-2283
-Joan Bruna,New York University,http://www.cs.nyu.edu/~bruna,L4bNmsMAAAAJ,0000-0000-0000-0000
 Joan Bruna Estrach,New York University,http://www.cs.nyu.edu/~bruna,L4bNmsMAAAAJ,0000-0000-0000-0000
+Joan Bruna,New York University,http://www.cs.nyu.edu/~bruna,L4bNmsMAAAAJ,0000-0000-0000-0000
 Joan Daemen,Radboud University,https://cs.ru.nl/~joan,onY4i0oAAAAJ,0000-0002-4102-0775
 Joan Espasa Arxer,University of St Andrews,https://www.st-andrews.ac.uk/computer-science/people/jea20,g4H0JuYAAAAJ,0000-0000-0000-0000
 Joan Feigenbaum,Yale University,http://www.cs.yale.edu/~jf,IAeKTGsAAAAJ,0000-0002-3735-6022
@@ -1873,16 +1873,16 @@ John Mariani,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/peopl
 John Mark Bishop,Goldsmiths University of London,https://www.gold.ac.uk/computing/staff/m-bishop,48y80igAAAAJ,0000-0000-0000-0000
 John Mark Smotherman,Clemson University,https://people.cs.clemson.edu/~mark,KADbB0cAAAAJ,0000-0000-0000-0000
 John McAllister,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=jp.mcallister,CZerWWQAAAAJ,0000-0000-0000-0000
-John McDonald,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=643,NOSCHOLARPAGE,0000-0000-0000-0000
 John McDonald 0001,Maynooth University,https://www.maynoothuniversity.ie/faculty-science-engineering/our-people/john-mcdonald,MrI1EV4AAAAJ,0000-0001-9225-673X
+John McDonald,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=643,NOSCHOLARPAGE,0000-0000-0000-0000
 John McGregor,Clemson University,https://people.cs.clemson.edu/~johnmc,Tw739kgAAAAJ,0000-0000-0000-0000
 John Millar Carroll,Pennsylvania State University,https://jcarroll.ist.psu.edu,7Mg8JZMAAAAJ,0000-0001-5189-337X
 John Murphy 0001,University College Dublin,https://people.ucd.ie/j.murphy,hRzqMboAAAAJ,0000-0000-0000-0000
 John Murray-Bruce,University of South Florida,https://www.cse.usf.edu/~murraybruce,lQkw3IoAAAAJ,0000-0002-1416-4175
 John Musacchio,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~johnm,NOSCHOLARPAGE,0009-0006-2504-1759
 John N. Tsitsiklis,Massachusetts Inst. of Technology,http://www.mit.edu/~jnt/home.html,bWTPrLEAAAAJ,0000-0000-0000-0000
-John O'Donnell,University of Glasgow,http://www.dcs.gla.ac.uk/~jtod,NOSCHOLARPAGE,0000-0000-0000-0000
 John O'Donnell 0001,University of Glasgow,http://www.dcs.gla.ac.uk/~jtod,NOSCHOLARPAGE,0000-0000-0000-0000
+John O'Donnell,University of Glasgow,http://www.dcs.gla.ac.uk/~jtod,NOSCHOLARPAGE,0000-0000-0000-0000
 John P. Collomosse,University of Surrey,http://personal.ee.surrey.ac.uk/Personal/J.Collomosse,yVnCUg0AAAAJ,0000-0003-3580-4685
 John P. Conley,Oregon State University,http://eecs.oregonstate.edu/~jconley,Q-LRVgpXOHcC,0000-0000-0000-0000
 John P. Lalor,University of Notre Dame,https://jplalor.github.io,d7r0R14AAAAJ,0000-0000-0000-0000
@@ -2082,8 +2082,8 @@ Jordan Kodner,Stony Brook University,https://jkodner05.github.io,hYxTJEcAAAAJ,00
 Jordan L. Boyd-Graber,Univ. of Maryland - College Park,http://www.umiacs.umd.edu/~jbg,BT4XTP4AAAAJ,0000-0000-0000-0000
 Jordan Pollack,Brandeis University,http://www.cs.brandeis.edu/~pollack,NOSCHOLARPAGE,0009-0008-0819-3819
 Jordi Domingo-Pascual,Polytechnic Univ. of Catalonia,http://personals.ac.upc.edu/jordid,sPD_L5YAAAAJ,0000-0000-0000-0000
-Jordi Garcia,Polytechnic Univ. of Catalonia,https://www.facebook.com/public/Jordi-Garcia/school/Polytechnic-University-of-Catalonia-109077209117931,S76yu0YAAAAJ,0000-0000-0000-0000
 Jordi Garcia Almiñana,Polytechnic Univ. of Catalonia,http://personals.ac.upc.edu/jordig,S76yu0YAAAAJ,0000-0000-0000-0000
+Jordi Garcia,Polytechnic Univ. of Catalonia,https://www.facebook.com/public/Jordi-Garcia/school/Polytechnic-University-of-Catalonia-109077209117931,S76yu0YAAAAJ,0000-0000-0000-0000
 Jordi Guitart,Polytechnic Univ. of Catalonia,https://www.facebook.com/public/Jordi-Guitart/school/Polytechnic-University-of-Catalonia-109077209117931,gq_W4DwAAAAJ,0000-0003-0751-3100
 Jordi Perello Muntan,Polytechnic Univ. of Catalonia,http://people.ccaba.upc.edu/perello,N3Xy7m0AAAAJ,0000-0000-0000-0000
 Jordi Torres,Polytechnic Univ. of Catalonia,https://www.facebook.com/public/Jordi-Torres-Sanchez/school/Polytechnic-University-of-Catalonia-109077209117931,waODsw0AAAAJ,0000-0003-1963-7418
@@ -2100,12 +2100,12 @@ Jorge Fandinno,University of Nebraska - Omaha,https://www.unomaha.edu/college-of
 Jorge Fernandes,Universidade de Lisboa,http://fcsh.unl.pt/faculdade/docentes/pfernandes,DGDFIzgAAAAJ,0000-0000-0000-0000
 Jorge Garcia Vidal,Polytechnic Univ. of Catalonia,http://people.ac.upc.edu/jorge,NOSCHOLARPAGE,0000-0000-0000-0000
 Jorge Gonçalves 0001,University of Melbourne,http://www.jorgegoncalves.com,SkQ6OisAAAAJ,0000-0002-0117-0322
-Jorge Graña,University of A Coruña,https://pdi.udc.es/en/File/Pdi/WY69E,NOSCHOLARPAGE,0000-0001-9952-1778
 Jorge Graña Gil,University of A Coruña,https://pdi.udc.es/en/File/Pdi/WY69E,NOSCHOLARPAGE,0000-0000-0000-0000
+Jorge Graña,University of A Coruña,https://pdi.udc.es/en/File/Pdi/WY69E,NOSCHOLARPAGE,0000-0001-9952-1778
 Jorge Marx Gómez,University of Oldenburg,https://uol.de/jorge-marx-gomez,NOSCHOLARPAGE,0000-0000-0000-0000
 Jorge Munoz-Gama,UC Chile,https://haplab.org/team/jorge,3Og-qpwAAAAJ,0000-0002-6908-3911
-Jorge Novo,University of A Coruña,http://www.varpa.es/~jnovo,6mRipmwAAAAJ,0000-0002-0125-3064
 Jorge Novo Buján,University of A Coruña,http://www.varpa.es/~jnovo,6mRipmwAAAAJ,0000-0000-0000-0000
+Jorge Novo,University of A Coruña,http://www.varpa.es/~jnovo,6mRipmwAAAAJ,0000-0002-0125-3064
 Jorge Pérez 0001,Universidad de Chile,https://users.dcc.uchile.cl/~jperez,a6lUuiwAAAAJ,0000-0000-0000-0000
 Jorge S. Marques,Universidade de Lisboa,http://users.isr.ist.utl.pt/~jsm,8Vwg-7sAAAAJ,0000-0000-0000-0000
 Jorge Stolfi,UNICAMP,https://twitter.com/jorgestolfi?lang=en,mLo7gCEAAAAJ,0000-0000-0000-0000
@@ -2166,8 +2166,8 @@ Joseph Hallett,University of Bristol,https://research-information.bris.ac.uk/en/
 Joseph Hummel,University of Illinois at Chicago,https://www.cs.uic.edu/~jhummel,NOSCHOLARPAGE,0000-0000-0000-0000
 Joseph Izraelevitz,University of Colorado Boulder,https://www.colorado.edu/faculty/izraelevitz,CtQUnFUAAAAJ,0009-0002-1267-5024
 Joseph J. Boutros,Texas A&M at Qatar,http://www.josephboutros.org,lyjl3nMAAAAJ,0000-0000-0000-0000
-Joseph J. LaViola,University of Central Florida,https://www.cs.ucf.edu/~jjl,kXZaMu8AAAAJ,0000-0003-1186-4130
 Joseph J. LaViola Jr.,University of Central Florida,https://www.cs.ucf.edu/~jjl,kXZaMu8AAAAJ,0000-0000-0000-0000
+Joseph J. LaViola,University of Central Florida,https://www.cs.ucf.edu/~jjl,kXZaMu8AAAAJ,0000-0003-1186-4130
 Joseph J. Lim,KAIST,https://www.clvrai.com,jTnQTBoAAAAJ,0000-0000-0000-0000
 Joseph Jaeger,Georgia Institute of Technology,https://faculty.cc.gatech.edu/~josephjaeger,r9K3MQwAAAAJ,0000-0002-4934-3405
 Joseph Jay Williams,University of Toronto,http://www.josephjaywilliams.com,Gdow0U4AAAAJ,0000-0002-9122-5242
@@ -2243,8 +2243,8 @@ José A. Ramos,Nova Southeastern University,https://cec.nova.edu/faculty/ramos-j
 José A. S. Monteiro,UFPE,http://www.di.ufpe.br/~suruagy,xCIQf-QAAAAJ,0000-0000-0000-0000
 José Alberto R. P. Sardinha,PUC-RIO,https://www-di.inf.puc-rio.br/~sardinha/Publications.html,ki58SvAAAAAJ,0000-0002-5782-3142
 José Alberto Rodrigues Pereira Sardinha,PUC-RIO,https://www-di.inf.puc-rio.br/~sardinha/Publications.html,ki58SvAAAAAJ,0000-0000-0000-0000
-José Antonio Becerra,University of A Coruña,https://pdi.udc.es/es/File/Pdi/EU69E,QTPUBioAAAAJ,0000-0000-0000-0000
 José Antonio Becerra Permuy,University of A Coruña,https://pdi.udc.es/es/File/Pdi/EU69E,QTPUBioAAAAJ,0000-0000-0000-0000
+José Antonio Becerra,University of A Coruña,https://pdi.udc.es/es/File/Pdi/EU69E,QTPUBioAAAAJ,0000-0000-0000-0000
 José António Beltran Gerald,Universidade de Lisboa,http://ieeexplore.ieee.org/document/7845358,NOSCHOLARPAGE,0000-0000-0000-0000
 José Augusto Suruagy Monteiro,UFPE,http://www.di.ufpe.br/~suruagy,xCIQf-QAAAAJ,0000-0000-0000-0000
 José Bento 0001,Boston College,http://www.jbento.net,8K6Z0lEAAAAJ,0000-0000-0000-0000
@@ -2300,9 +2300,9 @@ José Monteiro 0001,Universidade de Lisboa,http://algos.inesc-id.pt/~jcm,tkeh3OA
 José N. Amaral,University of Alberta,https://webdocs.cs.ualberta.ca/~amaral,NOSCHOLARPAGE,0000-0000-0000-0000
 José Nelson Amaral,University of Alberta,https://webdocs.cs.ualberta.ca/~amaral,NOSCHOLARPAGE,0000-0000-0000-0000
 José Nicoletti Junior,UFRGS,https://www.inf.ufrgs.br/site/docente/jose-nicoletti-junior,NOSCHOLARPAGE,0000-0000-0000-0000
-José Oramas,University of Antwerp,https://www.uantwerpen.be/en/staff/jose-oramas,FurBYlUAAAAJ,0000-0002-8607-5067
 José Oramas M.,University of Antwerp,https://www.uantwerpen.be/en/staff/jose-oramas,FurBYlUAAAAJ,0000-0002-8607-5067
 José Oramas Mogrovejo,University of Antwerp,https://www.uantwerpen.be/en/staff/jose-oramas,FurBYlUAAAAJ,0000-0000-0000-0000
+José Oramas,University of Antwerp,https://www.uantwerpen.be/en/staff/jose-oramas,FurBYlUAAAAJ,0000-0002-8607-5067
 José Palazzo M. de Oliveira,UFRGS,http://www.inf.ufrgs.br/~palazzo,8Xw1b6oAAAAJ,0000-0000-0000-0000
 José Palazzo Moreira de Oliveira,UFRGS,http://www.inf.ufrgs.br/~palazzo,8Xw1b6oAAAAJ,0000-0000-0000-0000
 José R. A. Torreão,UFF,http://www2.ic.uff.br/~jrat,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -2316,12 +2316,12 @@ José Rufino,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/jmrufino,
 José Santos Reyes,University of A Coruña,https://www.dc.fi.udc.es/ai/~santos,NOSCHOLARPAGE,0000-0000-0000-0000
 José Santos-Victor,Universidade de Lisboa,http://users.isr.ist.utl.pt/~jasv,ZMuNAXQAAAAJ,0000-0002-9036-1728
 José T. Hernández,Universidad de los Andes,http://imagine.uniandes.edu.co,-gUUc7oAAAAJ,0000-0000-0000-0000
-José Tiberio Hernández,Universidad de los Andes,http://imagine.uniandes.edu.co,-gUUc7oAAAAJ,0000-0000-0000-0000
 José Tiberio Hernández Peñaloza,Universidad de los Andes,http://imagine.uniandes.edu.co,-gUUc7oAAAAJ,0000-0000-0000-0000
+José Tiberio Hernández,Universidad de los Andes,http://imagine.uniandes.edu.co,-gUUc7oAAAAJ,0000-0000-0000-0000
 José Tribolet,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist10876,dzslQ5MAAAAJ,0000-0003-1903-4561
 José Valdeni de Lima,UFRGS,https://www.inf.ufrgs.br/site/docente/jose-valdeni-de-lima,0ROMJ0YAAAAJ,0000-0000-0000-0000
-José Viterbo,UFF,http://www.ic.uff.br/index.php/en-GB/people/317-faculty-ic?docente=36,twAYAPsAAAAJ,0000-0000-0000-0000
 José Viterbo Filho,UFF,http://www.ic.uff.br/index.php/en-GB/people/317-faculty-ic?docente=36,twAYAPsAAAAJ,0000-0000-0000-0000
+José Viterbo,UFF,http://www.ic.uff.br/index.php/en-GB/people/317-faculty-ic?docente=36,twAYAPsAAAAJ,0000-0000-0000-0000
 Jouko Lampinen,Aalto University,https://people.aalto.fi/new/jouko.lampinen,Hk0Q8TkAAAAJ,0000-0000-0000-0000
 Jovan Stojkovic,University of Texas at Austin,https://jovans2.github.io,1BcJ5ZAAAAAJ,0009-0007-4914-336X
 Jovita Lukasik,University of Siegen,https://www.vsa.informatik.uni-siegen.de/en/lukasik-jovita-0,TpsZenwAAAAJ,0000-0003-4243-9188
@@ -2349,8 +2349,8 @@ João Bimbo,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/jmbimbo,jj
 João Coelho Garcia,Universidade de Lisboa,http://www.gsd.inesc-id.pt/~jog,hYb5gDYAAAAJ,0000-0000-0000-0000
 João Comba,UFRGS,http://www.inf.ufrgs.br/~comba,jyeX-1sAAAAJ,0000-0003-2921-2130
 João Costa Seco,Universidade NOVA de Lisboa,https://docentes.fct.unl.pt/jrcs,EPFxA8YAAAAJ,0000-0002-2840-3966
-João Dias,Universidade de Lisboa,https://pt-br.facebook.com/public/Joao-Dias/school/fac.ciencias.ul,NOSCHOLARPAGE,0000-0000-0000-0000
 João Dias Pereira,Universidade de Lisboa,http://ihc.fcsh.unl.pt/pt/ihc/investigadores/item/1161-jdpereira,IREJZj4AAAAJ,0000-0000-0000-0000
+João Dias,Universidade de Lisboa,https://pt-br.facebook.com/public/Joao-Dias/school/fac.ciencias.ul,NOSCHOLARPAGE,0000-0000-0000-0000
 João Eduardo Ferreira,USP,http://www.ime.usp.br/~jef,wR2O6I0AAAAJ,0000-0001-9607-2014
 João F. Ferreira 0001,Universidade de Lisboa,https://joaoff.com,WurhenEAAAAJ,0000-0002-6612-9013
 João Fernando Ferreira,Universidade de Lisboa,https://joaoff.com,WurhenEAAAAJ,0000-0000-0000-0000
@@ -2403,14 +2403,14 @@ Ju Ren 0001,Tsinghua University,https://juren1987.github.io,QvqnU8wAAAAJ,0000-00
 Ju Sun,University of Minnesota,https://sunju.org,V6FaD-UAAAAJ,0000-0002-2017-5903
 Ju Wang 0003,Northwest University,https://faculty.nwu.edu.cn/ju/en/index.htm,NOSCHOLARPAGE,0000-0001-8026-9787
 Ju-yeon Jo,University of Nevada Las Vegas,http://joj5.faculty.unlv.edu,hqccsn8AAAAJ,0000-0000-0000-0000
-Juan A. Botía,University of Murcia,http://webs.um.es/juanbot/miwiki/doku.php,IFiSPE4AAAAJ,0000-0000-0000-0000
 Juan A. Botía Blaya,University of Murcia,http://webs.um.es/juanbot/miwiki/doku.php,IFiSPE4AAAAJ,0000-0000-0000-0000
+Juan A. Botía,University of Murcia,http://webs.um.es/juanbot/miwiki/doku.php,IFiSPE4AAAAJ,0000-0000-0000-0000
 Juan A. Fraire,Universidad Nacional de Córdoba,https://depend.cs.uni-saarland.de/~jfraire,YXq56tgAAAAJ,0000-0001-9816-6989
 Juan A. Garay 0001,Texas A&M University,https://engineering.tamu.edu/cse/profiles/garay-juan.html,pOCh6eAAAAAJ,0000-0003-0366-7110
 Juan A. Sánchez-Laguna,University of Murcia,https://ants.inf.um.es/staff/jlaguna,Ka4v6PIAAAAJ,0000-0000-0000-0000
 Juan Andres Fraire,Universidad Nacional de Córdoba,https://depend.cs.uni-saarland.de/~jfraire,YXq56tgAAAAJ,0000-0000-0000-0000
-Juan Ares,University of A Coruña,https://pdi.udc.es/en/File/Pdi/P679E,NOSCHOLARPAGE,0000-0000-0000-0000
 Juan Ares Casal,University of A Coruña,https://pdi.udc.es/en/File/Pdi/P679E,NOSCHOLARPAGE,0000-0000-0000-0000
+Juan Ares,University of A Coruña,https://pdi.udc.es/en/File/Pdi/P679E,NOSCHOLARPAGE,0000-0000-0000-0000
 Juan C. Caicedo,University of Wisconsin - Madison,https://datascience.wisc.edu/staff/caicedo-juan,U50zLvkAAAAJ,0000-0002-1277-4631
 Juan Caballero,IMDEA Software Institute,http://software.imdea.org/people/juan.caballero,6QjUClkAAAAJ,0000-0003-2962-1348
 Juan Cao 0001,Chinese Academy of Sciences,https://people.ucas.ac.cn/~caojuan,fSBdNg0AAAAJ,0000-0003-4256-6830
@@ -2534,8 +2534,8 @@ Julian Togelius,New York University,http://engineering.nyu.edu/people/julian-tog
 Juliana Bowles,University of St Andrews,https://juliana.host.cs.st-andrews.ac.uk,JstYoqcAAAAJ,0000-0002-5918-9114
 Juliana Freire,New York University,http://engineering.nyu.edu/user/4254,sSzAlq0AAAAJ,0000-0003-3915-7075
 Juliana Freitag Borin,UNICAMP,http://www.ic.unicamp.br/~juliana,MoEzFxoAAAAJ,0000-0000-0000-0000
-Juliana Küster Filipe,University of St Andrews,https://juliana.host.cs.st-andrews.ac.uk,JstYoqcAAAAJ,0000-0000-0000-0000
 Juliana Küster Filipe Bowles,University of St Andrews,https://juliana.host.cs.st-andrews.ac.uk,JstYoqcAAAAJ,0000-0000-0000-0000
+Juliana Küster Filipe,University of St Andrews,https://juliana.host.cs.st-andrews.ac.uk,JstYoqcAAAAJ,0000-0000-0000-0000
 Juliane Krämer,University of Regensburg,https://www.uni-regensburg.de/informatics-data-science/qpc/team/prof-dr-juliane-kraemer/index.html,Hebnan8AAAAJ,0000-0000-0000-0000
 Juliano Araujo Wickboldt,UFRGS,https://www.inf.ufrgs.br/site/docente/juliano-wickboldt,bqxkwSQAAAAJ,0000-0000-0000-0000
 Juliano Iyoda,UFPE,http://www.cin.ufpe.br/~jmi,ZF4EXI8AAAAJ,0000-0000-0000-0000
@@ -2554,8 +2554,8 @@ Julie Greensmith,University of Nottingham,https://www.nottingham.ac.uk/computers
 Julie Jacques,CRIStAL,https://www.cristal.univ-lille.fr/profil/jacques,NOSCHOLARPAGE,0000-0000-0000-0000
 Julie Porteous,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/p/porteous-dr-julie,B3AVEIoAAAAJ,0000-0003-4618-2359
 Julie R. Williamson,University of Glasgow,http://juliericowilliamson.com,qUtAKFQAAAAJ,0000-0002-1816-1393
-Julie Rico,University of Glasgow,http://juliericowilliamson.com,qUtAKFQAAAAJ,0000-0000-0000-0000
 Julie Rico Williamson,University of Glasgow,http://juliericowilliamson.com,qUtAKFQAAAAJ,0000-0000-0000-0000
+Julie Rico,University of Glasgow,http://juliericowilliamson.com,qUtAKFQAAAAJ,0000-0000-0000-0000
 Julie Shah,Massachusetts Inst. of Technology,http://people.csail.mit.edu/julie_a_shah,NOSCHOLARPAGE,0000-0003-1338-8107
 Julie Weeds,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/116624,goWjVPQAAAAJ,0000-0002-3831-4019
 Julie Williamson 0001,University of Glasgow,http://juliericowilliamson.com,qUtAKFQAAAAJ,0000-0002-1816-1393
@@ -2622,6 +2622,7 @@ Jun Wen 0001,MBZUAI,https://mbzuai.ac.ae/study/faculty/jun-wen,Gw2ekPsAAAAJ,000
 Jun Xiao 0001,Zhejiang University,http://mypage.zju.edu.cn/junx,fqOwFhQAAAAJ,0000-0000-0000-0000
 Jun Xu 0001,Renmin University of China,http://info.ruc.edu.cn/academic_professor.php?teacher_id=169,su14mcEAAAAJ,0000-0001-7170-111X
 Jun Xu 0014,Georgia Institute of Technology,http://www.cc.gatech.edu/~jx,mHwonDEAAAAJ,0000-0000-0000-0000
+Jun Xu 0019,Nankai University,https://csjunxu.github.io/,O6TnZ9EAAAAJ,0000-0002-1602-538X
 Jun Xu 0024,University of Utah,https://www.cs.utah.edu/~junxzm,9nHXbTEAAAAJ,0009-0002-8128-5062
 Jun Yan 0007,Concordia University,https://sites.google.com/view/jyan/home,3Yi1ZhsAAAAJ,0000-0000-0000-0000
 Jun Yan 0009,Chinese Academy of Sciences,http://people.ucas.ac.cn/~yanjun,YRuji3AAAAAJ,0000-0003-2328-0781
@@ -2665,8 +2666,8 @@ Jung-Chun Kao,National Tsing Hua University,http://www.cs.nthu.edu.tw/~jungchuk,
 Jung-Eun Kim,North Carolina State University,https://jungeunkim.wordpress.ncsu.edu,8HpZmN0AAAAJ,0000-0001-9780-2947
 Jung-Hong Chuang,National Chiao Tung University,http://cggmwww.csie.nctu.edu.tw/index.php/8-member/10-faculty,NOSCHOLARPAGE,0000-0002-9038-6124
 Jung-Hsien Chiang,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/depmember/teacherdetail/id/10,NaNxyQgAAAAJ,0000-0002-4657-6705
-Jung-Hwan Oh,University of North Texas,http://www.cse.unt.edu/~jhoh,NOSCHOLARPAGE,0000-0000-0000-0000
 Jung-Hwan Oh 0001,University of North Texas,http://www.cse.unt.edu/~jhoh,alNk_OkAAAAJ,0000-0000-0000-0000
+Jung-Hwan Oh,University of North Texas,http://www.cse.unt.edu/~jhoh,NOSCHOLARPAGE,0000-0000-0000-0000
 JungHyun Han,Korea University,https://media.korea.ac.kr,51TWc5UAAAAJ,0000-0001-6438-2974
 Jungbeom Lee,Korea University,https://dcai-lab.github.io/DCAI-Lab,6qTcgH0AAAAJ,0000-0000-0000-0000
 Jungdam Won,Seoul National University,https://sites.google.com/view/jungdam,mUWAgvgAAAAJ,0000-0001-5510-6425
@@ -2848,8 +2849,8 @@ Jürgen Hesser,Heidelberg University,http://medphyssrv1.medma.uni-heidelberg.de/
 Jürgen Peissig,University of Hannover,https://www.ikt.uni-hannover.de/321.html?&no_cache=1&tx_tkinstpersonen_pi1%5Balias%5D=pei,asWSO9QAAAAJ,0000-0000-0000-0000
 Jürgen Prestin,University of Lübeck,https://www.math.uni-luebeck.de/mitarbeiter/prestin,0SzrmIMAAAAJ,0000-0000-0000-0000
 Jürgen Sachau,University of Luxembourg,http://wwwen.uni.lu/snt/people/juergen_sachau,NOSCHOLARPAGE,0000-0000-0000-0000
-Jürgen Sauer,University of Oldenburg,https://uol.de/sao/personen/apl-prof-dr-ing-juergen-sauer,E6w1sCMAAAAJ,0000-0000-0000-0000
 Jürgen Sauer 0001,University of Oldenburg,https://uol.de/sao/personen/apl-prof-dr-ing-juergen-sauer,E6w1sCMAAAAJ,0000-0000-0000-0000
+Jürgen Sauer,University of Oldenburg,https://uol.de/sao/personen/apl-prof-dr-ing-juergen-sauer,E6w1sCMAAAAJ,0000-0000-0000-0000
 Jürgen Schmidhuber,KAUST,https://cemse.kaust.edu.sa/people/person/jurgen-schmidhuber,gLnCTgIAAAAJ,0000-0002-1468-6758
 Jürgen Schönwälder,Jacobs University Bremen,https://www.jacobs-university.de/directory/jschoenwaelder,YaiOokwAAAAJ,0000-0000-0000-0000
 Jürgen Steimle,Saarland University,https://hci.cs.uni-saarland.de/people/juergen-steimle,Cz_S3u8AAAAJ,0000-0003-3493-8745

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -220,8 +220,8 @@ Samuel Fiorini,Université libre de Bruxelles,http://homepages.ulb.ac.be/~sfiori
 Samuel Hopkins 0001,Massachusetts Inst. of Technology,https://www.samuelbhopkins.com,E_a3VB4AAAAJ,0000-0000-0000-0000
 Samuel Horváth,MBZUAI,https://mbzuai.ac.ae/study/faculty/samuel-horvath,k252J7kAAAAJ,0000-0000-0000-0000
 Samuel Hym,CRIStAL,https://www.cristal.univ-lille.fr/profil/hym,NOSCHOLARPAGE,0000-0000-0000-0000
-Samuel J. Lomonaco,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~lomonaco,0PMb9xcAAAAJ,0000-0000-0000-0000
 Samuel J. Lomonaco Jr.,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~lomonaco,0PMb9xcAAAAJ,0000-0000-0000-0000
+Samuel J. Lomonaco,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~lomonaco,0PMb9xcAAAAJ,0000-0000-0000-0000
 Samuel Kadoury,Polytechnique Montreal,https://www.polymtl.ca/expertises/en/kadoury-samuel,HOov_S8AAAAJ,0000-0000-0000-0000
 Samuel Kaski,Aalto University,https://users.ics.aalto.fi/sami,uF6H9jMAAAAJ,0000-0000-0000-0000
 Samuel Kounev,University of Würzburg,https://se.informatik.uni-wuerzburg.de/software-engineering-group/staff/samuel-kounev,1iN71-YAAAAJ,0000-0000-0000-0000
@@ -296,8 +296,8 @@ Sandy Gould,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles
 Sandy Irani,Univ. of California - Irvine,https://www.ics.uci.edu/~irani,dBhm_oIAAAAJ,0000-0000-0000-0000
 Sandy J. J. Gould,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/gould-sandy.aspx,DF7FgAQAAAAJ,0000-0003-0476-4270
 Sanem Kabadayi,Istanbul Technical University,http://web.itu.edu.tr/kabadayi,NOSCHOLARPAGE,0000-0000-0000-0000
-Sanem Sariel,Istanbul Technical University,http://web.itu.edu.tr/sariel,Fw0RC2IAAAAJ,0000-0003-2993-6681
 Sanem Sariel Talay,Istanbul Technical University,http://web.itu.edu.tr/sariel,Fw0RC2IAAAAJ,0000-0000-0000-0000
+Sanem Sariel,Istanbul Technical University,http://web.itu.edu.tr/sariel,Fw0RC2IAAAAJ,0000-0003-2993-6681
 Sang Ho Yoon,KAIST,https://hcitech.org,ejaRQn8AAAAJ,0000-0002-3780-5350
 Sang Kil Cha,KAIST,http://softsec.kaist.ac.kr/~sangkilc,kV40DzcAAAAJ,0000-0002-6012-7228
 Sang Lyul Min,Seoul National University,http://archi.snu.ac.kr/symin,U4ewRr0AAAAJ,0000-0000-0000-0000
@@ -336,8 +336,8 @@ Sanjam Garg,Univ. of California - Berkeley,http://www.cs.berkeley.edu/~sanjamg,m
 Sanjay Bhattacherjee,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/sanjay.bhattacherjee,rpUwbWIAAAAJ,0000-0002-3367-6192
 Sanjay G. Rao,Purdue University,https://engineering.purdue.edu/~sanjay,v_uxLhgAAAAJ,0000-0003-4825-4352
 Sanjay Jain 0001,National University of Singapore,https://www.comp.nus.edu.sg/~sanjay,PYOH-4kAAAAJ,0000-0001-6798-8330
-Sanjay Jha,UNSW,http://www.cse.unsw.edu.au/~sjha,Hiv2PjEAAAAJ,0000-0000-0000-0000
 Sanjay Jha 0001,UNSW,http://www.cse.unsw.edu.au/~sjha,Hiv2PjEAAAAJ,0000-0002-1844-1520
+Sanjay Jha,UNSW,http://www.cse.unsw.edu.au/~sjha,Hiv2PjEAAAAJ,0000-0000-0000-0000
 Sanjay K. Bose,Plaksha University,https://user.plaksha.edu.in/sanjay-bose,BR6HchkAAAAJ,0000-0000-0000-0000
 Sanjay K. Jha,UNSW,http://www.cse.unsw.edu.au/~sjha,Hiv2PjEAAAAJ,0000-0002-1844-1520
 Sanjay K. Sahay,BITS Pilani-Goa,https://www.bits-pilani.ac.in/goa/ssahay/profile,i6lSvKEAAAAJ,0000-0000-0000-0000
@@ -392,8 +392,8 @@ Santanu Kumar Dash 0001,Royal Holloway Univ. of London,https://pure.royalhollowa
 Santhosh Kamath,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/santhosh-kamath/_jcr_content.html,1JciSa8AAAAJ,0000-0002-1956-1727
 Santhosha Rao,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/santhosha-rao/_jcr_content.html,NOSCHOLARPAGE,0000-0001-9511-3048
 Santhoshini Velusamy,University of Waterloo,https://uwaterloo.ca/computer-science/contacts/santhoshini-velusamy,GpxRFs4AAAAJ,0000-0002-0294-5425
-Santi Ontañón,Drexel University,http://drexel.edu/cci/contact/Faculty/Ontanon-Santiago,aS-DrOwAAAAJ,0000-0000-0000-0000
 Santi Ontañón Villar,Drexel University,http://drexel.edu/cci/contact/Faculty/Ontanon-Santiago,aS-DrOwAAAAJ,0000-0000-0000-0000
+Santi Ontañón,Drexel University,http://drexel.edu/cci/contact/Faculty/Ontanon-Santiago,aS-DrOwAAAAJ,0000-0000-0000-0000
 Santiago Ceria,University of Buenos Aires,https://twitter.com/santiagoceria?lang=en,NOSCHOLARPAGE,0000-0000-0000-0000
 Santiago Chumbe,Heriot-Watt University,https://researchportal.hw.ac.uk/en/persons/santiago-segundo-chumbe,4zoTdQMAAAAJ,0000-0000-0000-0000
 Santiago Figueira,University of Buenos Aires,http://www.glyc.dc.uba.ar/santiago,WzLmB-4AAAAJ,0000-0000-0000-0000
@@ -457,8 +457,8 @@ Sarah Pink,Monash University,https://research.monash.edu/en/persons/sarah-pink,f
 Sarah Preum,Dartmouth College,https://web.cs.dartmouth.edu/people/sarah-masud-preum,TyO23NgAAAAJ,0000-0002-7771-8323
 Sarah Scheffler,Carnegie Mellon University,https://www.sarahscheffler.net,YPq45Q0AAAAJ,0000-0003-1202-7502
 Sarah Sebo,University of Chicago,https://sarahsebo.com,6gWYMigAAAAJ,0000-0003-2211-6429
-Sarah Strohkorb,University of Chicago,https://sarahsebo.com,6gWYMigAAAAJ,0000-0000-0000-0000
 Sarah Strohkorb Sebo,University of Chicago,https://sarahsebo.com,6gWYMigAAAAJ,0000-0000-0000-0000
+Sarah Strohkorb,University of Chicago,https://sarahsebo.com,6gWYMigAAAAJ,0000-0000-0000-0000
 Sarah Wiegreffe,Univ. of Maryland - College Park,https://www.cs.umd.edu/people/sarahwie,YoR3IugAAAAJ,0000-0000-0000-0000
 Sarah Wiseman,Goldsmiths University of London,https://www.gold.ac.uk/computing/people/wiseman-sarah,NdRUEYIAAAAJ,0000-0000-0000-0000
 Sarah Zelikovitz,CUNY,http://www.cs.csi.cuny.edu/~zelikovi,JJvTMLsAAAAJ,0000-0000-0000-0000
@@ -557,8 +557,8 @@ Sayak Ray Chowdhury,IIT Kanpur,https://sites.google.com/view/sayakraychowdhury/h
 Sayak Saha Roy,Louisiana State University,https://www.lsu.edu/eng/cse/people/faculty/saha-roy.php,WwR6ZPQAAAAJ,0000-0000-0000-0000
 Sayako Shimizu,National Inst. of Informatics,https://www.nii.ac.jp/en/faculty/architecture/sayako_shimizu,NOSCHOLARPAGE,0000-0000-0000-0000
 Sayan Bhattacharya,University of Warwick,https://www.dcs.warwick.ac.uk/~u1671158,ca-urkIAAAAJ,0000-0003-1612-0296
-Sayan Mitra,Univ. of Illinois at Urbana-Champaign,http://mitras.ece.illinois.edu,dXUl8ewAAAAJ,0000-0000-0000-0000
 Sayan Mitra 0001,Univ. of Illinois at Urbana-Champaign,https://mitras.ece.illinois.edu/index.html,dXUl8ewAAAAJ,0000-0001-7082-5516
+Sayan Mitra,Univ. of Illinois at Urbana-Champaign,http://mitras.ece.illinois.edu,dXUl8ewAAAAJ,0000-0000-0000-0000
 Sayan Mukherjee 0001,University of Leipzig,https://sayanmuk.github.io,YPD04uIAAAAJ,0000-0002-6715-3920
 Sayan Ranu,IIT Delhi,http://www.cse.iitd.ac.in/~sayan,K4w5qYUAAAAJ,0000-0003-4147-9372
 Sayan Sarcar,University of Tsukuba,https://sayansarcar.github.io/index.html,bIkNGO4AAAAJ,0009-0003-1052-4633
@@ -688,8 +688,8 @@ Sebastijan Dumančić,TU Delft,https://sebdumancic.github.io,besOUicAAAAJ,0000-0
 Sebastián Uchitel,University of Buenos Aires,http://lafhis.dc.uba.ar/en/~suchitel,v-rnR5UAAAAJ,0000-0001-9352-1478
 Sebastián Urrutia,UFMG,http://homepages.dcc.ufmg.br/~surrutia,mPBETD0AAAAJ,0000-0000-0000-0000
 Sebti Foufou,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/Sebti.php,E-8Pz2IAAAAJ,0000-0002-3555-9125
-Seda Ogrenci,Northwestern University,http://users.eecs.northwestern.edu/~seda,dojdbWYAAAAJ,0000-0000-0000-0000
 Seda Ogrenci Memik,Northwestern University,http://users.eecs.northwestern.edu/~seda,dojdbWYAAAAJ,0000-0001-8327-9585
+Seda Ogrenci,Northwestern University,http://users.eecs.northwestern.edu/~seda,dojdbWYAAAAJ,0000-0000-0000-0000
 Seda Ogrenci-Memik,Northwestern University,http://users.eecs.northwestern.edu/~seda,dojdbWYAAAAJ,0000-0000-0000-0000
 Sedat Akleylek,University of Tartu,https://sites.google.com/a/bil.omu.edu.tr/akleylek,plpKMjkAAAAJ,0000-0000-0000-0000
 Sedat Ozer,Özyeğin University,http://www.sedatozer.com,G8rbKi4AAAAJ,0000-0002-2069-3807
@@ -725,8 +725,8 @@ Sen Lin 0001,University of Houston,https://slin70.github.io,94-TbUsAAAAJ,0000-00
 Sen Su,BUPT,https://int.bupt.edu.cn/content/content.php?p=6_16_95,JaDhAfsAAAAJ,0000-0003-4266-7527
 Sencun Zhu,Pennsylvania State University,http://www.cse.psu.edu/~sxz16,5qwfn20AAAAJ,0000-0000-0000-0000
 Sendong Zhao,Harbin Institute of Technology,http://homepage.hit.edu.cn/stanzhao,ZtIhRvwAAAAJ,0000-0002-4676-1812
-Senem Velipasalar,Syracuse University,http://eng-cs.syr.edu/our-departments/electrical-engineering-and-computer-science/people/faculty,HEAE9XsAAAAJ,0000-0000-0000-0000
 Senem Velipasalar Gursoy,Syracuse University,http://eng-cs.syr.edu/our-departments/electrical-engineering-and-computer-science/people/faculty,HEAE9XsAAAAJ,0000-0000-0000-0000
+Senem Velipasalar,Syracuse University,http://eng-cs.syr.edu/our-departments/electrical-engineering-and-computer-science/people/faculty,HEAE9XsAAAAJ,0000-0000-0000-0000
 Senjuti Basu Roy,NJIT,https://web.njit.edu/~senjutib,O125w4cAAAAJ,0000-0003-3475-8138
 Sennur Ulukus,Univ. of Maryland - College Park,http://www.cyber.umd.edu/faculty/ulukus,nTG_TQMAAAAJ,0000-0000-0000-0000
 Senzhang Wang,Central South University,https://senzhangwangcsu.github.io/index.html,zdWyGRMAAAAJ,0000-0002-3615-4859
@@ -788,8 +788,8 @@ Sergey M. Plis,Georgia State University,https://trendscenter.org/sergey-plis,nm3
 Sergey Mechtaev,University College London,http://mechtaev.com,XTFR93cAAAAJ,0000-0001-6088-4993
 Sergey O. Kuznetsov,HSE University,https://www.hse.ru/staff/skuznetsov,PK5Qz0cAAAAJ,0000-0000-0000-0000
 Sergey Sosnovsky,Utrecht University,http://www.staff.science.uu.nl/~sosno002,91gXaZUAAAAJ,0000-0000-0000-0000
-Sergio Alvarez,Boston College,http://www.cs.bc.edu/~alvarez,X8_J4FEAAAAJ,0000-0000-0000-0000
 Sergio Alvarez Pardo,Boston College,http://www.cs.bc.edu/~alvarez,X8_J4FEAAAAJ,0000-0000-0000-0000
+Sergio Alvarez,Boston College,http://www.cs.bc.edu/~alvarez,X8_J4FEAAAAJ,0000-0000-0000-0000
 Sergio Bampi,UFRGS,http://inf.ufrgs.br/gme,emFRxDUAAAAJ,0000-0002-9018-6309
 Sergio De Agostino,Sapienza University of Rome,http://twiki.di.uniroma1.it/twiki/view/Users/SergioDeAgostino,lll7oscAAAAJ,0000-0000-0000-0000
 Sergio F. Ochoa,Universidad de Chile,https://www.dcc.uchile.cl/sochoa,aUtukf4AAAAJ,0000-0000-0000-0000
@@ -815,8 +815,8 @@ Seth Flaxman,University of Oxford,https://www.cs.ox.ac.uk/people/seth.flaxman,Wn
 Seth Frey,Univ. of California - Davis,https://cs.ucdavis.edu/directory/seth-frey,DO4uc-kAAAAJ,0000-0002-5298-5089
 Seth Gilbert,National University of Singapore,http://www.comp.nus.edu.sg/~gilbert,bKN3mSsAAAAJ,0000-0003-3298-7412
 Seth Holladay,Brigham Young University,https://cs.byu.edu/faculty/srh43,FLK47OIAAAAJ,0000-0000-0000-0000
-Seth Hutchinson,Northeastern University,https://www.khoury.northeastern.edu/people/seth-hutchinson,-JPZ21IAAAAJ,0000-0000-0000-0000
 Seth Hutchinson 0001,Northeastern University,https://www.khoury.northeastern.edu/people/seth-hutchinson,-JPZ21IAAAAJ,0000-0002-3949-6061
+Seth Hutchinson,Northeastern University,https://www.khoury.northeastern.edu/people/seth-hutchinson,-JPZ21IAAAAJ,0000-0000-0000-0000
 Seth Lewis Gilbert,National University of Singapore,http://www.comp.nus.edu.sg/~gilbert,bKN3mSsAAAAJ,0000-0003-3298-7412
 Seth Pettie,University of Michigan,http://web.eecs.umich.edu/~pettie,ao_EFbUAAAAJ,0000-0002-2610-1630
 Seth Poulsen,Utah State University,https://www.usu.edu/cs/directory/faculty/poulsen-seth,yoEvwpsAAAAJ,0000-0001-6284-9972
@@ -883,8 +883,8 @@ Shabnam Kasra Kermanshahi,RMIT University,https://www.rmit.edu.au/contact/staff-
 Shachar Itzhaky,Technion,https://csaws.cs.technion.ac.il/~shachari,U7MFtRwAAAAJ,0000-0002-7276-7644
 Shachar Lovett,Univ. of California - San Diego,http://cseweb.ucsd.edu/~slovett,f6JF7BkAAAAJ,0000-0003-4552-1443
 Shachi Sharma,South Asian University,http://sau.int/faculty/faculty-profile.html?staff_id=87,TltIxw8AAAAJ,0000-0000-0000-0000
-Shadan Sadeghian,University of Siegen,https://www.mediacoop.uni-siegen.de/de/personen/sadedhian-shadan,DYGZQO0AAAAJ,0000-0002-8590-656X
 Shadan Sadeghian Borojeni,University of Siegen,https://www.mediacoop.uni-siegen.de/de/personen/sadedhian-shadan,DYGZQO0AAAAJ,0000-0000-0000-0000
+Shadan Sadeghian,University of Siegen,https://www.mediacoop.uni-siegen.de/de/personen/sadedhian-shadan,DYGZQO0AAAAJ,0000-0002-8590-656X
 Shadan Sadeghianborojeni,University of Siegen,https://www.mediacoop.uni-siegen.de/de/personen/sadedhian-shadan,DYGZQO0AAAAJ,0000-0000-0000-0000
 Shaddi Hasan,Virginia Tech,https://people.cs.vt.edu/shaddi,IHburiYAAAAJ,0000-0001-5432-6952
 Shaddin Dughmi,University of Southern California,https://viterbi-web.usc.edu/~shaddin,jn-B_MoAAAAJ,0000-0002-2784-1868
@@ -907,8 +907,8 @@ Shahed Khan Mohammed,UNC - Charlotte,https://ece.charlotte.edu/directory/dr-shah
 Shahedur Rahman,Middlesex University,http://www.cs.mdx.ac.uk/people/shahedur-rahman,NOSCHOLARPAGE,0000-0000-0000-0000
 Shaheen Fatima,Loughborough University,https://www.lboro.ac.uk/departments/compsci/staff/academic-teaching/shaheen-fatima,KqRKHv4AAAAJ,0000-0000-0000-0000
 Shahid Raza,University of Glasgow,https://www.gla.ac.uk/schools/computing/staff/shahidraza,ivYcvvoAAAAJ,0000-0001-8192-0893
-Shahin Jabbari,Drexel University,https://shahin-jabbari.github.io,h60zIiUAAAAJ,0000-0000-0000-0000
 Shahin Jabbari Arfaee,Drexel University,https://shahin-jabbari.github.io,h60zIiUAAAAJ,0000-0000-0000-0000
+Shahin Jabbari,Drexel University,https://shahin-jabbari.github.io,h60zIiUAAAAJ,0000-0000-0000-0000
 Shahin Kamali,University of Manitoba,http://www.cs.umanitoba.ca/~kamalis,hQXlVLsAAAAJ,0000-0003-1404-2212
 Shahram Ghandeharizadeh,University of Southern California,https://www.flslab.org,FI5-sZEAAAAJ,0000-0002-1792-7879
 Shahram ShahbazPanahi,Ontario Tech University,https://engineering.ontariotechu.ca/people/ecse/shahram.shahbazpanahi.php,-kZ8x08AAAAJ,0000-0000-0000-0000
@@ -1331,8 +1331,8 @@ Shuai Li 0001,Beihang University,http://scse.buaa.edu.cn/info/1024/3022.htm,NOSC
 Shuai Li 0010,Shanghai Jiao Tong University,https://shuaili8.github.io,kMZgQxcAAAAJ,0000-0002-3935-0708
 Shuai Lü 0001,Jilin University,https://ccst.jlu.edu.cn/info/1367/19944.htm,S1T_HV0AAAAJ,0000-0002-8081-4498
 Shuai Ma 0001,Beihang University,http://mashuai.buaa.edu.cn,vJUjFpQAAAAJ,0000-0002-4050-0443
-Shuai Mu,Stony Brook University,http://mpaxos.com,wcbyR5UAAAAJ,0000-0000-0000-0000
 Shuai Mu 0001,Stony Brook University,http://mpaxos.com,wcbyR5UAAAAJ,0000-0001-8244-2109
+Shuai Mu,Stony Brook University,http://mpaxos.com,wcbyR5UAAAAJ,0000-0000-0000-0000
 Shuai Shao 0001,USTC,http://staff.ustc.edu.cn/~wwwucuc,Lh-UKzcAAAAJ,0000-0003-0935-2929
 Shuai Wang 0011,HKUST,https://home.cse.ust.hk/~shuaiw,POlWWAsAAAAJ,0000-0002-0866-0308
 Shuai Wang 0016,Nanjing University,https://shuaiwang-nju.github.io,vW1ZaucAAAAJ,0000-0000-0000-0000
@@ -1462,7 +1462,6 @@ Sichao Li,City University of Macau,https://fds.cityu.edu.mo/en/members/461,ylZQz
 Sicong Liu,NWPU,https://sicongliu-deep.github.io,_maZt1AAAAAJ,0000-0000-0000-0000
 Sicun Gao,Univ. of California - San Diego,https://scungao.github.io,UmyrEtcAAAAJ,0000-0000-0000-0000
 Sid Ray,Monash University,http://users.monash.edu/~sid/shadowfax,NOSCHOLARPAGE,0000-0000-0000-0000
-Siddharth,Plaksha University,https://ssiddharth.in/about-me,M3zP9NEAAAAJ,0000-0000-0000-0000
 Siddharth Barman,IISc Bangalore,http://www.csa.iisc.ac.in/~barman,HcGQSKIAAAAJ,0000-0001-9276-2181
 Siddharth Garg,New York University,http://engineering.nyu.edu/people/siddharth-garg,Yf8OqQQAAAAJ,0000-0002-6158-9512
 Siddharth Gupta 0002,BITS Pilani-Goa,https://guptasid.bitbucket.io,B_2PPFgAAAAJ,0000-0000-0000-0000
@@ -1470,6 +1469,7 @@ Siddharth Joshi 0001,University of Notre Dame,http://isn.ucsd.edu/~siddharth,Peg
 Siddharth Kaza,Towson University,https://www.towson.edu/fcsm/departments/computerinfosci/facultystaff/skaza.html,xj0-4yQAAAAJ,0000-0000-0000-0000
 Siddharth Krishnan,UNC - Charlotte,https://webpages.uncc.edu/~skrish21,I8HrLhQAAAAJ,0000-0000-0000-0000
 Siddharth Srivastava 0001,Arizona State University,http://siddharthsrivastava.net,H3ZnCqYAAAAJ,0000-0002-5217-2790
+Siddharth,Plaksha University,https://ssiddharth.in/about-me,M3zP9NEAAAAJ,0000-0000-0000-0000
 Siddhartha Banerjee,Cornell University,https://people.orie.cornell.edu/sbanerjee,_kqpoHIAAAAJ,0000-0002-8954-4578
 Siddhartha Jayanti,Dartmouth College,https://sites.google.com/view/siddhartha-jayanti,NKDBBGkAAAAJ,0000-0002-2681-1632
 Siddhartha Sarma,IIT Mandi,http://faculty.iitmandi.ac.in/~siddhartha/index.html,c-oFx5UAAAAJ,0000-0000-0000-0000
@@ -1486,6 +1486,7 @@ Sietse Overbeek,Utrecht University,http://www.sietseoverbeek.nl,JEmkfmsAAAAJ,000
 Siew Kei Lam,Nanyang Technological University,http://research.ntu.edu.sg/expertise/academicprofile/Pages/StaffProfile.aspx?ST_EMAILID=ASSKLAM&CategoryDescription=ComputerScienceandEngineering,NOSCHOLARPAGE,0000-0000-0000-0000
 Siew-Kei Lam,Nanyang Technological University,https://dr.ntu.edu.sg/cris/rp/rp00901,NOSCHOLARPAGE,0000-0002-8346-2635
 Sigrid Knust,University of Osnabrück,http://www2.inf.uos.de/knust,NOSCHOLARPAGE,0000-0000-0000-0000
+Sihan Xu,Nankai University,https://cc.nankai.edu.cn/2021/0323/c13620a549963/page.htm,Vg5mQD4AAAAJ,0000-0000-0000-0000
 Sihang Liu 0001,University of Waterloo,https://www.sihangliu.com,MapJqQYAAAAJ,0000-0001-9706-6177
 Sihong He,University of Texas at Arlington,https://www.uta.edu/academics/faculty/profile?username=hes2,jLLDCeoAAAAJ,0000-0000-0000-0000
 Sihong Xie,Lehigh University,http://www.cse.lehigh.edu/~sxie,qRp1xZwAAAAJ,0000-0001-5741-9740
@@ -1508,8 +1509,8 @@ Silvia Regina Vergilio,UFPR,https://www.inf.ufpr.br/silvia,2bkThnAAAAAJ,0000-000
 Silvia S. C. Botelho,Federal University of Rio Grande,http://www.silviacb.c3.furg.br,XKt2OlEAAAAJ,0000-0002-8857-0221
 Silvia Santini,Università della Svizzera italiana,https://tu-dresden.de/die_tu_dresden/fakultaeten/fakultaet_informatik/tei/es/mitarbeiter/silvia-santini,RjTLqRwAAAAJ,0000-0002-0882-2004
 Silvia Silva da Costa Botelho,Federal University of Rio Grande,http://www.silviacb.c3.furg.br,XKt2OlEAAAAJ,0000-0002-8857-0221
-Silvia Takahashi,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/stakahas/es/inicio,x7gjZ04AAAAJ,0000-0000-0000-0000
 Silvia Takahashi Rodríguez,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/stakahas/es/inicio,x7gjZ04AAAAJ,0000-0000-0000-0000
+Silvia Takahashi,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/stakahas/es/inicio,x7gjZ04AAAAJ,0000-0000-0000-0000
 Silvina L. Ferradal,Indiana University,https://luddy.indiana.edu/contact/profile/?Silvina_Ferradal,2JcHy3wAAAAJ,0000-0000-0000-0000
 Silvio Amir,Northeastern University,https://www.khoury.northeastern.edu/people/silvio-amir,jhUQvC0AAAAJ,0000-0000-0000-0000
 Silvio Meira 0001,UFPE,https://www.cin.ufpe.br/~srlm,ycIwxqsAAAAJ,0000-0000-0000-0000
@@ -1659,8 +1660,8 @@ Sivaraman Balakrishnan,Carnegie Mellon University,http://www.stat.cmu.edu/~siva,
 Sivaraman K. Anirudh,New York University,https://cs.nyu.edu/~anirudh,z9em5msAAAAJ,0000-0000-0000-0000
 Siwei Feng,Soochow University,http://web.suda.edu.cn/fsw,_7xkHz8AAAAJ,0000-0000-0000-0000
 Siwei Lyu,University at Buffalo,https://cse.buffalo.edu/~siweilyu,wefAEM4AAAAJ,0000-0000-0000-0000
-Siwei Ma,Peking University,http://idm.pku.edu.cn/staff/masiwei/masiwei.htm,y3YqlaUAAAAJ,0000-0000-0000-0000
 Siwei Ma 0001,Peking University,https://cs.pku.edu.cn/info/1236/2106.htm,y3YqlaUAAAAJ,0000-0002-2731-5403
+Siwei Ma,Peking University,http://idm.pku.edu.cn/staff/masiwei/masiwei.htm,y3YqlaUAAAAJ,0000-0000-0000-0000
 Siwei Tan,Zhejiang University,http://person.zju.edu.cn/tansiwei,Wj7H4EUAAAAJ,0000-0002-0634-8089
 Siyao Guo,NYU Shanghai,https://sites.google.com/site/siyaoguo,nscLxl4AAAAJ,0009-0008-3664-3928
 Siyi Lv,Nankai University,https://cc.nankai.edu.cn/2021/0323/c13620a570392/page.htm,RbowLSoAAAAJ,0009-0007-1857-5186
@@ -1762,8 +1763,8 @@ Songul Albayrak,Yıldız Technical University,https://www.ce.yildiz.edu.tr/perso
 Songwu Lu,Univ. of California - Los Angeles,http://www.cs.ucla.edu/~slu,PVdTviYAAAAJ,0000-0003-3779-0918
 Songze Li,Southeast University,https://cyber.seu.edu.cn/lsz/list.htm,vcGuNDYAAAAJ,0000-0003-4282-3307
 Songül Albayrak,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/songul?lang=en,LF5HfgEAAAAJ,0000-0000-0000-0000
-Songül Varli,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/songul?lang=en,LF5HfgEAAAAJ,0000-0000-0000-0000
 Songül Varli Albayrak,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/songul?lang=en,LF5HfgEAAAAJ,0000-0000-0000-0000
+Songül Varli,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/songul?lang=en,LF5HfgEAAAAJ,0000-0000-0000-0000
 Sonia Berman,University of Cape Town,https://www.cs.uct.ac.za/research/research-interests-sonia-berman,NOSCHOLARPAGE,0000-0000-0000-0000
 Sonia Chernova,Georgia Institute of Technology,http://www.cc.gatech.edu/~chernova,EYo_WkEAAAAJ,0000-0001-6320-0825
 Sonia Chiasson,Carleton University,https://carleton.ca/scs/people/sonia-chiasson,wg8yZz8AAAAJ,0000-0000-0000-0000
@@ -1822,8 +1823,8 @@ Soumaya Cherkaoui,Polytechnique Montreal,https://www.polymtl.ca/expertises/en/ch
 Soumen Chakrabarti,IIT Bombay,https://www.cse.iitb.ac.in/~soumen,LfF2zfQAAAAJ,0000-0000-0000-0000
 Soumitra Roy Joy,UNC - Charlotte,https://ece.charlotte.edu/people/soumitra-r-joy-ph-d,sBjj4LgAAAAJ,0000-0000-0000-0000
 Soumya Dutta,IIT Kanpur,https://soumyadutta-cse.github.io,7CGMUB8AAAAJ,0000-0001-5030-9979
-Soumya K. Ghosh,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ,0000-0000-0000-0000
 Soumya K. Ghosh 0001,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ,0000-0000-0000-0000
+Soumya K. Ghosh,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ,0000-0000-0000-0000
 Soumya Kanti Ghosh 0001,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ,0000-0000-0000-0000
 Soumya Ray,Case Western Reserve University,http://engr.case.edu/ray_soumya,T3Wxu_AAAAAJ,0000-0002-7497-3281
 Soumyabrata Dev,University College Dublin,https://people.ucd.ie/soumyabrata.dev,_akXw8IAAAAJ,0000-0000-0000-0000
@@ -2471,8 +2472,8 @@ Sukumar Nandi,IIT Guwahati,https://www.iitg.ernet.in/sukumar,ChtruacAAAAJ,0000-0
 Sukyoung Lee,Yonsei University,http://winet.yonsei.ac.kr/home/professor,NOSCHOLARPAGE,0000-0002-3497-3295
 Sukyoung Ryu,KAIST,http://plrg.kaist.ac.kr/ryu,c98U5D0AAAAJ,0000-0002-0019-9772
 Sulamita Klein,UFRJ,http://www.cos.ufrj.br/index.php/pt-BR/pessoas/details/18/1054-sula,r4ZrGiIAAAAJ,0000-0000-0000-0000
-Sule Gündüz,Istanbul Technical University,http://web.itu.edu.tr/sgunduz,E5OlkJMAAAAJ,0000-0000-0000-0000
 Sule Gündüz Ögüdücü,Istanbul Technical University,http://web.itu.edu.tr/sgunduz,E5OlkJMAAAAJ,0000-0000-0000-0000
+Sule Gündüz,Istanbul Technical University,http://web.itu.edu.tr/sgunduz,E5OlkJMAAAAJ,0000-0000-0000-0000
 Sule Ögüdücü,Istanbul Technical University,http://web.itu.edu.tr/sgunduz,E5OlkJMAAAAJ,0000-0000-0000-0000
 Suleman Shahid,LUMS,https://lums.edu.pk/lums_employee/4407,NOSCHOLARPAGE,0000-0000-0000-0000
 Suleyman Tosun,Hacettepe University,https://web.cs.hacettepe.edu.tr/~stosun,IiZP05YAAAAJ,0000-0000-0000-0000
@@ -2509,8 +2510,8 @@ Sun Kim,Seoul National University,http://biohealth.snu.ac.kr,lI_oWS8AAAAJ,0000-0
 Sun-Teck Tan,National University of Singapore,http://www.comp.nus.edu.sg/about/depts/cs/faculty,NOSCHOLARPAGE,0000-0000-0000-0000
 Sun-Yuan Hsieh,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/depmember/teacherdetail/id/15,xTcr9DoAAAAJ,0000-0000-0000-0000
 Sunbeom So,Korea University,https://ku-formal.github.io,UTug1PgAAAAJ,0009-0000-7005-1928
-Suncica Hadzidedic,Durham University,https://www.dur.ac.uk/computer.science/staff/profile/?id=18580,RYJDV5cAAAAJ,0000-0000-0000-0000
 Suncica Hadzidedic Bazdarevic,Durham University,https://www.dur.ac.uk/computer.science/staff/profile/?id=18580,RYJDV5cAAAAJ,0000-0000-0000-0000
+Suncica Hadzidedic,Durham University,https://www.dur.ac.uk/computer.science/staff/profile/?id=18580,RYJDV5cAAAAJ,0000-0000-0000-0000
 Sundar Balasubramaniam,BITS Pilani,http://www.bits-pilani.ac.in/pilani/sundarb/profile,2E9w-LgAAAAJ,0000-0000-0000-0000
 Sundar Vishwanathan,IIT Bombay,https://www.cse.iitb.ac.in/~sundar,8CK3IY4AAAAJ,0000-0000-0000-0000
 Sundaraja Sitharama Iyengar,Florida International University,http://users.cis.fiu.edu/~iyengar,eNONM8AAAAAJ,0000-0000-0000-0000
@@ -2599,8 +2600,8 @@ Surjya Ghosh,BITS Pilani-Goa,https://surjya-ghosh.github.io,jwQqy80AAAAJ,0000-00
 Surya P. N. Singh,University of Queensland,http://robotics.itee.uq.edu.au/~spns,GdBpqg4AAAAJ,0000-0000-0000-0000
 Surya Prakash 0001,IIT Indore,http://www.iiti.ac.in/~surya,6_PF2KEAAAAJ,0000-0000-0000-0000
 Suryadipta Majumdar,Concordia University,https://users.encs.concordia.ca/~majumdar,S4x0by4AAAAJ,0000-0000-0000-0000
-Sus Lundgren,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/sus-lundgren.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Sus Lundgren Lyckvi,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/sus-lundgren.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
+Sus Lundgren,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/sus-lundgren.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Sus Lyckvi,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/sus-lundgren.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Susan A. Mengel,Texas Tech University,https://www.depts.ttu.edu/cs/faculty/susan_a._mengel,SH_ZjnkAAAAJ,0000-0000-0000-0000
 Susan A. Murphy,Harvard University,https://www.seas.harvard.edu/directory/samurphy,q-DPFdUAAAAJ,0000-0002-2032-4286

--- a/csrankings-y.csv
+++ b/csrankings-y.csv
@@ -76,9 +76,9 @@ Yan Wang 0003,Temple University,https://www.binghamton.edu/cs/people/ywang.html,
 Yan Wang 0015,Sichuan University,https://cs.scu.edu.cn/info/1283/17268.htm,f6FgQ_bXEb4C,0000-0000-0000-0000
 Yan Xiao 0002,Sun Yat-sen University,https://yanxiao6.github.io,rSL_uscAAAAJ,0000-0002-2563-083X
 Yan Xiong 0001,USTC,http://dsxt.ustc.edu.cn/zj_ywjs.asp?zzid=709,X08c_CQAAAAJ,0000-0000-0000-0000
-Yan Yan,University of Guelph,https://www.uoguelph.ca/computing/people/yan-yan,98NFoK8AAAAJ,0000-0003-0680-5806
 Yan Yan 0002,University of Illinois at Chicago,https://tomyan555.github.io,zhi-j1wAAAAJ,0000-0002-7618-119X
 Yan Yan 0006,Washington State University,http://iemppu.github.io,A6co_BAAAAAJ,0000-0000-0000-0000
+Yan Yan,University of Guelph,https://www.uoguelph.ca/computing/people/yan-yan,98NFoK8AAAAJ,0000-0003-0680-5806
 Yan Zhang 0003,Western Sydney University,https://www.westernsydney.edu.au/staff_profiles/WSU/professor_yan_zhang,_9aQ1i8AAAAJ,0000-0000-0000-0000
 Yan Zhang 0004,Peking University,http://www.cis.pku.edu.cn/faculty/system/zhangyan,NOSCHOLARPAGE,0000-0002-5336-7100
 Yan Zheng 0002,Tianjin University,https://yanzzzzz.github.io,tJuhd1kAAAAJ,0000-0003-2741-058X
@@ -136,8 +136,8 @@ Yang Wang 0003,Concordia University,https://users.encs.concordia.ca/~wayang,2PBM
 Yang Wang 0005,Univ. of Illinois at Urbana-Champaign,https://yangwang.ischool.illinois.edu,bN-ipRAAAAAJ,0000-0003-3641-8241
 Yang Wang 0009,Ohio State University,https://cse.osu.edu/people/wang.7564,NOSCHOLARPAGE,0000-0002-9721-4923
 Yang Wang 0015,USTC,https://di.ustc.edu.cn/_upload/tpl/15/71/5489/template5489/PersonalSite/index.html,RJj2XXUAAAAJ,0000-0002-6079-7053
-Yang Xiang,Zhejiang University,http://mypage.zju.edu.cn/yxiang,NOSCHOLARPAGE,0009-0003-5991-4739
 Yang Xiang 0004,University of Guelph,https://www.uoguelph.ca/computing/people/yang-xiang,r71D60UAAAAJ,0000-0000-0000-0000
+Yang Xiang,Zhejiang University,http://mypage.zju.edu.cn/yxiang,NOSCHOLARPAGE,0009-0003-5991-4739
 Yang Xiao 0001,The University of Alabama,http://yangxiao.cs.ua.edu,HSxTENAAAAAJ,0000-0000-0000-0000
 Yang Xiao 0010,University of Kentucky,https://yang-sec.github.io,BiVROyUAAAAJ,0000-0000-0000-0000
 Yang Xu 0010,Fudan University,https://yangxu.info,CRVN2jwAAAAJ,0000-0002-0958-8547
@@ -287,6 +287,7 @@ Yapeng Tian,University of Texas at Dallas,http://www.yapengtian.com,lxCqdpoAAAAJ
 Yaping Lin,Hunan University,http://csee.hnu.edu.cn/people/linyaping,NOSCHOLARPAGE,0000-0000-0000-0000
 Yaqian Long,Shenzhen University,https://ieeexplore.ieee.org/author/37086502577,triu-OgAAAAJ,0000-0000-0000-0000
 Yaqian Zhou 0001,Fudan University,http://www.cs.fudan.edu.cn/?page_id=2319###,NOSCHOLARPAGE,0000-0000-0000-0000
+Yaqiong Qiao,Nankai University,https://cc.nankai.edu.cn/2021/0323/c13620a572366/page.htm,NOSCHOLARPAGE,0000-0002-7090-4094
 Yarin Gal,University of Oxford,http://www.cs.ox.ac.uk/people/yarin.gal,SIayDoQAAAAJ,0000-0000-0000-0000
 Yaron Lipman,Weizmann Institute of Science,https://www.weizmann.ac.il/pages/search/people?language=english&single=1&person_id=41941,vyteiT4AAAAJ,0000-0000-0000-0000
 Yarui Peng,University of Arkansas,https://sites.uark.edu/yrpeng,IjBaWWcAAAAJ,0000-0002-8550-2063
@@ -298,8 +299,8 @@ Yasemin Acar,Paderborn University,https://yaseminacar.de,cdFkUdcAAAAJ,0000-0001-
 Yaser Jararweh,JUST,http://www.just.edu.jo/eportfolio/Pages/Default.aspx?email=yijararweh,EXKxa6UAAAAJ,0000-0000-0000-0000
 Yaser M. Khamayseh,JUST,http://www.just.edu.jo/eportfolio/Pages/Default.aspx?email=yaser,UNE8oKUAAAAJ,0000-0000-0000-0000
 Yaser P. Fallah,University of Central Florida,https://www.ece.ucf.edu/person/yaser-p-fallah,Pni_ugMAAAAJ,0000-0000-0000-0000
-Yaser Pourmohammadi,University of Central Florida,https://www.ece.ucf.edu/person/yaser-p-fallah,Pni_ugMAAAAJ,0000-0000-0000-0000
 Yaser Pourmohammadi Fallah,University of Central Florida,https://www.ece.ucf.edu/person/yaser-p-fallah,Pni_ugMAAAAJ,0000-0000-0000-0000
+Yaser Pourmohammadi,University of Central Florida,https://www.ece.ucf.edu/person/yaser-p-fallah,Pni_ugMAAAAJ,0000-0000-0000-0000
 Yaser S. Abu-Mostafa,California Inst. of Technology,https://work.caltech.edu,NOSCHOLARPAGE,0000-0000-0000-0000
 Yash Sinha,BITS Pilani,https://www.bits-pilani.ac.in/pilani/yash-sinha,Ey5HIeQAAAAJ,0000-0003-0477-5236
 Yash Vasavada,DAIICT,http://www.daiict.ac.in/daiict/people/faculty.html,9KkhfBgAAAAJ,0000-0000-0000-0000
@@ -384,8 +385,8 @@ Yew-Soon Ong,Nanyang Technological University,https://www3.ntu.edu.sg/home/asyso
 Yewen Pu,Nanyang Technological University,https://dr.ntu.edu.sg/entities/person/Yewen-Pu,LJnNKXMAAAAJ,0009-0000-4190-0636
 Yexiang Xue,Purdue University,https://www.cs.purdue.edu/people/faculty/yexiang,3jJAvruHOWYC,0000-0000-0000-0000
 Yezhou Yang,Arizona State University,https://yezhouyang.engineering.asu.edu,k2suuZgAAAAJ,0000-0003-0126-8976
-Yezid Donoso,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/ydonoso/es/inicio,Razvs2MAAAAJ,0000-0000-0000-0000
 Yezid Donoso Meisel,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/ydonoso/es/inicio,Razvs2MAAAAJ,0000-0000-0000-0000
+Yezid Donoso,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/ydonoso/es/inicio,Razvs2MAAAAJ,0000-0000-0000-0000
 Yi Chang 0001,Jilin University,http://yichang-cs.com,drEkR50AAAAJ,0000-0003-2697-8093
 Yi Chen 0013,CUHK (SZ),https://sse.cuhk.edu.cn/en/faculty/chenyi,_LzdWjwAAAAJ,0000-0000-0000-0000
 Yi Chen 0024,University of Hong Kong,https://www.cs.hku.hk/index.php/people/academic-staff/chenyi,pJq5cKQAAAAJ,0000-0000-0000-0000
@@ -410,8 +411,8 @@ Yi Pan 0001,Georgia State University,https://grid.cs.gsu.edu/pan,2F-jTfEAAAAJ,00
 Yi Peng 0001,UESTC,http://www.mgmt.uestc.edu.cn/Document/TeacherList?Id=894,0WkOMQYAAAAJ,0000-0000-0000-0000
 Yi R. Fung 0001,HKUST,https://cse.hkust.edu.hk/admin/people/faculty/profile/yrfung,eUae2K0AAAAJ,0000-0000-0000-0000
 Yi Shang,University of Missouri,https://engineering.missouri.edu/faculty/yi-shang,o-xM3oMAAAAJ,0000-0001-7771-4034
-Yi Sheng,University of South Florida,https://www.usf.edu/ai-cybersecurity-computing/people/faculty/yi_sheng.aspx,SN69Jk0AAAAJ,0000-0002-4652-805X
 Yi Sheng 0001,University of South Florida,https://www.usf.edu/ai-cybersecurity-computing/people/faculty/yi_sheng.aspx,SN69Jk0AAAAJ,0000-0002-1411-3554
+Yi Sheng,University of South Florida,https://www.usf.edu/ai-cybersecurity-computing/people/faculty/yi_sheng.aspx,SN69Jk0AAAAJ,0000-0002-4652-805X
 Yi Wang 0003,Shenzhen University,http://www.escience.cn/people/yiwangszu/index.html,OPm4f_cAAAAJ,0000-0002-5773-3817
 Yi Wu 0013,Tsinghua University,https://iiis.tsinghua.edu.cn/en/People/Faculty/WuYi.htm,dusV5HMAAAAJ,0000-0001-9057-5817
 Yi Wu 0020,University of Oklahoma,https://ywu960702.github.io,0dxhJ04AAAAJ,0009-0006-3120-3769
@@ -493,8 +494,8 @@ Yikun Zhang 0001,Southeast University,https://cs.seu.edu.cn/yikun/main.htm,YdcGc
 Yile Wang 0001,Shenzhen University,https://ylwangy.github.io,v1YnW6gAAAAJ,0000-0000-0000-0000
 Yilei Chen 0001,Tsinghua University,https://iiis.tsinghua.edu.cn/en/People/Faculty/ChenYilei.htm,mJkYl8MAAAAJ,0000-0000-0000-0000
 Yili Ren,University of South Florida,https://yiliren.github.io,qk1kc00AAAAJ,0000-0003-4029-6945
-Yiling Chen,Harvard University,http://yiling.seas.harvard.edu,Q8vaKmUAAAAJ,0000-0000-0000-0000
 Yiling Chen 0001,Harvard University,http://yiling.seas.harvard.edu,Q8vaKmUAAAAJ,0000-0002-0166-594X
+Yiling Chen,Harvard University,http://yiling.seas.harvard.edu,Q8vaKmUAAAAJ,0000-0000-0000-0000
 Yiling Lou,Univ. of Illinois at Urbana-Champaign,https://yilinglou.github.io,FTf12C0AAAAJ,0000-0002-4066-3365
 Yilu Liu,University of Tennessee,http://www.eecs.utk.edu/people/faculty/liu,NOSCHOLARPAGE,0000-0000-0000-0000
 Yilun Du,Harvard University,https://seas.harvard.edu/person/yilun-du,GRMMc_MAAAAJ,0000-0001-6792-5946
@@ -716,6 +717,7 @@ Yong Yu 0001,Shanghai Jiao Tong University,https://apex.sjtu.edu.cn/members/yyu,
 Yong Zhang,UNC - Charlotte,https://ece.charlotte.edu/directory/dr-yong-zhang-phd,p7-nPv8AAAAJ,0000-0000-0000-0000
 Yong Zhao 0009,UESTC,https://www.en.scse.uestc.edu.cn/info/1085/1897.htm,3mixb94AAAAJ,0000-0000-0000-0000
 Yong Zhou 0006,ShanghaiTech University,https://faculty.sist.shanghaitech.edu.cn/faculty/zhouyong/Index.html,8bpAwKcAAAAJ,0000-0000-0000-0000
+Yong-Dao Zhou,Nankai University,http://web.stat.nankai.edu.cn/ydzhou/index_en.html,30XhqsoAAAAJ,0000-0003-3805-7021
 Yong-Jin Liu 0001,Tsinghua University,http://media.cs.tsinghua.edu.cn/en/liuyj,GNDtwWQAAAAJ,0000-0001-5774-1916
 Yong-Jun Xu 0001,Chinese Academy of Sciences,http://english.ict.cas.cn/people/scien/bln/202303/t20230320_328532.html,l34KxTYAAAAJ,0000-0000-0000-0000
 Yong-Lae Park,Seoul National University,https://softrobotics.snu.ac.kr,kBsTE7AAAAAJ,0000-0000-0000-0000


### PR DESCRIPTION
## Consolidated PR for Nankai University

This PR consolidates the following open PRs into a single submission:

| PR | Score | Title |
|---|---|---|
| #11713 | 0% | Add 5 faculty from Nankai University |
| #11935 | 72% | Add 1 faculty from Nankai University |
| #11990 | 62% | Add Chengwei Liu (Nankai University) |
| #12006 | 70% | Add Yaqiong Qiao (Nankai University) |

**Validation summary**: Scores range from 0% to 72% (avg 51%). Some constituent PRs have concerns that need resolution — see individual PR comments for details.

Total: 8 faculty additions.