### PR TITLE
Add 17 faculty from Southeast University (consolidated)

### DIFF
--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -222,6 +222,7 @@ Beibei Wang 0002,Nanjing University,https://wangningbei.github.io,ZfeakdQAAAAJ,0
 Beichuan Zhang 0001,University of Arizona,https://www.cs.arizona.edu/~bzhang,NOSCHOLARPAGE,0009-0001-5333-8465
 Beihong Jin,Chinese Academy of Sciences,http://work.iscas.ac.cn/index.php/Jinbeihong/index/index,NOSCHOLARPAGE,0000-0003-3683-4034
 Beijun Shen,Shanghai Jiao Tong University,https://base.sjtu.edu.cn/~bjshen,wnq7SiQAAAAJ,0000-0001-8370-3956
+Beilun Wang,Southeast University,https://cs.seu.edu.cn/beilun/main.htm,PoHiv9wAAAAJ,0000-0002-2646-1492
 Beiyu Lin,University of Oklahoma,https://beiyulincs.github.io,hou6waAAAAAJ,0000-0000-0000-0000
 Beki Grinter,Georgia Institute of Technology,http://www.cc.gatech.edu/~beki/Beki.html,PNalJ58AAAAJ,0000-0000-0000-0000
 Bela Gipp,University of Göttingen,https://gipplab.org,No2ot2YAAAAJ,0000-0001-6522-3019
@@ -626,6 +627,7 @@ Biswanath Dey,National Inst. of Tech. Silchar,http://cs.nits.ac.in/bdey,38RH3kAA
 Biswanath Mukherjee,Univ. of California - Davis,https://faculty.engineering.ucdavis.edu/mukherjee,ytXtLjkAAAAJ,0000-0000-0000-0000
 Bivas Mitra,IIT Kharagpur,http://cse.iitkgp.ac.in/~bivasm,mQ57itUAAAAJ,0000-0003-4668-8771
 Biwei Huang,Univ. of California - San Diego,https://biweihuang.com,hTRCBCgAAAAJ,0000-0000-0000-0000
+Bixin Li,Southeast University,https://cs.seu.edu.cn/bxli/main.htm,nxQBSlgAAAAJ,0000-0001-9916-4790
 Bixio Rimoldi,EPFL,https://people.epfl.ch/bixio.rimoldi,SsEHa6cAAAAJ,0000-0000-0000-0000
 Bjarne K. Ersbøll,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE,0000-0000-0000-0000
 Bjarne Kjær Ersbøll,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE,0000-0003-1262-7890
@@ -686,6 +688,7 @@ Bo Li 0005,Beihang University,https://scse.buaa.edu.cn/info/1078/11964.htm,CvjqO
 Bo Li 0026,Univ. of Illinois at Urbana-Champaign,https://aisecure.github.io,K8vJkTcAAAAJ,0000-0003-4883-7267
 Bo Li 0037,The Hong Kong Polytechnic Univ.,https://www4.comp.polyu.edu.hk/~bo2li,JsT0JNYAAAAJ,0000-0001-7500-8355
 Bo Liu 0001,University of Technology Sydney,https://profiles.uts.edu.au/Bo.Liu,Ixcq78YAAAAJ,0000-0002-3603-6617
+Bo Liu 0004,Southeast University,https://cs.seu.edu.cn/bliu/main.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Bo Liu 0006,Auburn University,https://liubo-cs.github.io,8MliTo4AAAAJ,0000-0000-0000-0000
 Bo Liu 0034,SUAT,https://csce.suat-sz.edu.cn/info/1011/1314.htm,ZJMO78sAAAAJ,0000-0000-0000-0000
 Bo Luo,University of Kansas,http://www.ittc.ku.edu/~bluo,roY9L1oAAAAJ,0000-0001-8196-2436

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -550,6 +550,7 @@ Chen Zhao,Harbin Institute of Technology,https://homepage.hit.edu.cn/zhaochen?la
 Chen-Ching Liu,Washington State University,https://school.eecs.wsu.edu/people/faculty/chen-ching-liu,NOSCHOLARPAGE,0000-0000-0000-0000
 Chen-Nee Chuah,Univ. of California - Davis,https://www.ece.ucdavis.edu/~chuah/rubinet/people/chuah/bio.html,bZNRLNAAAAAJ,0000-0002-2772-387X
 Chen-Yu Wei,University of Virginia,https://bahh723.github.io,2L2cR-kAAAAJ,0000-0000-0000-0000
+Chenchen Fu,Southeast University,https://cs.seu.edu.cn/chenchen_fu/main.htm,_uJzU5wAAAAJ,0000-0002-6724-9594
 Chenfanfu Jiang,Univ. of California - Los Angeles,https://www.math.ucla.edu/~cffjiang,jTivVMEAAAAJ,0000-0003-3506-0583
 Cheng Chang Lu,Kent State University,http://www.cs.kent.edu/~lucc,NOSCHOLARPAGE,0000-0000-0000-0000
 Cheng Deng,Xidian University,http://see.xidian.edu.cn/faculty/chdeng,OROjmc8AAAAJ,0000-0000-0000-0000
@@ -561,6 +562,7 @@ Cheng Li 0001,USTC,http://staff.ustc.edu.cn/~chengli7,3Fdv_mIAAAAJ,0000-0001-706
 Cheng Long 0001,Nanyang Technological University,https://personal.ntu.edu.sg/c.long/index.html,LybJ7ksAAAAJ,0000-0001-6806-8405
 Cheng Tan 0005,Northeastern University,https://naizhengtan.github.io,OTzvsa4AAAAJ,0000-0002-1420-5125
 Cheng Wang 0003,Xiamen University,https://asc.xmu.edu.cn/t/wangcheng,kAnv3SkAAAAJ,0000-0002-7906-8061
+Cheng Xue 0003,Southeast University,https://cs.seu.edu.cn/cxue/main.htm,v4eV3JcAAAAJ,0000-0001-8848-596X
 Cheng Yang 0002,BUPT,http://nlp.csai.tsinghua.edu.cn/~yangcheng,OlLjVUcAAAAJ,0000-0001-7821-0030
 Cheng Zhang 0011,Cornell University,https://infosci.cornell.edu/content/zhang-0,NOSCHOLARPAGE,0000-0000-0000-0000
 Cheng Zhang 0014,Texas A&M University,https://czhang0528.github.io,vb3l1ZMAAAAJ,0009-0003-6255-7648
@@ -1174,6 +1176,7 @@ Chuanxia Zheng,Nanyang Technological University,https://dr.ntu.edu.sg/entities/p
 Chuanyi Ji,Georgia Institute of Technology,https://jic.ece.gatech.edu,nHRYc6YAAAAJ,0000-0000-0000-0000
 Chuanyi Li,Nanjing University,http://lichuanyi.site,T6FZPEQAAAAJ,0000-0001-9270-5072
 Chuanyi Liu,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/liuchuanyi,Aec7FSQAAAAJ,0000-0000-0000-0000
+Chuanyou Li,Southeast University,https://cs.seu.edu.cn/cyli/main.htm,NOSCHOLARPAGE,0000-0002-8725-6417
 Chubo Liu,Hunan University,http://csee.hnu.edu.cn/people/liuchubo,NOSCHOLARPAGE,0000-0002-2372-6715
 Chuck Anderson 0001,Colorado State University,http://www.cs.colostate.edu/~anderson,NhnK838AAAAJ,0000-0000-0000-0000
 Chuck Yoo,Korea University,https://os.korea.ac.kr/?page_id=184,NOSCHOLARPAGE,0000-0002-1115-1862

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -1143,6 +1143,7 @@ Di Wu 0016,University of Central Florida,https://www.cs.ucf.edu/person/di-wu,v6D
 Di Yao 0001,Chinese Academy of Sciences,http://yaodi.info,HrjhP2AAAAAJ,0000-0003-1778-8319
 Di Yuan,Uppsala University,https://katalog.uu.se/empinfo/?id=N15-9,NOSCHOLARPAGE,0009-0002-4078-5140
 Dia Ali,University of Southern Mississippi,https://www.usm.edu/computing/faculty/dia-ali,NOSCHOLARPAGE,0000-0000-0000-0000
+Dian Shen,Southeast University,https://cs.seu.edu.cn/dianshen/main.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Dian Zhang,Shenzhen University,http://nhpcc.szu.edu.cn/zhangdian,tiE0IDMAAAAJ,0000-0000-0000-0000
 Diana Bental,Heriot-Watt University,https://researchportal.hw.ac.uk/en/persons/diana-bental,NOSCHOLARPAGE,0000-0000-0000-0000
 Diana F. Adamatti,Federal University of Rio Grande,http://www.diana.c3.furg.br,anyT2ZkAAAAJ,0000-0000-0000-0000
@@ -1675,6 +1676,7 @@ Dusit Tao Niyato,Nanyang Technological University,http://www.ntu.edu.sg/home/dni
 Dusko Pavlovic,University of Hawaii at Manoa,http://dusko.org,upXQmicAAAAJ,0000-0002-9855-6861
 Dustin Richmond,Univ. of California - Santa Cruz,https://www.dustinrichmond.com,U9hK8g4AAAAJ,0000-0002-4587-8947
 Dustin Wright 0001,Aalborg University,https://dustinbwright.com,OGk5UnYAAAAJ,0000-0001-6514-8733
+Duxin Chen,Southeast University,https://math.seu.edu.cn/cdx/list.htm,obnDqtMAAAAJ,0000-0002-3194-2258
 Dwight Deugo,Carleton University,http://www.scs.carleton.ca/~deugo,NOSCHOLARPAGE,0000-0000-0000-0000
 Dwight Makaroff,University of Saskatchewan,https://www.cs.usask.ca/faculty/makaroff,deJ2I6sAAAAJ,0000-0002-0049-4413
 Dylan A. Shell,Texas A&M University,http://robotics.cs.tamu.edu,Qt-JcygAAAAJ,0000-0000-0000-0000

--- a/csrankings-f.csv
+++ b/csrankings-f.csv
@@ -62,8 +62,8 @@ Fabrizio Granelli,University of Trento,https://www.granelli-lab.org/staff/fabriz
 Fabrizio Messina,University of Catania,https://www.dmi.unict.it/messina,iF1u8psAAAAJ,0000-0002-3685-3879
 Fabrizio Silvestri,Sapienza University of Rome,https://sites.google.com/diag.uniroma1.it/fabriziosilvestri,pi985dQAAAAJ,0000-0001-7669-9055
 Fabrizio d'Amore,Sapienza University of Rome,http://www.diag.uniroma1.it/users/fabrizio%20damore,NOSCHOLARPAGE,0000-0000-0000-0000
-Fabrício Benevenuto,UFMG,http://homepages.dcc.ufmg.br/~fabricio,iOnt0iMAAAAJ,0000-0001-6875-6259
 Fabrício Benevenuto de Souza,UFMG,http://homepages.dcc.ufmg.br/~fabricio,iOnt0iMAAAAJ,0000-0000-0000-0000
+Fabrício Benevenuto,UFMG,http://homepages.dcc.ufmg.br/~fabricio,iOnt0iMAAAAJ,0000-0001-6875-6259
 Fabrício Enembreck,PUCPR,http://www.ppgia.pucpr.br/~fabricio,LjsK1HgAAAAJ,0000-0002-1418-3245
 Facundo Mémoli,Ohio State University,https://people.math.osu.edu/memoli.2,E3APGcgAAAAJ,0000-0000-0000-0000
 Fadel Adib,Massachusetts Inst. of Technology,http://www.mit.edu/~fadel,OxKLBqwAAAAJ,0000-0003-2593-2069
@@ -84,8 +84,8 @@ Fairouz Kamareddine,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/fa
 Faisal N. Abu-Khzam,Lebanese American University,http://www.csm.lau.edu.lb/fabukhzam,NOSCHOLARPAGE,0000-0000-0000-0000
 Faisal Nawab,Univ. of California - Irvine,http://nawab.me,oMHn13QAAAAJ,0000-0003-2264-4600
 Faith E. Fich,University of Toronto,http://www.cs.toronto.edu/~faith,NOSCHOLARPAGE,0000-0000-0000-0000
-Faith Ellen,University of Toronto,http://www.cs.toronto.edu/~faith,NOSCHOLARPAGE,0000-0003-4473-931X
 Faith Ellen Fich,University of Toronto,http://www.cs.toronto.edu/~faith,NOSCHOLARPAGE,0000-0000-0000-0000
+Faith Ellen,University of Toronto,http://www.cs.toronto.edu/~faith,NOSCHOLARPAGE,0000-0003-4473-931X
 Faiyaz Doctor,University of Essex,https://www.essex.ac.uk/people/docto78602/faiyaz-doctor,_Wr-trcAAAAJ,0000-0002-8412-5489
 Faiz Ali Shah,University of Tartu,https://ut.ee/et/tootaja/faiz-ali-shah,CaJ3quAAAAAJ,0000-0003-1233-5425
 Faiza Allah Bukhsh,University of Twente,https://research.utwente.nl/en/persons/98f0f515-2dc3-4c73-9c78-079b197f0044,aBAuDJUAAAAJ,0000-0000-0000-0000
@@ -105,6 +105,7 @@ Fan Chao 0001,Shenzhen University,https://chaofan996.github.io,lgDtKZcAAAAJ,0000
 Fan Chen 0001,Indiana University,https://homes.luddy.indiana.edu/fc7,5HISWRIAAAAJ,0000-0001-7928-8331
 Fan Cheng 0002,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/~chengfan,aECSCPUAAAAJ,0000-0002-4307-6334
 Fan Lai 0001,Univ. of Illinois at Urbana-Champaign,https://www.fanlai.me,PlWcEMsAAAAJ,0009-0005-0472-107X
+Fan Liu 0008,Southeast University,https://liufancs.github.io/,qjECBscAAAAJ,0000-0002-4547-3982
 Fan Long,University of Toronto,http://www.cs.toronto.edu/~fanl,j6XdtXwAAAAJ,0000-0001-7973-1188
 Fan R. K. Chung,Univ. of California - San Diego,http://math.ucsd.edu/~fan,7hPnuFQAAAAJ,0000-0000-0000-0000
 Fan Wei,Duke University,https://sites.google.com/view/fan-wei/home,voxfw5EAAAAJ,0000-0000-0000-0000
@@ -118,6 +119,7 @@ Fan Zhong,Shandong University,https://cvfzhong.github.io,NOSCHOLARPAGE,0000-0001
 Fan Zhou 0002,UESTC,http://www.is.uestc.edu.cn/teachers.do?id=1121,Ihj2Rw8AAAAJ,0000-0002-8038-8150
 Fan-Tien Cheng,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/depmember/teacherdetail/id/37,m9IzwP8AAAAJ,0000-0001-8201-223X
 Fang Chen,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/fang-chen.aspx,M_PnmHUAAAAJ,0000-0000-0000-0000
+Fang Dong 0001,Southeast University,https://cs.seu.edu.cn/fdong/main.htm,rw0OSWsAAAAJ,0000-0001-6770-326X
 Fang Kong 0001,Soochow University,http://jxjylx.suda.edu.cn/c1/54/c12588a377172/page.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Fang Li 0001,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/~li-fang,U3Sm3-YAAAAJ,0009-0001-2404-1152
 Fang Liu 0001,Xidian University,https://web.xidian.edu.cn/fliu,qrQkfxYAAAAJ,0000-0002-5669-9354
@@ -178,8 +180,8 @@ Farookh Hussain,University of Technology Sydney,https://www.uts.edu.au/staff/far
 Farookh Khadeer Hussain,University of Technology Sydney,https://www.uts.edu.au/staff/farookh.hussain,L2Ve-R0AAAAJ,0000-0000-0000-0000
 Farshad Fotouhi,Wayne State University,http://www.cs.wayne.edu/fotouhi/page.php,IkBUnLYAAAAJ,0000-0000-0000-0000
 Faruk Polat,Middle East Technical University,http://user.ceng.metu.edu.tr/~polat,NOSCHOLARPAGE,0000-0000-0000-0000
-Farzad Farnoud,University of Virginia,https://engineering.virginia.edu/faculty/farzad-farnoud,s1NC4EMAAAAJ,0000-0002-8684-4487
 Farzad Farnoud Hassanzadeh,University of Virginia,https://engineering.virginia.edu/faculty/farzad-farnoud,s1NC4EMAAAAJ,0000-0000-0000-0000
+Farzad Farnoud,University of Virginia,https://engineering.virginia.edu/faculty/farzad-farnoud,s1NC4EMAAAAJ,0000-0002-8684-4487
 Farzan Farnia,Chinese University of Hong Kong,http://www.cse.cuhk.edu.hk/~farnia,GYPCqcYAAAAJ,0000-0002-6049-9232
 Farzaneh Derakhshan,Illinois Institute of Technology,https://www.iit.edu/directory/people/farzaneh-derakhshan,C5JlM6AAAAAJ,0000-0002-2156-2606
 Fateme Rajabiyazdi,University of Calgary,https://profiles.ucalgary.ca/fateme-rajabiyazdi,mvoc_5AAAAAJ,0000-0002-8710-865X
@@ -240,6 +242,7 @@ Fei Qi 0001,Xidian University,https://web.xidian.edu.cn/qifei,JGpo5vQAAAAJ,0000-
 Fei Song,University of Guelph,https://www.uoguelph.ca/computing/people/fei-song,NOSCHOLARPAGE,0000-0000-0000-0000
 Fei Su,BUPT,https://teacher.bupt.edu.cn/sufei/en/index/36998/list/index.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Fei Sun 0001,Chinese Academy of Sciences,https://ofey.me,OlRxBhcAAAAJ,0000-0002-6146-148X
+Fei Tong 0001,Southeast University,https://fei-tong.github.io/,tkSzax8AAAAJ,0000-0002-0629-4543
 Fei Wang 0001,Cornell University,https://wcm-wanglab.github.io/index.html,FjCbjDYAAAAJ,0000-0001-9459-9461
 Fei Wang 0014,Chinese Academy of Sciences,https://finleywang.github.io,MuEc_JEAAAAJ,0000-0002-3282-0535
 Fei Wang 0017,Fudan University,http://www.cs.fudan.edu.cn/?page_id=1948,NOSCHOLARPAGE,0000-0001-5890-0448
@@ -253,6 +256,7 @@ Feifei Ma,Chinese Academy of Sciences,http://people.ucas.edu.cn/~feifeima,nbUWp5
 Feiliang Ren,Northeastern University (China),http://faculty.neu.edu.cn/renfeiliang/en/index.htm,W7iUHB8AAAAJ,0000-0001-6824-1191
 Feilong Tang,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/PeopleDetail.aspx?id=343,x_WgkwcAAAAJ,0000-0002-1384-198X
 Feipei Lai,National Taiwan University,https://sites.google.com/site/medinfolabatntu,NOSCHOLARPAGE,0000-0001-7147-8122
+Feipeng Da,Southeast University,https://automation.seu.edu.cn/dfp/list.htm,NOSCHOLARPAGE,0000-0001-5475-3145
 Feiping Nie 0001,NWPU,http://www.escience.cn/people/fpnie/index.html,2oB4nAIAAAAJ,0000-0002-0871-6519
 Feiqiao Mao,Shenzhen University,https://csse.szu.edu.cn/en/pages/user/index?id=534,ABaMtH4AAAAJ,0000-0003-1512-5503
 Felipe Fronchetti,Louisiana State University,https://www.lsu.edu/eng/cse/people/faculty/fronchetti.php,-6jIjG8AAAAJ,0000-0000-0000-0000
@@ -345,14 +349,14 @@ Ferkan Yilmaz,Yıldız Technical University,https://www.ce.yildiz.edu.tr/persona
 Fermi Ma,New York University,https://fermima.com,iYKXRK0AAAAJ,0009-0002-2437-0535
 Fermín Moscoso del Prado Martín,University of Cambridge,https://www.cst.cam.ac.uk/people/fm611,ijkDfKcAAAAJ,0000-0000-0000-0000
 Fernanda B. Viégas,Harvard University,https://seas.harvard.edu/person/fernanda-viegas,GvXDNsYAAAAJ,0000-0002-4951-4008
-Fernanda Gusmão de Lima,UFRGS,http://www.inf.ufrgs.br/~fglima,vazfTWQAAAAJ,0000-0000-0000-0000
 Fernanda Gusmão de Lima Kastensmidt,UFRGS,http://www.inf.ufrgs.br/~fglima,vazfTWQAAAAJ,0000-0000-0000-0000
+Fernanda Gusmão de Lima,UFRGS,http://www.inf.ufrgs.br/~fglima,vazfTWQAAAAJ,0000-0000-0000-0000
 Fernanda Lima Kastensmidt,UFRGS,http://www.inf.ufrgs.br/~fglima,vazfTWQAAAAJ,0000-0000-0000-0000
 Fernanda Madeiral,UFPE,https://fermadeiral.github.io,Jqy0cu0AAAAJ,0000-0003-2048-7648
 Fernando A. Kuipers,TU Delft,https://www.fernandokuipers.nl,W9BWce4AAAAJ,0000-0002-6686-8350
 Fernando Alva-Manchego,Cardiff University,https://feralvam.github.io,4SnHu7sAAAAJ,0000-0001-6218-8377
-Fernando Castor,University of Twente,http://fernandocastor.github.io,c_egjh0AAAAJ,0000-0002-6389-3630
 Fernando Castor Filho,University of Twente,http://fernandocastor.github.io,c_egjh0AAAAJ,0000-0002-6389-3630
+Fernando Castor,University of Twente,http://fernandocastor.github.io,c_egjh0AAAAJ,0000-0002-6389-3630
 Fernando De la Rosa,Universidad de los Andes,https://sistemasacademico.uniandes.edu.co/~fde,UB6e9ywAAAAJ,0000-0000-0000-0000
 Fernando Diaz 0001,Carnegie Mellon University,https://841.io,212SLn0AAAAJ,0000-0003-2345-1288
 Fernando E. B. Otero,University of Kent,https://www.cs.kent.ac.uk/people/staff/febo,pEa-vucAAAAJ,0000-0000-0000-0000
@@ -771,6 +775,7 @@ Frédéric Suter,Ecole Normale Superieure de Lyon,http://www.ens-lyon.fr/annuair
 Frédérique Laforest,Université Jean Monnet,http://satin-ppl.telecom-st-etienne.fr/flaforest,dlCqLHsAAAAJ,0000-0000-0000-0000
 Fuat Akal,Hacettepe University,http://yunus.hacettepe.edu.tr/~akal,rnq1_mIAAAAJ,0000-0003-2582-4180
 Fubing Mao,HUST,http://faculty.hust.edu.cn/maofubing/en/index.htm,NOSCHOLARPAGE,0000-0003-2589-0073
+Fucai Zhou,Northeastern University (China),http://faculty.neu.edu.cn/zhoufucai/en/index.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Fuchun Guo,University of Wollongong,https://documents.uow.edu.au/~fuchun,nM4s968AAAAJ,0000-0001-6939-7710
 Fuchun J. Lin,National Chiao Tung University,http://www.cs.nctu.edu.tw/~fuchun_lin,Pei7LGcAAAAJ,0000-0000-0000-0000
 Fuchun Joseph Lin,National Chiao Tung University,http://www.cs.nctu.edu.tw/~fuchun_lin,Pei7LGcAAAAJ,0000-0002-3188-5580
@@ -779,11 +784,10 @@ Fuhai Li 0001,Washington University in St. Louis,https://engineering.washu.edu/f
 Fuheng Zhao,University of Utah,https://zhaofuheng.github.io,y4g9O38AAAAJ,0000-0000-0000-0000
 Fuhua (Frank) Cheng,University of Kentucky,http://www.cs.uky.edu/~cheng,NOSCHOLARPAGE,0000-0000-0000-0000
 Fuhua Cheng,University of Kentucky,http://www.cs.uky.edu/~cheng,NOSCHOLARPAGE,0000-0000-0000-0000
-Fucai Zhou,Northeastern University (China),http://faculty.neu.edu.cn/zhoufucai/en/index.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Fuji Ren,UESTC,https://www.scse.uestc.edu.cn/info/1081/12686.htm,eyLJ0fMAAAAJ,0000-0003-4860-9184
+Fulai Liu,Northeastern University (China),http://jsjytx.neuq.edu.cn/info/1038/4125.htm,NOSCHOLARPAGE,0000-0001-7888-2750
 Fuli Feng,USTC,https://fulifeng.github.io,QePM4u8AAAAJ,0000-0002-5828-9842
 Fulin Luo,Chongqing University,http://www.cs.cqu.edu.cn/info/1325/6041.htm,TICo9iQAAAAJ,0000-0000-0000-0000
-Fulai Liu,Northeastern University (China),http://jsjytx.neuq.edu.cn/info/1038/4125.htm,NOSCHOLARPAGE,0000-0001-7888-2750
 Fumeng Yang,Univ. of Maryland - College Park,https://www.cs.umd.edu/people/fmy,0JofUMQAAAAJ,0000-0002-8401-2580
 Fumihide Tanaka,University of Tsukuba,http://fumihide-tanaka.org/lab/en/members.html,NOSCHOLARPAGE,0000-0002-8443-5591
 Fumin Shen,UESTC,http://cfm.uestc.edu.cn/~fshen,oqYL6fQAAAAJ,0000-0001-7303-3231

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -829,6 +829,7 @@ Guang Wang 0001,Florida State University,https://guangwang.me,DfHyVboAAAAJ,0000-
 Guang-Hong Yang,Northeastern University (China),http://faculty.neu.edu.cn/yangguanghong/en/index.htm,ansRqM4AAAAJ,0000-0000-0000-0000
 Guang-Yu Sun 0003,Peking University,http://ceca.pku.edu.cn/en/team.php?action=show&member_id=15,m3f70oYAAAAJ,0000-0000-0000-0000
 Guang-Zhong Yang,Imperial College London,http://www.imperial.ac.uk/people/g.z.yang,NOSCHOLARPAGE,0000-0003-4060-4020
+Guangchi Liu,Southeast University,https://cs.seu.edu.cn/gcliu/main.htm,_Xi_fakAAAAJ,0000-0003-4588-3196
 Guangchun Luo,UESTC,https://www.is.uestc.edu.cn/teachers.do?id=7308,NOSCHOLARPAGE,0000-0000-0000-0000
 Guangdong Bai,City University of Hong Kong,https://baigd.github.io,4TjSSaUAAAAJ,0000-0002-6390-9890
 Guanghui Lan,Georgia Institute of Technology,https://sites.gatech.edu/guanghui-lan,l3SflUcAAAAJ,0000-0002-2103-087X
@@ -959,6 +960,7 @@ Guohao Lan,TU Delft,https://guohao.netlify.app,1ebZN5gAAAAJ,0000-0003-2190-9937
 Guohong Cao,Pennsylvania State University,http://www.cse.psu.edu/~gxc27,zD5ZfacAAAAJ,0000-0003-2115-7165
 Guohong Fu,Soochow University,http://web.suda.edu.cn/ghfu,NOSCHOLARPAGE,0000-0000-0000-0000
 Guohui Lin,University of Alberta,https://webdocs.cs.ualberta.ca/~ghlin,XSgTV7gAAAAJ,0000-0000-0000-0000
+Guohui Xiao 0001,Southeast University,https://cs.seu.edu.cn/guohuixiao/main.htm,hbek3dcAAAAJ,0000-0002-5115-4769
 Guojie Luo,Peking University,http://ceca.pku.edu.cn/guojie,8-mT29YAAAAJ,0000-0003-4932-3655
 Guojie Song,Peking University,http://www.klmp.pku.edu.cn/Faculty/FacultyDetail.aspx?FacultyID=44,a832IIMAAAAJ,0000-0001-8295-2520
 Guojun Peng,Wuhan University,https://cse.whu.edu.cn/info/3301/37331.htm,NOSCHOLARPAGE,0000-0001-5731-8958

--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -338,6 +338,7 @@ Hao Che,University of Texas at Arlington,http://crystal.uta.edu/~hche,Vyrg19YAAA
 Hao Chen 0002,Hunan University,http://www.aimlab.org/haochen,NOSCHOLARPAGE,0000-0001-9857-6283
 Hao Chen 0003,University of Hong Kong,https://www.cs.hku.hk/index.php/people/academic-staff/chenho,1Aa3qxIAAAAJ,0000-0002-4072-0710
 Hao Chen 0011,HKUST,https://cse.hkust.edu.hk/~jhc,Z_t5DjwAAAAJ,0000-0002-8400-3780
+Hao Chen 0034,Southeast University,https://cs.seu.edu.cn/haochen303/main.htm,6qVQ7ZMAAAAJ,0000-0000-0000-0000
 Hao Chen 0062,City University of Macau,https://fds.cityu.edu.mo/en/members/413,7oeLWT0AAAAJ,0000-0001-6816-5344
 Hao Deng 0002,Tongji University,https://cs.tongii.edu.cn/info/1063/3303.htm,IVOUeJkAAAAJ,0000-0002-4627-9110
 Hao Dong 0003,Peking University,https://zsdonghao.github.io,xLFL4sMAAAAJ,0000-0002-7984-9909
@@ -1164,6 +1165,7 @@ Huiyan Sun,Jilin University,https://www.researchgate.net/profile/Huiyan-Sun,A9t1
 Huiyan Wang 0001,Nanjing University,http://www.why.ink:8080,uGha7wIAAAAJ,0000-0001-6879-1628
 Huiyang Zhou,North Carolina State University,https://people.engr.ncsu.edu/hzhou,_2gFUN0AAAAJ,0000-0003-2133-0722
 Huiying Li 0002,Jilin University,https://ccst.jlu.edu.cn/info/1367/20715.htm,NOSCHOLARPAGE,0000-0002-3637-2581
+Huiying Li 0003,Southeast University,https://cs.seu.edu.cn/huiyingli/main.htm,NOSCHOLARPAGE,0000-0002-6425-7193
 Huiyuan Fu,BUPT,https://scs.bupt.edu.cn/info/1097/1781.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Huiyuan Yang,Missouri S&T,https://hyang428.github.io,13z7nowAAAAJ,0000-0000-0000-0000
 Huizhang Luo,Hunan University,http://csee.hnu.edu.cn/people/luohuizhang,NOSCHOLARPAGE,0000-0003-2392-0267

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -1214,6 +1214,7 @@ Jiaoyang Li 0001,Carnegie Mellon University,https://jiaoyangli.me,kUVJywwAAAAJ,0
 Jiapeng Zhang,University of Southern California,https://sites.google.com/site/jiapeng0708,9eQOP14AAAAJ,0000-0002-6410-8649
 Jiaping Gui,Shanghai Jiao Tong University,https://infosec.sjtu.edu.cn/DirectoryDetail.aspx?id=173,PCHAczoAAAAJ,0009-0001-4272-9604
 Jiaqi Liu 0001,Central South University,https://faculty.csu.edu.cn/liujiaqi/zh_CN/index.htm,NOSCHOLARPAGE,0000-0000-0000-0000
+Jiaqi Lv,Southeast University,https://cs.seu.edu.cn/jiaqilv/main.htm,PK8L9mYAAAAJ,0000-0000-0000-0000
 Jiaqi W. Ma,Univ. of Illinois at Urbana-Champaign,https://jiaqima.github.io,Z9X2A1MAAAAJ,0000-0001-8292-5901
 Jiaqi Wang 0002,Auburn University,https://jackqqwang.github.io,ZGTVInsAAAAJ,0000-0002-9874-6622
 Jiaqi Zheng 0001,Nanjing University,https://cs.nju.edu.cn/jzheng,cQYY20IAAAAJ,0000-0001-8403-9655

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -159,6 +159,7 @@ Kamlesh Tiwari,BITS Pilani,http://www.bits-pilani.ac.in/pilani/kamleshtiwari/pro
 Kamran Sedig,Western University,http://www.csd.uwo.ca/faculty/sedig,NTTQNNoAAAAJ,0000-0002-6970-5469
 Kan Ren,ShanghaiTech University,http://www.saying.ren,USnQVWgAAAAJ,0000-0002-4032-9615
 Kan Yang 0001,University of Memphis,https://www.memphis.edu/cs/people/faculty_pages/kan-yang.php,QqGPbXYAAAAJ,0000-0000-0000-0000
+Kan-Jian Zhang,Southeast University,https://automation.seu.edu.cn/zkj/list.htm,NOSCHOLARPAGE,0009-0005-8443-4811
 Kan-Le Shi,Tsinghua University,http://cgcad.thss.tsinghua.edu.cn/?people=kanle-shi,NOSCHOLARPAGE,0000-0000-0000-0000
 Kana Shimizu,Waseda University,https://iskana.github.io/index.html,-EEsgxUAAAAJ,0000-0001-6452-9091
 Kanad Ghose,Binghamton University,http://www.cs.binghamton.edu/~ghose,3itxM90AAAAJ,0000-0002-5509-6543

--- a/csrankings-l.csv
+++ b/csrankings-l.csv
@@ -263,6 +263,7 @@ Lei Li 0005,Carnegie Mellon University,https://lileicc.github.io,BYXqAlwAAAAJ,00
 Lei Liu 0040,Jilin University,https://ccst.jlu.edu.cn/info/1367/19052.htm,NOSCHOLARPAGE,0000-0001-5217-6129
 Lei Luo 0004,UESTC,https://www.scse.uestc.edu.cn/info/1081/11412.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Lei Meng,Shandong University,https://ercdm.sdu.edu.cn/info/1013/1413.htm,KuukGGkAAAAJ,0000-0000-0000-0000
+Lei Qi 0001,Southeast University,https://cs.seu.edu.cn/qilei/main.htm,7mm8iZwAAAAJ,0000-0001-7091-0702
 Lei Sha,Beihang University,https://shalei120.github.io,EbZ_P6gAAAAJ,0000-0001-5914-7590
 Lei Shi 0003,Durham University,https://www.dur.ac.uk/computer.science/staff/profile/?id=18349,t6vecXsAAAAJ,0000-0000-0000-0000
 Lei Sun 0001,Nankai University,https://ai.nankai.edu.cn/info/1033/3561.htm,NOSCHOLARPAGE,0000-0002-8886-9012
@@ -434,6 +435,7 @@ Li Li 0029,Beihang University,http://lilicoding.github.io,zuUsFkgAAAAJ,0000-0003
 Li Li 0040,USTC,https://faculty.ustc.edu.cn/lil1/en,dEm6VKAAAAAJ,0000-0000-0000-0000
 Li Li 0064,University of Macau,https://www.fst.um.edu.mo/personal/llili,uLzU3OcAAAAJ,0000-0002-2044-8289
 Li Liao,University of Delaware,https://www.eecis.udel.edu/~lliao,o6e8dvUAAAAJ,0000-0000-0000-0000
+Li Lin 0011,Southeast University,https://cs.seu.edu.cn/linli321/main.htm,HdHiMG8AAAAJ,0000-0002-3511-5559
 Li Liu 0001,Chongqing University,http://www.cse.cqu.edu.cn/info/2095/5647.htm,DfxieQEAAAAJ,0000-0002-4776-5292
 Li Liu 0028,Soochow University,http://web.suda.edu.cn/lliu6819,G1pw9G0AAAAJ,0000-0002-3161-0464
 Li Lu 0001,UESTC,https://www.scse.uestc.edu.cn/info/1081/12001.htm,NOSCHOLARPAGE,0000-0002-4361-012X
@@ -450,6 +452,7 @@ Li Xiong 0001,Emory University,https://cs.emory.edu/~lxiong,jJ8BLgsAAAAJ,0000-00
 Li Xiu 0001,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101224001632440223805/20101224001632440223805_.html,wrKyJYsAAAAJ,0000-0000-0000-0000
 Li Yang 0008,Western Michigan University,https://wmich.edu/geography/directory/yang,NOSCHOLARPAGE,0000-0000-0000-0000
 Li Yang 0009,UNC - Charlotte,https://lyang-666.github.io,qpUT1I8AAAAJ,0000-0002-2839-6196
+Li Yao 0003,Southeast University,https://cs.seu.edu.cn/yaoli/main.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Li Yi 0001,Tsinghua University,https://iiis.tsinghua.edu.cn/en/People/Faculty/YiLi.htm,UyZL660AAAAJ,0000-0002-9319-0354
 Li Zhang 0004,Soochow University,http://web.suda.edu.cn/zhangliml,NOSCHOLARPAGE,0000-0000-0000-0000
 Li Zhang 0013,Royal Holloway Univ. of London,https://pure.royalholloway.ac.uk/en/persons/li-zhang,SNh9qOQAAAAJ,0000-0000-0000-0000
@@ -795,6 +798,7 @@ Longbu Huang,Tsinghua University,http://iiis.tsinghua.edu.cn/~huang,g9d_K0sAAAAJ
 Longfei Shangguan,University of Pittsburgh,https://shanggdlk.github.io,JsQoLTQAAAAJ,0000-0002-1153-7087
 Longin Jan Latecki,Temple University,https://cis.temple.edu/~latecki,6sQtqo8AAAAJ,0000-0002-5102-8244
 Longjun Liu,Xi'an Jiaotong University,http://gr.xjtu.edu.cn/en/web/liulongjun,Fq8U66oAAAAJ,0000-0002-7467-4994
+Longyu Jiang,Southeast University,https://cs.seu.edu.cn/jly/main.htm,NOSCHOLARPAGE,0000-0001-8387-3162
 Lonnie R. Welch,Ohio University,https://www.ohio.edu/engineering/about/people/profiles.cfm?profile=welch,NOSCHOLARPAGE,0000-0000-0000-0000
 Lora Aroyo,VU Amsterdam,http://www.cs.vu.nl/~laroyo,FXGgl5IAAAAJ,0000-0001-9402-1133
 Lora Oehlberg,University of Calgary,http://cpsc.ucalgary.ca/~lora.oehlberg,8GzaBdwAAAAJ,0000-0001-7216-7895
@@ -1038,6 +1042,7 @@ Luke Zettlemoyer,University of Washington,https://www.cs.washington.edu/people/f
 Lukás Burget,Brno University of Technology,https://www.fit.vut.cz/person/burget,pRBbU7wAAAAJ,0000-0000-0000-0000
 Lukás Holík,Brno University of Technology,https://www.fit.vut.cz/person/holik,0cPbvY0AAAAJ,0000-0001-6957-1651
 Lukás Sekanina,Brno University of Technology,https://www.fit.vut.cz/person/sekanina,-fLMT2cAAAAJ,0000-0000-0000-0000
+Lulu Wang 0001,Southeast University,https://cs.seu.edu.cn/wanglulu/main.htm,NOSCHOLARPAGE,0000-0002-8575-4172
 Luma da Rocha Seixas,Federal University of Bahia,https://computacao.ufba.br/pt-br/luma-da-rocha-seixas,UzxZIMoAAAAJ,0000-0000-0000-0000
 Lune Bellec,University of Montreal,https://simexp.github.io/intro.html,Yz8WY8YAAAAJ,0000-0000-0000-0000
 Lung-Pan Cheng,National Taiwan University,https://www.lungpancheng.tw,qfORd34AAAAJ,0000-0002-7712-8622

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -2432,6 +2432,7 @@ Ming Tang 0002,Wuhan University,https://cse.whu.edu.cn/info/1104/1798.htm,NOSCHO
 Ming Tang 0006,SUSTech,https://mingtang.site,4v9UxPYAAAAJ,0000-0000-0000-0000
 Ming Wen 0001,HUST,https://mingwen-cs.github.io,ht2MknAAAAAJ,0000-0001-5588-9618
 Ming Yan 0006,CUHK (SZ),https://mingyan08.github.io,IR1mvb0AAAAJ,0000-0000-0000-0000
+Ming Yang 0001,Southeast University,https://cs.seu.edu.cn/yangming2002/main.htm,NOSCHOLARPAGE,0000-0002-8209-1000
 Ming Yin 0001,Purdue University,https://mingyin.org,J8ei9I0AAAAJ,0000-0002-7364-139X
 Ming Zeng 0008,Xiamen University,https://informatics.xmu.edu.cn/info/1475/25649.htm,Q75SLf4AAAAJ,0000-0002-5056-0706
 Ming Zhang 0004,Peking University,http://net.pku.edu.cn/dlib/mzhang,LbzoQBsAAAAJ,0000-0002-9809-3430
@@ -2629,6 +2630,7 @@ Moacir P. Ponti,USP-ICMC,http://www.icmc.usp.br/pessoas/moacir,ZxQDyNcAAAAJ,0000
 Moacir Ponti,USP-ICMC,http://www.icmc.usp.br/pessoas/moacir,ZxQDyNcAAAAJ,0000-0003-2059-9463
 Mobin Javed,LUMS,http://web.lums.edu.pk/~mobin,jVAQ9IAAAAAJ,0000-0002-1321-1988
 Mobyen Uddin Ahmed,Mälardalen University,http://www.es.mdh.se/staff/149-Mobyen_Uddin_Ahmed,4M4ynPkAAAAJ,0000-0000-0000-0000
+Mofei Song,Southeast University,https://cs.seu.edu.cn/songmf/main.htm,Z4JBQIkAAAAJ,0000-0002-9912-1560
 Moffat Mathews,University of Canterbury,http://www.cosc.canterbury.ac.nz/moffat.mathews,S_0AsA4AAAAJ,0000-0002-2063-1569
 Moh'd B. Al-Zoubi,University of Jordan,http://old.bau.edu.jo/ar/Colleges/fet/new/Academic%20_Departments/Applied%20Sciences/Academic%20Staff/Professor%20Abu-Hamatteh%20CV%202013.pdf,NOSCHOLARPAGE,0000-0000-0000-0000
 Mohamad Gharib,University of Tartu,https://kodu.ut.ee/~gharib,xDTf-jgAAAAJ,0000-0003-2286-2819

--- a/csrankings-n.csv
+++ b/csrankings-n.csv
@@ -46,8 +46,8 @@ Nadim W. Alkharouf,Towson University,https://www.towson.edu/fcsm/departments/com
 Nadin Kökciyan,University of Edinburgh,http://www.inf.ed.ac.uk/people/staff/Nadin_Kokciyan.html,MzquQysAAAAJ,0000-0000-0000-0000
 Nadine Abu Rumman,Brunel University London,https://www.brunel.ac.uk/people/nadine-aburumman,g7kT-s8AAAAJ,0000-0003-4578-8738
 Nadine Aburumman,Brunel University London,https://www.brunel.ac.uk/people/nadine-aburumman,g7kT-s8AAAAJ,0000-0000-0000-0000
-Nadine Akkari,King Abdulaziz University,https://www.intechopen.com/profiles/122512/Nadine%20Akkari-Adra,GOL8WHoAAAAJ,0000-0000-0000-0000
 Nadine Akkari Adra,King Abdulaziz University,https://www.intechopen.com/profiles/122512/Nadine%20Akkari-Adra,GOL8WHoAAAAJ,0000-0000-0000-0000
+Nadine Akkari,King Abdulaziz University,https://www.intechopen.com/profiles/122512/Nadine%20Akkari-Adra,GOL8WHoAAAAJ,0000-0000-0000-0000
 Nadine Marcus,UNSW,https://research.unsw.edu.au/people/dr-nadine-marcus,NOSCHOLARPAGE,0000-0000-0000-0000
 Nadir Durrani,Qatar Computing Research Inst.,http://www.qcri.org/our-people/bio?pid=210&amp;par=acc&amp;name=NadirDurrani,K6uisFAAAAAJ,0000-0000-0000-0000
 Nadir Weibel,Univ. of California - San Diego,https://www.ubicomp.ucsd.edu/weibel,KMVQjuQAAAAJ,0000-0002-3457-4227
@@ -77,8 +77,8 @@ Nakul Garg,Rice University,https://nakulg.com,2YIGP0sAAAAJ,0000-0002-8585-0180
 Nakul Gopalan,Arizona State University,https://search.asu.edu/profile/4293865,dPsQR14AAAAJ,0000-0000-0000-0000
 Nalini K. Ratha,University at Buffalo,https://nalini-ratha.github.io,mIPd9DkAAAAJ,0000-0001-7913-5722
 Nalini Venkatasubramanian,Univ. of California - Irvine,https://www.ics.uci.edu/~nalini,qfCah3sAAAAJ,0000-0000-0000-0000
-Nalvo F. Almeida,UFMS,https://www.facom.ufms.br/~nalvo,kU9d-GIAAAAJ,0000-0000-0000-0000
 Nalvo F. Almeida Jr.,UFMS,https://www.facom.ufms.br/~nalvo,kU9d-GIAAAAJ,0000-0000-0000-0000
+Nalvo F. Almeida,UFMS,https://www.facom.ufms.br/~nalvo,kU9d-GIAAAAJ,0000-0000-0000-0000
 Nalvo F. de Almeida Jr.,UFMS,https://www.facom.ufms.br/~nalvo,kU9d-GIAAAAJ,0000-0001-5615-1746
 Nam Ik Cho,Seoul National University,http://ispl.snu.ac.kr/xe/index.php?mid=professor,Ntx5VRIAAAAJ,0000-0001-5297-4649
 Nam P. Nguyen,Towson University,https://www.towson.edu/fcsm/departments/computerinfosci/facultystaff/nnguyen.html,aJcBWkgAAAAJ,0000-0000-0000-0000
@@ -164,8 +164,8 @@ Natacha Gueorguieva,CUNY,https://www.csi.cuny.edu/campus-directory/natacha-gueor
 Natacha Portier,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/natacha.portier,NOSCHOLARPAGE,0000-0000-0000-0000
 Natalia A. Schmid,West Virginia University,https://www.statler.wvu.edu/faculty-staff/faculty/natalia-schmid,NOSCHOLARPAGE,0000-0000-0000-0000
 Natalia Beloff,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/109401,NOSCHOLARPAGE,0000-0000-0000-0000
-Natalia Criado,King's College London,https://www.kcl.ac.uk/people/natalia-criado,9TL1eM4AAAAJ,0000-0000-0000-0000
 Natalia Criado Pacheco,King's College London,https://www.kcl.ac.uk/people/natalia-criado,9TL1eM4AAAAJ,0000-0000-0000-0000
+Natalia Criado,King's College London,https://www.kcl.ac.uk/people/natalia-criado,9TL1eM4AAAAJ,0000-0000-0000-0000
 Natalia Sidorova,TU Eindhoven,http://www.win.tue.nl/~sidorova,MpuRqeQAAAAJ,0000-0002-9223-938X
 Natalia Stakhanova,University of New Brunswick,https://www.cs.unb.ca/people/natalia,LRC4gpUAAAAJ,0000-0000-0000-0000
 Natalia V. Andrienko,City University of London,https://www.city.ac.uk/people/academics/natalia-andrienko,t8LK29QAAAAJ,0000-0003-3313-1560
@@ -317,8 +317,8 @@ Nelson L. S. Da Fonseca,UNICAMP,http://www.ic.unicamp.br/~nfonseca,NOSCHOLARPAGE
 Nelson L. S. da Fonseca,UNICAMP,http://www.ic.unicamp.br/~nfonseca,NOSCHOLARPAGE,0000-0000-0000-0000
 Nelson Lopes Duarte Filho,Federal University of Rio Grande,http://www.nelson.c3.furg.br,NOSCHOLARPAGE,0000-0000-0000-0000
 Nelson Luis Saldanha da Fonseca,UNICAMP,http://www.ic.unicamp.br/~nfonseca,NOSCHOLARPAGE,0000-0000-0000-0000
-Nelson Maculan,UFRJ,http://www.cos.ufrj.br/index.php/pt-BR/pessoas/details/18/1042-maculan,BxuuIPUAAAAJ,0000-0000-0000-0000
 Nelson Maculan Filho,UFRJ,http://www.cos.ufrj.br/index.php/pt-BR/pessoas/details/18/1042-maculan,BxuuIPUAAAAJ,0000-0000-0000-0000
+Nelson Maculan,UFRJ,http://www.cos.ufrj.br/index.php/pt-BR/pessoas/details/18/1042-maculan,BxuuIPUAAAAJ,0000-0000-0000-0000
 Nelson Marcos,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742675245&command=GETPROFILE,-vU32yoAAAAJ,0000-0000-0000-0000
 Nelson S. Rosa,UFPE,https://gfads.cin.ufpe.br,KZFI9qEAAAAJ,0000-0001-9374-6351
 Nelson Souto Rosa,UFPE,https://gfads.cin.ufpe.br,KZFI9qEAAAAJ,0000-0000-0000-0000
@@ -585,8 +585,8 @@ Nikolaj Tatti,University of Helsinki,https://researchportal.helsinki.fi/en/perso
 Nikolaos Alachiotis 0001,University of Twente,https://research.utwente.nl/en/persons/ccd18344-8725-46c2-babb-76bc0378be00,ikKpszgAAAAJ,0000-0001-8162-3792
 Nikolaos Aletras,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/nikos-aletras,uxRWFhoAAAAJ,0000-0003-4285-1965
 Nikolaos Athanasopoulos,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=n.athanasopoulos,q4mXFiwAAAAJ,0000-0000-0000-0000
-Nikolaos Drivalos,University of York,https://www-users.cs.york.ac.uk/~nikos,Dvp7fNoAAAAJ,0000-0000-0000-0000
 Nikolaos Drivalos Matragkas,University of York,https://www-users.cs.york.ac.uk/~nikos,Dvp7fNoAAAAJ,0000-0000-0000-0000
+Nikolaos Drivalos,University of York,https://www-users.cs.york.ac.uk/~nikos,Dvp7fNoAAAAJ,0000-0000-0000-0000
 Nikolaos Hardavellas,Northwestern University,http://www.eecs.northwestern.edu/~hardav,0pdiFKEAAAAJ,0000-0002-1137-8100
 Nikolaos Laoutaris,IMDEA Networks Institute,http://laoutaris.info,KaqnVUcAAAAJ,0000-0002-7361-106X
 Nikolaos M. Freris,USTC,http://staff.ustc.edu.cn/~nfr,j38QfhkAAAAJ,0000-0000-0000-0000
@@ -660,8 +660,8 @@ Nina Bresnihan,Trinity College Dublin,https://www.scss.tcd.ie/Nina.Bresnihan,GQV
 Nina C. Hubig,Clemson University,https://sites.google.com/view/dzrpt-lab/about,NOSCHOLARPAGE,0000-0000-0000-0000
 Nina Gierasimczuk,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE,0000-0000-0000-0000
 Nina S. T. Hirata,USP,http://www.ime.usp.br/~nina,NOSCHOLARPAGE,0000-0001-9722-5764
-Nina Sumiko Tomita,USP,http://www.ime.usp.br/~nina,NOSCHOLARPAGE,0000-0000-0000-0000
 Nina Sumiko Tomita Hirata,USP,http://www.ime.usp.br/~nina,NOSCHOLARPAGE,0000-0000-0000-0000
+Nina Sumiko Tomita,USP,http://www.ime.usp.br/~nina,NOSCHOLARPAGE,0000-0000-0000-0000
 Ning Ding 0001,Shanghai Jiao Tong University,https://cs.sjtu.edu.cn/en/PeopleDetail.aspx?id=262,NOSCHOLARPAGE,0000-0000-0000-0000
 Ning Ding 0002,Tsinghua University,https://www.stingning.cn,uZXQuYAAAAAJ,0000-0000-0000-0000
 Ning Gu,Fudan University,http://www.cs.fudan.edu.cn/?page_id=2089,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -671,6 +671,7 @@ Ning Tan 0003,Sun Yat-sen University,http://ningtan.weebly.com,n3zyOCEAAAAJ,0000
 Ning Wang 0022,University of South Florida,https://ning-wang1.github.io,nrAMv9cAAAAJ,0000-0000-0000-0000
 Ning Xie 0002,Florida International University,http://www.cs.fiu.edu/~nxie,H9x5YXkAAAAJ,0000-0002-5092-0353
 Ning Xie 0003,UESTC,http://cfm.uestc.edu.cn/~xiening,sTKVj4IAAAAJ,0000-0002-1509-464X
+Ning Xu 0009,Southeast University,https://cs.seu.edu.cn/xning/main.htm,Tit4V58AAAAJ,0000-0001-8336-5926
 Ning Yang 0001,Sichuan University,https://yneversky.github.io,z4KbvOoAAAAJ,0000-0002-2265-3155
 Ning Zhang 0001,University of Manchester,https://www.research.manchester.ac.uk/portal/ning.zhang-2.html,aAtJXuwAAAAJ,0000-0001-9519-9128
 Ning Zhang 0017,Washington University in St. Louis,https://n1ngz.github.io,gwB_pJcAAAAJ,0000-0003-0670-2161
@@ -731,8 +732,8 @@ Nitish K. Panigrahy,Binghamton University,https://www.binghamton.edu/computer-sc
 Nitish Panigrahy,Binghamton University,https://www.binghamton.edu/computer-science/people/profile.html?id=npanigrahy,cyrWzJ0AAAAJ,0000-0000-0000-0000
 Niusen Chen,University of Nevada,https://niusenc.github.io,sCxQ0ncAAAAJ,0000-0000-0000-0000
 Niv Dayan,University of Toronto,https://nivdayan.net,16LSwPEAAAAJ,0000-0003-0314-0167
-Nivan Ferreira,UFPE,http://www.cin.ufpe.br/~nivan,aXnmMnkAAAAJ,0000-0001-6631-4609
 Nivan Ferreira Júnior,UFPE,https://www.cin.ufpe.br/~nivan,aXnmMnkAAAAJ,0000-0000-0000-0000
+Nivan Ferreira,UFPE,http://www.cin.ufpe.br/~nivan,aXnmMnkAAAAJ,0000-0001-6631-4609
 Nivan Roberto Ferreira Júnior,UFPE,https://www.cin.ufpe.br/~nivan,aXnmMnkAAAAJ,0000-0000-0000-0000
 Nivedita Arora,Northwestern University,https://niveditaarora.com,iqQgkQYAAAAJ,0000-0002-8630-9919
 Nivio Ziviani,UFMG,http://homepages.dcc.ufmg.br/~nivio,OZ2ju_EAAAAJ,0000-0000-0000-0000

--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -613,6 +613,7 @@ Peng Wang 0015,NWPU,https://wangpengnorman.github.io,aPLp7pAAAAAJ,0000-0000-0000
 Peng Wang 0027,Fudan University,http://www.cs.fudan.edu.cn/?page_id=1953,NOSCHOLARPAGE,0000-0002-8136-9621
 Peng Wang 0098,University of Macau,https://www.fst.um.edu.mo/people/pengw,baF3HKUAAAAJ,0000-0002-6799-0745
 Peng Yang 0008,SUSTech,http://cse.sustech.edu.cn/faculty/~yangp,5T9jy2MAAAAJ,0000-0001-5333-6155
+Peng Yang 0014,Southeast University,https://cs.seu.edu.cn/pengyang/main.htm,pveOvXEAAAAJ,0000-0000-0000-0000
 Peng Zhang 0011,Xi'an Jiaotong University,https://nskeylab.xjtu.edu.cn/people/pzhang,AdvgGYgAAAAJ,0000-0001-7721-2675
 Peng Zhang 0052,Rutgers University,https://sites.google.com/site/pengzhang27182,OeJee_QAAAAJ,0009-0009-5812-1212
 Peng Zhao 0001,Xi'an Jiaotong University,http://gr.xjtu.edu.cn/web/p.zhao,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -625,6 +626,7 @@ Pengcheng An,SUSTech,https://www.sustech.edu.cn/en/faculties/pengchengan.html,8N
 Pengcheng Shi,Rochester Inst. of Technology,https://www.rit.edu/gccis/pengcheng-shi,JiVaZf8AAAAJ,0000-0003-2504-9890
 Pengdi Huang,Shenzhen University,http://vcc.szu.edu.cn/~pengdi,MKjgy_UAAAAJ,0000-0002-9926-4393
 Pengfei Chen 0002,Sun Yat-sen University,https://cse.sysu.edu.cn/content/3747,g9tdjgQAAAAJ,0000-0003-0972-6900
+Pengfei Fang,Southeast University,https://cs.seu.edu.cn/fangpengfei/main.htm,Fk4A13IAAAAJ,0000-0001-8939-0460
 Pengfei Li,Rochester Inst. of Technology,https://people.rit.edu/pflics,irA8gqoAAAAJ,0000-0003-3257-9929
 Pengfei Liu 0003,Shanghai Jiao Tong University,http://pfliu.com,oIz_CYEAAAAJ,0000-0000-0000-0000
 Pengfei Su 0001,Univ. of California - Merced,https://pengfei-su.github.io,LAttsHIAAAAJ,0000-0000-0000-0000

--- a/csrankings-q.csv
+++ b/csrankings-q.csv
@@ -149,6 +149,7 @@ Qinghua Li,University of Arkansas,http://csce.uark.edu/~qinghual,bRTsPsEAAAAJ,00
 Qinghua Liu,Washington University in St. Louis,https://engineering.washu.edu/faculty/Qinghua-Liu.html,CotFJJsAAAAJ,0000-0003-4644-5518
 Qinghua Zheng,Xi'an Jiaotong University,http://gr.xjtu.edu.cn/web/qhzheng,0uEzYQYAAAAJ,0000-0002-8436-4754
 Qingjiang Shi,Tongji University,https://sse.tongji.edu.cn/Data/View/3555,8xoKeR0AAAAJ,0000-0000-0000-0000
+Qingjun Xiao,Southeast University,https://csqjxiao.github.io/PersonalPage/,zxcI7a4AAAAJ,0000-0001-8348-6277
 Qingkai Meng,Nanjing University,https://mengqingkai.github.io,HtPxsUcAAAAJ,0000-0000-0000-0000
 Qingkai Shi,Nanjing University,https://qingkaishi.github.io,EmSYY1EAAAAJ,0000-0002-8297-8998
 Qingkai Zeng 0002,Nanjing University,https://cs.nju.edu.cn/58/1a/c2639a153626/page.htm,NOSCHOLARPAGE,0000-0000-0000-0000

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -1350,8 +1350,10 @@ Shuai Ma 0001,Beihang University,http://mashuai.buaa.edu.cn,vJUjFpQAAAAJ,0000-00
 Shuai Mu 0001,Stony Brook University,http://mpaxos.com,wcbyR5UAAAAJ,0000-0001-8244-2109
 Shuai Mu,Stony Brook University,http://mpaxos.com,wcbyR5UAAAAJ,0000-0000-0000-0000
 Shuai Shao 0001,USTC,http://staff.ustc.edu.cn/~wwwucuc,Lh-UKzcAAAAJ,0000-0003-0935-2929
+Shuai Wang 0008,Southeast University,https://cs.seu.edu.cn/shuaiwang/main.htm,gfDfZqAAAAAJ,0000-0002-3609-2205
 Shuai Wang 0011,HKUST,https://home.cse.ust.hk/~shuaiw,POlWWAsAAAAJ,0000-0002-0866-0308
 Shuai Wang 0016,Nanjing University,https://shuaiwang-nju.github.io,vW1ZaucAAAAJ,0000-0000-0000-0000
+Shuai Wang 0021,Southeast University,https://cs.seu.edu.cn/shuaiwang_iot/main.htm,lOJUEfoAAAAJ,0000-0003-2766-1135
 Shuai Zhang 0015,NJIT,https://inchs708.github.io/shuaizhang.github.io/index.html,RvDk-iwAAAAJ,0000-0000-0000-0000
 Shuai Zhang 0024,City University of Macau,https://fds.cityu.edu.mo/en/members/460,6AVACdkAAAAJ,0000-0000-0000-0000
 Shuai Zhao 0001,BUPT,https://int.bupt.edu.cn/content/content.php?p=6_16_345,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -1366,6 +1368,7 @@ Shuang Li 0002,CUHK (SZ),https://shuangli01.github.io,HxCZsCUAAAAJ,0009-0006-665
 Shuang Luan,University of New Mexico,https://www.cs.unm.edu/~sluan,JF8EmRMAAAAJ,0000-0000-0000-0000
 Shuang Qiu,City University of Hong Kong,https://shq-ml.github.io,-Z7fY00AAAAJ,0000-0000-0000-0000
 Shuang Wang 0001,Xidian University,https://web.xidian.edu.cn/shwang,CeLvrv8AAAAJ,0000-0000-0000-0000
+Shuang Wang 0012,Southeast University,https://cs.seu.edu.cn/shuangwang/main.htm,NOSCHOLARPAGE,0000-0003-3405-5942
 Shuang Zhao,Univ. of Illinois at Urbana-Champaign,http://shuangz.com,cbQB0MMAAAAJ,0000-0003-4759-0514
 Shuang-Hua Yang,SUSTech,https://faculty.sustech.edu.cn/yangsh,7HXwJqEAAAAJ,0000-0003-0717-5009
 Shuanghua Yang,SUSTech,https://faculty.sustech.edu.cn/yangsh,7HXwJqEAAAAJ,0000-0000-0000-0000
@@ -1772,6 +1775,7 @@ Songbai Liu,Shenzhen University,https://www.researchgate.net/profile/Songbai-Liu
 Songhe Feng,Beijing Jiaotong University,https://faculty.bjtu.edu.cn/8407,K5lqMYgAAAAJ,0000-0002-5922-9358
 Songhwai Oh,Seoul National University,http://rllab.snu.ac.kr,VEzNY_oAAAAJ,0000-0000-0000-0000
 Songlei Wang,Shenzhen University,https://songleiw.github.io/homepage,xx-tGM8AAAAJ,0000-0000-0000-0000
+Songlin Du,Southeast University,https://automation.seu.edu.cn/dsl/list.htm,NOSCHOLARPAGE,0000-0003-4937-2713
 Songqiao Han,SUFE,http://simecv.sufe.edu.cn/page.aspx?id=53,C73EXPMAAAAJ,0000-0002-2896-0607
 Songqing Chen,George Mason University,https://people.cs.gmu.edu/~sqchen,T7IRM8EAAAAJ,0000-0003-4650-7125
 Songtao Lu,Chinese University of Hong Kong,https://songtaogithub.github.io,LRsjX7kAAAAJ,0000-0001-9256-9648

--- a/csrankings-w.csv
+++ b/csrankings-w.csv
@@ -131,6 +131,7 @@ Wei Ju 0001,Sichuan University,https://juweipku.github.io,GX05vA4AAAAJ,0000-0001
 Wei Le,Iowa State University,http://www.cs.iastate.edu/~weile,QjFu7LEAAAAJ,0000-0002-6797-0648
 Wei Lee Woon,Masdar Institute,https://www.masdar.ac.ae/aboutus/management/faculty-directory/item/5730-wei-lee-woon,cmHsRGoAAAAJ,0000-0000-0000-0000
 Wei Li 0012,Fudan University,https://dblp.uni-trier.de/pers/hd/l/Li_0012:Wei,NOSCHOLARPAGE,0000-0000-0000-0000
+Wei Li 0017,Southeast University,https://cs.seu.edu.cn/xchlw/main.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Wei Li 0022,Beihang University,http://sites.nlsde.buaa.edu.cn/~liwei,NOSCHOLARPAGE,0000-0000-0000-0000
 Wei Li 0058,University of Sydney,https://www.sydney.edu.au/engineering/about/our-people/academic-staff/weiwilson-li.html,NOSCHOLARPAGE,0000-0003-4731-3226
 Wei Li 0059,Georgia State University,https://grid.cs.gsu.edu/~wli28,tHTIu_EAAAAJ,0000-0002-0370-5183
@@ -278,6 +279,7 @@ Weisong Shi,University of Delaware,http://weisongshi.org,4rPcoCEAAAAJ,0000-0001-
 Weitao Xu,City University of Hong Kong,https://www.weitaoxu.com,-RbADtgAAAAJ,0000-0001-9741-5912
 Weitong Huang,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101223231615208546402/20101223231615208546402_.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Weiwei Liu 0003,Wuhan University,https://sites.google.com/site/weiweiliuhomepage,l6RB1WsAAAAJ,0000-0000-0000-0000
+Weiwei Ni,Southeast University,https://cs.seu.edu.cn/wni/main.htm,NOSCHOLARPAGE,0000-0003-2534-4750
 Weiwei Sun 0008,Fudan University,http://www.cs.fudan.edu.cn/?page_id=1923,NOSCHOLARPAGE,0000-0000-0000-0000
 Weiwei Xu,Zhejiang University,http://www.cad.zju.edu.cn/home/weiweixu,qRXK__gAAAAJ,0000-0000-0000-0000
 Weiwen Jiang,George Mason University,https://www.gmu.edu/profiles/wjiang8,62oDIG4AAAAJ,0000-0002-9004-487X
@@ -364,6 +366,7 @@ Wenhu Chen,University of Waterloo,https://wenhuchen.github.io,U8ShbhUAAAAJ,0009-
 Wenhui Li 0002,Jilin University,https://ccst.jlu.edu.cn/info/1367/19067.htm,wDYOD8AAAAAJ,0000-0001-6490-9852
 Wenjia Bai,Imperial College London,https://www.doc.ic.ac.uk/~wbai,IA1QFM4AAAAJ,0000-0003-2943-7698
 Wenjia Li,New York Tech,https://site.nyit.edu/bio/wli20,DDsDx6UAAAAJ,0000-0001-6059-6422
+Wenjia Wu,Southeast University,https://cs.seu.edu.cn/wjwu/main.htm,NOSCHOLARPAGE,0000-0002-4437-0850
 Wenjian Liu,City University of Macau,https://fds.cityu.edu.mo/en/members/143,Tu6VkO4AAAAJ,0000-0000-0000-0000
 Wenjian Yu,Tsinghua University,http://numbda.cs.tsinghua.edu.cn,hGfUQZYAAAAJ,0000-0003-4897-7251
 Wenjie Li 0002,The Hong Kong Polytechnic Univ.,http://www4.comp.polyu.edu.hk/~cswjli,Rx5swD4AAAAJ,0000-0002-7360-8864
@@ -381,6 +384,7 @@ Wenjing Zhang 0002,University of Guelph,https://www.uoguelph.ca/computing/people
 Wenjuan Tang,Hunan University,http://csee.hnu.edu.cn/people/tangwenjuan,NOSCHOLARPAGE,0000-0000-0000-0000
 Wenjun Hu,Yale University,https://www.eng.yale.edu/wenjun,SvnnEI8AAAAJ,0009-0007-5988-3193
 Wenjun Jiang,Hunan University,https://sites.google.com/site/happywenjunjiang2012,y8hIib8AAAAJ,0009-0005-3194-7365
+Wenjun Ke 0002,Southeast University,https://cs.seu.edu.cn/kewenjun/main.htm,sujHjLQAAAAJ,0000-0001-7352-1710
 Wenke Lee,Georgia Institute of Technology,http://wenke.gtisc.gatech.edu,nfkH5V4AAAAJ,0000-0000-0000-0000
 Wenli Zheng,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/PeopleDetail.aspx?id=371,HHGCAPoAAAAJ,0000-0002-5010-2326
 Wenliang Chen,Soochow University,http://hlt.suda.edu.cn/index.php/Wenliang,YfYi8VMAAAAJ,0000-0000-0000-0000

--- a/csrankings-x.csv
+++ b/csrankings-x.csv
@@ -110,6 +110,7 @@ Xiangyang Xue 0001,Fudan University,http://homepage.fudan.edu.cn/xyxue/zh,DTbhX6
 Xiangyao Yu,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~yxy,FkcaTZYAAAAJ,0009-0001-0785-2519
 Xiangyu Duan,Soochow University,https://xyda.github.io,NOSCHOLARPAGE,0009-0005-8563-2772
 Xiangyu Meng 0002,Jilin University,https://ccst.jlu.edu.cn/info/1367/20151.htm,NOSCHOLARPAGE,0000-0002-1621-7445
+Xiangyu Xu 0001,Southeast University,https://cs.seu.edu.cn/xyxu/main.htm,QZbKVNoAAAAJ,0000-0002-1628-906X
 Xiangyu Xu 0002,Xi'an Jiaotong University,https://xuxy09.github.io,Ec5Biz4AAAAJ,0000-0002-9305-5830
 Xiangyu Yue 0001,Chinese University of Hong Kong,https://xyue.io,-xQ-C1sAAAAJ,0000-0002-6887-2046
 Xiangyu Zhang 0001,Purdue University,https://www.cs.purdue.edu/homes/xyzhang,PXbu1wIAAAAJ,0000-0002-9544-2500
@@ -167,6 +168,7 @@ Xiaobing Feng 0002,Chinese Academy of Sciences,http://people.ucas.ac.cn/~fengxia
 Xiaobing Sun 0001,Yangzhou University,https://risame.github.io/sun,8yYA6FEAAAAJ,0000-0001-5165-5080
 Xiaobo Hu 0001,University of Notre Dame,http://www3.nd.edu/~shu,NOSCHOLARPAGE,0000-0002-6636-9738
 Xiaobo Hu,University of Notre Dame,http://www3.nd.edu/~shu,NOSCHOLARPAGE,0000-0000-0000-0000
+Xiaobo Lu,Southeast University,https://automation.seu.edu.cn/lxb/list.htm,NOSCHOLARPAGE,0000-0002-7707-7538
 Xiaobo Sharon Hu,University of Notre Dame,http://www3.nd.edu/~shu,NOSCHOLARPAGE,0000-0002-6636-9738
 Xiaobo Zhou 0002,University of Macau,https://www.fst.um.edu.mo/people/waynexzhou,M50Z43QAAAAJ,0000-0002-0466-7609
 Xiaobu Yuan,University of Windsor,http://www.uwindsor.ca/science/computerscience/1032/dr-xiaobu-yuan,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -523,6 +525,7 @@ Xirong Li 0001,Renmin University of China,http://lixirong.net,6m-ZQ1EAAAAJ,0000-
 Xiting Wang,Renmin University of China,https://gsai.ruc.edu.cn/english/wangxt,urC8meQAAAAJ,0000-0001-5768-1095
 Xiu Cao,Fudan University,http://www.cs.fudan.edu.cn/en/?page_id=1765,NOSCHOLARPAGE,0000-0000-0000-0000
 Xiu Li 0001,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101224001632440223805/20101224001632440223805_.html,wrKyJYsAAAAJ,0000-0003-0403-1923
+Xiu-Shen Wei,Southeast University,https://cs.seu.edu.cn/weixs/main.htm,Qzyy5mcAAAAJ,0000-0000-0000-0000
 Xiucheng Li,Harbin Institute of Technology,https://xiucheng.org/contact.html,NOSCHOLARPAGE,0009-0006-4145-6698
 Xiugang Wu,University of Delaware,https://www.eecis.udel.edu/~xwu,tRvs8ikAAAAJ,0000-0000-0000-0000
 Xiuhua Li,Chongqing University,http://www.cse.cqu.edu.cn/info/2095/4507.htm,NNZ2sdgAAAAJ,0000-0000-0000-0000

--- a/csrankings-y.csv
+++ b/csrankings-y.csv
@@ -66,6 +66,7 @@ Yan Leng,University of Texas at Austin,https://yleng.github.io/www,WfU3qjQAAAAJ,
 Yan Li 0018,Claremont Graduate University,https://www.cgu.edu/people/yan-li,NOSCHOLARPAGE,0000-0000-0000-0000
 Yan Liu 0002,University of Southern California,https://sites.google.com/view/yanliu-ai/home,UUKLPMYAAAAJ,0000-0002-7055-9518
 Yan Long 0002,University of Virginia,https://yanlong.site,1OHEpEsAAAAJ,0000-0002-3429-7127
+Yan Lyu,Southeast University,https://cs.seu.edu.cn/lvyanly/main.htm,60XG9FIAAAAJ,0000-0000-0000-0000
 Yan Meng 0001,Shanghai Jiao Tong University,https://yan4meng.github.io,NOSCHOLARPAGE,0000-0001-5445-0347
 Yan Qiu Chen,Fudan University,http://www.cs.fudan.edu.cn/en/?page_id=1781,NOSCHOLARPAGE,0000-0000-0000-0000
 Yan Shoshitaishvili,Arizona State University,http://www.yancomm.net,ff1RkwcAAAAJ,0000-0001-8832-1789
@@ -291,6 +292,7 @@ Yaoxue Zhang,Tsinghua University,http://media.cs.tsinghua.edu.cn/~zyxe,NOSCHOLAR
 Yaoyao Liu 0001,Univ. of Illinois at Urbana-Champaign,https://yaoyaoliu.web.illinois.edu,Qi2PSmEAAAAJ,0000-0002-5316-3028
 Yapeng Tian,University of Texas at Dallas,http://www.yapengtian.com,lxCqdpoAAAAJ,0000-0003-1423-4513
 Yaping Lin,Hunan University,http://csee.hnu.edu.cn/people/linyaping,NOSCHOLARPAGE,0000-0000-0000-0000
+Yaping Yan,Southeast University,https://cs.seu.edu.cn/yan/main.htm,Tjxa3McAAAAJ,0000-0002-1933-732X
 Yaqian Long,Shenzhen University,https://ieeexplore.ieee.org/author/37086502577,triu-OgAAAAJ,0000-0000-0000-0000
 Yaqian Zhou 0001,Fudan University,http://www.cs.fudan.edu.cn/?page_id=2319###,NOSCHOLARPAGE,0000-0000-0000-0000
 Yarin Gal,University of Oxford,http://www.cs.ox.ac.uk/people/yarin.gal,SIayDoQAAAAJ,0000-0000-0000-0000
@@ -778,6 +780,7 @@ Yongmin Li 0001,Brunel University London,http://people.brunel.ac.uk/~csstyyl,R5d
 Yongmin Zhang,Central South University,https://faculty.csu.edu.cn/ymzhang/zh_CN/index.htm,nC72zmwAAAAJ,0000-0003-4484-3483
 Yongpan Zou,Shenzhen University,https://yongpanzou.github.io,RO4w5pAAAAAJ,0000-0000-0000-0000
 Yongqian Sun,Nankai University,https://nkcs.iops.ai/yongqiansun,NOSCHOLARPAGE,0000-0003-0266-7899
+Yongqiang Dong,Southeast University,https://cs.seu.edu.cn/dongyq/main.htm,NOSCHOLARPAGE,0000-0002-9861-4224
 Yongqiang Tian 0001,Monash University,https://yqtian.com,51iYgNAAAAAJ,0000-0003-1644-2965
 Yongqiang zhao,NWPU,https://teacher.nwpu.edu.cn/m/en/2001000069.html,FsJyR8QAAAAJ,0000-0000-0000-0000
 Yongseok Son,Chung-Ang University,https://sites.google.com/view/syslab-cau,uSquPgoAAAAJ,0000-0003-4512-0121
@@ -944,6 +947,7 @@ Yu Yin 0001,Case Western Reserve University,https://yin-yu.github.io,pY0_YNcAAAA
 Yu Yokoi,Institute of Science Tokyo,https://www.nii.ac.jp/en/faculty/informatics/yokoi_yu,NOSCHOLARPAGE,0000-0000-0000-0000
 Yu Yu 0001,Shanghai Jiao Tong University,http://yuyu.hk,lpRkCB4AAAAJ,0000-0002-9278-4521
 Yu Zang,Xiamen University,https://asc.xmu.edu.cn/t/zangyu,C6yF-0gAAAAJ,0000-0000-0000-0000
+Yu Zhang 0004,Southeast University,https://cs.seu.edu.cn/zhang_yu/main.htm,NOSCHOLARPAGE,0000-0003-0140-7366
 Yu Zhang 0006,SUSTech,http://cse.sustech.edu.cn/faculty/~zhangy,jaRS5w4AAAAJ,0000-0003-1100-4835
 Yu Zhang 0027,HUST,http://faculty.hust.edu.cn/ZhangYu/zh_CN/index.htm,NOSCHOLARPAGE,0000-0003-0718-8045
 Yu Zhang 0030,Harbin Institute of Technology,http://homepage.hit.edu.cn/yzhang,yyG8xWcAAAAJ,0000-0003-2040-5059
@@ -985,6 +989,7 @@ Yuan Luo 0001,Northwestern University,https://labs.feinberg.northwestern.edu/luo
 Yuan Luo 0002,Middlesex University,https://www.mdx.ac.uk/about-us/our-people/staff-directory/profile/luo-yuan-roger,NOSCHOLARPAGE,0000-0000-0000-0000
 Yuan Luo 0003,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/en/PeopleDetail.aspx?id=155,NOSCHOLARPAGE,0000-0000-0000-0000
 Yuan Luo 0005,CUHK (SZ),http://yuanluo.info,NOSCHOLARPAGE,0000-0000-0000-0000
+Yuan Qiu 0002,Southeast University,https://cyber.seu.edu.cn/qy/list.htm,G3Q_MzIAAAAJ,0000-0002-3488-6386
 Yuan Tang,Fudan University,http://people.csail.mit.edu/yuantang,kC2YD14AAAAJ,0000-0001-5243-233X
 Yuan Tian 0001,Univ. of California - Los Angeles,https://www.ytian.info,ja0GtqgAAAAJ,0000-0002-6435-564X
 Yuan Tian 0008,Queen’s University,http://sophiaytian.com,wX4le_QAAAAJ,0000-0000-0000-0000
@@ -1183,6 +1188,7 @@ Yun Lu 0001,University of Victoria,https://yunlupage.wordpress.com,NOSCHOLARPAGE
 Yun Ma 0002,Peking University,https://www.ai.pku.edu.cn/info/1138/2064.htm,1hnJ3TgAAAAJ,0000-0001-7866-4075
 Yun S. Song,Univ. of California - Berkeley,http://www.eecs.berkeley.edu/~yss,NOSCHOLARPAGE,0000-0000-0000-0000
 Yun Sing Koh,University of Auckland,https://www.cs.auckland.ac.nz/~yunsing,0L38IrAAAAAJ,0000-0001-7256-4049
+Yun Wang 0041,Southeast University,https://cs.seu.edu.cn/yunwang/main.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Yun William Yu,Carnegie Mellon University,https://yunwilliamyu.net,h9r7yWkAAAAJ,0000-0002-8275-9576
 Yun Wu 0003,Queen's University Belfast,https://pure.qub.ac.uk/en/persons/yun-wu-2,E232JgIAAAAJ,0000-0000-0000-0000
 Yun Xiong,Fudan University,http://www.cs.fudan.edu.cn/?page_id=1979,NOSCHOLARPAGE,0000-0002-8575-5415

--- a/csrankings-z.csv
+++ b/csrankings-z.csv
@@ -110,6 +110,7 @@ Zhe Chen 0015,Fudan University,https://www.zhe-chen.com,hhl5-78AAAAJ,0000-0002-3
 Zhe Dang,Washington State University,http://www.eecs.wsu.edu/~zdang,NOSCHOLARPAGE,0000-0000-0000-0000
 Zhe Hou,Griffith University,https://zhehou.github.io,sxuQmIIAAAAJ,0000-0001-7164-0580
 Zhe Jiang 0001,University of Florida,https://www.jiangteam.org,R7xPuT8AAAAJ,0000-0002-3576-6976
+Zhe Jiang 0004,Southeast University,https://zhejianguk.github.io/,V5e-7hcAAAAJ,0000-0002-8509-3167
 Zhe Quan,Hunan University,http://csee.hnu.edu.cn/people/quanzhe,NOSCHOLARPAGE,0000-0000-0000-0000
 Zhe Tang,Central South University,https://faculty.csu.edu.cn/tangzhe/zh_CN/index.htm,NOSCHOLARPAGE,0009-0004-0449-6581
 Zhe Wang 0001,Griffith University,https://experts.griffith.edu.au/9818-zhe-wang,mIUGVLoAAAAJ,0000-0002-9092-6143
@@ -363,6 +364,7 @@ Zhiyuan Yu 0001,Texas A&M University,https://zhiyuanyu.org,z4UYftwAAAAJ,0000-000
 Zhiyun Qian,Univ. of California - Riverside,http://www.cs.ucr.edu/~zhiyunq,OSBfM5sAAAAJ,0000-0003-1506-2522
 Zhize Li 0001,Singapore Management University,https://zhizeli.github.io,uAFPPigAAAAJ,0000-0000-0000-0000
 Zhizheng Wu 0001,CUHK (SZ),https://drwuz.com,K6zhweAAAAAJ,0000-0000-0000-0000
+Zhizheng Zhang 0002,Southeast University,https://cs.seu.edu.cn/seu_zzz/main.htm,NOSCHOLARPAGE,0000-0001-9851-6184
 Zhizhong Han,Wayne State University,https://h312h.github.io,RGNWczEAAAAJ,0000-0001-9540-9973
 Zhizhuo Jiang,Nankai University,https://cc.nankai.edu.cn/2021/0323/c13620a588912/page.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Zhong Chen 0001,Peking University,https://cs.pku.edu.cn/info/1062/1605.htm,NOSCHOLARPAGE,0000-0002-5785-2912
@@ -490,6 +492,7 @@ Ziyu Chen,Chongqing University,http://www.cs.cqu.edu.cn/info/1333/4224.htm,mPx4p
 Ziyu Guan,Xidian University,https://web.xidian.edu.cn/zyguan/en/index.html,mSJcQwYAAAAJ,0000-0003-2413-4698
 Ziyu Shao,ShanghaiTech University,https://faculty.sist.shanghaitech.edu.cn/faculty/shaozy,04mPO4wAAAAJ,0000-0000-0000-0000
 Ziyu Yao 0002,George Mason University,https://ziyuyao.org,4lYrMNUAAAAJ,0009-0007-4571-3505
+Ziyuan Pu,Southeast University,https://tc.seu.edu.cn/pzy/main.psp,EzCLa-4AAAAJ,0000-0002-9488-9175
 Zizhan Zheng,Tulane University,http://www2.tulane.edu/sse/cs/faculty/zizhan-zheng.cfm,B1v2AUYAAAAJ,0000-0003-4799-1051
 Zizhong Chen,Univ. of California - Riverside,http://www.cs.ucr.edu/~chen,AvanGFkAAAAJ,0000-0003-2578-4940
 Zohar Levi,Victoria University of Wellington,https://ecs.victoria.ac.nz/Main/ZoharLevi,kLGQWIsAAAAJ,0000-0002-1045-5880


### PR DESCRIPTION
## Consolidated PR for Southeast University

This PR consolidates the following open PRs into a single submission:

| PR | Score | Title |
|---|---|---|
| #11881 | 70% | Add 3 faculty from Southeast University (auto-batched) |
| #11900 | 70% | Add 6 faculty from Southeast University (auto-batched) |
| #11910 | 72% | Add 8 faculty from Southeast University (auto-batched) |

**Validation summary**: Scores range from 70% to 72% (avg 70%). Some constituent PRs have concerns that need resolution — see individual PR comments for details.

Total: 17 faculty additions.