### PR TITLE
Add 2 faculty from South China Univ. of Technology (consolidated)

### DIFF
--- a/csrankings-y.csv
+++ b/csrankings-y.csv
@@ -116,6 +116,7 @@ Yang Deng 0002,Singapore Management University,https://dengyang17.github.io,OshW
 Yang Feng 0003,Nanjing University,https://fengyang-nju.github.io,FaMWKcsAAAAJ,0000-0002-7477-3642
 Yang Gao 0001,Nanjing University,https://cs.nju.edu.cn/gaoyang,k0jjQo8AAAAJ,0000-0001-8886-2569
 Yang Gao 0021,Royal Holloway Univ. of London,https://pure.royalholloway.ac.uk/portal/en/persons/yang-gao(6a837f7f-07f6-4ac8-b0c7-d6d444016d2f).html,AwoB-SwAAAAJ,0000-0000-0000-0000
+Yang Gao 0025,South China Univ. of Technology,https://www2.scut.edu.cn/ft_en/2025/1021/c45325a606212/page.htm,F1set54AAAAJ,0000-0001-6811-0183
 Yang Gao 0029,Tsinghua University,https://iiis.tsinghua.edu.cn/en/People/Faculty/GaoYang.htm,bo0P2qYAAAAJ,0000-0000-0000-0000
 Yang Hao 0001,Queen Mary University of London,http://www.eecs.qmul.ac.uk/~yang,W6hvCOAAAAAJ,0000-0000-0000-0000
 Yang Hua 0001,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=y.hua,N0tFi8MAAAAJ,0000-0001-5536-503X
@@ -421,6 +422,7 @@ Yi Sheng,University of South Florida,https://www.usf.edu/ai-cybersecurity-comput
 Yi Wang 0003,Shenzhen University,http://www.escience.cn/people/yiwangszu/index.html,OPm4f_cAAAAJ,0000-0002-5773-3817
 Yi Wu 0013,Tsinghua University,https://iiis.tsinghua.edu.cn/en/People/Faculty/WuYi.htm,dusV5HMAAAAJ,0000-0001-9057-5817
 Yi Wu 0020,University of Oklahoma,https://ywu960702.github.io,0dxhJ04AAAAJ,0009-0006-3120-3769
+Yi Xiang 0002,South China Univ. of Technology,http://faculty.scut.edu.cn/rj/xy4/main.htm,RGgm8QQAAAAJ,0000-0003-2118-4825
 Yi Xiao 0004,Hunan University,http://design.hnu.edu.cn/info/1023/5773.htm,NOSCHOLARPAGE,0000-0002-4018-994X
 Yi Yang 0001,Zhejiang University,https://person.zju.edu.cn/yiyang,RMSuNFwAAAAJ,0000-0000-0000-0000
 Yi Yu 0001,National Inst. of Informatics,http://research.nii.ac.jp/~yiyu,oqxXhPsAAAAJ,0000-0000-0000-0000


### PR DESCRIPTION
## Consolidated PR for South China Univ. of Technology

This PR consolidates the following open PRs into a single submission:

| PR | Score | Title |
|---|---|---|
| #11760 | 78% | Add Yang Gao 0025 (South China Univ. of Technology) |
| #12120 | 70% | Add Yi Xiang 0002 (South China Univ. of Technology) |

**Validation summary**: Scores range from 70% to 78% (avg 74%). Some constituent PRs have concerns that need resolution — see individual PR comments for details.

Total: 2 faculty additions.