### PR TITLE
Add 2 faculty from Tsinghua University (consolidated)

### DIFF
--- a/csrankings-x.csv
+++ b/csrankings-x.csv
@@ -550,6 +550,7 @@ Xu Chen 0004,Sun Yat-sen University,https://sites.google.com/view/xcsysu/home,Bm
 Xu Chen 0017,Renmin University of China,http://xu-chen.com,loPoqy0AAAAJ,0000-0003-0144-1775
 Xu Chen 0042,Wuhan University,https://jszy.whu.edu.cn/chenxu1/zh_CN/index.htm,NOSCHOLARPAGE,0000-0003-0967-0521
 Xu Cheng 0001,Peking University,http://eecs.pku.edu.cn/EN/People/Faculty/Detail/?ID=6014,NOSCHOLARPAGE,0000-0000-0000-0000
+Xu Han 0007,Tsinghua University,https://thucsthanxu13.github.io/,rz4rOSMAAAAJ,0000-0002-4726-7621
 Xu He,Hunan University,http://csee.hnu.edu.cn/people/hexu,NOSCHOLARPAGE,0000-0002-7700-2341
 Xu Lin 0003,Washington State University,https://school.eecs.wsu.edu/faculty/profile/?nid=xu.lin,9wpoGuMAAAAJ,0009-0002-4239-1479
 Xu Liu 0001,North Carolina State University,https://xl10.github.io,qhLT67EAAAAJ,0000-0002-1487-963X

--- a/csrankings-y.csv
+++ b/csrankings-y.csv
@@ -511,6 +511,7 @@ Yimin Chen 0004,University of Massachusetts Lowell,https://ianchen88.github.io,T
 Yimin Yang,Xidian University,https://web.xidian.edu.cn/ymyang,RqH1weAAAAAJ,0000-0000-0000-0000
 Yiming Hu,University of Cincinnati,http://www.ece.uc.edu/~yhu,NOSCHOLARPAGE,0000-0000-0000-0000
 Yiming Jiang 0001,Hunan University,http://robotics.hnu.edu.cn/info/1071/1790.htm,NOSCHOLARPAGE,0000-0000-0000-0000
+Yiming Li,Tsinghua University,https://collegeai.tsinghua.edu.cn/en/People/Full_time_PI/Yiming_Li.htm,i_aajNoAAAAJ,0000-0000-0000-0000
 Yiming Miao,CUHK (SZ),https://sds.cuhk.edu.cn/en/teacher/451,uKUBH38AAAAJ,0000-0000-0000-0000
 Yiming Qian,University of Manitoba,https://yi-ming-qian.github.io,2xMfNpMAAAAJ,0000-0002-1795-2038
 Yiming Qiu,University of Hong Kong,https://www.cs.hku.hk/index.php/people/academic-staff/yimingq,AhLXqHbth54C,0000-0000-0000-0000
@@ -1070,6 +1071,7 @@ Yue Li 0013,Nankai University,https://my.nankai.edu.cn/jkxy/ly/list.htm,s9VyYRwA
 Yue Ning 0001,Stevens Institute of Technology,https://yue-ning.github.io,mVR8ROsAAAAJ,0000-0002-1227-440X
 Yue Qi,Beihang University,http://scse.buaa.edu.cn/info/1078/2661.htm,NOSCHOLARPAGE,0000-0001-9304-1933
 Yue Song 0002,Tsinghua University,https://collegeai.tsinghua.edu.cn/en/People/Full_time_PI/Yue_song.htm,Uza2i10AAAAJ,0000-0000-0000-0000
+Yue Song,Tsinghua University,https://kingjamessong.github.io/,Uza2i10AAAAJ,0000-0003-1573-5643
 Yue Wang 0041,University of Southern California,https://yuewang.xyz,v-AEFIEAAAAJ,0000-0000-0000-0000
 Yue Wang 0068,University of Central Florida,https://www.cs.ucf.edu/person/yue-wang,ndMi_z8AAAAJ,0009-0001-9786-052X
 Yue Xiao 0007,College of William and Mary,https://sites.google.com/view/yue-xiao/bio?authuser=0,dFg329IAAAAJ,0009-0005-7945-464X


### PR DESCRIPTION
## Consolidated PR for Tsinghua University

This PR consolidates the following open PRs into a single submission:

| PR | Score | Title |
|---|---|---|
| #11797 | 80% | Add Xu Han 0007 (Tsinghua University) |
| #12101 | 70% | Add Yiming Li (Tsinghua University) |

**Validation summary**: Scores range from 70% to 80% (avg 75%). Some constituent PRs have concerns that need resolution — see individual PR comments for details.

Total: 2 faculty additions.