### PR TITLE
Add 2 faculty from Shandong University (consolidated)

### DIFF
--- a/csrankings-l.csv
+++ b/csrankings-l.csv
@@ -581,6 +581,7 @@ Lin Li 0051,UESTC,https://www.en.scse.uestc.edu.cn/info/1085/1922.htm,NOSCHOLARP
 Lin Li 0067,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=LLI1,krQPTJcAAAAJ,0000-0000-0000-0000
 Lin Liu 0001,Tsinghua University,http://ise.thss.tsinghua.edu.cn/~liulin,0-SZSzgAAAAJ,0000-0002-3704-2322
 Lin Liu 0003,Adelaide University,https://researchers.adelaide.edu.au/profile/lin.liu,QP6jqRwAAAAJ,0000-0003-2843-5738
+Lin Lu 0001,Shandong University,https://irc.cs.sdu.edu.cn/~lulin/index.html,B9fHveAAAAAJ,0000-0001-5881-892X
 Lin Lv,Shandong University,https://irc.cs.sdu.edu.cn/~lulin/index.html,B9fHveAAAAAJ,0000-0000-0000-0000
 Lin Ma 0006,University of Michigan,https://web.eecs.umich.edu/~linmacse,UU9gkwEAAAAJ,0009-0003-7177-7327
 Lin Padgham,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/p/padgham-professor-lin,Bt3NOyAAAAAJ,0000-0002-6974-3318

--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -629,6 +629,7 @@ Pengfei Li,Rochester Inst. of Technology,https://people.rit.edu/pflics,irA8gqoAA
 Pengfei Liu 0003,Shanghai Jiao Tong University,http://pfliu.com,oIz_CYEAAAAJ,0000-0000-0000-0000
 Pengfei Su 0001,Univ. of California - Merced,https://pengfei-su.github.io,LAttsHIAAAAJ,0000-0000-0000-0000
 Pengfei Wang 0009,BUPT,https://wangpengfeii.github.io,BEDKYxUAAAAJ,0000-0001-8658-7102
+Pengfei Wang,Shandong University,https://faculty.sdu.edu.cn/~zeU3Eb/zh_CN/index.htm,-55ih00AAAAJ,0000-0002-0938-267X
 Pengfei Xu 0002,Shenzhen University,http://pengfeixu.com,bmC8UcoAAAAJ,0000-0003-4770-4374
 Pengfei Zhu 0001,Tianjin University,http://aiskyeye.com,iS27HZ8AAAAJ,0000-0002-4310-9140
 Penghui Yao,Nanjing University,http://penghuiyao.info,iFxJ6XIAAAAJ,0000-0002-4104-2069

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -992,6 +992,7 @@ Shannon David Blunt,University of Kansas,http://www.eecs.ku.edu/people/faculty/s
 Shannon P. Quinn,University of Georgia,http://cobweb.cs.uga.edu/~squinn,4EjRiycAAAAJ,0000-0000-0000-0000
 Shannon Quinn,University of Georgia,http://cobweb.cs.uga.edu/~squinn,4EjRiycAAAAJ,0000-0000-0000-0000
 Shanping Li,Zhejiang University,https://person.zju.edu.cn/en/0087125,NOSCHOLARPAGE,0000-0003-2615-9792
+Shanqing Guo,Shandong University,https://faculty.sdu.edu.cn/guoshanqing/en/index.htm,zsoQa0cAAAAJ,0000-0003-3367-0951
 Shanshan Feng 0001,Wuhan University,https://jszy.whu.edu.cn/fengshanshan12/zh_CN/index.htm,yX-lswoAAAAJ,0000-0002-6161-9232
 Shanshan Li 0002,Nanjing University,https://software.nju.edu.cn//lss/index.html,E86VWYEAAAAJ,0000-0002-7588-5603
 Shantanu Sharma 0001,NJIT,https://web.njit.edu/~ss797,NOSCHOLARPAGE,0000-0002-1339-5481
@@ -1682,6 +1683,7 @@ Siyi Lv,Nankai University,https://cc.nankai.edu.cn/2021/0323/c13620a570392/page.
 Siyu Huang,Clemson University,https://siyuhuang.github.io,hQN7Zn0AAAAJ,0000-0002-2929-0115
 Siyu Tang 0001,ETH Zurich,https://vlg.inf.ethz.ch/people/person-detail.siyutang.html,BUDh_4wAAAAJ,0000-0002-1015-4770
 Siyuan Ji,University of York,https://www.cs.york.ac.uk/people/?group=Academic%20and%20Teaching%20Staff&username=ji,oZdrNNwAAAAJ,0000-0001-6139-3539
+Siyuan Li 0014,Shandong University,https://siyuan-li201.github.io/,PAeteqUAAAAJ,0009-0004-4096-1209
 Sjaak Smetsers,Radboud University,http://www.cs.ru.nl/S.Smetsers,acnD_MEAAAAJ,0000-0000-0000-0000
 Sjouke Mauw,University of Luxembourg,http://satoss.uni.lu/members/sjouke,NDXZhwcAAAAJ,0000-0002-2818-4433
 Sjur Didrik Flåm,University of Bergen,https://www.uib.no/en/persons/Sjur.Didrik.Fl%C3%A5m,NOSCHOLARPAGE,0000-0000-0000-0000


### PR DESCRIPTION
## Consolidated PR for Shandong University

This PR consolidates the following open PRs into a single submission:

| PR | Score | Title |
|---|---|---|
| #12036 | 85% | Add 1 faculty from Shandong University |
| #12040 | 85% | Add Siyuan Li 0014 (Shandong University) |

**Validation summary**: Scores range from 85% to 85% (avg 85%). Some constituent PRs have concerns that need resolution — see individual PR comments for details.

Total: 2 faculty additions.