### PR TITLE
Add 2 faculty from University of South Florida (consolidated)

### DIFF
--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -1970,6 +1970,7 @@ Ankit Rajpal,University of Delhi,http://people.du.ac.in/~arajpal,KUh24kwAAAAJ,00
 Ankita Shukla,University of Nevada,https://ankita-shukla.github.io,c-S0ouYAAAAJ,0000-0002-1878-2667
 Ankur Agarwal,Florida Atlantic University,http://www.eng.fau.edu/directory/faculty/agarwal,lHvOG4EAAAAJ,0000-0000-0000-0000
 Ankur Arjun Mali,University of South Florida,https://ankurmali.github.io,ogxlzgcAAAAJ,0000-0000-0000-0000
+Ankur Mali,University of South Florida,https://www.usf.edu/ai-cybersecurity-computing/people/faculty/mali-ankur.aspx,ogxlzgcAAAAJ,0000-0000-0000-0000
 Ankur Moitra,Massachusetts Inst. of Technology,http://people.csail.mit.edu/moitra,umFQktIAAAAJ,0000-0001-7047-0495
 Ankur Srivastava,Univ. of Maryland - College Park,https://ece.umd.edu/clark/faculty/484/Ankur-Srivastava,rx92O6IAAAAJ,0000-0000-0000-0000
 Ankush Das,Boston University,https://ankushdas.github.io,yd-uFwMAAAAJ,0000-0003-2459-1258

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -1886,6 +1886,7 @@ John McAllister,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/C
 John McDonald 0001,Maynooth University,https://www.maynoothuniversity.ie/faculty-science-engineering/our-people/john-mcdonald,MrI1EV4AAAAJ,0000-0001-9225-673X
 John McDonald,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=643,NOSCHOLARPAGE,0000-0000-0000-0000
 John McGregor,Clemson University,https://people.cs.clemson.edu/~johnmc,Tw739kgAAAAJ,0000-0000-0000-0000
+John Michael Templeton,University of South Florida,https://www.usf.edu/ai-cybersecurity-computing/people/faculty/john_templeton.aspx,vBxiFTsAAAAJ,0000-0000-0000-0000
 John Millar Carroll,Pennsylvania State University,https://jcarroll.ist.psu.edu,7Mg8JZMAAAAJ,0000-0001-5189-337X
 John Murphy 0001,University College Dublin,https://people.ucd.ie/j.murphy,hRzqMboAAAAJ,0000-0000-0000-0000
 John Murray-Bruce,University of South Florida,https://www.cse.usf.edu/~murraybruce,lQkw3IoAAAAJ,0000-0002-1416-4175

--- a/csrankings-l.csv
+++ b/csrankings-l.csv
@@ -197,6 +197,7 @@ Lawrence Hunter,University of Colorado Boulder,https://www.colorado.edu/cs/lawre
 Lawrence J. Cavedon,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/c/cavedon-associate-professor-lawrence,ZAEiiEUAAAAJ,0000-0000-0000-0000
 Lawrence L. Larmore,University of Nevada Las Vegas,http://web.cs.unlv.edu/larmore,_mRgp6cAAAAJ,0000-0000-0000-0000
 Lawrence Mitchell,Durham University,https://www.dur.ac.uk/computer.science/staff/profile/?id=17243,GfzjtHEAAAAJ,0000-0001-8062-1453
+Lawrence O. Hall,University of South Florida,https://www.usf.edu/ai-cybersecurity-computing/people/faculty/hall-lawrence.aspx,AKHplAUAAAAJ,0000-0000-0000-0000
 Lawrence Rauchwerger,Univ. of Illinois at Urbana-Champaign,https://parasollab.web.illinois.edu/people/rwerger,ronge0AAAAAJ,0000-0002-1545-4991
 Lawrence S. Moss,Indiana University,https://iulg.sitehost.iu.edu/moss,9XDfKqYAAAAJ,0000-0000-0000-0000
 Lawson L. S. Wong,Northeastern University,http://www.ccs.neu.edu/home/lsw,MbDzOP0AAAAJ,0000-0000-0000-0000
@@ -654,6 +655,7 @@ Lingxiao Huang,Nanjing University,https://sites.google.com/site/lingxiaohuang199
 Lingxiao Jiang,Singapore Management University,http://www.mysmu.edu/faculty/lxjiang,0hssXLPZL2YC,0000-0002-4336-8548
 Lingxiao Wang 0001,NJIT,https://lingxiaowang-ai.github.io,VPyxd6kAAAAJ,0000-0000-0000-0000
 Lingyang Chu,McMaster University,https://lingyangchu.github.io,VfSFLR0AAAAJ,0000-0002-8937-1750
+Lingyao Li,University of South Florida,https://sites.google.com/view/lingyaoli,AhS0SckAAAAJ,0000-0001-5888-8311
 Lingyu Duan,Peking University,http://eecs.pku.edu.cn/EN/People/Faculty/Detail/?ID=6096,NOSCHOLARPAGE,0000-0002-4491-2023
 Lingyu Wang 0001,Concordia University,https://users.encs.concordia.ca/~wang,lf_G8EAAAAAJ,0000-0000-0000-0000
 Lingyun Sun,Zhejiang University,http://mypage.zju.edu.cn/sly,zzW8d-wAAAAJ,0000-0002-5561-0493

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -2677,6 +2677,7 @@ Mohammad Abdollahi Azgomi,IUST,http://www.iust.ac.ir/content/8313/Dr.-Abdollahi-
 Mohammad Abdulaziz,King's College London,https://www.kcl.ac.uk/people/mohammad-abdulaziz,x5z4rRkAAAAJ,0000-0002-8244-518X
 Mohammad Abdullah Al Faruque,Univ. of California - Irvine,http://aicps.eng.uci.edu,ejWHC-cAAAAJ,0000-0002-5390-0497
 Mohammad Al Hasan,IUPUI,http://cs.iupui.edu/~alhasan,fsCnri8AAAAJ,0000-0002-8279-1023
+Mohammad Al Olaimat,University of South Florida,https://www.usf.edu/ai-cybersecurity-computing/people/faculty/mohammad_al_olaimat.aspx,waVA4f0AAAAJ,0000-0000-0000-0000
 Mohammad Al-Smadi,JUST,http://www.just.edu.jo/eportfolio/Pages/Default.aspx?email=maalsmadi9,im_3CvwAAAAJ,0000-0000-0000-0000
 Mohammad Ali Abam,Sharif University of Technology,http://sharif.ir/~abam,xuNJ-d8AAAAJ,0000-0000-0000-0000
 Mohammad Alian,Cornell University,https://alian.csl.cornell.edu,wzQ8-gsAAAAJ,0000-0002-4622-2181

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -411,6 +411,7 @@ Santosh Biswas,IIT Bhilai,https://www.iitbhilai.ac.in/index.php?pid=santosh,Myp5
 Santosh Kumar 0001,University of Memphis,https://www.memphis.edu/cs/people/faculty_pages/santosh-kumar.php,f0i_WNoAAAAJ,0000-0002-9273-0291
 Santosh Nagarakatte,Rutgers University,https://www.cs.rutgers.edu/~santosh.nagarakatte,J7H4N_4AAAAJ,0000-0002-5048-8548
 Santosh Pande,Georgia Institute of Technology,http://www.cc.gatech.edu/fac/Santosh.Pande,d6vL_ZkAAAAJ,0000-0001-6723-8062
+Santosh Pandey 0001,University of South Florida,https://www.usf.edu/ai-cybersecurity-computing/people/faculty/santosh_pandey.aspx,4jtGttIAAAAJ,0000-0002-3528-6868
 Santosh Pandey,University of South Florida,https://www.usf.edu/ai-cybersecurity-computing/people/faculty/santosh_pandey.aspx,4jtGttIAAAAJ,0000-0000-0000-0000
 Santosh S. Vempala,Georgia Institute of Technology,http://www.cc.gatech.edu/~vempala,hRggMmIAAAAJ,0000-0002-3779-433X
 Santosh Srinivas Vempala,Georgia Institute of Technology,http://www.cc.gatech.edu/~vempala,hRggMmIAAAAJ,0000-0000-0000-0000
@@ -1170,6 +1171,7 @@ Shibiao Xu,BUPT,https://teacher.bupt.edu.cn/xushibiao/zh_CN/index.htm,NOSCHOLARP
 Shibo Li,Florida State University,https://www.cs.fsu.edu/department/faculty/shiboli,thvPDwgAAAAJ,0000-0000-0000-0000
 Shibu Yooseph,University of Central Florida,http://www.cs.ucf.edu/~syooseph,OJKibFgAAAAJ,0000-0001-5581-5002
 Shichao Pei,University of Massachusetts Boston,https://scpei.github.io,IDaNWgIAAAAJ,0000-0002-0802-1506
+Shichen Zhang 0001,University of South Florida,https://sczhang6.github.io,RvFFvTYAAAAJ,0000-0001-8432-0834
 Shichen Zhang,University of South Florida,https://www.usf.edu/ai-cybersecurity-computing/people/faculty/shichen_zhang.aspx,RvFFvTYAAAAJ,0000-0000-0000-0000
 Shie Mannor,Technion,http://shie.webee.eedev.technion.ac.il,q1HlbIUAAAAJ,0000-0003-4439-7647
 Shie Yuan Wang,National Chiao Tung University,http://www.csie.nctu.edu.tw/~shieyuan,NOSCHOLARPAGE,0000-0000-0000-0000


### PR DESCRIPTION
## Consolidated PR for University of South Florida

This PR consolidates the following open PRs into a single submission:

| PR | Score | Title |
|---|---|---|
| #11965 | 82% | Add Santosh Pandey 0001 (University of South Florida) |
| #11978 | 85% | Add Shichen Zhang 0001 (University of South Florida) |

**Validation summary**: Scores range from 82% to 85% (avg 83%). Some constituent PRs have concerns that need resolution — see individual PR comments for details.

Total: 2 faculty additions.