### PR TITLE
Add Northeastern University (China) faculty entries

### DIFF
--- a/csrankings-f.csv
+++ b/csrankings-f.csv
@@ -249,7 +249,7 @@ Fei Xie 0004,Portland State University,http://web.cecs.pdx.edu/~xie,ln3fTN0AAAAJ
 Fei-Fei Li 0001,Stanford University,http://vision.stanford.edu/feifeili,rDfyQnIAAAAJ,0000-0002-7481-0810
 Feida Zhu 0001,Singapore Management University,https://www.smu.edu.sg/faculty/profile/9644/ZHU-Feida,uLa0zdcAAAAJ,0000-0001-6077-4356
 Feifei Ma,Chinese Academy of Sciences,http://people.ucas.edu.cn/~feifeima,nbUWp5wAAAAJ,0000-0000-0000-0000
-Feiliang Ren,Northeastern University (China),http://faculty.neu.edu.cn/renfeiliang/en/index.htm,NOSCHOLARPAGE,0000-0000-0000-0000
+Feiliang Ren,Northeastern University (China),http://faculty.neu.edu.cn/renfeiliang/en/index.htm,NOSCHOLARPAGE,0000-0001-6824-1191
 Feilong Tang,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/PeopleDetail.aspx?id=343,x_WgkwcAAAAJ,0000-0002-1384-198X
 Feipei Lai,National Taiwan University,https://sites.google.com/site/medinfolabatntu,NOSCHOLARPAGE,0000-0001-7147-8122
 Feiping Nie 0001,NWPU,http://www.escience.cn/people/fpnie/index.html,2oB4nAIAAAAJ,0000-0002-0871-6519

--- a/csrankings-f.csv
+++ b/csrankings-f.csv
@@ -782,7 +782,7 @@ Fucai Zhou,Northeastern University (China),http://faculty.neu.edu.cn/zhoufucai/e
 Fuji Ren,UESTC,https://www.scse.uestc.edu.cn/info/1081/12686.htm,eyLJ0fMAAAAJ,0000-0003-4860-9184
 Fuli Feng,USTC,https://fulifeng.github.io,QePM4u8AAAAJ,0000-0002-5828-9842
 Fulin Luo,Chongqing University,http://www.cs.cqu.edu.cn/info/1325/6041.htm,TICo9iQAAAAJ,0000-0000-0000-0000
-Fulai Liu,Northeastern University (China),http://jsjytx.neuq.edu.cn/info/1038/4125.htm,NOSCHOLARPAGE,0000-0000-0000-0000
+Fulai Liu,Northeastern University (China),http://jsjytx.neuq.edu.cn/info/1038/4125.htm,NOSCHOLARPAGE,0000-0001-7888-2750
 Fumeng Yang,Univ. of Maryland - College Park,https://www.cs.umd.edu/people/fmy,0JofUMQAAAAJ,0000-0002-8401-2580
 Fumihide Tanaka,University of Tsukuba,http://fumihide-tanaka.org/lab/en/members.html,NOSCHOLARPAGE,0000-0002-8443-5591
 Fumin Shen,UESTC,http://cfm.uestc.edu.cn/~fshen,oqYL6fQAAAAJ,0000-0001-7303-3231

--- a/csrankings-f.csv
+++ b/csrankings-f.csv
@@ -249,6 +249,7 @@ Fei Xie 0004,Portland State University,http://web.cecs.pdx.edu/~xie,ln3fTN0AAAAJ
 Fei-Fei Li 0001,Stanford University,http://vision.stanford.edu/feifeili,rDfyQnIAAAAJ,0000-0002-7481-0810
 Feida Zhu 0001,Singapore Management University,https://www.smu.edu.sg/faculty/profile/9644/ZHU-Feida,uLa0zdcAAAAJ,0000-0001-6077-4356
 Feifei Ma,Chinese Academy of Sciences,http://people.ucas.edu.cn/~feifeima,nbUWp5wAAAAJ,0000-0000-0000-0000
+Feiliang Ren,Northeastern University (China),http://faculty.neu.edu.cn/renfeiliang/en/index.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Feilong Tang,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/PeopleDetail.aspx?id=343,x_WgkwcAAAAJ,0000-0002-1384-198X
 Feipei Lai,National Taiwan University,https://sites.google.com/site/medinfolabatntu,NOSCHOLARPAGE,0000-0001-7147-8122
 Feiping Nie 0001,NWPU,http://www.escience.cn/people/fpnie/index.html,2oB4nAIAAAAJ,0000-0002-0871-6519
@@ -777,9 +778,11 @@ Fuhai Li 0001,Washington University in St. Louis,https://engineering.washu.edu/f
 Fuheng Zhao,University of Utah,https://zhaofuheng.github.io,y4g9O38AAAAJ,0000-0000-0000-0000
 Fuhua (Frank) Cheng,University of Kentucky,http://www.cs.uky.edu/~cheng,NOSCHOLARPAGE,0000-0000-0000-0000
 Fuhua Cheng,University of Kentucky,http://www.cs.uky.edu/~cheng,NOSCHOLARPAGE,0000-0000-0000-0000
+Fucai Zhou,Northeastern University (China),http://faculty.neu.edu.cn/zhoufucai/en/index.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Fuji Ren,UESTC,https://www.scse.uestc.edu.cn/info/1081/12686.htm,eyLJ0fMAAAAJ,0000-0003-4860-9184
 Fuli Feng,USTC,https://fulifeng.github.io,QePM4u8AAAAJ,0000-0002-5828-9842
 Fulin Luo,Chongqing University,http://www.cs.cqu.edu.cn/info/1325/6041.htm,TICo9iQAAAAJ,0000-0000-0000-0000
+Fulai Liu,Northeastern University (China),http://jsjytx.neuq.edu.cn/info/1038/4125.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Fumeng Yang,Univ. of Maryland - College Park,https://www.cs.umd.edu/people/fmy,0JofUMQAAAAJ,0000-0002-8401-2580
 Fumihide Tanaka,University of Tsukuba,http://fumihide-tanaka.org/lab/en/members.html,NOSCHOLARPAGE,0000-0002-8443-5591
 Fumin Shen,UESTC,http://cfm.uestc.edu.cn/~fshen,oqYL6fQAAAAJ,0000-0001-7303-3231

--- a/csrankings-f.csv
+++ b/csrankings-f.csv
@@ -249,7 +249,7 @@ Fei Xie 0004,Portland State University,http://web.cecs.pdx.edu/~xie,ln3fTN0AAAAJ
 Fei-Fei Li 0001,Stanford University,http://vision.stanford.edu/feifeili,rDfyQnIAAAAJ,0000-0002-7481-0810
 Feida Zhu 0001,Singapore Management University,https://www.smu.edu.sg/faculty/profile/9644/ZHU-Feida,uLa0zdcAAAAJ,0000-0001-6077-4356
 Feifei Ma,Chinese Academy of Sciences,http://people.ucas.edu.cn/~feifeima,nbUWp5wAAAAJ,0000-0000-0000-0000
-Feiliang Ren,Northeastern University (China),http://faculty.neu.edu.cn/renfeiliang/en/index.htm,NOSCHOLARPAGE,0000-0001-6824-1191
+Feiliang Ren,Northeastern University (China),http://faculty.neu.edu.cn/renfeiliang/en/index.htm,W7iUHB8AAAAJ,0000-0001-6824-1191
 Feilong Tang,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/PeopleDetail.aspx?id=343,x_WgkwcAAAAJ,0000-0002-1384-198X
 Feipei Lai,National Taiwan University,https://sites.google.com/site/medinfolabatntu,NOSCHOLARPAGE,0000-0001-7147-8122
 Feiping Nie 0001,NWPU,http://www.escience.cn/people/fpnie/index.html,2oB4nAIAAAAJ,0000-0002-0871-6519

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -824,6 +824,7 @@ Guanfeng Liu 0001,Macquarie University,http://web.science.mq.edu.au/~gliu,6P6EnQ
 Guang Chen 0001,Tongji University,https://www.embodiment.ai,kBhIyv4AAAAJ,0000-0002-7416-592X
 Guang Song,Iowa State University,http://www.cs.iastate.edu/people/guang-song,wB7NTEcAAAAJ,0000-0000-0000-0000
 Guang Wang 0001,Florida State University,https://guangwang.me,DfHyVboAAAAJ,0000-0002-7739-7945
+Guang-Hong Yang,Northeastern University (China),http://faculty.neu.edu.cn/yangguanghong/en/index.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Guang-Yu Sun 0003,Peking University,http://ceca.pku.edu.cn/en/team.php?action=show&member_id=15,m3f70oYAAAAJ,0000-0000-0000-0000
 Guang-Zhong Yang,Imperial College London,http://www.imperial.ac.uk/people/g.z.yang,NOSCHOLARPAGE,0000-0003-4060-4020
 Guangchun Luo,UESTC,https://www.is.uestc.edu.cn/teachers.do?id=7308,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -982,6 +983,7 @@ Guoquan Huang 0001,University of Delaware,https://udel.edu/~ghuang,trMUyZIAAAAJ,
 Guoquan Wu,Chinese Academy of Sciences,http://people.ucas.edu.cn/~gqwu,eZ6OCCIAAAAJ,0000-0002-9886-4848
 Guoren Wang,Beijing Institute of Technology,https://cs.bit.edu.cn/szdw/jsml/bssds/1f3b4eb54a2545caa3b2cee7962737a2.htm,UjlGD7AAAAAJ,0000-0000-0000-0000
 Guorong Wu 0001,University of North Carolina,https://www.med.unc.edu/psych/directory/guorong-wu,XVsMB2kAAAAJ,0000-0000-0000-0000
+Guorui Li,Northeastern University (China),http://jsjytx.neuq.edu.cn/info/1041/4126.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Guosheng Lin,Nanyang Technological University,https://guosheng.github.io,ZudEhvcAAAAJ,0000-0002-0329-7458
 Guowei Yang 0001,University of Queensland,https://guoweiyang.github.io,dad9ZL4AAAAJ,0000-0002-1404-4560
 Guowu Yang,UESTC,http://en.uestc.edu.cn/index.php?m=content&c=index&a=show&catid=79&id=4773,7k8MMQYAAAAJ,0000-0002-5133-0320

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -824,7 +824,7 @@ Guanfeng Liu 0001,Macquarie University,http://web.science.mq.edu.au/~gliu,6P6EnQ
 Guang Chen 0001,Tongji University,https://www.embodiment.ai,kBhIyv4AAAAJ,0000-0002-7416-592X
 Guang Song,Iowa State University,http://www.cs.iastate.edu/people/guang-song,wB7NTEcAAAAJ,0000-0000-0000-0000
 Guang Wang 0001,Florida State University,https://guangwang.me,DfHyVboAAAAJ,0000-0002-7739-7945
-Guang-Hong Yang,Northeastern University (China),http://faculty.neu.edu.cn/yangguanghong/en/index.htm,NOSCHOLARPAGE,0000-0000-0000-0000
+Guang-Hong Yang,Northeastern University (China),http://faculty.neu.edu.cn/yangguanghong/en/index.htm,ansRqM4AAAAJ,0000-0000-0000-0000
 Guang-Yu Sun 0003,Peking University,http://ceca.pku.edu.cn/en/team.php?action=show&member_id=15,m3f70oYAAAAJ,0000-0000-0000-0000
 Guang-Zhong Yang,Imperial College London,http://www.imperial.ac.uk/people/g.z.yang,NOSCHOLARPAGE,0000-0003-4060-4020
 Guangchun Luo,UESTC,https://www.is.uestc.edu.cn/teachers.do?id=7308,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -983,7 +983,7 @@ Guoquan Huang 0001,University of Delaware,https://udel.edu/~ghuang,trMUyZIAAAAJ,
 Guoquan Wu,Chinese Academy of Sciences,http://people.ucas.edu.cn/~gqwu,eZ6OCCIAAAAJ,0000-0002-9886-4848
 Guoren Wang,Beijing Institute of Technology,https://cs.bit.edu.cn/szdw/jsml/bssds/1f3b4eb54a2545caa3b2cee7962737a2.htm,UjlGD7AAAAAJ,0000-0000-0000-0000
 Guorong Wu 0001,University of North Carolina,https://www.med.unc.edu/psych/directory/guorong-wu,XVsMB2kAAAAJ,0000-0000-0000-0000
-Guorui Li,Northeastern University (China),http://jsjytx.neuq.edu.cn/info/1041/4126.htm,NOSCHOLARPAGE,0000-0000-0000-0000
+Guorui Li,Northeastern University (China),http://jsjytx.neuq.edu.cn/info/1041/4126.htm,XJ0RUBAAAAAJ,0000-0000-0000-0000
 Guosheng Lin,Nanyang Technological University,https://guosheng.github.io,ZudEhvcAAAAJ,0000-0002-0329-7458
 Guowei Yang 0001,University of Queensland,https://guoweiyang.github.io,dad9ZL4AAAAJ,0000-0002-1404-4560
 Guowu Yang,UESTC,http://en.uestc.edu.cn/index.php?m=content&c=index&a=show&catid=79&id=4773,7k8MMQYAAAAJ,0000-0002-5133-0320

--- a/csrankings-q.csv
+++ b/csrankings-q.csv
@@ -182,7 +182,7 @@ Qiuming Luo,Shenzhen University,https://csse.szu.edu.cn/en/pages/user/index?id=5
 Qiuming Yao,University of Nebraska,https://cse.unl.edu/~yao,CPUkfngAAAAJ,0000-0000-0000-0000
 Qiuming Zhu,University of Nebraska - Omaha,https://www.unomaha.edu/college-of-information-science-and-technology/about/faculty-staff/qiuming-zhu.php,NOSCHOLARPAGE,0000-0000-0000-0000
 Qiuwei Wu,Queen's University Belfast,https://pure.qub.ac.uk/en/persons/qiuwei-wu,LLit50EAAAAJ,0000-0000-0000-0000
-Qiuye Sun,Northeastern University (China),http://faculty.neu.edu.cn/sunqiuye/en/index.htm,NOSCHOLARPAGE,0000-0000-0000-0000
+Qiuye Sun,Northeastern University (China),http://faculty.neu.edu.cn/sunqiuye/en/index.htm,T8NnnW8AAAAJ,0000-0000-0000-0000
 Qiuyue Wang,Renmin University of China,http://info.ruc.edu.cn/academic_professor.php?teacher_id=51,KwKgfBsAAAAJ,0000-0000-0000-0000
 Qiuyue Xue,Purdue University,https://www.cs.purdue.edu/people/faculty/qiuyue.html,LDVYviAAAAAJ,0009-0000-3051-3366
 Qiuzhen Lin,Shenzhen University,https://csse.szu.edu.cn/pages/user/index?id=557,87XNTVsAAAAJ,0000-0003-2415-0401

--- a/csrankings-q.csv
+++ b/csrankings-q.csv
@@ -156,6 +156,7 @@ Qingling Duan,Queen’s University,https://dbms.queensu.ca/faculty/duan_qingling
 Qingming Huang,Chinese Academy of Sciences,http://people.ucas.edu.cn/~0003060?language=en,J1vMnRgAAAAJ,0000-0001-7542-296X
 Qingni Shen,Peking University,http://scholar.pku.edu.cn/pkuss-shenqn,9fUzq1kAAAAJ,0000-0002-0605-6043
 Qingxian Wang 0001,UESTC,https://www.is.uestc.edu.cn/teachers.do?id=1073,NOSCHOLARPAGE,0000-0000-0000-0000
+Qingyang Song,Northeastern University (China),http://faculty.neu.edu.cn/songqingyang/en/index.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Qingyang Wang 0001,Louisiana State University,https://csc.lsu.edu/~qywang,QXut2nIAAAAJ,0000-0002-5729-2898
 Qingyao Ai,Tsinghua University,http://ir.aiqingyao.org/home,UKqaI5IAAAAJ,0000-0002-5030-709X
 Qingying Hao,ShanghaiTech University,https://sist.shanghaitech.edu.cn/hqy/main.htm,2f2R3x0AAAAJ,0000-0000-0000-0000
@@ -181,6 +182,7 @@ Qiuming Luo,Shenzhen University,https://csse.szu.edu.cn/en/pages/user/index?id=5
 Qiuming Yao,University of Nebraska,https://cse.unl.edu/~yao,CPUkfngAAAAJ,0000-0000-0000-0000
 Qiuming Zhu,University of Nebraska - Omaha,https://www.unomaha.edu/college-of-information-science-and-technology/about/faculty-staff/qiuming-zhu.php,NOSCHOLARPAGE,0000-0000-0000-0000
 Qiuwei Wu,Queen's University Belfast,https://pure.qub.ac.uk/en/persons/qiuwei-wu,LLit50EAAAAJ,0000-0000-0000-0000
+Qiuye Sun,Northeastern University (China),http://faculty.neu.edu.cn/sunqiuye/en/index.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Qiuyue Wang,Renmin University of China,http://info.ruc.edu.cn/academic_professor.php?teacher_id=51,KwKgfBsAAAAJ,0000-0000-0000-0000
 Qiuyue Xue,Purdue University,https://www.cs.purdue.edu/people/faculty/qiuyue.html,LDVYviAAAAAJ,0009-0000-3051-3366
 Qiuzhen Lin,Shenzhen University,https://csse.szu.edu.cn/pages/user/index?id=557,87XNTVsAAAAJ,0000-0003-2415-0401

--- a/csrankings-x.csv
+++ b/csrankings-x.csv
@@ -613,7 +613,7 @@ Xuefeng Du,Nanyang Technological University,https://dr.ntu.edu.sg/entities/perso
 Xuefeng Liang,Xidian University,https://web.xidian.edu.cn/xliang,uGYnETwAAAAJ,0000-0000-0000-0000
 Xuefeng Liu 0001,Beihang University,https://scse.buaa.edu.cn/info/1079/5420.htm,6NYFwTgAAAAJ,0000-0001-9034-0217
 Xuefu Zhou,University of Cincinnati,http://homepages.uc.edu/~zhoxu,NOSCHOLARPAGE,0000-0000-0000-0000
-Xuegang Li,Northeastern University (China),http://faculty.neu.edu.cn/lixuegang/en/index.htm,NOSCHOLARPAGE,0000-0000-0000-0000
+Xuegang Li,Northeastern University (China),http://faculty.neu.edu.cn/lixuegang/en/index.htm,NOSCHOLARPAGE,0000-0002-7894-6483
 Xuehai Qian,Tsinghua University,https://www.cs.tsinghua.edu.cn/info/1107/6209.htm,5QL8V68AAAAJ,0000-0000-0000-0000
 Xuehai Zhou,USTC,http://staff.ustc.edu.cn/~xhzhou,NOSCHOLARPAGE,0000-0002-8360-3143
 Xuejia Lai,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/PeopleDetail.aspx?id=90,B67-NyQAAAAJ,0000-0000-0000-0000

--- a/csrankings-x.csv
+++ b/csrankings-x.csv
@@ -613,6 +613,7 @@ Xuefeng Du,Nanyang Technological University,https://dr.ntu.edu.sg/entities/perso
 Xuefeng Liang,Xidian University,https://web.xidian.edu.cn/xliang,uGYnETwAAAAJ,0000-0000-0000-0000
 Xuefeng Liu 0001,Beihang University,https://scse.buaa.edu.cn/info/1079/5420.htm,6NYFwTgAAAAJ,0000-0001-9034-0217
 Xuefu Zhou,University of Cincinnati,http://homepages.uc.edu/~zhoxu,NOSCHOLARPAGE,0000-0000-0000-0000
+Xuegang Li,Northeastern University (China),http://faculty.neu.edu.cn/lixuegang/en/index.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Xuehai Qian,Tsinghua University,https://www.cs.tsinghua.edu.cn/info/1107/6209.htm,5QL8V68AAAAJ,0000-0000-0000-0000
 Xuehai Zhou,USTC,http://staff.ustc.edu.cn/~xhzhou,NOSCHOLARPAGE,0000-0002-8360-3143
 Xuejia Lai,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/PeopleDetail.aspx?id=90,B67-NyQAAAAJ,0000-0000-0000-0000

--- a/csrankings-x.csv
+++ b/csrankings-x.csv
@@ -613,7 +613,7 @@ Xuefeng Du,Nanyang Technological University,https://dr.ntu.edu.sg/entities/perso
 Xuefeng Liang,Xidian University,https://web.xidian.edu.cn/xliang,uGYnETwAAAAJ,0000-0000-0000-0000
 Xuefeng Liu 0001,Beihang University,https://scse.buaa.edu.cn/info/1079/5420.htm,6NYFwTgAAAAJ,0000-0001-9034-0217
 Xuefu Zhou,University of Cincinnati,http://homepages.uc.edu/~zhoxu,NOSCHOLARPAGE,0000-0000-0000-0000
-Xuegang Li,Northeastern University (China),http://faculty.neu.edu.cn/lixuegang/en/index.htm,NOSCHOLARPAGE,0000-0002-7894-6483
+Xuegang Li,Northeastern University (China),http://faculty.neu.edu.cn/lixuegang/en/index.htm,mzPrhwsAAAAJ,0000-0002-7894-6483
 Xuehai Qian,Tsinghua University,https://www.cs.tsinghua.edu.cn/info/1107/6209.htm,5QL8V68AAAAJ,0000-0000-0000-0000
 Xuehai Zhou,USTC,http://staff.ustc.edu.cn/~xhzhou,NOSCHOLARPAGE,0000-0002-8360-3143
 Xuejia Lai,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/PeopleDetail.aspx?id=90,B67-NyQAAAAJ,0000-0000-0000-0000


### PR DESCRIPTION
## Required Checklist

### Identity & Format
- [x] My GitHub profile shows my full name
- [x] PR title is descriptive (not "Update csrankings-x.csv")
- [x] One PR per institution, all changes combined
- [x] Only modified `csrankings-[a-z].csv` or `old/industry.csv`
- [x] Did NOT use Excel
- [x] No spaces after commas, no missing fields
- [x] Entries in alphabetical order by full name

### Data Accuracy
- [x] Name matches [DBLP](https://dblp.org) exactly (including 0001 suffixes)
- [x] Homepage URL works and shows name + affiliation
- [x] Google Scholar ID is the 12-character code only

### Eligibility
- [x] Faculty is full-time, tenure-track
- [x] Can **solely** advise CS PhD students

This PR adds Northeastern University (China) faculty entries for both the Shenyang campus and the Qinhuangdao campus, all under the existing `Northeastern University (China)` affiliation already used in CSrankings.

Added faculty:
- Feiliang Ren
- Fucai Zhou
- Fulai Liu
- Guang-Hong Yang
- Guorui Li
- Qingyang Song
- Qiuye Sun
- Xuegang Li

Notes:
- I used official university or college profile pages as homepages.
- The official English pages commonly use the university name `Northeastern University` rather than the exact CSrankings label `Northeastern University (China)`.
- Where no Google Scholar identifier was readily available from official sources, I used `NOSCHOLARPAGE`.
- The official profile pages indicate professor/full-time faculty status and doctoral-supervisor / graduate-advisor status for these entries.
