### PR TITLE
Add faculty for VNU-UET with verified homepages

### DIFF
--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -1645,6 +1645,7 @@ Duarte de Mesquita e Sousa,Universidade de Lisboa,https://fenix.tecnico.ulisboa.
 Duc A. Tran,University of Massachusetts Boston,http://www.cs.umb.edu/~duc/www,Wi02UQoAAAAJ,0000-0001-8129-0940
 Duc Viet Le 0002,University of Twente,https://research.utwente.nl/en/persons/20abb2e9-ad8d-4b78-8ed0-ebab8528ceda,Zgwx0zAAAAAJ,0000-0000-0000-0000
 Duc-Tien Dang-Nguyen,University of Bergen,https://dnductien.github.io,NOSCHOLARPAGE,0000-0002-2761-2213
+Duc-Trong Le,VNU Univ. of Eng. and Tech.,https://uet.vnu.edu.vn/~trongld,irb6x1cAAAAJ,0000-0003-4621-8956
 Duen Horng (Polo) Chau,Georgia Institute of Technology,http://www.cc.gatech.edu/~dchau,YON32W4AAAAJ,0000-0001-9824-3323
 Duen Horng Chau,Georgia Institute of Technology,http://www.cc.gatech.edu/~dchau,YON32W4AAAAJ,0000-0001-9824-3323
 Dugang Liu,Shenzhen University,https://dgliu.github.io,JQiDCZUAAAAJ,0000-0003-3612-709X

--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -836,6 +836,7 @@ Hoa Khanh Dam,University of Wollongong,https://documents.uow.edu.au/~hoa,LzBiAcs
 Hoai Phuong Ha,UiT The Arctic Univ. of Norway,https://uit.no/ansatte/phuong.hoai.ha,KfuUnC8AAAAJ,0000-0000-0000-0000
 Hoang Dau,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/d/dau-dr-son-hoang,dEdfBuwAAAAJ,0000-0003-2439-5185
 Hoang-Dung Tran,University of Florida,https://sites.google.com/view/v2a2/about,_RzS3uMAAAAJ,0000-0001-6946-9526
+Hoang-Quynh Le,VNU Univ. of Eng. and Tech.,https://uet.vnu.edu.vn/~lhquynh/,LBYOZ00AAAAJ,0000-0002-1778-0600
 Hock Soon Seah,Nanyang Technological University,http://www.ntu.edu.sg/home/ashsseah,NOSCHOLARPAGE,0000-0000-0000-0000
 Hoda Bidkhori,George Mason University,https://cs.gmu.edu/directory/detail/172,NOSCHOLARPAGE,0000-0000-0000-0000
 Hoda Eldardiry,Virginia Tech,http://people.cs.vt.edu/hdardiry,3IVJGxcAAAAJ,0000-0002-9712-6667

--- a/csrankings-v.csv
+++ b/csrankings-v.csv
@@ -261,6 +261,7 @@ Vidhya V.,Manipal Academy of Higher Education,https://www.manipal.edu/mit/depart
 Vidya Muthukumar,Georgia Institute of Technology,https://vmuthukumar.ece.gatech.edu,NOSCHOLARPAGE,0000-0000-0000-0000
 Vidya Rao,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/vidya-rao/_jcr_content.html,XEAeSVcAAAAJ,0000-0001-7282-7726
 Viera Rozinajová,Kempelen Institute - KInIT,https://kinit.sk/member/viera-rozinajova,Kv2JpV0AAAAJ,0000-0000-0000-0000
+Viet Cuong Ta,VNU Univ. of Eng. and Tech.,https://uet.vnu.edu.vn/~cuongtv/,j9_spcUAAAAJ,0000-0001-8058-5915
 Viet Tung Hoang,Florida State University,http://www.cs.fsu.edu/~tvhoang,ggcCMuIAAAAJ,0000-0003-3092-6405
 Viggo Kann,KTH Royal Inst. of Technology,http://www.csc.kth.se/~viggo,4Fexy5ml2cMC,0000-0000-0000-0000
 Vignesh Narayanan,University of South Carolina,https://vigsnar.github.io,IXy6vzsAAAAJ,0000-0000-0000-0000


### PR DESCRIPTION
Following the approval of **Issue #9935**, I am submitting the initial faculty list for **VNU University of Engineering and Technology, Hanoi (VNU Univ. of Eng. and Tech.)**.

While our institution has approximately 45 faculty members with PhD degrees (as mentioned in the issue), this initial submission includes the **3 faculty members** who currently have active publications in the selective venues tracked by CSRankings. This ensures that our institutional profile starts with accurately mapped data. We plan to submit additional faculty members in future PRs as they meet the publication criteria.

All listed individuals are full-time tenure-track faculty who can solely advise PhD students in Computer Science.

## Required Checklist

### Identity & Format
- [x] My GitHub profile shows my full name
- [x] PR title is descriptive
- [x] One PR per institution, all changes combined
- [x] Only modified `csrankings-[a-z].csv`
- [x] Did NOT use Excel (used VS Code)
- [x] No spaces after commas, no missing fields
- [x] Entries in alphabetical order by full name

### Data Accuracy
- [x] Name matches [DBLP](https://dblp.org) exactly
- [x] Homepage URL works and shows name + affiliation
- [x] Google Scholar ID is the 12-character code only

### Eligibility
- [x] Faculty is full-time, tenure-track
- [x] Can **solely** advise CS PhD students
- [x] If not in CS department: included justification with links (Faculty of Information Technology is the primary CS entity at UET)

### New Institutions
- [x] If adding new institution: opened issue first (#9935)
- [x] Adding **all** CS faculty currently meeting CSRankings' publication criteria

---