### PR TITLE
Add 6 faculty from Beijing Normal University (consolidated)

### DIFF
--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -48,8 +48,8 @@ Haggai Maron,Technion,https://haggaim.github.io,4v8uJrIAAAAJ,0009-0001-4088-6286
 Hagit Attiya,Technion,http://hagit.net.technion.ac.il,eoMK92MAAAAJ,0000-0002-8017-6457
 Hagit Hel-Or,University of Haifa,http://cs.haifa.ac.il/~hagit,GMM3-EUAAAAJ,0000-0001-8488-0380
 Hagit Shatkay,University of Delaware,https://www.eecis.udel.edu/~shatkay,NOSCHOLARPAGE,0000-0000-0000-0000
-Hagit Zabrodsky,University of Haifa,http://cs.haifa.ac.il/~hagit,GMM3-EUAAAAJ,0000-0000-0000-0000
 Hagit Zabrodsky Hel-Or,University of Haifa,http://cs.haifa.ac.il/~hagit,GMM3-EUAAAAJ,0000-0000-0000-0000
+Hagit Zabrodsky,University of Haifa,http://cs.haifa.ac.il/~hagit,GMM3-EUAAAAJ,0000-0000-0000-0000
 Hai (Helen) Li,Duke University,https://ece.duke.edu/people/hai-helen-li,E6Tpfq8AAAAJ,0000-0003-3228-6544
 Hai Dong,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/d/dong-dr-hai,ENWFU4gAAAAJ,0000-0002-7033-5688
 Hai Helen Li,Duke University,https://ece.duke.edu/people/hai-helen-li,E6Tpfq8AAAAJ,0000-0003-3228-6544
@@ -101,8 +101,8 @@ Hainan Zhang,Beihang University,https://zhanghainan.github.io,D22QG1557LgC,0000-
 Haining Fan,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/cs/4616/2017/20170303112105728431532/20170303112105728431532_.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Haining Zhang,Nankai University,https://cs.nankai.edu.cn/szdw/js/zhn.htm,NOSCHOLARPAGE,0009-0007-1320-3981
 Haipeng Cai,University at Buffalo,https://chapering.github.io,Ru4B_wkAAAAJ,0000-0002-5224-9970
-Haipeng Chen,College of William and Mary,https://haipeng-chen.github.io,YT-b72QAAAAJ,0000-0000-0000-0000
 Haipeng Chen 0002,Jilin University,https://ccst.jlu.edu.cn/info/1367/20675.htm,NOSCHOLARPAGE,0000-0002-9410-4120
+Haipeng Chen,College of William and Mary,https://haipeng-chen.github.io,YT-b72QAAAAJ,0000-0000-0000-0000
 Haipeng Dai 0001,Nanjing University,https://cs.nju.edu.cn/daihp,fb9R-QgAAAAJ,0000-0003-0545-8187
 Haipeng Luo,University of Southern California,https://haipeng-luo.net,ct2hw4UAAAAJ,0000-0001-8056-6271
 Haipeng Peng,BUPT,https://scss.bupt.edu.cn/info/1063/1188.htm,pZqxzFoAAAAJ,0000-0000-0000-0000
@@ -603,8 +603,8 @@ Helen Xu 0001,Georgia Institute of Technology,https://itshelenxu.github.io,ZcguQ
 Helen Yannakoudakis,King's College London,https://www.kcl.ac.uk/people/helen-yannakoudakis,B3WGvRsAAAAJ,0000-0000-0000-0000
 Helena Cristina da Gama Leitão,UFF,http://www2.ic.uff.br/~hcgl,NOSCHOLARPAGE,0000-0000-0000-0000
 Helena Galhardas,Universidade de Lisboa,http://web.ist.utl.pt/helena.galhardas,oBY_WrMAAAAJ,0000-0000-0000-0000
-Helena Holmström,Malmö University,https://mau.se/en/persons/helena.holmstrom.olsson,bjGw_5QAAAAJ,0000-0000-0000-0000
 Helena Holmström Olsson,Malmö University,https://mau.se/en/persons/helena.holmstrom.olsson,bjGw_5QAAAAJ,0000-0000-0000-0000
+Helena Holmström,Malmö University,https://mau.se/en/persons/helena.holmstrom.olsson,bjGw_5QAAAAJ,0000-0000-0000-0000
 Helena Karasti,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/helena-karasti(fdbd5c94-bf35-463a-ab70-1224809bbbf4).html,oEzi1K0AAAAJ,0000-0000-0000-0000
 Helena M. Mentis,Drexel University,https://drexel.edu/cci/about/directory/M/Mentis-Helena,_VdWyEcAAAAJ,0000-0002-0142-3529
 Helena Sarmento,Universidade de Lisboa,http://lisboa.academia.edu/HelenaSarmento,cn9nh7UAAAAJ,0000-0000-0000-0000
@@ -1038,6 +1038,7 @@ Hu Ding,USTC,http://staff.ustc.edu.cn/~huding/index.html,D1-liJEAAAAJ,0000-0000-
 Hu Fu 0001,SUFE,http://www.fuhuthu.com,fcqBMQgAAAAJ,0009-0005-4217-4329
 Hu Han 0001,Chinese Academy of Sciences,https://sites.google.com/site/huhanhomepage/publication,4v709-MAAAAJ,0000-0001-6010-1792
 Hu Xiong,UESTC,https://www.is.uestc.edu.cn/teachers.do?id=7986,dZR8algAAAAJ,0000-0000-0000-0000
+Hua Huang 0001,Beijing Normal University,https://ai.bnu.edu.cn/xygk/szdw/zgj/194482e0996d4044806ac39019896e9c.htm,EplUB7oAAAAJ,0000-0000-0000-0000
 Hua Huang 0003,Univ. of California - Merced,https://sites.ucmerced.edu/huahuang,MymQmUcAAAAJ,0000-0002-2817-2950
 Hua Lu 0001,Aalborg University,http://people.cs.aau.dk/~luhua,h1mExmcAAAAJ,0000-0003-1199-6678
 Hua Ming,Oakland University,http://www.secs.oakland.edu/~ming/publications,NOSCHOLARPAGE,0000-0000-0000-0000

--- a/csrankings-q.csv
+++ b/csrankings-q.csv
@@ -67,6 +67,7 @@ Qiang Zeng 0001,George Mason University,https://people.cs.gmu.edu/~qzeng2,NOSCHO
 Qiang Zhou 0001,Tsinghua University,http://www.tsinghua.edu.cn/publish/csen/4623/2010/20101225001843542358511/20101225001843542358511_.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Qiang Zhu 0001,University of Michigan-Dearborn,https://www-personal.umd.umich.edu/~qzhu,NOSCHOLARPAGE,0000-0000-0000-0000
 Qiang-Sheng Hua,HUST,https://qiangshenghua.github.io,bFyRg7wAAAAJ,0000-0000-0000-0000
+Qiannan Zhu,Beijing Normal University,https://ai.bnu.edu.cn/xygk/szdw/fgj/88c6de446e6845a09b76d616ea20d035.htm,NosrkdgAAAAJ,0000-0000-0000-0000
 Qianni Deng,Shanghai Jiao Tong University,http://english.seiee.sjtu.edu.cn/english/detail/841_689.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Qianping Gu,Simon Fraser University,https://www.cs.sfu.ca/~qgu,NOSCHOLARPAGE,0000-0000-0000-0000
 Qianqian Xie,Wuhan University,https://jszy.whu.edu.cn/xieqianqian/en/index.htm,UYW7X_0AAAAJ,0000-0002-9588-7454

--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -17,8 +17,8 @@ R. K. Bagga,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/rbagga,NOSCHOLA
 R. Krithika 0001,IIT Palakkad,https://www.iitpkd.ac.in/people/krithika,nAeD9dUAAAAJ,0000-0000-0000-0000
 R. M. Duwairi,JUST,http://www.just.edu.jo/eportfolio/Pages/Default.aspx?email=rehab,J6lMBuEAAAAJ,0000-0000-0000-0000
 R. Michael Young,University of Utah,https://faculty.utah.edu/u6006841-ROBERT_MICHAEL_YOUNG/research/index.hml,HLz6zx4AAAAJ,0000-0000-0000-0000
-R. Mukundan,University of Canterbury,http://www.cosc.canterbury.ac.nz/mukundan,Bk5BJ80AAAAJ,0000-0000-0000-0000
 R. Mukundan 0001,University of Canterbury,http://www.cosc.canterbury.ac.nz/mukundan,Bk5BJ80AAAAJ,0000-0000-0000-0000
+R. Mukundan,University of Canterbury,http://www.cosc.canterbury.ac.nz/mukundan,Bk5BJ80AAAAJ,0000-0000-0000-0000
 R. Padmavathy,National Inst. of Tech. Warangal,https://wsdc.nitw.ac.in/facultynew/facultyprofile/id/16345,QVuSh6EAAAAJ,0000-0000-0000-0000
 R. Ramanujam,IMSc,http://www.imsc.res.in/~jam,NOSCHOLARPAGE,0000-0000-0000-0000
 R. Rodrey Howell,Kansas State University,http://people.cs.ksu.edu/~rhowell,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -362,8 +362,8 @@ Ramtin Zand,University of South Carolina,https://sc.edu/study/colleges_schools/e
 Ramviyas Parasuraman,University of Georgia,https://cobweb.cs.uga.edu/~ramviyas,gmhcslQAAAAJ,0000-0001-5451-8209
 Ramya D. Shetty,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/RamyaShetty/_jcr_content.html,NOSCHOLARPAGE,0000-0003-3530-0102
 Ramya Korlakai Vinayak,University of Wisconsin - Madison,https://ramyakv.github.io,-dDKMgoAAAAJ,0000-0003-0248-9551
-Ramyaa,New Mexico Tech,https://www.cs.nmt.edu/~ramyaa,NOSCHOLARPAGE,0000-0000-0000-0000
 Ramyaa Ramyaa,New Mexico Tech,https://www.cs.nmt.edu/~ramyaa,NOSCHOLARPAGE,0000-0000-0000-0000
+Ramyaa,New Mexico Tech,https://www.cs.nmt.edu/~ramyaa,NOSCHOLARPAGE,0000-0000-0000-0000
 Ramzi A. Haraty,Lebanese American University,http://sas.lau.edu.lb/csm/people/rharaty.php,yHGvAkYAAAAJ,0000-0000-0000-0000
 Ramzi Ahmed Haraty,Lebanese American University,http://sas.lau.edu.lb/csm/people/rharaty.php,yHGvAkYAAAAJ,0000-0000-0000-0000
 Ran Ben Basat,University College London,https://www.bbasat.com,6G61qDwAAAAJ,0000-0003-0196-9190
@@ -405,8 +405,8 @@ Ranjay A. Krishna,University of Washington,http://www.ranjaykrishna.com/index.ht
 Ranjay Krishna,University of Washington,http://www.ranjaykrishna.com/index.html,IcqahyAAAAAJ,0000-0001-8784-2531
 Ranjit Jhala,Univ. of California - San Diego,https://ranjitjhala.github.io,H3wb878AAAAJ,0000-0002-1802-9421
 Ranjitha Kumar,Univ. of Illinois at Urbana-Champaign,https://cs.illinois.edu/directory/profile/ranjitha,5fiQ8-YAAAAJ,0009-0001-2107-1647
-Ranko Lazic,University of Warwick,https://warwick.ac.uk/fac/sci/dcs/people/ranko_lazic/biography,yGOk7boAAAAJ,0000-0000-0000-0000
 Ranko Lazic 0001,University of Warwick,https://warwick.ac.uk/fac/sci/dcs/people/ranko_lazic/biography,yGOk7boAAAAJ,0000-0000-0000-0000
+Ranko Lazic,University of Warwick,https://warwick.ac.uk/fac/sci/dcs/people/ranko_lazic/biography,yGOk7boAAAAJ,0000-0000-0000-0000
 Ranko S. Lazic,University of Warwick,https://warwick.ac.uk/fac/sci/dcs/people/ranko_lazic/biography,yGOk7boAAAAJ,0000-0000-0000-0000
 Rann Smorodinsky,Technion,https://web.iem.technion.ac.il/en/people/rann.html,ZAwAVJkAAAAJ,0000-0001-7447-5605
 Ransalu Senanayake,Arizona State University,https://search.asu.edu/profile/4843390,mmo0bDIAAAAJ,0000-0000-0000-0000
@@ -487,8 +487,8 @@ Ravishankar Ramanathan,University of Hong Kong,https://www.cs.hku.hk/index.php/p
 Raviv Raich,Oregon State University,http://web.engr.oregonstate.edu/~raich,NOSCHOLARPAGE,0000-0000-0000-0000
 Rawan Alghofaili,University of Texas at Dallas,https://rawanmg.com,5iCpo_8AAAAJ,0000-0001-6510-4562
 Ray-I Chang,National Taiwan University,http://homepage.ntu.edu.tw/~rayichang,YiqWyHkAAAAJ,0000-0000-0000-0000
-Rayford B. Vaughn,University of Alabama - Huntsville,https://www.uah.edu/images/research/ovpr/cvs/vaughn.pdf,UK-AZvMAAAAJ,0000-0000-0000-0000
 Rayford B. Vaughn Jr.,University of Alabama - Huntsville,https://www.uah.edu/images/research/ovpr/cvs/vaughn.pdf,UK-AZvMAAAAJ,0000-0000-0000-0000
+Rayford B. Vaughn,University of Alabama - Huntsville,https://www.uah.edu/images/research/ovpr/cvs/vaughn.pdf,UK-AZvMAAAAJ,0000-0000-0000-0000
 Rayid Ghani,Carnegie Mellon University,http://www.rayidghani.com,_ufWH4IAAAAJ,0000-0003-0235-1843
 Raymond A. Yeh,Purdue University,https://www.cs.purdue.edu/people/faculty/rayyeh.html,7HDE1ZwAAAAJ,0000-0003-4375-0680
 Raymond Bisdorff,University of Luxembourg,http://wwwen.uni.lu/studies/doctoral_education/contact/raymond_bisdorff,Vz4YXfcAAAAJ,0000-0000-0000-0000
@@ -496,8 +496,8 @@ Raymond Chi-Wing Wong,HKUST,http://www.cse.ust.hk/~raywong,IKgiD0AAAAAJ,0000-000
 Raymond D. Gumb,University of Massachusetts Lowell,http://www.cs.uml.edu/~gumb,NOSCHOLARPAGE,0000-0000-0000-0000
 Raymond Hu,Queen Mary University of London,https://www.qmul.ac.uk/eecs/people/profiles/huraymond.html,b08Zz1kAAAAJ,0000-0003-4361-6772
 Raymond J. Mooney,University of Texas at Austin,https://www.cs.utexas.edu/~mooney,p9RsPG4AAAAJ,0000-0000-0000-0000
-Raymond K. Wong,UNSW,http://www.cse.unsw.edu.au/~wong,h1zOnWUAAAAJ,0000-0000-0000-0000
 Raymond K. Wong 0001,UNSW,http://www.cse.unsw.edu.au/~wong,h1zOnWUAAAAJ,0000-0000-0000-0000
+Raymond K. Wong,UNSW,http://www.cse.unsw.edu.au/~wong,h1zOnWUAAAAJ,0000-0000-0000-0000
 Raymond Knopp,EURECOM,http://www.eurecom.fr/en/people/knopp-raymond,jE-78dsAAAAJ,0000-0000-0000-0000
 Raymond Kwok-Kay Wong,UNSW,http://www.cse.unsw.edu.au/~wong,h1zOnWUAAAAJ,0000-0000-0000-0000
 Raymond Laflamme,University of Waterloo,https://laflamme.iqc.uwaterloo.ca,UBusZfYAAAAJ,0000-0000-0000-0000
@@ -552,8 +552,8 @@ Rehab Duwairi,JUST,http://www.just.edu.jo/eportfolio/Pages/Default.aspx?email=re
 Rehab M. Duwairi,JUST,http://www.just.edu.jo/eportfolio/Pages/Default.aspx?email=rehab,J6lMBuEAAAAJ,0000-0000-0000-0000
 Reheem Beyah,Georgia Institute of Technology,https://rbeyah.ece.gatech.edu,KhnJQ20AAAAJ,0000-0000-0000-0000
 Reid Holmes,University of British Columbia,https://www.cs.ubc.ca/~rtholmes,i2jSMA8AAAAJ,0000-0003-4213-494X
-Reihaneh Rabbany,McGill University,http://www.reirab.com,Foh_c-QAAAAJ,0000-0003-2348-0353
 Reihaneh Rabbany Khorasgani,McGill University,http://www.reirab.com,Foh_c-QAAAAJ,0000-0000-0000-0000
+Reihaneh Rabbany,McGill University,http://www.reirab.com,Foh_c-QAAAAJ,0000-0003-2348-0353
 Reihaneh Safavi-Naini,University of Calgary,http://pages.cpsc.ucalgary.ca/~rei,SjZEzOYAAAAJ,0000-0000-0000-0000
 Reiji Suda,University of Tokyo,http://olab.is.s.u-tokyo.ac.jp/~reiji,NOSCHOLARPAGE,0000-0000-0000-0000
 Reimo Palm,University of Tartu,http://www.ut.ee/en/reimo-palm,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -663,8 +663,8 @@ Reuven Bar-Yehuda,Technion,http://www.cs.technion.ac.il/~reuven,NOSCHOLARPAGE,00
 Reuven Cohen,Technion,http://rcohen.cs.technion.ac.il,lYCzcUIAAAAJ,0000-0000-0000-0000
 Reyer Zwiggelaar,Aberystwyth University,https://www.aber.ac.uk/en/cs/staff-profiles/listing/profile/rrz,NZldyesAAAAJ,0000-0000-0000-0000
 Reyhan Aydogan,Özyeğin University,https://faculty.ozyegin.edu.tr/reyhanaydogan,sHL3j0kAAAAJ,0000-0000-0000-0000
-Reyhaneh Jabbarvand,Univ. of Illinois at Urbana-Champaign,http://reyhaneh.cs.illinois.edu,9gmW8MYAAAAJ,0000-0002-0668-8526
 Reyhaneh Jabbarvand Behrouz,Univ. of Illinois at Urbana-Champaign,http://reyhaneh.cs.illinois.edu,9gmW8MYAAAAJ,0000-0000-0000-0000
+Reyhaneh Jabbarvand,Univ. of Illinois at Urbana-Champaign,http://reyhaneh.cs.illinois.edu,9gmW8MYAAAAJ,0000-0002-0668-8526
 Reynold Bailey,Rochester Inst. of Technology,https://www.cs.rit.edu/~rjb,H_BCGA0AAAAJ,0000-0001-8964-9663
 Reynold C. K. Cheng,University of Hong Kong,https://i.cs.hku.hk/~ckcheng,7R7MSb4AAAAJ,0000-0002-9480-9809
 Reynold Cheng,University of Hong Kong,https://i.cs.hku.hk/~ckcheng,7R7MSb4AAAAJ,0000-0002-9480-9809
@@ -791,8 +791,8 @@ Richard Han 0001,University of Colorado Boulder,http://www.cs.colorado.edu/~rhan
 Richard Harper 0001,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/people/richard-harper,RGVGixkAAAAJ,0000-0001-8838-2012
 Richard Haverkamp,Massey University,http://www.massey.ac.nz/massey/expertise/profile.cfm?stref=627430,UanjyZMAAAAJ,0000-0000-0000-0000
 Richard Hughey,Univ. of California - Santa Cruz,https://www.soe.ucsc.edu/people/rph,D8iiWtEAAAAJ,0000-0000-0000-0000
-Richard J. Duro,University of A Coruña,https://pdi.udc.es/en/File/Pdi/RX99E,XhXX7ZkAAAAJ,0000-0002-6807-524X
 Richard J. Duro Fernandez,University of A Coruña,https://pdi.udc.es/en/File/Pdi/RX99E,XhXX7ZkAAAAJ,0000-0000-0000-0000
+Richard J. Duro,University of A Coruña,https://pdi.udc.es/en/File/Pdi/RX99E,XhXX7ZkAAAAJ,0000-0002-6807-524X
 Richard J. Enbody,Michigan State University,http://www.cse.msu.edu/~enbody,QR4VpsIAAAAJ,0000-0000-0000-0000
 Richard J. Samworth,University of Cambridge,https://www.statslab.cam.ac.uk/~rjs57,AmLUgFAAAAAJ,0000-0000-0000-0000
 Richard J. Trefler,University of Waterloo,https://cs.uwaterloo.ca/~trefler,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -886,9 +886,9 @@ Ritambhara Singh,Brown University,https://ritambharasingh.com,V6lRMxoAAAAJ,0000-
 Ritesh Ajoodha,University of the Witwatersrand,https://www.wits.ac.za/people/academic-a-z-listing/a/riteshajoodhawitsacza,LFCxjo4AAAAJ,0000-0002-6443-8592
 Rittika Shamsuddin,Oklahoma State University,https://ileadlab.okstate.edu,NOSCHOLARPAGE,0000-0002-5848-8630
 Ritu Chaturvedi,University of Guelph,https://www.uoguelph.ca/computing/people/ritu-chaturvedi,NOSCHOLARPAGE,0000-0000-0000-0000
-Rivalino Matias,UFU,http://www.facom.ufu.br/~rivalino,ldNItkAAAAAJ,0000-0000-0000-0000
 Rivalino Matias Jr.,UFU,http://www.facom.ufu.br/~rivalino,ldNItkAAAAAJ,0000-0000-0000-0000
 Rivalino Matias Júnior,UFU,http://www.facom.ufu.br/~rivalino,ldNItkAAAAAJ,0000-0000-0000-0000
+Rivalino Matias,UFU,http://www.facom.ufu.br/~rivalino,ldNItkAAAAAJ,0000-0000-0000-0000
 Rivka Levitan,CUNY,http://www.sci.brooklyn.cuny.edu/~levitan,BKeOMSkAAAAJ,0000-0000-0000-0000
 Riyadh Baghdadi,NYU Abu Dhabi,https://nyuad.nyu.edu/en/academics/divisions/science/faculty/riyadh-baghdadi.html,cVZZ7PAAAAAJ,0000-0002-9350-3998
 Riza Batista-Navarro,University of Manchester,http://www.cs.manchester.ac.uk/about-us/staff/profile/?ea=riza.batista,NOSCHOLARPAGE,0000-0001-6693-7531
@@ -916,9 +916,9 @@ Rob van der Goot,IT University of Copenhagen,https://robvanderg.github.io,lU4zpO
 Rob van der Mei,CWI,http://www.few.vu.nl/~mei,MTrV8cgAAAAJ,0000-0000-0000-0000
 Robbert Krebbers,Radboud University,http://robbertkrebbers.nl,8JmcliwAAAAJ,0000-0002-1185-5237
 Robbert van Renesse,Cornell University,https://www.cs.cornell.edu/home/rvr,uJbM58UAAAAJ,0000-0000-0000-0000
-Robby,Kansas State University,http://robby.santoslab.org,j5aiHcsAAAAJ,0000-0000-0000-0000
 Robby Bruce Findler,Northwestern University,https://www.eecs.northwestern.edu/~robby,eBqftc8AAAAJ,0000-0000-0000-0000
 Robby van Delden,University of Twente,https://research.utwente.nl/en/persons/bed2c5c1-0654-47ec-a4c7-7dafb0709b55,qlAMzzwAAAAJ,0000-0002-6592-1199
+Robby,Kansas State University,http://robby.santoslab.org,j5aiHcsAAAAJ,0000-0000-0000-0000
 Robert A. van Engelen,Florida State University,https://www.asee.org/public/conferences/32/papers/9523/view,6qaOBTMAAAAJ,0000-0000-0000-0000
 Robert A. van de Geijn,University of Texas at Austin,https://cs.utexas.edu/~rvdg,62GM5XcAAAAJ,0009-0004-6434-8492
 Robert Akl,University of North Texas,http://www.cse.unt.edu/~rakl/index.html,P5ZVxE0AAAAJ,0000-0000-0000-0000
@@ -945,8 +945,8 @@ Robert C. Williamson,University of Tübingen,https://uni-tuebingen.de/en/197812,
 Robert Cartwright,Rice University,https://www.cs.rice.edu/~cork/index.shtml,TtJeqqoAAAAJ,0000-0000-0000-0000
 Robert Craig Holte,University of Alberta,https://webdocs.cs.ualberta.ca/~holte,CXPlI08AAAAJ,0000-0000-0000-0000
 Robert D. Cameron,Simon Fraser University,http://www.cs.sfu.ca/~cameron,NOSCHOLARPAGE,0000-0000-0000-0000
-Robert D. Gregg,University of Michigan,https://gregg.engin.umich.edu,hEypYOEAAAAJ,0000-0002-0729-2857
 Robert D. Gregg IV,University of Michigan,https://gregg.engin.umich.edu,hEypYOEAAAAJ,0000-0000-0000-0000
+Robert D. Gregg,University of Michigan,https://gregg.engin.umich.edu,hEypYOEAAAAJ,0000-0002-0729-2857
 Robert D. Kent,University of Windsor,http://www.uwindsor.ca/science/computerscience/1037/dr-robert-kent,NOSCHOLARPAGE,0000-0000-0000-0000
 Robert D. Kleinberg,Cornell University,http://www.cs.cornell.edu/~rdk,zkvW8FQAAAAJ,0000-0002-8306-3407
 Robert D. Macredie,Brunel University London,https://www.brunel.ac.uk/people/robert-macredie,jdB84x8AAAAJ,0000-0000-0000-0000
@@ -958,8 +958,8 @@ Robert D. Tennent,Queen’s University,http://www.cs.queensu.ca/people/faculty.p
 Robert D. van der Mei,CWI,http://www.few.vu.nl/~mei,MTrV8cgAAAAJ,0000-0000-0000-0000
 Robert Dabrowski,University of Warsaw,https://www.facebook.com/public/Robert-Dabrowski/school/Warsaw-University-of-Technology-109438579082305,jJXYs6EAAAAJ,0000-0000-0000-0000
 Robert Duncan Macredie,Brunel University London,https://www.brunel.ac.uk/people/robert-macredie,jdB84x8AAAAJ,0000-0000-0000-0000
-Robert Dyer,University of Nebraska,https://go.unl.edu/rdyer,-tLiAa8AAAAJ,0000-0000-0000-0000
 Robert Dyer 0001,University of Nebraska,https://go.unl.edu/rdyer,-tLiAa8AAAAJ,0000-0001-9571-5567
+Robert Dyer,University of Nebraska,https://go.unl.edu/rdyer,-tLiAa8AAAAJ,0000-0000-0000-0000
 Robert E. Bodenheimer,Vanderbilt University,http://www.vuse.vanderbilt.edu/~bobbyb,hI4XguUAAAAJ,0000-0000-0000-0000
 Robert E. Fields,Middlesex University,http://www.cs.mdx.ac.uk/people/bob-fields,DrLWtAYAAAAJ,0000-0000-0000-0000
 Robert E. Hiromoto,University of Idaho,http://www.uidaho.edu/engr/departments/cs/our-people/faculty/robert-hiromoto,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -996,8 +996,8 @@ Robert Ian Davis,University of York,https://www-users.cs.york.ac.uk/~robdavis,xj
 Robert J. Brunner,Univ. of Illinois at Urbana-Champaign,http://www.astro.illinois.edu/people/bigdog,tL8qoFQAAAAJ,0000-0000-0000-0000
 Robert J. Fornaro,North Carolina State University,https://www.csc.ncsu.edu/people/fornaro,NOSCHOLARPAGE,0000-0000-0000-0000
 Robert J. Gaizauskas,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/rob-gaizauskas,HY8ATOgAAAAJ,0000-0002-3356-5126
-Robert J. Hammell,Towson University,https://www.towson.edu/fcsm/departments/computerinfosci/facultystaff/rhammell.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Robert J. Hammell II,Towson University,https://www.towson.edu/fcsm/departments/computerinfosci/facultystaff/rhammell.html,NOSCHOLARPAGE,0000-0000-0000-0000
+Robert J. Hammell,Towson University,https://www.towson.edu/fcsm/departments/computerinfosci/facultystaff/rhammell.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Robert J. Hendley,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/hendley-bob.aspx,9KywR_cAAAAJ,0000-0000-0000-0000
 Robert J. Hilderman,University of Regina,http://www.cs.uregina.ca/People/Profiles/RobertHilderman.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Robert J. K. Jacob,Tufts University,http://www.cs.tufts.edu/~jacob,NOSCHOLARPAGE,0000-0002-5983-7388
@@ -1030,8 +1030,8 @@ Robert Michael Kirby,University of Utah,https://www.cs.utah.edu/~kirby,IATz8BMAA
 Robert Michael Lewis,College of William and Mary,http://www.wm.edu/as/computerscience/faculty/lewis_rm.php,hdoSFx0AAAAJ,0000-0000-0000-0000
 Robert Michael Young,University of Utah,https://faculty.utah.edu/u6006841-ROBERT_MICHAEL_YOUNG/research/index.hml,HLz6zx4AAAAJ,0000-0000-0000-0000
 Robert Muller,Boston College,http://www.cs.bc.edu/~muller,NOSCHOLARPAGE,0000-0000-0000-0000
-Robert Mullins,University of Cambridge,https://www.cl.cam.ac.uk/~rdm34,zjXO2HMAAAAJ,0000-0000-0000-0000
 Robert Mullins 0001,University of Cambridge,https://www.cl.cam.ac.uk/~rdm34,zjXO2HMAAAAJ,0000-0002-8393-2748
+Robert Mullins,University of Cambridge,https://www.cl.cam.ac.uk/~rdm34,zjXO2HMAAAAJ,0000-0000-0000-0000
 Robert N. M. Watson,University of Cambridge,https://www.cl.cam.ac.uk/~rnw24,wAO9FfoAAAAJ,0000-0001-8139-8783
 Robert Nicholas Maxwell Watson,University of Cambridge,https://www.cl.cam.ac.uk/~rnw24,wAO9FfoAAAAJ,0000-0000-0000-0000
 Robert Nowak 0001,University of Wisconsin - Madison,http://nowak.ece.wisc.edu,fn13u8IAAAAJ,0000-0000-0000-0000
@@ -1099,8 +1099,8 @@ Roberto Grossi,University of Pisa,http://www.di.unipi.it/~grossi,IisGl48AAAAJ,00
 Roberto Guanciale,KTH Royal Inst. of Technology,http://www.csc.kth.se/~robertog,VZUWVp4AAAAJ,0000-0002-8069-6495
 Roberto Hirata Jr,USP,http://www.ime.usp.br/~hirata,Z6UgkRkAAAAJ,0000-0000-0000-0000
 Roberto Ierusalimschy,PUC-RIO,http://www.inf.puc-rio.br/~roberto,_pZgPlIAAAAJ,0000-0000-0000-0000
-Roberto M. Cesar,USP,http://www.ime.usp.br/~cesar,NOSCHOLARPAGE,0000-0000-0000-0000
 Roberto M. Cesar Jr.,USP,http://www.ime.usp.br/~cesar,NOSCHOLARPAGE,0000-0003-2701-4288
+Roberto M. Cesar,USP,http://www.ime.usp.br/~cesar,NOSCHOLARPAGE,0000-0000-0000-0000
 Roberto M. Negrini,Politecnico di Milano,http://www.deib.polimi.it/eng/people/details/474684,r8hwBOcAAAAJ,0000-0000-0000-0000
 Roberto Manduchi,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~manduchi,7YDSuZEAAAAJ,0000-0000-0000-0000
 Roberto Marcondes Cesar Jr.,USP,http://www.ime.usp.br/~cesar,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -1294,8 +1294,8 @@ Romina Spalazzese,Malmö University,https://www.rominaspalazzese.com,gXtk7Y0AAAA
 Romit Roy Choudhury,Univ. of Illinois at Urbana-Champaign,http://croy.web.engr.illinois.edu,dq2wG-AAAAAJ,0000-0000-0000-0000
 Ron Alterovitz,University of North Carolina,https://www.cs.unc.edu/~ron,NOSCHOLARPAGE,0000-0000-0000-0000
 Ron Baecker,University of Toronto,http://ron.taglab.ca,NOSCHOLARPAGE,0000-0000-0000-0000
-Ron Brachman,Cornell University,http://brachman.org,NOSCHOLARPAGE,0000-0000-0000-0000
 Ron Brachman [Tech],Cornell University,http://brachman.org,NOSCHOLARPAGE,0000-0000-0000-0000
+Ron Brachman,Cornell University,http://brachman.org,NOSCHOLARPAGE,0000-0000-0000-0000
 Ron Chrisley,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/476,9Cy00wEAAAAJ,0000-0000-0000-0000
 Ron Cytron,Washington University in St. Louis,https://www.cs.wustl.edu/~cytron,NOSCHOLARPAGE,0000-0000-0000-0000
 Ron Day,Indiana University,https://info.sice.indiana.edu/~roday,hJsSfQkAAAAJ,0000-0000-0000-0000
@@ -1372,6 +1372,7 @@ Rong Xie,Wuhan University,https://cs.whu.edu.cn/info/1019/2883.htm,NOSCHOLARPAGE
 Rong Zheng 0001,McMaster University,http://www.cas.mcmaster.ca/~rzheng,hO6xhakAAAAJ,0000-0003-4070-075X
 Rong-Hua Li,Beijing Institute of Technology,https://ronghuali.github.io,fOKGw-EAAAAJ,0000-0000-0000-0000
 Rong-Jaye Chen,National Chiao Tung University,http://www.cs.nctu.edu.tw/~rjchen,NOSCHOLARPAGE,0000-0000-0000-0000
+Rongfang Bie,Beijing Normal University,https://ai.bnu.edu.cn/xygk/szdw/zgj/4f7244011345405d8650f0d59bd1c812.htm,66EuHAUAAAAJ,0000-0000-0000-0000
 Rongfang Wang,Xidian University,https://web.xidian.edu.cn/rfwang,OSTHVJYAAAAJ,0000-0000-0000-0000
 Ronghua Shang,Xidian University,https://web.xidian.edu.cn/rhshang,SYcWIJEAAAAJ,0000-0000-0000-0000
 Ronghua Shi,Central South University,https://faculty.csu.edu.cn/shironghua/zh_CN/index.htm,NOSCHOLARPAGE,0000-0000-0000-0000

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -220,8 +220,8 @@ Samuel Fiorini,Université libre de Bruxelles,http://homepages.ulb.ac.be/~sfiori
 Samuel Hopkins 0001,Massachusetts Inst. of Technology,https://www.samuelbhopkins.com,E_a3VB4AAAAJ,0000-0000-0000-0000
 Samuel Horváth,MBZUAI,https://mbzuai.ac.ae/study/faculty/samuel-horvath,k252J7kAAAAJ,0000-0000-0000-0000
 Samuel Hym,CRIStAL,https://www.cristal.univ-lille.fr/profil/hym,NOSCHOLARPAGE,0000-0000-0000-0000
-Samuel J. Lomonaco,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~lomonaco,0PMb9xcAAAAJ,0000-0000-0000-0000
 Samuel J. Lomonaco Jr.,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~lomonaco,0PMb9xcAAAAJ,0000-0000-0000-0000
+Samuel J. Lomonaco,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~lomonaco,0PMb9xcAAAAJ,0000-0000-0000-0000
 Samuel Kadoury,Polytechnique Montreal,https://www.polymtl.ca/expertises/en/kadoury-samuel,HOov_S8AAAAJ,0000-0000-0000-0000
 Samuel Kaski,Aalto University,https://users.ics.aalto.fi/sami,uF6H9jMAAAAJ,0000-0000-0000-0000
 Samuel Kounev,University of Würzburg,https://se.informatik.uni-wuerzburg.de/software-engineering-group/staff/samuel-kounev,1iN71-YAAAAJ,0000-0000-0000-0000
@@ -296,8 +296,8 @@ Sandy Gould,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles
 Sandy Irani,Univ. of California - Irvine,https://www.ics.uci.edu/~irani,dBhm_oIAAAAJ,0000-0000-0000-0000
 Sandy J. J. Gould,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/gould-sandy.aspx,DF7FgAQAAAAJ,0000-0003-0476-4270
 Sanem Kabadayi,Istanbul Technical University,http://web.itu.edu.tr/kabadayi,NOSCHOLARPAGE,0000-0000-0000-0000
-Sanem Sariel,Istanbul Technical University,http://web.itu.edu.tr/sariel,Fw0RC2IAAAAJ,0000-0003-2993-6681
 Sanem Sariel Talay,Istanbul Technical University,http://web.itu.edu.tr/sariel,Fw0RC2IAAAAJ,0000-0000-0000-0000
+Sanem Sariel,Istanbul Technical University,http://web.itu.edu.tr/sariel,Fw0RC2IAAAAJ,0000-0003-2993-6681
 Sang Ho Yoon,KAIST,https://hcitech.org,ejaRQn8AAAAJ,0000-0002-3780-5350
 Sang Kil Cha,KAIST,http://softsec.kaist.ac.kr/~sangkilc,kV40DzcAAAAJ,0000-0002-6012-7228
 Sang Lyul Min,Seoul National University,http://archi.snu.ac.kr/symin,U4ewRr0AAAAJ,0000-0000-0000-0000
@@ -336,8 +336,8 @@ Sanjam Garg,Univ. of California - Berkeley,http://www.cs.berkeley.edu/~sanjamg,m
 Sanjay Bhattacherjee,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/sanjay.bhattacherjee,rpUwbWIAAAAJ,0000-0002-3367-6192
 Sanjay G. Rao,Purdue University,https://engineering.purdue.edu/~sanjay,v_uxLhgAAAAJ,0000-0003-4825-4352
 Sanjay Jain 0001,National University of Singapore,https://www.comp.nus.edu.sg/~sanjay,PYOH-4kAAAAJ,0000-0001-6798-8330
-Sanjay Jha,UNSW,http://www.cse.unsw.edu.au/~sjha,Hiv2PjEAAAAJ,0000-0000-0000-0000
 Sanjay Jha 0001,UNSW,http://www.cse.unsw.edu.au/~sjha,Hiv2PjEAAAAJ,0000-0002-1844-1520
+Sanjay Jha,UNSW,http://www.cse.unsw.edu.au/~sjha,Hiv2PjEAAAAJ,0000-0000-0000-0000
 Sanjay K. Bose,Plaksha University,https://user.plaksha.edu.in/sanjay-bose,BR6HchkAAAAJ,0000-0000-0000-0000
 Sanjay K. Jha,UNSW,http://www.cse.unsw.edu.au/~sjha,Hiv2PjEAAAAJ,0000-0002-1844-1520
 Sanjay K. Sahay,BITS Pilani-Goa,https://www.bits-pilani.ac.in/goa/ssahay/profile,i6lSvKEAAAAJ,0000-0000-0000-0000
@@ -392,8 +392,8 @@ Santanu Kumar Dash 0001,Royal Holloway Univ. of London,https://pure.royalhollowa
 Santhosh Kamath,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/santhosh-kamath/_jcr_content.html,1JciSa8AAAAJ,0000-0002-1956-1727
 Santhosha Rao,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/santhosha-rao/_jcr_content.html,NOSCHOLARPAGE,0000-0001-9511-3048
 Santhoshini Velusamy,University of Waterloo,https://uwaterloo.ca/computer-science/contacts/santhoshini-velusamy,GpxRFs4AAAAJ,0000-0002-0294-5425
-Santi Ontañón,Drexel University,http://drexel.edu/cci/contact/Faculty/Ontanon-Santiago,aS-DrOwAAAAJ,0000-0000-0000-0000
 Santi Ontañón Villar,Drexel University,http://drexel.edu/cci/contact/Faculty/Ontanon-Santiago,aS-DrOwAAAAJ,0000-0000-0000-0000
+Santi Ontañón,Drexel University,http://drexel.edu/cci/contact/Faculty/Ontanon-Santiago,aS-DrOwAAAAJ,0000-0000-0000-0000
 Santiago Ceria,University of Buenos Aires,https://twitter.com/santiagoceria?lang=en,NOSCHOLARPAGE,0000-0000-0000-0000
 Santiago Chumbe,Heriot-Watt University,https://researchportal.hw.ac.uk/en/persons/santiago-segundo-chumbe,4zoTdQMAAAAJ,0000-0000-0000-0000
 Santiago Figueira,University of Buenos Aires,http://www.glyc.dc.uba.ar/santiago,WzLmB-4AAAAJ,0000-0000-0000-0000
@@ -457,8 +457,8 @@ Sarah Pink,Monash University,https://research.monash.edu/en/persons/sarah-pink,f
 Sarah Preum,Dartmouth College,https://web.cs.dartmouth.edu/people/sarah-masud-preum,TyO23NgAAAAJ,0000-0002-7771-8323
 Sarah Scheffler,Carnegie Mellon University,https://www.sarahscheffler.net,YPq45Q0AAAAJ,0000-0003-1202-7502
 Sarah Sebo,University of Chicago,https://sarahsebo.com,6gWYMigAAAAJ,0000-0003-2211-6429
-Sarah Strohkorb,University of Chicago,https://sarahsebo.com,6gWYMigAAAAJ,0000-0000-0000-0000
 Sarah Strohkorb Sebo,University of Chicago,https://sarahsebo.com,6gWYMigAAAAJ,0000-0000-0000-0000
+Sarah Strohkorb,University of Chicago,https://sarahsebo.com,6gWYMigAAAAJ,0000-0000-0000-0000
 Sarah Wiegreffe,Univ. of Maryland - College Park,https://www.cs.umd.edu/people/sarahwie,YoR3IugAAAAJ,0000-0000-0000-0000
 Sarah Wiseman,Goldsmiths University of London,https://www.gold.ac.uk/computing/people/wiseman-sarah,NdRUEYIAAAAJ,0000-0000-0000-0000
 Sarah Zelikovitz,CUNY,http://www.cs.csi.cuny.edu/~zelikovi,JJvTMLsAAAAJ,0000-0000-0000-0000
@@ -557,8 +557,8 @@ Sayak Ray Chowdhury,IIT Kanpur,https://sites.google.com/view/sayakraychowdhury/h
 Sayak Saha Roy,Louisiana State University,https://www.lsu.edu/eng/cse/people/faculty/saha-roy.php,WwR6ZPQAAAAJ,0000-0000-0000-0000
 Sayako Shimizu,National Inst. of Informatics,https://www.nii.ac.jp/en/faculty/architecture/sayako_shimizu,NOSCHOLARPAGE,0000-0000-0000-0000
 Sayan Bhattacharya,University of Warwick,https://www.dcs.warwick.ac.uk/~u1671158,ca-urkIAAAAJ,0000-0003-1612-0296
-Sayan Mitra,Univ. of Illinois at Urbana-Champaign,http://mitras.ece.illinois.edu,dXUl8ewAAAAJ,0000-0000-0000-0000
 Sayan Mitra 0001,Univ. of Illinois at Urbana-Champaign,https://mitras.ece.illinois.edu/index.html,dXUl8ewAAAAJ,0000-0001-7082-5516
+Sayan Mitra,Univ. of Illinois at Urbana-Champaign,http://mitras.ece.illinois.edu,dXUl8ewAAAAJ,0000-0000-0000-0000
 Sayan Mukherjee 0001,University of Leipzig,https://sayanmuk.github.io,YPD04uIAAAAJ,0000-0002-6715-3920
 Sayan Ranu,IIT Delhi,http://www.cse.iitd.ac.in/~sayan,K4w5qYUAAAAJ,0000-0003-4147-9372
 Sayan Sarcar,University of Tsukuba,https://sayansarcar.github.io/index.html,bIkNGO4AAAAJ,0009-0003-1052-4633
@@ -688,8 +688,8 @@ Sebastijan Dumančić,TU Delft,https://sebdumancic.github.io,besOUicAAAAJ,0000-0
 Sebastián Uchitel,University of Buenos Aires,http://lafhis.dc.uba.ar/en/~suchitel,v-rnR5UAAAAJ,0000-0001-9352-1478
 Sebastián Urrutia,UFMG,http://homepages.dcc.ufmg.br/~surrutia,mPBETD0AAAAJ,0000-0000-0000-0000
 Sebti Foufou,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/Sebti.php,E-8Pz2IAAAAJ,0000-0002-3555-9125
-Seda Ogrenci,Northwestern University,http://users.eecs.northwestern.edu/~seda,dojdbWYAAAAJ,0000-0000-0000-0000
 Seda Ogrenci Memik,Northwestern University,http://users.eecs.northwestern.edu/~seda,dojdbWYAAAAJ,0000-0001-8327-9585
+Seda Ogrenci,Northwestern University,http://users.eecs.northwestern.edu/~seda,dojdbWYAAAAJ,0000-0000-0000-0000
 Seda Ogrenci-Memik,Northwestern University,http://users.eecs.northwestern.edu/~seda,dojdbWYAAAAJ,0000-0000-0000-0000
 Sedat Akleylek,University of Tartu,https://sites.google.com/a/bil.omu.edu.tr/akleylek,plpKMjkAAAAJ,0000-0000-0000-0000
 Sedat Ozer,Özyeğin University,http://www.sedatozer.com,G8rbKi4AAAAJ,0000-0002-2069-3807
@@ -725,8 +725,8 @@ Sen Lin 0001,University of Houston,https://slin70.github.io,94-TbUsAAAAJ,0000-00
 Sen Su,BUPT,https://int.bupt.edu.cn/content/content.php?p=6_16_95,JaDhAfsAAAAJ,0000-0003-4266-7527
 Sencun Zhu,Pennsylvania State University,http://www.cse.psu.edu/~sxz16,5qwfn20AAAAJ,0000-0000-0000-0000
 Sendong Zhao,Harbin Institute of Technology,http://homepage.hit.edu.cn/stanzhao,ZtIhRvwAAAAJ,0000-0002-4676-1812
-Senem Velipasalar,Syracuse University,http://eng-cs.syr.edu/our-departments/electrical-engineering-and-computer-science/people/faculty,HEAE9XsAAAAJ,0000-0000-0000-0000
 Senem Velipasalar Gursoy,Syracuse University,http://eng-cs.syr.edu/our-departments/electrical-engineering-and-computer-science/people/faculty,HEAE9XsAAAAJ,0000-0000-0000-0000
+Senem Velipasalar,Syracuse University,http://eng-cs.syr.edu/our-departments/electrical-engineering-and-computer-science/people/faculty,HEAE9XsAAAAJ,0000-0000-0000-0000
 Senjuti Basu Roy,NJIT,https://web.njit.edu/~senjutib,O125w4cAAAAJ,0000-0003-3475-8138
 Sennur Ulukus,Univ. of Maryland - College Park,http://www.cyber.umd.edu/faculty/ulukus,nTG_TQMAAAAJ,0000-0000-0000-0000
 Senzhang Wang,Central South University,https://senzhangwangcsu.github.io/index.html,zdWyGRMAAAAJ,0000-0002-3615-4859
@@ -788,8 +788,8 @@ Sergey M. Plis,Georgia State University,https://trendscenter.org/sergey-plis,nm3
 Sergey Mechtaev,University College London,http://mechtaev.com,XTFR93cAAAAJ,0000-0001-6088-4993
 Sergey O. Kuznetsov,HSE University,https://www.hse.ru/staff/skuznetsov,PK5Qz0cAAAAJ,0000-0000-0000-0000
 Sergey Sosnovsky,Utrecht University,http://www.staff.science.uu.nl/~sosno002,91gXaZUAAAAJ,0000-0000-0000-0000
-Sergio Alvarez,Boston College,http://www.cs.bc.edu/~alvarez,X8_J4FEAAAAJ,0000-0000-0000-0000
 Sergio Alvarez Pardo,Boston College,http://www.cs.bc.edu/~alvarez,X8_J4FEAAAAJ,0000-0000-0000-0000
+Sergio Alvarez,Boston College,http://www.cs.bc.edu/~alvarez,X8_J4FEAAAAJ,0000-0000-0000-0000
 Sergio Bampi,UFRGS,http://inf.ufrgs.br/gme,emFRxDUAAAAJ,0000-0002-9018-6309
 Sergio De Agostino,Sapienza University of Rome,http://twiki.di.uniroma1.it/twiki/view/Users/SergioDeAgostino,lll7oscAAAAJ,0000-0000-0000-0000
 Sergio F. Ochoa,Universidad de Chile,https://www.dcc.uchile.cl/sochoa,aUtukf4AAAAJ,0000-0000-0000-0000
@@ -815,8 +815,8 @@ Seth Flaxman,University of Oxford,https://www.cs.ox.ac.uk/people/seth.flaxman,Wn
 Seth Frey,Univ. of California - Davis,https://cs.ucdavis.edu/directory/seth-frey,DO4uc-kAAAAJ,0000-0002-5298-5089
 Seth Gilbert,National University of Singapore,http://www.comp.nus.edu.sg/~gilbert,bKN3mSsAAAAJ,0000-0003-3298-7412
 Seth Holladay,Brigham Young University,https://cs.byu.edu/faculty/srh43,FLK47OIAAAAJ,0000-0000-0000-0000
-Seth Hutchinson,Northeastern University,https://www.khoury.northeastern.edu/people/seth-hutchinson,-JPZ21IAAAAJ,0000-0000-0000-0000
 Seth Hutchinson 0001,Northeastern University,https://www.khoury.northeastern.edu/people/seth-hutchinson,-JPZ21IAAAAJ,0000-0002-3949-6061
+Seth Hutchinson,Northeastern University,https://www.khoury.northeastern.edu/people/seth-hutchinson,-JPZ21IAAAAJ,0000-0000-0000-0000
 Seth Lewis Gilbert,National University of Singapore,http://www.comp.nus.edu.sg/~gilbert,bKN3mSsAAAAJ,0000-0003-3298-7412
 Seth Pettie,University of Michigan,http://web.eecs.umich.edu/~pettie,ao_EFbUAAAAJ,0000-0002-2610-1630
 Seth Poulsen,Utah State University,https://www.usu.edu/cs/directory/faculty/poulsen-seth,yoEvwpsAAAAJ,0000-0001-6284-9972
@@ -883,8 +883,8 @@ Shabnam Kasra Kermanshahi,RMIT University,https://www.rmit.edu.au/contact/staff-
 Shachar Itzhaky,Technion,https://csaws.cs.technion.ac.il/~shachari,U7MFtRwAAAAJ,0000-0002-7276-7644
 Shachar Lovett,Univ. of California - San Diego,http://cseweb.ucsd.edu/~slovett,f6JF7BkAAAAJ,0000-0003-4552-1443
 Shachi Sharma,South Asian University,http://sau.int/faculty/faculty-profile.html?staff_id=87,TltIxw8AAAAJ,0000-0000-0000-0000
-Shadan Sadeghian,University of Siegen,https://www.mediacoop.uni-siegen.de/de/personen/sadedhian-shadan,DYGZQO0AAAAJ,0000-0002-8590-656X
 Shadan Sadeghian Borojeni,University of Siegen,https://www.mediacoop.uni-siegen.de/de/personen/sadedhian-shadan,DYGZQO0AAAAJ,0000-0000-0000-0000
+Shadan Sadeghian,University of Siegen,https://www.mediacoop.uni-siegen.de/de/personen/sadedhian-shadan,DYGZQO0AAAAJ,0000-0002-8590-656X
 Shadan Sadeghianborojeni,University of Siegen,https://www.mediacoop.uni-siegen.de/de/personen/sadedhian-shadan,DYGZQO0AAAAJ,0000-0000-0000-0000
 Shaddi Hasan,Virginia Tech,https://people.cs.vt.edu/shaddi,IHburiYAAAAJ,0000-0001-5432-6952
 Shaddin Dughmi,University of Southern California,https://viterbi-web.usc.edu/~shaddin,jn-B_MoAAAAJ,0000-0002-2784-1868
@@ -907,8 +907,8 @@ Shahed Khan Mohammed,UNC - Charlotte,https://ece.charlotte.edu/directory/dr-shah
 Shahedur Rahman,Middlesex University,http://www.cs.mdx.ac.uk/people/shahedur-rahman,NOSCHOLARPAGE,0000-0000-0000-0000
 Shaheen Fatima,Loughborough University,https://www.lboro.ac.uk/departments/compsci/staff/academic-teaching/shaheen-fatima,KqRKHv4AAAAJ,0000-0000-0000-0000
 Shahid Raza,University of Glasgow,https://www.gla.ac.uk/schools/computing/staff/shahidraza,ivYcvvoAAAAJ,0000-0001-8192-0893
-Shahin Jabbari,Drexel University,https://shahin-jabbari.github.io,h60zIiUAAAAJ,0000-0000-0000-0000
 Shahin Jabbari Arfaee,Drexel University,https://shahin-jabbari.github.io,h60zIiUAAAAJ,0000-0000-0000-0000
+Shahin Jabbari,Drexel University,https://shahin-jabbari.github.io,h60zIiUAAAAJ,0000-0000-0000-0000
 Shahin Kamali,University of Manitoba,http://www.cs.umanitoba.ca/~kamalis,hQXlVLsAAAAJ,0000-0003-1404-2212
 Shahram Ghandeharizadeh,University of Southern California,https://www.flslab.org,FI5-sZEAAAAJ,0000-0002-1792-7879
 Shahram ShahbazPanahi,Ontario Tech University,https://engineering.ontariotechu.ca/people/ecse/shahram.shahbazpanahi.php,-kZ8x08AAAAJ,0000-0000-0000-0000
@@ -1116,6 +1116,7 @@ Shengjie Zhao,Tongji University,https://sse.tongji.edu.cn/Data/View/3914,NOSCHOL
 Shengli Liu 0001,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/PeopleDetail.aspx?id=96,bd8fPdsAAAAJ,0000-0003-1366-8256
 Shenglin Gui,UESTC,https://www.en.scse.uestc.edu.cn/info/1085/2076.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Shenglin Zhang,Nankai University,https://nkcs.iops.ai/shenglinzhang,be0_960AAAAJ,0000-0003-0330-0028
+Shengling Wang 0001,Beijing Normal University,https://ai.bnu.edu.cn/xygk/szdw/zgj/428ee4daffca472d81f3104c52dc40a2.htm,PnFUA5wAAAAJ,0000-0000-0000-0000
 Shengping Zhang,Harbin Institute of Technology,http://homepage.hit.edu.cn/zhangshengping,hMNsT8sAAAAJ,0000-0001-5200-3420
 Shengpu Tang,Emory University,https://shengpu-tang.me,a_z5a5wAAAAJ,0000-0000-0000-0000
 Shengru Tu,University of New Orleans,http://new.uno.edu/profile/faculty/shengru_tu,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -1332,8 +1333,8 @@ Shuai Li 0001,Beihang University,http://scse.buaa.edu.cn/info/1024/3022.htm,NOSC
 Shuai Li 0010,Shanghai Jiao Tong University,https://shuaili8.github.io,kMZgQxcAAAAJ,0000-0002-3935-0708
 Shuai Lü 0001,Jilin University,https://ccst.jlu.edu.cn/info/1367/19944.htm,S1T_HV0AAAAJ,0000-0002-8081-4498
 Shuai Ma 0001,Beihang University,http://mashuai.buaa.edu.cn,vJUjFpQAAAAJ,0000-0002-4050-0443
-Shuai Mu,Stony Brook University,http://mpaxos.com,wcbyR5UAAAAJ,0000-0000-0000-0000
 Shuai Mu 0001,Stony Brook University,http://mpaxos.com,wcbyR5UAAAAJ,0000-0001-8244-2109
+Shuai Mu,Stony Brook University,http://mpaxos.com,wcbyR5UAAAAJ,0000-0000-0000-0000
 Shuai Shao 0001,USTC,http://staff.ustc.edu.cn/~wwwucuc,Lh-UKzcAAAAJ,0000-0003-0935-2929
 Shuai Wang 0011,HKUST,https://home.cse.ust.hk/~shuaiw,POlWWAsAAAAJ,0000-0002-0866-0308
 Shuai Wang 0016,Nanjing University,https://shuaiwang-nju.github.io,vW1ZaucAAAAJ,0000-0000-0000-0000
@@ -1464,7 +1465,6 @@ Sichao Li,City University of Macau,https://fds.cityu.edu.mo/en/members/461,ylZQz
 Sicong Liu,NWPU,https://sicongliu-deep.github.io,_maZt1AAAAAJ,0000-0000-0000-0000
 Sicun Gao,Univ. of California - San Diego,https://scungao.github.io,UmyrEtcAAAAJ,0000-0000-0000-0000
 Sid Ray,Monash University,http://users.monash.edu/~sid/shadowfax,NOSCHOLARPAGE,0000-0000-0000-0000
-Siddharth,Plaksha University,https://ssiddharth.in/about-me,M3zP9NEAAAAJ,0000-0000-0000-0000
 Siddharth Barman,IISc Bangalore,http://www.csa.iisc.ac.in/~barman,HcGQSKIAAAAJ,0000-0001-9276-2181
 Siddharth Garg,New York University,http://engineering.nyu.edu/people/siddharth-garg,Yf8OqQQAAAAJ,0000-0002-6158-9512
 Siddharth Gupta 0002,BITS Pilani-Goa,https://guptasid.bitbucket.io,B_2PPFgAAAAJ,0000-0000-0000-0000
@@ -1472,6 +1472,7 @@ Siddharth Joshi 0001,University of Notre Dame,http://isn.ucsd.edu/~siddharth,Peg
 Siddharth Kaza,Towson University,https://www.towson.edu/fcsm/departments/computerinfosci/facultystaff/skaza.html,xj0-4yQAAAAJ,0000-0000-0000-0000
 Siddharth Krishnan,UNC - Charlotte,https://webpages.uncc.edu/~skrish21,I8HrLhQAAAAJ,0000-0000-0000-0000
 Siddharth Srivastava 0001,Arizona State University,http://siddharthsrivastava.net,H3ZnCqYAAAAJ,0000-0002-5217-2790
+Siddharth,Plaksha University,https://ssiddharth.in/about-me,M3zP9NEAAAAJ,0000-0000-0000-0000
 Siddhartha Banerjee,Cornell University,https://people.orie.cornell.edu/sbanerjee,_kqpoHIAAAAJ,0000-0002-8954-4578
 Siddhartha Jayanti,Dartmouth College,https://sites.google.com/view/siddhartha-jayanti,NKDBBGkAAAAJ,0000-0002-2681-1632
 Siddhartha Sarma,IIT Mandi,http://faculty.iitmandi.ac.in/~siddhartha/index.html,c-oFx5UAAAAJ,0000-0000-0000-0000
@@ -1510,8 +1511,8 @@ Silvia Regina Vergilio,UFPR,https://www.inf.ufpr.br/silvia,2bkThnAAAAAJ,0000-000
 Silvia S. C. Botelho,Federal University of Rio Grande,http://www.silviacb.c3.furg.br,XKt2OlEAAAAJ,0000-0002-8857-0221
 Silvia Santini,Università della Svizzera italiana,https://tu-dresden.de/die_tu_dresden/fakultaeten/fakultaet_informatik/tei/es/mitarbeiter/silvia-santini,RjTLqRwAAAAJ,0000-0002-0882-2004
 Silvia Silva da Costa Botelho,Federal University of Rio Grande,http://www.silviacb.c3.furg.br,XKt2OlEAAAAJ,0000-0002-8857-0221
-Silvia Takahashi,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/stakahas/es/inicio,x7gjZ04AAAAJ,0000-0000-0000-0000
 Silvia Takahashi Rodríguez,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/stakahas/es/inicio,x7gjZ04AAAAJ,0000-0000-0000-0000
+Silvia Takahashi,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/stakahas/es/inicio,x7gjZ04AAAAJ,0000-0000-0000-0000
 Silvina L. Ferradal,Indiana University,https://luddy.indiana.edu/contact/profile/?Silvina_Ferradal,2JcHy3wAAAAJ,0000-0000-0000-0000
 Silvio Amir,Northeastern University,https://www.khoury.northeastern.edu/people/silvio-amir,jhUQvC0AAAAJ,0000-0000-0000-0000
 Silvio Meira 0001,UFPE,https://www.cin.ufpe.br/~srlm,ycIwxqsAAAAJ,0000-0000-0000-0000
@@ -1661,8 +1662,8 @@ Sivaraman Balakrishnan,Carnegie Mellon University,http://www.stat.cmu.edu/~siva,
 Sivaraman K. Anirudh,New York University,https://cs.nyu.edu/~anirudh,z9em5msAAAAJ,0000-0000-0000-0000
 Siwei Feng,Soochow University,http://web.suda.edu.cn/fsw,_7xkHz8AAAAJ,0000-0000-0000-0000
 Siwei Lyu,University at Buffalo,https://cse.buffalo.edu/~siweilyu,wefAEM4AAAAJ,0000-0000-0000-0000
-Siwei Ma,Peking University,http://idm.pku.edu.cn/staff/masiwei/masiwei.htm,y3YqlaUAAAAJ,0000-0000-0000-0000
 Siwei Ma 0001,Peking University,https://cs.pku.edu.cn/info/1236/2106.htm,y3YqlaUAAAAJ,0000-0002-2731-5403
+Siwei Ma,Peking University,http://idm.pku.edu.cn/staff/masiwei/masiwei.htm,y3YqlaUAAAAJ,0000-0000-0000-0000
 Siwei Tan,Zhejiang University,http://person.zju.edu.cn/tansiwei,Wj7H4EUAAAAJ,0000-0002-0634-8089
 Siyao Guo,NYU Shanghai,https://sites.google.com/site/siyaoguo,nscLxl4AAAAJ,0009-0008-3664-3928
 Siyi Lv,Nankai University,https://cc.nankai.edu.cn/2021/0323/c13620a570392/page.htm,RbowLSoAAAAJ,0009-0007-1857-5186
@@ -1764,8 +1765,8 @@ Songul Albayrak,Yıldız Technical University,https://www.ce.yildiz.edu.tr/perso
 Songwu Lu,Univ. of California - Los Angeles,http://www.cs.ucla.edu/~slu,PVdTviYAAAAJ,0000-0003-3779-0918
 Songze Li,Southeast University,https://cyber.seu.edu.cn/lsz/list.htm,vcGuNDYAAAAJ,0000-0003-4282-3307
 Songül Albayrak,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/songul?lang=en,LF5HfgEAAAAJ,0000-0000-0000-0000
-Songül Varli,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/songul?lang=en,LF5HfgEAAAAJ,0000-0000-0000-0000
 Songül Varli Albayrak,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/songul?lang=en,LF5HfgEAAAAJ,0000-0000-0000-0000
+Songül Varli,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/songul?lang=en,LF5HfgEAAAAJ,0000-0000-0000-0000
 Sonia Berman,University of Cape Town,https://www.cs.uct.ac.za/research/research-interests-sonia-berman,NOSCHOLARPAGE,0000-0000-0000-0000
 Sonia Chernova,Georgia Institute of Technology,http://www.cc.gatech.edu/~chernova,EYo_WkEAAAAJ,0000-0001-6320-0825
 Sonia Chiasson,Carleton University,https://carleton.ca/scs/people/sonia-chiasson,wg8yZz8AAAAJ,0000-0000-0000-0000
@@ -1824,8 +1825,8 @@ Soumaya Cherkaoui,Polytechnique Montreal,https://www.polymtl.ca/expertises/en/ch
 Soumen Chakrabarti,IIT Bombay,https://www.cse.iitb.ac.in/~soumen,LfF2zfQAAAAJ,0000-0000-0000-0000
 Soumitra Roy Joy,UNC - Charlotte,https://ece.charlotte.edu/people/soumitra-r-joy-ph-d,sBjj4LgAAAAJ,0000-0000-0000-0000
 Soumya Dutta,IIT Kanpur,https://soumyadutta-cse.github.io,7CGMUB8AAAAJ,0000-0001-5030-9979
-Soumya K. Ghosh,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ,0000-0000-0000-0000
 Soumya K. Ghosh 0001,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ,0000-0000-0000-0000
+Soumya K. Ghosh,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ,0000-0000-0000-0000
 Soumya Kanti Ghosh 0001,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ,0000-0000-0000-0000
 Soumya Ray,Case Western Reserve University,http://engr.case.edu/ray_soumya,T3Wxu_AAAAAJ,0000-0002-7497-3281
 Soumyabrata Dev,University College Dublin,https://people.ucd.ie/soumyabrata.dev,_akXw8IAAAAJ,0000-0000-0000-0000
@@ -2473,8 +2474,8 @@ Sukumar Nandi,IIT Guwahati,https://www.iitg.ernet.in/sukumar,ChtruacAAAAJ,0000-0
 Sukyoung Lee,Yonsei University,http://winet.yonsei.ac.kr/home/professor,NOSCHOLARPAGE,0000-0002-3497-3295
 Sukyoung Ryu,KAIST,http://plrg.kaist.ac.kr/ryu,c98U5D0AAAAJ,0000-0002-0019-9772
 Sulamita Klein,UFRJ,http://www.cos.ufrj.br/index.php/pt-BR/pessoas/details/18/1054-sula,r4ZrGiIAAAAJ,0000-0000-0000-0000
-Sule Gündüz,Istanbul Technical University,http://web.itu.edu.tr/sgunduz,E5OlkJMAAAAJ,0000-0000-0000-0000
 Sule Gündüz Ögüdücü,Istanbul Technical University,http://web.itu.edu.tr/sgunduz,E5OlkJMAAAAJ,0000-0000-0000-0000
+Sule Gündüz,Istanbul Technical University,http://web.itu.edu.tr/sgunduz,E5OlkJMAAAAJ,0000-0000-0000-0000
 Sule Ögüdücü,Istanbul Technical University,http://web.itu.edu.tr/sgunduz,E5OlkJMAAAAJ,0000-0000-0000-0000
 Suleman Shahid,LUMS,https://lums.edu.pk/lums_employee/4407,NOSCHOLARPAGE,0000-0000-0000-0000
 Suleyman Tosun,Hacettepe University,https://web.cs.hacettepe.edu.tr/~stosun,IiZP05YAAAAJ,0000-0000-0000-0000
@@ -2511,8 +2512,8 @@ Sun Kim,Seoul National University,http://biohealth.snu.ac.kr,lI_oWS8AAAAJ,0000-0
 Sun-Teck Tan,National University of Singapore,http://www.comp.nus.edu.sg/about/depts/cs/faculty,NOSCHOLARPAGE,0000-0000-0000-0000
 Sun-Yuan Hsieh,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/depmember/teacherdetail/id/15,xTcr9DoAAAAJ,0000-0000-0000-0000
 Sunbeom So,Korea University,https://ku-formal.github.io,UTug1PgAAAAJ,0009-0000-7005-1928
-Suncica Hadzidedic,Durham University,https://www.dur.ac.uk/computer.science/staff/profile/?id=18580,RYJDV5cAAAAJ,0000-0000-0000-0000
 Suncica Hadzidedic Bazdarevic,Durham University,https://www.dur.ac.uk/computer.science/staff/profile/?id=18580,RYJDV5cAAAAJ,0000-0000-0000-0000
+Suncica Hadzidedic,Durham University,https://www.dur.ac.uk/computer.science/staff/profile/?id=18580,RYJDV5cAAAAJ,0000-0000-0000-0000
 Sundar Balasubramaniam,BITS Pilani,http://www.bits-pilani.ac.in/pilani/sundarb/profile,2E9w-LgAAAAJ,0000-0000-0000-0000
 Sundar Vishwanathan,IIT Bombay,https://www.cse.iitb.ac.in/~sundar,8CK3IY4AAAAJ,0000-0000-0000-0000
 Sundaraja Sitharama Iyengar,Florida International University,http://users.cis.fiu.edu/~iyengar,eNONM8AAAAAJ,0000-0000-0000-0000
@@ -2601,8 +2602,8 @@ Surjya Ghosh,BITS Pilani-Goa,https://surjya-ghosh.github.io,jwQqy80AAAAJ,0000-00
 Surya P. N. Singh,University of Queensland,http://robotics.itee.uq.edu.au/~spns,GdBpqg4AAAAJ,0000-0000-0000-0000
 Surya Prakash 0001,IIT Indore,http://www.iiti.ac.in/~surya,6_PF2KEAAAAJ,0000-0000-0000-0000
 Suryadipta Majumdar,Concordia University,https://users.encs.concordia.ca/~majumdar,S4x0by4AAAAJ,0000-0000-0000-0000
-Sus Lundgren,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/sus-lundgren.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Sus Lundgren Lyckvi,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/sus-lundgren.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
+Sus Lundgren,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/sus-lundgren.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Sus Lyckvi,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/sus-lundgren.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Susan A. Mengel,Texas Tech University,https://www.depts.ttu.edu/cs/faculty/susan_a._mengel,SH_ZjnkAAAAJ,0000-0000-0000-0000
 Susan A. Murphy,Harvard University,https://www.seas.harvard.edu/directory/samurphy,q-DPFdUAAAAJ,0000-0002-2032-4286

--- a/csrankings-w.csv
+++ b/csrankings-w.csv
@@ -282,6 +282,7 @@ Weiwei Sun 0008,Fudan University,http://www.cs.fudan.edu.cn/?page_id=1923,NOSCHO
 Weiwei Xu,Zhejiang University,http://www.cad.zju.edu.cn/home/weiweixu,qRXK__gAAAAJ,0000-0000-0000-0000
 Weiwen Jiang,George Mason University,https://www.gmu.edu/profiles/wjiang8,62oDIG4AAAAJ,0000-0002-9004-487X
 Weixin Li 0001,Beihang University,http://irip.buaa.edu.cn/weixinli/index.html,ZRl2aAwAAAAJ,0000-0002-5093-5635
+Weixing Ji,Beijing Normal University,https://jiweixing.github.io/,9NfXp9MAAAAJ,0000-0002-3250-0435
 Weixiong Rao,Tongji University,https://sse.tongji.edu.cn/wrao,7ubWTOMAAAAJ,0000-0000-0000-0000
 Weiyan Shi,Northeastern University,https://wyshi.github.io,xj666rUAAAAJ,0000-0003-0850-5831
 Weiyang Liu,Chinese University of Hong Kong,https://wyliu.com,DMjROf0AAAAJ,0000-0000-0000-0000
@@ -319,6 +320,7 @@ Wen-Yan Daniel Lin,Singapore Management University,https://sis.smu.edu.sg/facult
 Wen-Yan Lin,Singapore Management University,https://sis.smu.edu.sg/faculty/profile/161811/Daniel-LIN,cGClKZkAAAAJ,0000-0002-1681-6595
 Wenbin Hu,Wuhan University,https://cs.whu.edu.cn/info/1019/2886.htm,K3l1qnoAAAAJ,0000-0000-0000-0000
 Wenbin Jiang 0001,HUST,http://faculty.hust.edu.cn/jiangwenbin/en/index/1572153/list/index.htm,NOSCHOLARPAGE,0000-0001-5628-8806
+Wenbin Jiang 0002,Beijing Normal University,https://ai.bnu.edu.cn/xygk/szdw/zgj/7862037fc5624f7aa91b60fddfd5ae0f.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Wenbin Li 0006,Nanjing University,https://liwenbin.cn,K-kC4yYAAAAJ,0000-0002-0935-7124
 Wenbin Zhang 0002,Florida International University,https://users.cs.fiu.edu/~wbzhang,M802p54AAAAJ,0000-0003-3024-5415
 Wenbing Huang 0001,Renmin University of China,https://gsai.ruc.edu.cn/addons/teacher/index/info.html?user_id=31&ruccode=20220125&ln=en,0yNkmO4AAAAJ,0000-0002-2566-4159
@@ -334,8 +336,8 @@ Wendelin Boehmer,TU Delft,https://www.tudelft.nl/ewi/over-de-faculteit/afdelinge
 Wendelin Böhmer,TU Delft,https://www.tudelft.nl/ewi/over-de-faculteit/afdelingen/software-technology/algorithmics/people/wendelin-boehmer,wI5MV8IAAAAJ,0000-0000-0000-0000
 Wendi B. Heinzelman,University of Rochester,http://www2.ece.rochester.edu/~wheinzel,myYVVuYAAAAJ,0000-0000-0000-0000
 Wendi Beth Heinzelman,University of Rochester,http://www2.ece.rochester.edu/~wheinzel,myYVVuYAAAAJ,0000-0000-0000-0000
-Wendi Rabiner,University of Rochester,http://www2.ece.rochester.edu/~wheinzel,myYVVuYAAAAJ,0000-0000-0000-0000
 Wendi Rabiner Heinzelman,University of Rochester,http://www2.ece.rochester.edu/~wheinzel,myYVVuYAAAAJ,0000-0002-7541-4086
+Wendi Rabiner,University of Rochester,http://www2.ece.rochester.edu/~wheinzel,myYVVuYAAAAJ,0000-0000-0000-0000
 Wendy Hall 0001,University of Southampton,https://www.ecs.soton.ac.uk/people/wh,9NaDv3oAAAAJ,0000-0003-4327-7811
 Wendy Hui Wang,Stevens Institute of Technology,http://www.cs.stevens.edu/~hwang4,3pXvHPUAAAAJ,0000-0002-3913-815X
 Wendy Ju [Tech],Cornell University,https://wendyju.com,kjYhZYwAAAAJ,0000-0000-0000-0000
@@ -490,8 +492,8 @@ William D. Gropp,Univ. of Illinois at Urbana-Champaign,http://wgropp.cs.illinois
 William E. Skeith III,CUNY,http://www-cs.ccny.cuny.edu/~wes,NOSCHOLARPAGE,0000-0000-0000-0000
 William Eiers,Stevens Institute of Technology,https://william-eiers.github.io,shZGzBwAAAAJ,0009-0007-0235-2332
 William Enck,North Carolina State University,http://www.enck.org,KcM-4NsAAAAJ,0000-0002-3043-8092
-William F. Punch,Michigan State University,http://www.cse.msu.edu/~punch,U9HQ2qUAAAAJ,0000-0000-0000-0000
 William F. Punch III,Michigan State University,http://www.cse.msu.edu/~punch,U9HQ2qUAAAAJ,0000-0000-0000-0000
+William F. Punch,Michigan State University,http://www.cse.msu.edu/~punch,U9HQ2qUAAAAJ,0000-0000-0000-0000
 William Fornaciari,Politecnico di Milano,http://home.deib.polimi.it/fornacia,NOSCHOLARPAGE,0000-0001-8294-730X
 William G. J. Halfond,University of Southern California,https://viterbi-web.usc.edu/~halfond,98W28JoAAAAJ,0000-0003-4951-9367
 William G. Wee,University of Cincinnati,http://www.ece.uc.edu/%7Ewwee,NOSCHOLARPAGE,0000-0000-0000-0000


### PR DESCRIPTION
## Consolidated PR for Beijing Normal University

This PR consolidates the following open PRs:

| PR | Score | Title |
|---|---|---|
| #12085 | 80% | Add 1 faculty from Beijing Normal University |
| #12171 | 75% | Add 1 faculty from Beijing Normal University |
| #12497 | 70% | Add Shengling Wang 0001 (Beijing Normal University) |
| #12563 | 80% | Add Weixing Ji (Beijing Normal University) |
| #12593 | 75% | Add 1 faculty from Beijing Normal University |
| #12596 | 60% | Add Wenbin Jiang 0002 (Beijing Normal University) |

Total: 6 faculty additions.
Average individual score: 78%
Joint probability (all valid): 21.3%
