### PR TITLE
Add 10 faculty from Beijing Institute of Technology (consolidated)

### DIFF
--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -391,8 +391,8 @@ Ah-Hwee Tan,Singapore Management University,https://sis.smu.edu.sg/faculty/profi
 Ahad N. Zehmakan,Australian National University,https://comp.anu.edu.au/people/ahad-zehmakan,bB3qVuEAAAAJ,0000-0002-8569-6347
 Ahamed Shafeeq B. M.,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/ahamed-shafeeq-bm/_jcr_content.html,FvPxOJcAAAAJ,0000-0001-6555-6980
 Aharon Bar-Hillel,Ben-Gurion University of the Negev,https://sites.google.com/site/aharonbarhillel,x4GlT3IAAAAJ,0000-0002-7303-0687
-Ahmad Akbari,IUST,http://ce.iust.ac.ir/page.php?slct_pg_id=6537&sid=14&slc_lang=en,pCil4_cAAAAJ,0000-0000-0000-0000
 Ahmad Akbari Azirani,IUST,http://ce.iust.ac.ir/page.php?slct_pg_id=6537&sid=14&slc_lang=en,pCil4_cAAAAJ,0000-0002-0387-1616
+Ahmad Akbari,IUST,http://ce.iust.ac.ir/page.php?slct_pg_id=6537&sid=14&slc_lang=en,pCil4_cAAAAJ,0000-0000-0000-0000
 Ahmad Alzahrani,King Abdulaziz University,http://asalzahrani.kau.edu.sa/Default.aspx?Site_ID=0005199&lng=EN,10GPVtsAAAAJ,0000-0000-0000-0000
 Ahmad Azab,University of Sydney,https://www.sydney.edu.au/engineering/about/our-people/academic-staff/ahmad-azab.html,4Hpg1a0AAAAJ,0000-0002-9807-1602
 Ahmad Biniaz,University of Windsor,http://www.uwindsor.ca/science/computerscience/1151/dr-ahmad-biniaz,ZbHrRcEAAAAJ,0000-0002-6396-4494
@@ -532,8 +532,8 @@ Alain Tapp,University of Montreal,http://diro.umontreal.ca/repertoire-departemen
 Alain Trémeau,Université Jean Monnet,http://www.create.uwe.ac.uk/membership/tremeau.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Alain Wegmann,EPFL,https://people.epfl.ch/alain.wegmann,NOSCHOLARPAGE,0000-0002-8847-0191
 Alan Akbik,Humboldt University of Berlin,https://www.informatik.hu-berlin.de/de/forschung/gebiete/ml,adKmg3IAAAAJ,0009-0003-9551-6447
-Alan Blair,UNSW,http://www.cse.unsw.edu.au/~blair,oYi8fBIAAAAJ,0000-0000-0000-0000
 Alan Blair 0001,UNSW,http://www.cse.unsw.edu.au/~blair,oYi8fBIAAAAJ,0000-0002-1039-4766
+Alan Blair,UNSW,http://www.cse.unsw.edu.au/~blair,oYi8fBIAAAAJ,0000-0000-0000-0000
 Alan Bundy,University of Edinburgh,https://sweb.inf.ed.ac.uk/bundy,n7STZEYAAAAJ,0000-0002-0578-6474
 Alan Burns 0001,University of York,https://www-users.cs.york.ac.uk/~burns,Io7KbYcAAAAJ,0000-0001-5621-8816
 Alan C. H. Ling,University of Vermont,http://www.emba.uvm.edu/~aling,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -671,8 +671,8 @@ Alejandro Martínez-Ríos,University of Buenos Aires,https://www.facebook.com/pu
 Alejandro Masrur,TU Chemnitz,https://www.tu-chemnitz.de/informatik/CAS/people/masrur.php,UrRzVz4AAAAJ,0000-0003-2524-1751
 Alejandro P. Buchmann,TU Darmstadt,http://www.dvs.tu-darmstadt.de/staff/buchmann,ppMxk_YAAAAJ,0000-0000-0000-0000
 Alejandro Paz-Lopez,University of A Coruña,https://pdi.udc.es/en/File/Pdi/QP8LF,NOSCHOLARPAGE,0000-0003-4952-7308
-Alejandro Pazos,University of A Coruña,https://pdi.udc.es/en/File/Pdi/4649E,bPAk6fYAAAAJ,0000-0000-0000-0000
 Alejandro Pazos Sierra,University of A Coruña,https://pdi.udc.es/en/File/Pdi/4649E,bPAk6fYAAAAJ,0000-0000-0000-0000
+Alejandro Pazos,University of A Coruña,https://pdi.udc.es/en/File/Pdi/4649E,bPAk6fYAAAAJ,0000-0000-0000-0000
 Alejandro Quintero,Polytechnique Montreal,https://www.polymtl.ca/expertises/en/quintero-alejandro,NOSCHOLARPAGE,0000-0000-0000-0000
 Alejandro Russo,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/russo.aspx,8sz4s7YAAAAJ,0000-0002-4338-6316
 Alek Vainshtein,University of Haifa,http://cs.haifa.ac.il/VAIN/vainshtein.html,NOSCHOLARPAGE,0000-0001-5452-1977
@@ -981,8 +981,8 @@ Alf Weaver,University of Virginia,https://engineering.virginia.edu/faculty/alfre
 Alfie Abdul-Rahman,King's College London,https://www.kcl.ac.uk/people/alfie-abdul-rahman,odURYTkAAAAJ,0000-0002-6257-876X
 Alfons Kemper,TU Munich,https://db.in.tum.de/~kemper,5n3YivwAAAAJ,0000-0000-0000-0000
 Alfons Laarman,Leiden University,https://alfons.laarman.com,InHyqKgAAAAJ,0000-0002-2433-4174
-Alfonso Baños,University of Murcia,http://www.um.es/iindus/abanos,VOrE_H0AAAAJ,0000-0000-0000-0000
 Alfonso Baños Torrico,University of Murcia,http://www.um.es/iindus/abanos,VOrE_H0AAAAJ,0000-0000-0000-0000
+Alfonso Baños,University of Murcia,http://www.um.es/iindus/abanos,VOrE_H0AAAAJ,0000-0000-0000-0000
 Alfonso Bueno-Orovio,University of Oxford,https://www.cs.ox.ac.uk/people/alfonso.bueno-orovio,TmlWPsIAAAAJ,0000-0002-1634-3601
 Alfonso Castro Martínez,University of A Coruña,https://pdi.udc.es/en/File/Pdi/5259E,NOSCHOLARPAGE,0000-0000-0000-0000
 Alfonso Fuggetta,Politecnico di Milano,http://home.deib.polimi.it/fuggetta,ZJXTUa8AAAAJ,0000-0000-0000-0000
@@ -1000,11 +1000,11 @@ Alfred Olivier Hero,University of Michigan,http://web.eecs.umich.edu/~hero,NOSCH
 Alfred Ultsch,University of Marburg,https://www.uni-marburg.de/fb12/arbeitsgruppen/datenbionik/mitarbeiter,NOSCHOLARPAGE,0000-0002-7845-3283
 Alfredo De Santis,University of Salerno,http://www.di.unisa.it/~ads/curriculum.htm,Wt7Y3-oAAAAJ,0000-0001-8962-1919
 Alfredo Ferreira,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist14275,YtEBFw0AAAAJ,0000-0001-9278-142X
-Alfredo Goldman,USP,http://www.ime.usp.br/~gold,Cgl09uMAAAAJ,0000-0001-5746-4154
 Alfredo Goldman vel Lejbman,USP,http://www.ime.usp.br/~gold,Cgl09uMAAAAJ,0000-0000-0000-0000
+Alfredo Goldman,USP,http://www.ime.usp.br/~gold,Cgl09uMAAAAJ,0000-0001-5746-4154
 Alfredo Pulvirenti,University of Catania,https://www.dmi.unict.it/~apulvirenti/site,eU40mWYAAAAJ,0000-0002-9764-0295
-Alfredo Weitzenfeld,University of South Florida,http://robolat.org,0QFPg3oAAAAJ,0000-0001-7016-3751
 Alfredo Weitzenfeld Ridel,University of South Florida,http://robolat.org,0QFPg3oAAAAJ,0000-0000-0000-0000
+Alfredo Weitzenfeld,University of South Florida,http://robolat.org,0QFPg3oAAAAJ,0000-0001-7016-3751
 Alham Fikri Aji,MBZUAI,https://mbzuai.ac.ae/study/faculty/alham-fikri-aji,0Cyfqv4AAAAJ,0000-0000-0000-0000
 Ali A. Al-Ataby,University of Liverpool,https://liverpool.ac.uk/electrical-engineering-and-electronics/staff/ali-alataby,o0C1omgAAAAJ,0000-0000-0000-0000
 Ali A. Ghorbani 0001,University of New Brunswick,http://www.cs.unb.ca/~ghorbani,tMc1RhUAAAAJ,0000-0000-0000-0000
@@ -1039,8 +1039,8 @@ Ali H. Dogru,Middle East Technical University,http://user.ceng.metu.edu.tr/~dogr
 Ali H. Sayed,EPFL,https://people.epfl.ch/ali.sayed,uDG9sXQAAAAJ,0000-0000-0000-0000
 Ali Hikmet Dogru,Middle East Technical University,http://user.ceng.metu.edu.tr/~dogru,tS3i4GMAAAAJ,0000-0000-0000-0000
 Ali Ismail Awad,UAEU,https://www.uaeu.ac.ae/en/cit/profile.shtml?email=ali.awad@uaeu.ac.ae,-JinZTsAAAAJ,0000-0000-0000-0000
-Ali Jannesari,Iowa State University,https://www.cs.iastate.edu/swapp/people/ali-jannesari,YhWnhQEAAAAJ,0000-0001-8672-5317
 Ali Jannesari Ladani,Iowa State University,https://www.cs.iastate.edu/swapp/people/ali-jannesari,YhWnhQEAAAAJ,0000-0000-0000-0000
+Ali Jannesari,Iowa State University,https://www.cs.iastate.edu/swapp/people/ali-jannesari,YhWnhQEAAAAJ,0000-0001-8672-5317
 Ali Jaoua,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/ali.php,rWJLBq8AAAAJ,0000-0001-6578-8191
 Ali Javey,Univ. of California - Berkeley,http://nano.eecs.berkeley.edu,1gqyKqcAAAAJ,0000-0000-0000-0000
 Ali José Mashtizadeh,University of Waterloo,https://cs.uwaterloo.ca/~mashti,djMOD-IAAAAJ,0000-0002-8672-5138
@@ -1515,12 +1515,12 @@ Andrea F. Abate,University of Salerno,http://www.unisa.it/docenti/andreafrancesc
 Andrea Francesco Abate,University of Salerno,http://www.unisa.it/docenti/andreafrancescoabate/cv,AwaMdEsAAAAJ,0000-0000-0000-0000
 Andrea G. Parker,Georgia Institute of Technology,https://www.cc.gatech.edu/~andrea,zh8E4voAAAAJ,0000-0002-2362-7717
 Andrea Grimes Parker,Georgia Institute of Technology,https://www.cc.gatech.edu/~andrea,zh8E4voAAAAJ,0000-0000-0000-0000
-Andrea Herrera,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/aherrer/es/inicio,BvuaquwAAAAJ,0000-0003-2898-7161
 Andrea Herrera 0001,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/aherrer/es/inicio,BvuaquwAAAAJ,0000-0003-2898-7161
+Andrea Herrera,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/aherrer/es/inicio,BvuaquwAAAAJ,0000-0003-2898-7161
 Andrea Kleinsmith,Univ. of Maryland - Baltimore County,http://www.andisplanet.com,dXHpxgMAAAAJ,0000-0003-1007-2553
 Andrea Lincoln,Boston University,https://andrealincoln.github.io,o_3wS3AAAAAJ,0000-0003-4653-8730
-Andrea Lockerd,University of Texas at Austin,https://sim.ece.utexas.edu/people.html,jIs-Y2gAAAAJ,0000-0000-0000-0000
 Andrea Lockerd Thomaz,University of Texas at Austin,https://sim.ece.utexas.edu/people.html,jIs-Y2gAAAAJ,0000-0000-0000-0000
+Andrea Lockerd,University of Texas at Austin,https://sim.ece.utexas.edu/people.html,jIs-Y2gAAAAJ,0000-0000-0000-0000
 Andrea Lodi 0001 [Tech],Cornell University,https://tech.cornell.edu/people/andrea-lodi,udwtIesAAAAJ,0000-0000-0000-0000
 Andrea M. Tonello,University of Klagenfurt,http://www.andreatonello.com,qBiseEsAAAAJ,0000-0000-0000-0000
 Andrea Marongiu,Univ. of Modena and Reggio Emilia,https://personale.unimore.it/rubrica/dettaglio/amarongiu,Hwl6xgwAAAAJ,0000-0003-1010-4762
@@ -1939,8 +1939,8 @@ Anirbit Mukherjee,University of Manchester,https://www.research.manchester.ac.uk
 Aniruddha Bora,Texas State University,https://aniruddhabora.github.io,4OMm56YAAAAJ,0000-0001-8015-9924
 Aniruddha Gokhale,Vanderbilt University,http://www.dre.vanderbilt.edu/~gokhale,yvvjnhIAAAAJ,0000-0002-7706-7102
 Aniruddha S. Gokhale,Vanderbilt University,http://www.dre.vanderbilt.edu/~gokhale,yvvjnhIAAAAJ,0000-0002-7706-7102
-Anirudh Sivaraman,New York University,https://cs.nyu.edu/~anirudh,z9em5msAAAAJ,0000-0001-5025-4234
 Anirudh Sivaraman Kaushalram,New York University,https://cs.nyu.edu/~anirudh,z9em5msAAAAJ,0000-0000-0000-0000
+Anirudh Sivaraman,New York University,https://cs.nyu.edu/~anirudh,z9em5msAAAAJ,0000-0001-5025-4234
 Anirudha Majumdar,Princeton University,https://irom-lab.princeton.edu/majumdar,ibu3FwsAAAAJ,0009-0002-2296-7485
 Anish Arora,Ohio State University,http://web.cse.ohio-state.edu/~anish,Bn0zSwQAAAAJ,0000-0003-2152-0462
 Anish Hirwe,IIT Palakkad,https://iitpkd.ac.in/people/anish,iXw0xpoAAAAJ,0000-0000-0000-0000
@@ -2003,8 +2003,8 @@ Anna K. Jordanous,University of Kent,https://www.cs.kent.ac.uk/people/staff/akj2
 Anna Kicheva,IST Austria,https://ist.ac.at/research/research-groups/kicheva-group,zBpAlHkAAAAJ,0000-0000-0000-0000
 Anna Korhonen,University of Cambridge,https://www.cl.cam.ac.uk/~alk23,SCoVoOYAAAAJ,0000-0002-3692-3144
 Anna L. Cox,University College London,https://uclic.ucl.ac.uk/people/anna-cox,NOSCHOLARPAGE,0000-0003-2231-2964
-Anna Levina,University of Tübingen,http://anna.hronopik.de,KJSnbQoAAAAJ,0000-0000-0000-0000
 Anna Levina (Martius),University of Tübingen,http://anna.hronopik.de,KJSnbQoAAAAJ,0000-0000-0000-0000
+Anna Levina,University of Tübingen,http://anna.hronopik.de,KJSnbQoAAAAJ,0000-0000-0000-0000
 Anna Lisa Ferrara,University of Molise,http://docenti.unimol.it/index.php?u=a.ferrara8,t_YswdMAAAAJ,0000-0000-0000-0000
 Anna Louise Cox,University College London,https://uclic.ucl.ac.uk/people/anna-cox,NOSCHOLARPAGE,0000-0003-2231-2964
 Anna Lukina,TU Delft,https://annalukina.com,ztyK2toAAAAJ,0000-0001-9525-0333
@@ -2019,8 +2019,8 @@ Anna Sperotto,University of Twente,https://research.utwente.nl/en/persons/464a92
 Anna V. Kononova,Leiden University,https://www.universiteitleiden.nl/en/staffmembers/anna-kononova/publications#tab-3,yu9kaQkAAAAJ,0000-0000-0000-0000
 Anna V. Zhdanova,University of Innsbruck,http://anna.fensel.com,R73gJDcAAAAJ,0000-0000-0000-0000
 Anna Vallgårda,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/anna-vallgaarda(2fa5dc89-7d78-45d0-96c7-e8f39b78dd3e).html,sRVXyvkAAAAJ,0000-0001-9898-8106
-Anna Vilanova,TU Delft,https://graphics.tudelft.nl/anna-vilanova,P83cpEEAAAAJ,0000-0002-1034-737X
 Anna Vilanova Bartrolí,TU Delft,https://graphics.tudelft.nl/anna-vilanova,P83cpEEAAAAJ,0000-0000-0000-0000
+Anna Vilanova,TU Delft,https://graphics.tudelft.nl/anna-vilanova,P83cpEEAAAAJ,0000-0002-1034-737X
 Anna Zych,University of Warsaw,http://informatorects.uw.edu.pl/en/courses/view?prz_kod=1000-712ASD,NOSCHOLARPAGE,0000-0002-5361-8969
 Anna Zych-Pawlewicz,University of Warsaw,http://informatorects.uw.edu.pl/en/courses/view?prz_kod=1000-712ASD,NOSCHOLARPAGE,0000-0002-5361-8969
 Anna-Lena Lamprecht,Utrecht University,https://www.uu.nl/staff/allamprecht,d-GAM1oAAAAJ,0000-0003-1953-5606
@@ -2172,8 +2172,8 @@ Antonio Blanca,Pennsylvania State University,http://www.cse.psu.edu/~azb1015,tl6
 Antonio Brogi,University of Pisa,https://pages.di.unipi.it/brogi,lOFQGacAAAAJ,0000-0003-2048-2468
 Antonio C. S. Beck,UFRGS,http://inf.ufrgs.br/~caco,E-VfVv4AAAAJ,0000-0000-0000-0000
 Antonio Capone,Politecnico di Milano,http://home.deib.polimi.it/capone,KS1VFqgAAAAJ,0000-0000-0000-0000
-Antonio Carlos Schneider Beck,UFRGS,http://inf.ufrgs.br/~caco,E-VfVv4AAAAJ,0000-0000-0000-0000
 Antonio Carlos Schneider Beck Filho,UFRGS,http://inf.ufrgs.br/~caco,E-VfVv4AAAAJ,0000-0000-0000-0000
+Antonio Carlos Schneider Beck,UFRGS,http://inf.ufrgs.br/~caco,E-VfVv4AAAAJ,0000-0000-0000-0000
 Antonio Carzaniga,Università della Svizzera italiana,http://www.inf.usi.ch/carzaniga,NOSCHOLARPAGE,0009-0008-9969-3981
 Antonio Cicchetti,Mälardalen University,http://www.es.mdh.se/staff/198-Antonio_Cicchetti,I-9eMoMAAAAJ,0000-0003-0416-1787
 Antonio Cisternino,University of Pisa,http://www.di.unipi.it/~cisterni,SiCtgi8AAAAJ,0000-0000-0000-0000
@@ -2196,8 +2196,8 @@ Antonio Miele,Politecnico di Milano,http://home.deib.polimi.it/miele,CPGr-IUAAAA
 Antonio Nicolosi,Stevens Institute of Technology,https://www.stevens.edu/profile/anicolos,rr1cfRkAAAAJ,0009-0002-6817-953X
 Antonio Pecchia,University of Sannio,https://www.unisannio.it/it/users/apecchia,11QO_iIAAAAJ,0000-0003-2869-8423
 Antonio Ruiz-Martínez,University of Murcia,http://webs.um.es/arm,x-whC_gAAAAJ,0000-0002-8433-159X
-Antonio Toral,University of Groningen,http://antoniotor.al,YcdNfhcAAAAJ,0000-0003-2357-2960
 Antonio Toral Ruiz,University of Groningen,http://antoniotor.al,YcdNfhcAAAAJ,0000-0000-0000-0000
+Antonio Toral,University of Groningen,http://antoniotor.al,YcdNfhcAAAAJ,0000-0003-2357-2960
 Antonio Torralba 0001,Massachusetts Inst. of Technology,http://web.mit.edu/torralba/www,8cxDHS4AAAAJ,0000-0003-4915-0256
 Antonio Vergari,University of Edinburgh,http://www.inf.ed.ac.uk/people/staff/Antonio_Vergari.html,YK0NLaUAAAAJ,0000-0003-0036-5678
 Antonios A. Savidis,University of Crete,https://www.ics.forth.gr/hci/index_main.php?l=g&c=517,m0b5D28AAAAJ,0000-0000-0000-0000
@@ -2218,10 +2218,10 @@ Antti Salovaara,Aalto University,https://people.aalto.fi/antti.salovaara,SFkQ65s
 Antti Ylä-Jääski,Aalto University,http://cse.aalto.fi/en/personnel/antti-yla-jaaski,ojkArgn5IlAC,0000-0002-2069-1721
 Antónia Lopes,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/malopes,BQluvIMAAAAJ,0000-0003-0688-3521
 António Branco,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/ambranco,JeBor2UAAAAJ,0000-0002-7174-4942
-António Casimiro,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/accosta,wKMmqlUAAAAJ,0000-0002-5522-5739
 António Casimiro Costa,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/accosta,wKMmqlUAAAAJ,0000-0000-0000-0000
-António Grilo,Universidade de Lisboa,http://www.demi.fct.unl.pt/en/pessoas/docentes/antonio-carlos-barbara-grilo,G6nldpYAAAAJ,0000-0002-3806-0055
+António Casimiro,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/accosta,wKMmqlUAAAAJ,0000-0002-5522-5739
 António Grilo 0001,Universidade de Lisboa,http://www.demi.fct.unl.pt/en/pessoas/docentes/antonio-carlos-barbara-grilo,G6nldpYAAAAJ,0000-0002-3806-0055
+António Grilo,Universidade de Lisboa,http://www.demi.fct.unl.pt/en/pessoas/docentes/antonio-carlos-barbara-grilo,G6nldpYAAAAJ,0000-0002-3806-0055
 António Horta Branco,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/ambranco,JeBor2UAAAAJ,0000-0000-0000-0000
 António M. Grilo,Universidade de Lisboa,http://www.demi.fct.unl.pt/en/pessoas/docentes/antonio-carlos-barbara-grilo,G6nldpYAAAAJ,0000-0000-0000-0000
 António M. R. C. Grilo,Universidade de Lisboa,http://www.demi.fct.unl.pt/en/pessoas/docentes/antonio-carlos-barbara-grilo,G6nldpYAAAAJ,0000-0000-0000-0000
@@ -2278,6 +2278,7 @@ Anys Bacha,University of Michigan-Dearborn,https://umdearborn.edu/users/anysbach
 Ao Ren,Chongqing University,http://www.cs.cqu.edu.cn/info/1322/5178.htm,K5vVwSAAAAAJ,0000-0002-2322-8038
 Ao Zhou 0001,BUPT,https://scs.bupt.edu.cn/info/1287/2704.htm,vRar40cAAAAJ,0000-0001-5743-9418
 Aonghus Lawlor,University College Dublin,https://people.ucd.ie/aonghus.lawlor,kyrXm8EAAAAJ,0000-0002-6160-4639
+Aoqian Zhang,Beijing Institute of Technology,https://zaqthss.github.io/,uKmgKfMAAAAJ,0000-0000-0000-0000
 Apan Qasem,Texas State University,http://www.cs.txstate.edu/~aq10,CxAVF0YAAAAJ,0009-0000-6213-829X
 Aparna Bharati,Lehigh University,https://sites.google.com/view/aparna-bharati,3SuzNJ4AAAAJ,0000-0002-6404-9466
 Aparna Chandramowlishwaran,Univ. of California - Irvine,https://hpcforge.eng.uci.edu,7ASJ6JoAAAAJ,0000-0003-0840-4192
@@ -2461,8 +2462,8 @@ Artur Czumaj,University of Warwick,https://warwick.ac.uk/fac/sci/dcs/people/artu
 Artur Jez,University of Wroclaw,http://www.ii.uni.wroc.pl/~aje,z4tT55IAAAAJ,0000-0003-4321-3105
 Artur S. d'Avila Garcez,City University of London,https://www.city.ac.uk/people/academics/artur-davila-garcez,BCpY0gsAAAAJ,0000-0000-0000-0000
 Artur d'Avila Garcez,City University of London,https://www.city.ac.uk/people/academics/artur-davila-garcez,BCpY0gsAAAAJ,0000-0000-0000-0000
-Arturo Azcorra,IMDEA Networks Institute,https://networks.imdea.org/team/imdea-networks-team/people/arturo-azcorra,pui4ym6mQiwC,0000-0000-0000-0000
 Arturo Azcorra Saloña,IMDEA Networks Institute,https://networks.imdea.org/team/imdea-networks-team/people/arturo-azcorra,pui4ym6mQiwC,0000-0000-0000-0000
+Arturo Azcorra,IMDEA Networks Institute,https://networks.imdea.org/team/imdea-networks-team/people/arturo-azcorra,pui4ym6mQiwC,0000-0000-0000-0000
 Arturo Caronongan,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742735361&command=GETPROFILE,XfZmeCYAAAAJ,0000-0000-0000-0000
 Arturo P. Caronongan III,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742735361&command=GETPROFILE,XfZmeCYAAAAJ,0000-0000-0000-0000
 Arun Abraham Ross,Michigan State University,http://www.cse.msu.edu/~rossarun,7IiUQDkAAAAJ,0000-0000-0000-0000
@@ -2669,8 +2670,8 @@ Aviad Rubinstein,Stanford University,https://cs.stanford.edu/~aviad,ZTsHfNAAAAAJ
 Aviezri S. Fraenkel,Weizmann Institute of Science,https://www.weizmann.ac.il/pages/search/people?language=english&single=1&person_id=3774,NOSCHOLARPAGE,0000-0000-0000-0000
 Avigdor Gal,Technion,https://agp.iem.technion.ac.il/avigal,APs1p2oAAAAJ,0000-0002-7028-661X
 Avinash Gautam,BITS Pilani,http://universe.bits-pilani.ac.in/pilani/avinash/profile,V6-4CfQAAAAJ,0000-0000-0000-0000
-Avinash Karanth,Ohio University,http://oucsace.cs.ohiou.edu/~avinashk,NOSCHOLARPAGE,0000-0002-9472-4637
 Avinash Karanth Kodi,Ohio University,http://oucsace.cs.ohiou.edu/~avinashk,NOSCHOLARPAGE,0000-0000-0000-0000
+Avinash Karanth,Ohio University,http://oucsace.cs.ohiou.edu/~avinashk,NOSCHOLARPAGE,0000-0002-9472-4637
 Avinash Kodi,Ohio University,http://oucsace.cs.ohiou.edu/~avinashk,NOSCHOLARPAGE,0000-0000-0000-0000
 Avinash Sharma 0001,IIT Jodhpur,https://3dcomputervision.github.io,4ladtC0AAAAJ,0000-0001-5013-5024
 Avinatan Hassidim,Bar-Ilan University,http://u.cs.biu.ac.il/~avinatan,CnBvgwcAAAAJ,0000-0002-3855-344X
@@ -2703,8 +2704,8 @@ Aydin Kaya 0001,Hacettepe University,https://web.cs.hacettepe.edu.tr/~aydinkaya,
 Ayellet Tal,Technion,http://webee.technion.ac.il/people/ayellet,eFGgX-QAAAAJ,0000-0002-4967-7309
 Ayesha Khalid,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=a.khalid,YXQolr4AAAAJ,0000-0002-4815-6966
 Aykut Erdem,Koç University,https://aykuterdem.github.io,-xA1_OAAAAAJ,0000-0002-6280-8422
-Aylin Caliskan,University of Washington,https://faculty.washington.edu/aylin/index.html,zxzZAi0AAAAJ,0000-0001-7154-8629
 Aylin Caliskan Islam,University of Washington,https://faculty.washington.edu/aylin/index.html,zxzZAi0AAAAJ,0000-0000-0000-0000
+Aylin Caliskan,University of Washington,https://faculty.washington.edu/aylin/index.html,zxzZAi0AAAAJ,0000-0001-7154-8629
 Aylin Yener,Ohio State University,https://ece.osu.edu/people/yener.5,W6DNu0cAAAAJ,0000-0003-0820-3390
 Ayman I. Kayssi,American University of Beirut,https://www.aub.edu.lb/fea/publicprofile/Pages/profile.aspx?MemberId=ayman,JzsqVaMAAAAJ,0000-0000-0000-0000
 Ayon Chakraborty,IIT Madras,https://www.cse.iitm.ac.in/~ayon,xKrkM1EAAAAJ,0000-0000-0000-0000
@@ -2713,8 +2714,8 @@ Ayse K. Coskun,Boston University,https://www.bu.edu/eng/profile/ayse-coskun,euIQ
 Ayse Kivilcim Coskun,Boston University,https://www.bu.edu/eng/profile/ayse-coskun,euIQ_RkAAAAJ,0000-0000-0000-0000
 Ayse Küçükyilmaz,University of Nottingham,https://www.nottingham.ac.uk/computerscience/people/ayse.kucukyilmaz,NOSCHOLARPAGE,0000-0003-3202-6750
 Ayse Nur Zincir-Heywood,Dalhousie University,https://www.cs.dal.ca/~zincir,F9nG0F4AAAAJ,0000-0000-0000-0000
-Ayse Tosun,Istanbul Technical University,http://web.itu.edu.tr/tosunay,KktAed0AAAAJ,0000-0003-1859-7872
 Ayse Tosun Misirli,Istanbul Technical University,http://web.itu.edu.tr/tosunay,KktAed0AAAAJ,0000-0003-1859-7872
+Ayse Tosun,Istanbul Technical University,http://web.itu.edu.tr/tosunay,KktAed0AAAAJ,0000-0003-1859-7872
 Ayse Yilmazer,Istanbul Technical University,https://web.itu.edu.tr/yilmazerayse,PSsiqbYAAAAJ,0000-0003-4502-7365
 Ayse Yilmazer-Metin,Istanbul Technical University,https://web.itu.edu.tr/yilmazerayse,PSsiqbYAAAAJ,0000-0000-0000-0000
 Aysegul Dundar,Bilkent University,http://www.cs.bilkent.edu.tr/~adundar,pvu770UAAAAJ,0000-0000-0000-0000
@@ -2750,8 +2751,8 @@ Aïda Ouangraoua,Université de Sherbrooke,https://www.usherbrooke.ca/informatiq
 Ágoston E. Eiben,VU Amsterdam,http://www.cs.vu.nl/~gusz,NMuDAe0AAAAJ,0000-0000-0000-0000
 Ákos Lédeczi,Vanderbilt University,https://www.isis.vanderbilt.edu/akos,taqkLgoAAAAJ,0000-0000-0000-0000
 Álvaro Barreiro,University of A Coruña,https://www.dc.fi.udc.es/~barreiro,73tqFdsAAAAJ,0000-0002-6698-2946
-Ángel Viña,University of A Coruña,https://pdi.udc.es/es/File/Pdi/FK7AF,NOSCHOLARPAGE,0000-0000-0000-0000
 Ángel Viña Castiñeiras,University of A Coruña,https://pdi.udc.es/es/File/Pdi/FK7AF,NOSCHOLARPAGE,0000-0000-0000-0000
-Ángeles Saavedra,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=5,IYkBYzQAAAAJ,0000-0000-0000-0000
+Ángel Viña,University of A Coruña,https://pdi.udc.es/es/File/Pdi/FK7AF,NOSCHOLARPAGE,0000-0000-0000-0000
 Ángeles Saavedra Places,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=5,IYkBYzQAAAAJ,0000-0000-0000-0000
+Ángeles Saavedra,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=5,IYkBYzQAAAAJ,0000-0000-0000-0000
 Åse Jevinger,Malmö University,https://mau.se/en/persons/ase.jevinger,NOSCHOLARPAGE,0000-0002-6019-1182

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -637,6 +637,7 @@ Chetan Arora 0002,Monash University,https://research.monash.edu/en/persons/cheta
 Chetan D. Parikh,IIIT Bangalore,http://www.iiitb.ac.in/faculty_page.php?name=ChetanParikh,S1edNtAAAAAJ,0000-0000-0000-0000
 Chetana Pujari,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/chetana-pujari/_jcr_content.html,45yWeBUAAAAJ,0000-0001-6717-5567
 Chethan Kamath,IIT Bombay,https://www.cse.iitb.ac.in/~ckamath,NOSCHOLARPAGE,0009-0006-6812-7317
+Chi Harold Liu,Beijing Institute of Technology,https://cs.bit.edu.cn/szdw/jsml2/sjkxyzsgcyjs2/e99eddb6f93f4c1f9388bea0b4f9979e.htm,3IgFTEkAAAAJ,0000-0002-0252-329X
 Chi Jin 0001,Princeton University,https://sites.google.com/view/cjin/home,GINhGvwAAAAJ,0000-0002-2865-5610
 Chi Zhang 0007,Westlake University,https://en.westlake.edu.cn/faculty/chi-zhang.html,J4s398EAAAAJ,0000-0000-0000-0000
 Chi-Keung Tang,HKUST,http://www.cse.ust.hk/~cktang,EWfpM74AAAAJ,0000-0001-6495-3685

--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -383,6 +383,7 @@ Haopeng Chen,Shanghai Jiao Tong University,http://reins.se.sjtu.edu.cn/~chenhp,D
 Haopeng Zhang 0005,University of Hawaii at Manoa,https://hpzhang94.github.io,DT_HlbYAAAAJ,0009-0007-7017-0717
 Haoqi Zhang,Northwestern University,http://eecs.northwestern.edu/~hq,FaGbxW0AAAAJ,0000-0003-3363-7545
 Haoqiong Bian,Renmin University of China,https://scholar.google.com/citations?hl=zh-CN&user=pCcoxYUAAAAJ,pCcoxYUAAAAJ,0000-0001-5144-4427
+Haoran Yu 0001,Beijing Institute of Technology,https://yu-haoran.github.io/,-vZRFXgAAAAJ,0009-0006-2156-9492
 Haotian Jiang,University of Chicago,https://jhtdavid96.wixsite.com/jianghaotian,3mGx0eoAAAAJ,0000-0002-7501-2247
 Haotian Zhang 0006,NJIT,https://haotianzhang.com,sMHyQnYAAAAJ,0000-0003-0844-3730
 Haoxian Chen 0001,ShanghaiTech University,https://faculty.sist.shanghaitech.edu.cn/hxchen,wDMoU3UAAAAJ,0000-0002-8574-2120

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -111,6 +111,7 @@ Kaito Fujii,Kyoto University,https://fujiik.github.io,RcFjdYwAAAAJ,0000-0002-431
 Kaixiong Zhou,North Carolina State University,https://ece.ncsu.edu/people/kzhou22,KlvcurEAAAAJ,0000-0001-5226-8736
 Kaiyang Zhou,Hong Kong Baptist University,https://kaiyangzhou.github.io,gRIejugAAAAJ,0000-0000-0000-0000
 Kaiyi Ji,University at Buffalo,https://jikaiyi.github.io,E0A3lSIAAAAJ,0000-0000-0000-0000
+Kaiyu Feng,Beijing Institute of Technology,https://fengkaiyu.github.io/,3Rn3sJ4AAAAJ,0000-0000-0000-0000
 Kaiyu Hang,Rice University,https://hangkaiyu.github.io/index.html,GrgH1lQAAAAJ,0000-0000-0000-0000
 Kaiyuan Yang 0001,Rice University,https://vlsi.rice.edu/authors/admin,jbdA71QAAAAJ,0000-0000-0000-0000
 Kaiyuan Zhu,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/jiaoshiml/z.html,44g2NCsAAAAJ,0000-0000-0000-0000
@@ -173,6 +174,7 @@ Kang Liu 0001,Chinese Academy of Sciences,http://www.nlpr.ia.ac.cn/cip/~liukang/
 Kang Wook Lee 0001,University of Wisconsin - Madison,https://kangwooklee.com,sCEl8r-n5VEC,0000-0000-0000-0000
 Kang-Min Kim,Kyung Hee University,https://cuknlp.com,PQsJWfsAAAAJ,0000-0003-2335-7072
 KangKang Yin,Simon Fraser University,https://www.cs.sfu.ca/~kkyin,5P2jxPQAAAAJ,0000-0000-0000-0000
+Kangfei Zhao,Beijing Institute of Technology,https://kangfei.github.io/,ZPCRhOsAAAAJ,0000-0000-0000-0000
 Kangjie Lu,University of Minnesota,https://www.cs.umn.edu/people/kangjie-lu,1F9N6icAAAAJ,0000-0002-4763-7354
 Kangkook Jee,University of Texas at Dallas,https://kangkookjee.github.io,x-ApqMUAAAAJ,0000-0003-3797-4637
 Kangning Wang 0001,Rutgers University,https://sites.google.com/view/kangningwang/home,tK_Ty_IAAAAJ,0000-0001-8688-2478

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -1683,6 +1683,7 @@ Mei Kang Qiu,Augusta University,https://www.augusta.edu/faculty/directory/view.p
 Mei Kuan Lim,Monash University Malaysia,https://research.monash.edu/en/persons/lim-mei-kuan,u5VRx_kAAAAJ,0000-0001-8834-9933
 Mei-Hwa Chen,University at Albany - SUNY,https://www.albany.edu/ceas/mei-hwa-chen.php,P1s523UAAAAJ,0000-0000-0000-0000
 Meibao Yao,Jilin University,http://www.inrobotslab.com,8j2UgWwAAAAJ,0000-0002-7069-6782
+Meihui Zhang,Beijing Institute of Technology,https://zmeihui.github.io/,DuLgpaQAAAAJ,0000-0000-0000-0000
 Meikang Qiu,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=MQIU,smMVdtwAAAAJ,0000-0002-1004-0140
 Meike Albrecht,University of Rostock,https://www.informatik.uni-rostock.de/ueber-uns/bereich/homepages/meike-klettke/startseite,Rj6p8R8AAAAJ,0000-0000-0000-0000
 Meike Klettke,University of Regensburg,https://www.uni-regensburg.de/informatik-data-science/data-engineering/startseite/index.html,Rj6p8R8AAAAJ,0000-0003-0551-8389

--- a/csrankings-t.csv
+++ b/csrankings-t.csv
@@ -622,6 +622,7 @@ Tianbao Yang,Texas A&M University,http://people.tamu.edu/~tianbao-yang,BCxFU0EAA
 Tianbo Wang 0001,Beihang University,https://cst.buaa.edu.cn/info/1112/2749.htm,Mba_uU0AAAAJ,0000-0000-0000-0000
 Tianfan Fu,Nanjing University,https://futianfan.github.io,KPQ49w4AAAAJ,0000-0002-5574-2541
 Tianfang Yao,Shanghai Jiao Tong University,http://bcmi.sjtu.edu.cn/~yaotianfang,NOSCHOLARPAGE,0000-0000-0000-0000
+Tianfei Zhou,Beijing Institute of Technology,https://www.tfzhou.com/,-_33ccMAAAAJ,0000-0000-0000-0000
 Tianhao Wang 0001,University of Virginia,https://tianhao.wang,TkgyXGwAAAAJ,0000-0002-9017-7947
 Tianhong Dai,University of Aberdeen,https://www.abdn.ac.uk/people/tianhong.dai,9apiamkAAAAJ,0000-0001-8904-1551
 Tianjia Shao,Zhejiang University,http://tianjiashao.com,NOSCHOLARPAGE,0000-0001-5485-3752

--- a/csrankings-y.csv
+++ b/csrankings-y.csv
@@ -530,6 +530,7 @@ Yinan Wu 0003,Nankai University,https://ai.nankai.edu.cn/info/1281/6423.htm,NOSC
 Yincheng Jin,Binghamton University,https://www.binghamton.edu/computer-science/people/profile.html?id=yjin5,eRQgxJEAAAAJ,0000-0002-1812-4234
 Ying Cai,Iowa State University,http://www.cs.iastate.edu/~yingcai,N3Jc1zMAAAAJ,0000-0000-0000-0000
 Ying Cao 0001,ShanghaiTech University,http://www.ying-cao.com,uFjhoxYAAAAJ,0000-0002-9288-3167
+Ying Fu 0001,Beijing Institute of Technology,https://ying-fu.github.io/,PE4xMlkAAAAJ,0009-0003-3074-078X
 Ying Gao 0006,Beihang University,https://shi.buaa.edu.cn/gaoying/zh_CN/index.htm,SFHMnYIAAAAJ,0000-0001-8992-651X
 Ying He 0001,Nanyang Technological University,https://www3.ntu.edu.sg/home/yhe,sVf_tdoAAAAJ,0000-0002-6749-4485
 Ying He 0006,Shenzhen University, https://csse.szu.edu.cn/en/pages/user/index?id=958,N0U7s7AAAAAJ,0000-0000-0000-0000

--- a/csrankings-z.csv
+++ b/csrankings-z.csv
@@ -91,6 +91,7 @@ Zhaohui Luo,Royal Holloway Univ. of London,https://pure.royalholloway.ac.uk/port
 Zhaohui Peng,Shandong University,http://www.cs.sdu.edu.cn/info/1090/2342.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Zhaohui S. Qin,Emory University,https://www.sph.emory.edu/faculty/profile/index.php?FID=8697,9F-Jk74AAAAJ,0000-0002-1583-146X
 Zhaohui Wu 0001,Zhejiang University,http://mypage.zju.edu.cn/wuzhaohui,qV631P8AAAAJ,0000-0000-0000-0000
+Zhaojing Luo,Beijing Institute of Technology,https://zhaojingluo.github.io/,963a9psAAAAJ,0000-0000-0000-0000
 Zhaojun Bai,Univ. of California - Davis,http://www.cs.ucdavis.edu/~bai,soiDQbQAAAAJ,0000-0000-0000-0000
 Zhaolei Zhang,University of Toronto,http://sites.utoronto.ca/zhanglab,WvJIvxQAAAAJ,0000-0000-0000-0000
 Zhaolin Chen,Monash University,https://research.monash.edu/en/persons/zhaolin-chen,wM9Y-I0AAAAJ,0000-0000-0000-0000
@@ -330,6 +331,7 @@ Zhiwei Jiang 0001,Nanjing University,https://zhiweinju.github.io,RMeCJCoAAAAJ,00
 Zhiwei Steven Wu,Carnegie Mellon University,https://zstevenwu.com,MbF6rTEAAAAJ,0000-0002-8125-8227
 Zhiwei Xiong,USTC,http://staff.ustc.edu.cn/~zwxiong,Snl0HPEAAAAJ,0000-0002-9787-7460
 Zhiwei Xu 0001,University of Michigan-Dearborn,https://www-personal.umd.umich.edu/~zwxu,NIBk-JUAAAAJ,0000-0000-0000-0000
+Zhiwei Zhang,Beijing Institute of Technology,https://zhangzhiwei-zzw.github.io/,Q7QvAjgAAAAJ,0000-0000-0000-0000
 Zhiwei Zhao,UESTC,https://mobinets.cn/zzw,marMFnQAAAAJ,0000-0001-5293-0558
 Zhiwen Yu 0001,NWPU,http://www.ccm.media.kyoto-u.ac.jp/~yu,H0qmM6gAAAAJ,0000-0002-9905-3238
 Zhiwu Lu 0001,Renmin University of China,https://sites.google.com/site/zhiwulu,OUXS8doAAAAJ,0000-0001-6429-7956


### PR DESCRIPTION
## Consolidated PR for Beijing Institute of Technology

This PR consolidates the following open PRs:

| PR | Score | Title |
|---|---|---|
| #12218 | 80% | Add 2 faculty from Beijing Institute of Technology |
| #12319 | 85% | Add Chi Harold Liu (Beijing Institute of Technology) |
| #12324 | 80% | Add 1 faculty from Beijing Institute of Technology |
| #12336 | 80% | Add Haoran Yu 0001 (Beijing Institute of Technology) |
| #12485 | 75% | Add 5 faculty from Beijing Institute of Technology |

Total: 10 faculty additions.
Average individual score: 81%
Joint probability (all valid): 12.1%
