### PR TITLE
Add 17 faculty from Shanghai Jiao Tong University (consolidated)

### DIFF
--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -13,8 +13,8 @@ G. Stefano Sukhatme,University of Southern California,http://www-robotics.usc.ed
 Ga Wu,Dalhousie University,https://web.cs.dal.ca/~gaw,IdBlVPUAAAAJ,0000-0002-0370-0622
 Gabe Sibley,University of Colorado Boulder,https://www.colorado.edu/cs/users/gasi6462,MNp5hwoAAAAJ,0000-0002-3168-8878
 Gabe T. Sibley,University of Colorado Boulder,https://www.colorado.edu/cs/users/gasi6462,MNp5hwoAAAAJ,0000-0000-0000-0000
-Gabi Dreo,Bundeswehr University Munich,https://www.unibw.de/technische-informatik/mitarbeiter/professoren/univ-prof-in-dr-gabi-dreo-rodosek,NOSCHOLARPAGE,0000-0000-0000-0000
 Gabi Dreo Rodosek,Bundeswehr University Munich,https://www.unibw.de/technische-informatik/mitarbeiter/professoren/univ-prof-in-dr-gabi-dreo-rodosek,NOSCHOLARPAGE,0000-0000-0000-0000
+Gabi Dreo,Bundeswehr University Munich,https://www.unibw.de/technische-informatik/mitarbeiter/professoren/univ-prof-in-dr-gabi-dreo-rodosek,NOSCHOLARPAGE,0000-0000-0000-0000
 Gabi Stanovsky,Hebrew University of Jerusalem,https://gabrielstanovsky.github.io,AtkvBFYAAAAJ,0000-0000-0000-0000
 Gabi Taentzer,University of Marburg,https://www.uni-marburg.de/fb12/arbeitsgruppen/swt/gabi-taentzer,4Gu2XUEAAAAJ,0000-0000-0000-0000
 Gabin An,Korea University,https://ku-selene.github.io,T-58s1oAAAAJ,0000-0002-6521-8858
@@ -32,8 +32,8 @@ Gabriel J. Brostow,University College London,http://www0.cs.ucl.ac.uk/staff/g.br
 Gabriel Kaptchuk,Univ. of Maryland - College Park,https://www.cs.umd.edu/users/kaptchuk,gbq5qjYAAAAJ,0000-0002-8886-4748
 Gabriel L. Nazar,UFRGS,http://inf.ufrgs.br/~glnazar,z6oRVPUAAAAJ,0000-0000-0000-0000
 Gabriel Luca Nazar,UFRGS,http://inf.ufrgs.br/~glnazar,z6oRVPUAAAAJ,0000-0000-0000-0000
-Gabriel López,University of Murcia,http://webs.um.es/gabilm/miwiki/doku.php,TogbwmUAAAAJ,0000-0001-8258-7260
 Gabriel López Millán,University of Murcia,http://webs.um.es/gabilm/miwiki/doku.php,TogbwmUAAAAJ,0000-0000-0000-0000
+Gabriel López,University of Murcia,http://webs.um.es/gabilm/miwiki/doku.php,TogbwmUAAAAJ,0000-0001-8258-7260
 Gabriel M. Kuper,University of Trento,http://disi.unitn.eu/~kuper,9zljEDcAAAAJ,0000-0000-0000-0000
 Gabriel Nivasch,Ariel University,http://www.ariel.ac.il/Projects/TRP/GeneralInformation.asp?numRec=365&numtafrit=1&id_lang=1&d=,s11gsQUAAAAJ,0000-0001-5960-4253
 Gabriel Parmer,George Washington University,https://www.seas.gwu.edu/~gparmer,NOSCHOLARPAGE,0000-0003-1343-4492
@@ -49,8 +49,8 @@ Gabriela Czibula,Babeș-Bolyai University,http://www.cs.ubbcluj.ro/~gabis,0_ybi_
 Gabriela F. Ciocarlie,Stevens Institute of Technology,https://gabrielaciocarlie.github.io,w4dzwfQAAAAJ,0000-0002-4405-0742
 Gabriela Montoya,Aalborg University,https://vbn.aau.dk/en/persons/gabriela-valentina-montoya-castillo,qXfMXnYAAAAJ,0000-0001-5835-0335
 Gabriela Nicolescu,Polytechnique Montreal,https://www.polymtl.ca/expertises/nicolescu-gabriela,ef6bdBoAAAAJ,0000-0000-0000-0000
-Gabriela Serban,Babeș-Bolyai University,http://www.cs.ubbcluj.ro/~gabis,0_ybi_oAAAAJ,0000-0000-0000-0000
 Gabriela Serban Czibula,Babeș-Bolyai University,http://www.cs.ubbcluj.ro/~gabis,0_ybi_oAAAAJ,0000-0000-0000-0000
+Gabriela Serban,Babeș-Bolyai University,http://www.cs.ubbcluj.ro/~gabis,0_ybi_oAAAAJ,0000-0000-0000-0000
 Gabriele Anderst-Kotsis,JKU Linz,https://www.jku.at/institut-fuer-telekooperation/ueber-uns/team/gabriele-anderst-kotsis,9QhutOMAAAAJ,0000-0000-0000-0000
 Gabriele Bavota,Università della Svizzera italiana,http://search.usi.ch/people/e63382729ce424274797f0c45f4bc7e8/Bavota-Gabriele,inc2FLEAAAAJ,0000-0002-2216-3148
 Gabriele E. Danninger-Uchida,University of Vienna,https://cs.univie.ac.at/gabriele.uchida,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -112,12 +112,13 @@ Gangshan Wu,Nanjing University,http://mcg.nju.edu.cn/member/gswu/en/index.html,N
 Ganzhao Yuan,SUAT,https://csce.suat-sz.edu.cn/info/1011/1332.htm,-mDAbWQAAAAJ,0000-0000-0000-0000
 Gao Cong,Nanyang Technological University,https://www3.ntu.edu.sg/home/gaocong,WFFamJkAAAAJ,0000-0002-4430-6373
 Gaochao Xu,Jilin University,https://ccst.jlu.edu.cn/info/1367/19069.htm,NOSCHOLARPAGE,0000-0002-4450-7941
+Gaolei Li,Shanghai Jiao Tong University,https://cs.sjtu.edu.cn/jiaoshiml/ligaolei.html,Y9vPI2MAAAAJ,0000-0000-0000-0000
 Gaoli Wang,East China Normal University,https://faculty.ecnu.edu.cn/_s43/wgl2/main.psp,E51NElcAAAAJ,0000-0000-0000-0000
 Gaoning Pan,Hangzhou Dianzi University,https://faculty.hdu.edu.cn/wlkjaqxy/pgn/main.htm,CfTwWkYAAAAJ,0009-0003-9944-5009
 Gareth A. Conway,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=g.conway,hnYRpmsAAAAJ,0000-0000-0000-0000
 Gareth Tyson,HKUST,http://www.eecs.qmul.ac.uk/~tysong,91hmRA0AAAAJ,0000-0003-3010-791X
-Gargi Alavani,BITS Pilani-Goa,https://www.bits-pilani.ac.in/goa/gargi-sanket-prabhu,L1f1S_MAAAAJ,0000-0003-2758-4694
 Gargi Alavani Prabhu,BITS Pilani-Goa,https://www.bits-pilani.ac.in/goa/gargi-sanket-prabhu,L1f1S_MAAAAJ,0000-0000-0000-0000
+Gargi Alavani,BITS Pilani-Goa,https://www.bits-pilani.ac.in/goa/gargi-sanket-prabhu,L1f1S_MAAAAJ,0000-0003-2758-4694
 Gargi Kabirdas Alavani,BITS Pilani-Goa,https://www.bits-pilani.ac.in/goa/gargi-sanket-prabhu,L1f1S_MAAAAJ,0000-0000-0000-0000
 Gari D. Clifford,Emory University,http://gdclifford.info/people/gari,VwYoZ6gAAAAJ,0000-0000-0000-0000
 Gari David Clifford,Emory University,http://gdclifford.info/people/gari,VwYoZ6gAAAAJ,0000-0000-0000-0000
@@ -383,8 +384,8 @@ Geraldo R. Mateus,UFMG,http://homepages.dcc.ufmg.br/~mateus,k_rGXy0AAAAJ,0000-00
 Geraldo Robson Mateus,UFMG,http://homepages.dcc.ufmg.br/~mateus,k_rGXy0AAAAJ,0000-0000-0000-0000
 Geraldo Xexéo,UFRJ,http://www.cos.ufrj.br/index.php/pt-BR/pessoas/details/18/1020-xexeo,VbVw7-4AAAAJ,0000-0000-0000-0000
 Geraldo Zimbrao,UFRJ,http://www.cos.ufrj.br/~zimbrao,nJ1JMwcAAAAJ,0000-0000-0000-0000
-Geraldo Zimbrão,UFRJ,http://www.cos.ufrj.br/~zimbrao,nJ1JMwcAAAAJ,0000-0000-0000-0000
 Geraldo Zimbrão da Silva,UFRJ,http://www.cos.ufrj.br/~zimbrao,nJ1JMwcAAAAJ,0000-0000-0000-0000
+Geraldo Zimbrão,UFRJ,http://www.cos.ufrj.br/~zimbrao,nJ1JMwcAAAAJ,0000-0000-0000-0000
 Gerard Jounghyun Kim,Korea University,https://dxp.korea.ac.kr/index.php?mid=page_QEGJ80,7UCco8IAAAAJ,0000-0001-9880-8021
 Gerard Pons-Moll,University of Tübingen,https://virtualhumans.mpi-inf.mpg.de,OpXMNnMAAAAJ,0000-0001-5115-7794
 Gerard R. Richter,Rutgers University,http://www.cs.rutgers.edu/~richter,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -486,7 +487,6 @@ Gian Carlo Bongiovanni,Sapienza University of Rome,https://sites.google.com/a/di
 Gian Luca Marcialis,University of Cagliari,https://web.unica.it/unica/page/en/gianluca_marcialis,7pMEyo4AAAAJ,0000-0002-8719-9643
 Gian Pietro Picco,University of Trento,http://disi.unitn.it/~picco,DqcmXQ8AAAAJ,0000-0000-0000-0000
 Gian-Luigi Ferrari 0002,University of Pisa,http://pages.di.unipi.it/ferrari,NOSCHOLARPAGE,0000-0003-3548-5514
-Gianluca Demartini,University of Queensland,https://about.uq.edu.au/experts/18932,PCAiILsAAAAJ,0000-0002-7311-3693
 GianMario Besana,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=274,NOSCHOLARPAGE,0000-0001-6031-0658
 Giancarlo Bigi,University of Pisa,http://www.di.unipi.it/~bigig,NOSCHOLARPAGE,0000-0000-0000-0000
 Giancarlo Bongiovanni,Sapienza University of Rome,https://sites.google.com/a/di.uniroma1.it/bongiovanni,ZZUIEqgAAAAJ,0000-0000-0000-0000
@@ -499,6 +499,7 @@ Gianfranco Doretto,University of Utah,https://sci.utah.edu/people/gianfranco-dor
 Gianlorenzo D'Angelo,GSSI,https://cs.gssi.it/gianlorenzo.dangelo,FlZ-5sMAAAAJ,0000-0003-0377-7037
 Gianluca Bontempi,Université libre de Bruxelles,http://www.ulb.ac.be/di/map/gbonte/Welcome.html,SX-QoHsAAAAJ,0000-0001-8621-316X
 Gianluca De Marco,University of Salerno,http://www.unisa.it/docenti/gianlucademarco/index,NOSCHOLARPAGE,0000-0002-1204-0646
+Gianluca Demartini,University of Queensland,https://about.uq.edu.au/experts/18932,PCAiILsAAAAJ,0000-0002-7311-3693
 Gianluca Memoli,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/390809,ticqPMYAAAAJ,0000-0003-2578-2814
 Gianluca Palermo,Politecnico di Milano,http://home.deib.polimi.it/gpalermo,A5GSaaoAAAAJ,0000-0001-7955-8012
 Gianluca Pollastri,University College Dublin,https://people.ucd.ie/gianluca.pollastri,YFUQzzokG40C,0000-0002-5825-4949
@@ -690,8 +691,8 @@ Gordon I. Goodman,Rochester Inst. of Technology,https://www.rit.edu/gccis/gordon
 Gordon J. Pace,University of Malta,http://www.cs.um.edu.mt/gordon.pace,XtYG-jsAAAAJ,0000-0003-0743-6272
 Gordon L. Kindlmann,University of Chicago,http://people.cs.uchicago.edu/~glk,Ky1op0MAAAAJ,0000-0000-0000-0000
 Gordon S. Blair,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/people/gordon-blair,TQj5qo0AAAAJ,0000-0001-6212-1906
-Gordon S. Novak,University of Texas at Austin,https://www.cs.utexas.edu/users/novak,eHhHOD0AAAAJ,0000-0000-0000-0000
 Gordon S. Novak Jr.,University of Texas at Austin,https://www.cs.utexas.edu/users/novak,eHhHOD0AAAAJ,0000-0000-0000-0000
+Gordon S. Novak,University of Texas at Austin,https://www.cs.utexas.edu/users/novak,eHhHOD0AAAAJ,0000-0000-0000-0000
 Gordon V. Cormack,University of Waterloo,http://cormack.uwaterloo.ca,wFuZKaUAAAAJ,0000-0002-5890-0293
 Gordon Wetzstein,Stanford University,https://stanford.edu/~gordonwz,VOf45S0AAAAJ,0000-0002-9243-6885
 Gorkem Serbes,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/gorkem?lang=en,96vDpfcAAAAJ,0000-0003-4591-7368
@@ -1061,8 +1062,8 @@ Görschwin Fey,Hamburg University of Technology,https://www.tuhh.de/es/ce/people
 Gösta Grahne,Concordia University,http://www.cs.concordia.ca/~grahne,NOSCHOLARPAGE,0000-0000-0000-0000
 Gözde B. Ünal,Istanbul Technical University,http://akademi.itu.edu.tr/en/unalgo,soanB6MAAAAJ,0000-0001-5942-8966
 Gül Çalikli,University of Glasgow,https://gulcalikli.github.io,lShgfvwAAAAJ,0000-0003-4578-1747
-Gülfem Isiklar,Galatasaray University,https://avesis.gsu.edu.tr/gisiklar,QsiWkyMAAAAJ,0000-0000-0000-0000
 Gülfem Isiklar Alptekin,Galatasaray University,https://avesis.gsu.edu.tr/gisiklar,QsiWkyMAAAAJ,0000-0000-0000-0000
+Gülfem Isiklar,Galatasaray University,https://avesis.gsu.edu.tr/gisiklar,QsiWkyMAAAAJ,0000-0000-0000-0000
 Gülfem Işıklar Alptekin,Galatasaray University,https://avesis.gsu.edu.tr/gisiklar,QsiWkyMAAAAJ,0000-0000-0000-0000
 Gülsen Eryigit,Istanbul Technical University,http://web.itu.edu.tr/gulsenc,25CpSdkAAAAJ,0000-0000-0000-0000
 Günter Kemnitz,TU Clausthal,http://techwww.in.tu-clausthal.de/site/Personen/Index,NOSCHOLARPAGE,0000-0000-0000-0000

--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -373,6 +373,7 @@ Hao-Chuan Wang,Univ. of California - Davis,http://www.haochuanwang.info,2cAqDukA
 Haodi Feng,Shandong University,http://www.cs.sdu.edu.cn/info/1112/2723.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Haodi Zhang,Shenzhen University,https://hdzhangust.github.io,Xev_4JMAAAAJ,0000-0001-8470-7246
 Haodong Wang,Cleveland State University,http://cis.csuohio.edu/~hwang/publications.html,NOSCHOLARPAGE,0000-0000-0000-0000
+Haohua Zhao 0001,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/jiaoshiml/zhaohaohua.html,r0FIQBAAAAAJ,0000-0000-0000-0000
 Haojian Jin,Univ. of California - San Diego,http://haojianj.in,IivlhesAAAAJ,0000-0001-5212-2235
 Haojin Zhu,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/PeopleDetail.aspx?id=62,_5lzNDUAAAAJ,0000-0001-5079-4556
 Haomiao Ni,University of Memphis,https://www.memphis.edu/cs/people/faculty_pages/haomiao-ni.php,3PzBXAsAAAAJ,0009-0004-6747-4080

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -2724,6 +2724,7 @@ Junpei Komiyama,MBZUAI,https://mbzuai.ac.ae/study/faculty/junpei-komiyama,1uFfIm
 Junping Du 0001,BUPT,https://scs.bupt.edu.cn/info/1092/1327.htm,ljg1PKcAAAAJ,0000-0002-9402-3806
 Junping Sun,Nova Southeastern University,http://scis.nova.edu/~jps,NOSCHOLARPAGE,0000-0001-9164-8061
 Junqiao Qiu,City University of Hong Kong,https://junqiao-qiu.github.io/website,ftIjnJkAAAAJ,0000-0001-7776-3944
+Junqin Huang,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/jiaoshiml/huangjunqin.html,vkLqOFwAAAAJ,0000-0002-1306-9088
 Junqing Gong 0001,East China Normal University,https://faculty.ecnu.edu.cn/_s43/gjq/main.psp,7b4mW08AAAAJ,0000-0000-0000-0000
 Junqing Zhang,University of Liverpool,https://liverpool.ac.uk/electrical-engineering-and-electronics/staff/junqing-zhang,MIPbyQ0AAAAJ,0000-0000-0000-0000
 Junqiu Wei 0001,MUST,https://fie.must.edu.mo/id-1444/person/view/id-12708.html?locale=en_US,zDrFGLgAAAAJ,0000-0000-0000-0000

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -113,6 +113,7 @@ Kaiyang Zhou,Hong Kong Baptist University,https://kaiyangzhou.github.io,gRIejugA
 Kaiyi Ji,University at Buffalo,https://jikaiyi.github.io,E0A3lSIAAAAJ,0000-0000-0000-0000
 Kaiyu Hang,Rice University,https://hangkaiyu.github.io/index.html,GrgH1lQAAAAJ,0000-0000-0000-0000
 Kaiyuan Yang 0001,Rice University,https://vlsi.rice.edu/authors/admin,jbdA71QAAAAJ,0000-0000-0000-0000
+Kaiyuan Zhu,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/jiaoshiml/z.html,44g2NCsAAAAJ,0000-0000-0000-0000
 Kaizhong Zhang,Western University,http://www.csd.uwo.ca/~kzhang,a089X_0AAAAJ,0009-0006-5735-2949
 Kaj Grønbæk,Aarhus University,https://cs.au.dk/~kgronbak,zaL7iZ4AAAAJ,0000-0002-3752-6714
 Kaleem Siddiqi,McGill University,http://www.cim.mcgill.ca/~siddiqi,1jEAOVcAAAAJ,0000-0002-7347-9716
@@ -220,8 +221,8 @@ Karin Anna Hummel,JKU Linz,https://www.jku.at/institut-fuer-telekooperation/uebe
 Karin Becker,UFRGS,http://inf.ufrgs.br/~kbecker,aZA2pGQAAAAJ,0000-0000-0000-0000
 Karin Harbusch,University of Koblenz-Landau,https://www.uni-koblenz-landau.de/de/koblenz/fb4/icv/agharbusch/mitarbeiter/harbusch,NOSCHOLARPAGE,0000-0000-0000-0000
 Karin M. Verspoor,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/v/verspoor-professor-karin,dUxHnbcAAAAJ,0000-0000-0000-0000
-Karin Verspoor,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/v/verspoor-professor-karin,dUxHnbcAAAAJ,0000-0002-8661-1544
 Karin Verspoor 0001,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/v/verspoor-professor-karin,dUxHnbcAAAAJ,0000-0002-8661-1544
+Karin Verspoor,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/v/verspoor-professor-karin,dUxHnbcAAAAJ,0000-0002-8661-1544
 Karina S. Machado,Federal University of Rio Grande,http://karina.c3.furg.br,3j-IYXoAAAAJ,0000-0000-0000-0000
 Karina Santos Machado,Federal University of Rio Grande,http://karina.c3.furg.br,3j-IYXoAAAAJ,0000-0000-0000-0000
 Karina Valdivia Delgado,USP,http://www.ime.usp.br/~kvd,xSgMBCMAAAAJ,0000-0000-0000-0000
@@ -632,8 +633,8 @@ Ketan D. Mulmuley,University of Chicago,https://www.cs.uchicago.edu/directory/ke
 Ketan Mayer-Patel,University of North Carolina,http://www.cs.unc.edu/~kmp,S4GP-G4AAAAJ,0000-0001-5049-6583
 Ketan Meyer-Patel,University of North Carolina,http://www.cs.unc.edu/~kmp,S4GP-G4AAAAJ,0000-0000-0000-0000
 Ketan Mulmuley,University of Chicago,https://www.cs.uchicago.edu/directory/ketan-mulmuley,NOSCHOLARPAGE,0000-0000-0000-0000
-Ketan Patel,University of North Carolina,http://www.cs.unc.edu/~kmp,S4GP-G4AAAAJ,0000-0000-0000-0000
 Ketan Patel 0001,University of North Carolina,http://www.cs.unc.edu/~kmp,S4GP-G4AAAAJ,0000-0000-0000-0000
+Ketan Patel,University of North Carolina,http://www.cs.unc.edu/~kmp,S4GP-G4AAAAJ,0000-0000-0000-0000
 Ketil Malde,University of Bergen,https://www.uib.no/en/persons/Ketil.Malde,NOSCHOLARPAGE,0000-0001-7381-1849
 Keting Jia,Tsinghua University,http://www.castu.tsinghua.edu.cn/publish/casen/1257/index.html,NOSCHOLARPAGE,0000-0002-6396-8882
 Keunsoo Ko,The Catholic University of Korea,https://imlab-cuk.github.io,stpMbagAAAAJ,0000-0003-0203-4530
@@ -1043,8 +1044,8 @@ Kun She 0001,UESTC,https://www.is.uestc.edu.cn/teachers.do?id=1044,NOSCHOLARPAGE
 Kun Sun 0001,George Mason University,https://csis.gmu.edu/ksun,u18hG4gAAAAJ,0000-0003-4152-2107
 Kun Xie 0001,Hunan University,https://cskxie.github.io,2cfH6_0AAAAJ,0000-0002-2163-2723
 Kun Xu 0003,Tsinghua University,http://cg.cs.tsinghua.edu.cn/people/~kun,dRlBzscAAAAJ,0000-0002-2671-4170
-Kun Yang,Nanjing University,https://ninelab.org.cn/?p=959,qpe3iUkAAAAJ,0000-0000-0000-0000
 Kun Yang 0001,University of Essex,https://www.essex.ac.uk/people/yangk82907/kun-yang,qpe3iUkAAAAJ,0000-0000-0000-0000
+Kun Yang,Nanjing University,https://ninelab.org.cn/?p=959,qpe3iUkAAAAJ,0000-0000-0000-0000
 Kun Zhang 0001,MBZUAI,https://mbzuai.ac.ae/study/faculty/kun-zhang,RGoypN4AAAAJ,0000-0002-0738-9958
 Kun Zhou 0001,Zhejiang University,http://mypage.zju.edu.cn/kunzhou,N-iYby0AAAAJ,0000-0003-4243-6112
 Kun-Mao Chao,National Taiwan University,https://www.csie.ntu.edu.tw/~kmchao,rkpVQI4AAAAJ,0000-0003-2837-1279

--- a/csrankings-l.csv
+++ b/csrankings-l.csv
@@ -52,6 +52,7 @@ Lane T. Harrison,Worcester Polytechnic Institute,http://web.cs.wpi.edu/~ltharris
 Lang Huang 0001,National Inst. of Informatics,https://layneh.github.io,fhr1LrUAAAAJ,0000-0002-3405-0298
 Langis Roy,Ontario Tech University,https://engineering.ontariotechu.ca/people/ecse/langis.roy.php,NOSCHOLARPAGE,0000-0000-0000-0000
 Lannan Luo,George Mason University,https://lannan.github.io,JPXjw04AAAAJ,0000-0003-2476-7831
+Lanqing Yang,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/jiaoshiml/yanglanqing.html,ZCZE34oAAAAJ,0000-0002-1551-224X
 Lanshun Nie,Harbin Institute of Technology,http://homepage.hit.edu.cn/lanshun,NOSCHOLARPAGE,0000-0003-2079-1252
 Lantao Liu,Indiana University,http://homes.sice.indiana.edu/lantao,L5dHk5cAAAAJ,0000-0000-0000-0000
 Lanxin Yang,Nanjing University,https://software.nju.edu.cn/lxyang/index.html,Y_S5nT4AAAAJ,0000-0002-0406-2263
@@ -223,8 +224,8 @@ Leandro Krug Wives,UFRGS,http://www.inf.ufrgs.br/~wives,VV5p1EEAAAAJ,0000-0000-0
 Leandro L. Minku,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/academic-staff/minku-leandro.aspx,meC54dkAAAAJ,0000-0002-2639-0671
 Leandro M. Almeida,UFPE,https://www.cin.ufpe.br/~lma3,4VLuIWgAAAAJ,0000-0000-0000-0000
 Leandro Maciel Almeida,UFPE,https://www.cin.ufpe.br/~lma3,4VLuIWgAAAAJ,0000-0000-0000-0000
-Leandro Marín,University of Murcia,http://webs.um.es/leandro/miwiki/doku.php,7l_3V7cAAAAJ,0000-0000-0000-0000
 Leandro Marín Muñoz,University of Murcia,http://webs.um.es/leandro/miwiki/doku.php,7l_3V7cAAAAJ,0000-0000-0000-0000
+Leandro Marín,University of Murcia,http://webs.um.es/leandro/miwiki/doku.php,7l_3V7cAAAAJ,0000-0000-0000-0000
 Leandro Soares Indrusiak,University of Leeds,https://eps.leeds.ac.uk/computing/staff/14038/professor-leandro-soares-indrusiak-,f1PUDsEAAAAJ,0000-0002-9938-2920
 Leandro Soriano Marcolino,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/people/leandro-soriano-marcolino,PBzg9G4AAAAJ,0000-0002-3337-8611
 Leandro Villas,UNICAMP,http://www.ic.unicamp.br/~leandro,7ZTnzxQAAAAJ,0000-0000-0000-0000
@@ -436,6 +437,7 @@ Li Lu 0001,UESTC,https://www.scse.uestc.edu.cn/info/1081/12001.htm,NOSCHOLARPAGE
 Li Lu 0008,Zhejiang University,https://person.zju.edu.cn/lynnluli,mQSqGYAAAAAJ,0000-0001-5230-3749
 Li Lucy,University of Wisconsin - Madison,https://lucy3.github.io,9IyAwc4AAAAJ,0000-0000-0000-0000
 Li Niu 0002,Shanghai Jiao Tong University,http://bcmi.sjtu.edu.cn/home/niuli/index.html,OhT3AWMAAAAJ,0000-0003-1970-8634
+Li Pan 0002,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/jiaoshiml/panli.html,HsveBdUAAAAJ,0000-0000-0000-0000
 Li Shen 0008,Sun Yat-sen University,https://scst.sysu.edu.cn/teacher/ShenLi,yVhgENIAAAAJ,0000-0001-5659-3464
 Li Sun 0005,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/academic/li-sun,JZViN_4AAAAJ,0000-0002-0393-8665
 Li Weigang 0001,Universidade de Brasília,http://cic.unb.br/~weigang,Sw_i7yQAAAAJ,0000-0000-0000-0000
@@ -473,6 +475,7 @@ Liang Bao,Xidian University,https://web.xidian.edu.cn/baoliang,PScbt3kAAAAJ,0000
 Liang Chen 0001,Sun Yat-sen University,https://chenliang.tech,pGZtPjcAAAAJ ,0000-0002-3787-8832
 Liang Cheng 0001,Lehigh University,http://liangcheng.info,7_2bG-YAAAAJ,0000-0000-0000-0000
 Liang Feng 0001,Chongqing University,http://www.cs.cqu.edu.cn/info/1322/4182.htm,vUFmMrQAAAAJ,0000-0002-8356-7242
+Liang Feng Zhang,ShanghaiTech University,https://sist.shanghaitech.edu.cn/zhanglf/main.htm,dlkYO5gAAAAJ,0000-0000-0000-0000
 Liang He 0005,University of Texas at Dallas,https://www.lianghe.me,AXIunRIAAAAJ,0000-0003-4826-629X
 Liang Hong 0001,Wuhan University,https://jszy.whu.edu.cn/hongliang/en/index/262757/list/index.htm,mWqxcvYAAAAJ,0000-0002-1466-9843
 Liang Hu 0001,Jilin University,https://ccst.jlu.edu.cn/info/1367/19276.htm,NOSCHOLARPAGE,0000-0002-6077-1873
@@ -488,7 +491,6 @@ Liang Zheng 0001,Australian National University,https://cs.anu.edu.au/people/lia
 Liang-Jie Zhang,Shenzhen University,https://orcid.org/0000-0002-6219-0853,DkEKl2QAAAAJ,0000-0002-6219-0853
 Liang-Tien Chia,Nanyang Technological University,https://dr.ntu.edu.sg/cris/rp/rp00991,Eeolw80AAAAJ,0000-0000-0000-0000
 Liangcai Gao,Peking University,http://www.icst.pku.edu.cn/cpdp/index.php/research-team/12-gaoliangcai,NOSCHOLARPAGE,0000-0002-5196-4825
-Liang Feng Zhang,ShanghaiTech University,https://sist.shanghaitech.edu.cn/zhanglf/main.htm,dlkYO5gAAAAJ,0000-0000-0000-0000
 Liangming Pan,Peking University,https://cs.pku.edu.cn/info/1223/3939.htm,JcjjOTUAAAAJ,0000-0002-7789-7739
 Liangqiong Qu,University of Hong Kong,https://ai.hku.hk/people/academic-staff/liangqqu,ruKpgzwAAAAJ,0000-0000-0000-0000
 Lianhui Qin,Univ. of California - San Diego,https://sites.google.com/view/lianhuiqin/home,smd19iIAAAAJ,0009-0002-4757-8136
@@ -498,6 +500,7 @@ Liat Cohen,Ariel University,https://pniot.ariel.ac.il/projects/trp/GeneralInform
 Liat Peterfreund,Hebrew University of Jerusalem,https://www.cs.huji.ac.il/~liatpeter,K16Gp8sAAAAJ,0000-0002-4788-0944
 Libertario Demi,University of Trento,https://sites.google.com/view/drlibertariodemi/home,QiKVYI0AAAAJ,0000-0002-0635-2133
 Libin Liu 0002,Peking University,http://libliu.info,q7FiLBkAAAAJ,0000-0003-2280-6817
+Libo Chen 0001,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/jiaoshiml/chenlibo.html,7ikP578AAAAJ,0000-0000-0000-0000
 Libo Ivy Liu,University of Melbourne,https://findanexpert.unimelb.edu.au/profile/864133-libo-liu,NYRYeR0AAAAJ,0000-0000-0000-0000
 Libo Zhang 0001,Chinese Academy of Sciences,http://people.ucas.ac.cn/~zhanglibo,u92yhxUAAAAJ,0000-0002-7153-6465
 Lichao Sun 0001,Lehigh University,https://www.cs.uic.edu/~lsun,WhGUE7AAAAAJ,0000-0003-1539-7939
@@ -754,8 +757,8 @@ Lizzie Coles-Kemp,Royal Holloway Univ. of London,https://pure.royalholloway.ac.u
 Ljubomir Perkovic,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=188,6dwowIYAAAAJ,0000-0000-0000-0000
 Llorenç Cerdà,Polytechnic Univ. of Catalonia,http://dsg.ac.upc.edu/llorenc,LwfxWokAAAAJ,0000-0000-0000-0000
 Llorenç Cerdà-Alabern,Polytechnic Univ. of Catalonia,http://dsg.ac.upc.edu/llorenc,LwfxWokAAAAJ,0000-0000-0000-0000
-Lluís Màrquez,Qatar Computing Research Inst.,http://www.qcri.org/our-people/bio?pid=145&amp;par=acc&amp;name=LluisMarquez,yFNUfjsAAAAJ,0000-0000-0000-0000
 Lluís Màrquez i Villodre,Qatar Computing Research Inst.,http://www.qcri.org/our-people/bio?pid=145&amp;par=acc&amp;name=LluisMarquez,yFNUfjsAAAAJ,0000-0000-0000-0000
+Lluís Màrquez,Qatar Computing Research Inst.,http://www.qcri.org/our-people/bio?pid=145&amp;par=acc&amp;name=LluisMarquez,yFNUfjsAAAAJ,0000-0000-0000-0000
 Lluís Vilanova,Imperial College London,https://www.doc.ic.ac.uk/~lvilanov,aMMzgPoAAAAJ,0000-0002-1452-840X
 Loai M. Alnemer,University of Jordan,http://eacademic.ju.edu.jo/L.nemer,4w18VJgAAAAJ,0000-0000-0000-0000
 Loana Tito Nogueira,UFF,http://www2.ic.uff.br/~loana,AQsF0MYAAAAJ,0000-0000-0000-0000
@@ -766,8 +769,8 @@ Loek G. Cleophas,TU Eindhoven,https://www.tue.nl/en/university/departments/mathe
 Lois Wright Hawkes,Florida State University,http://www.cs.fsu.edu/~hawkes,NOSCHOLARPAGE,0000-0000-0000-0000
 Lok-won Kim,Kyung Hee University,http://ce.khu.ac.kr/eng/blog/blog_page.php?r_Idx=28&b_menuNum=2,Df1_a_4AAAAJ,0000-0000-0000-0000
 Lokesh Das,Wichita State University,https://www.wichita.edu/profiles/academics/engineering/SoC/01_Faculty/Das-Lokesh.php,72vb6msAAAAJ,0000-0002-5855-0334
-Lone Leth,Aalborg University,http://people.cs.aau.dk/~lone,vyYcihcAAAAJ,0000-0000-0000-0000
 Lone Leth Thomsen,Aalborg University,http://people.cs.aau.dk/~lone,vyYcihcAAAAJ,0000-0003-1035-5975
+Lone Leth,Aalborg University,http://people.cs.aau.dk/~lone,vyYcihcAAAAJ,0000-0000-0000-0000
 Long Chen 0001,University of Macau,https://www.fst.um.edu.mo/personal/longchen/,vicu3yEAAAAJ,0000-0003-0184-5446
 Long Chen 0016,HKUST,https://zjuchenlong.github.io,-gtmMpIAAAAJ,0000-0001-6148-9709
 Long Cheng 0005,Clemson University,https://people.computing.clemson.edu/~lcheng2,GuaBhicAAAAJ,0000-0003-1736-0873
@@ -984,8 +987,8 @@ Luis Felipe Gonzalez,Queensland Univ. of Technology,https://research.qut.edu.au/
 Luis Garcia 0001,University of Utah,https://lagarcia.us,F6Gzg9gAAAAJ,0000-0002-5111-0694
 Luis Gravano,Columbia University,http://www.cs.columbia.edu/~gravano,Ff6era8AAAAJ,0000-0000-0000-0000
 Luis Mateus Rocha,Indiana University,https://homes.luddy.indiana.edu/rocha,SIouE70AAAAJ,0000-0000-0000-0000
-Luis Mejías,Queensland Univ. of Technology,https://research.qut.edu.au/qcr/people/luis-mejias-alvarez,MDWCSOQAAAAJ,0000-0002-6298-2340
 Luis Mejías Alvarez,Queensland Univ. of Technology,https://research.qut.edu.au/qcr/people/luis-mejias-alvarez,MDWCSOQAAAAJ,0000-0002-6298-2340
+Luis Mejías,Queensland Univ. of Technology,https://research.qut.edu.au/qcr/people/luis-mejias-alvarez,MDWCSOQAAAAJ,0000-0002-6298-2340
 Luis Pedrosa,Universidade de Lisboa,https://pedrosa.2y.net,Rue7JwcAAAAJ,0000-0002-4611-8309
 Luis Rademacher,Univ. of California - Davis,https://www.math.ucdavis.edu/~lrademac,wNqCOAEAAAAJ,0000-0001-8708-2755
 Luis Ramos Pinto,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/lmpinto,stvtLQgAAAAJ,0000-0003-1997-5484

--- a/csrankings-q.csv
+++ b/csrankings-q.csv
@@ -174,6 +174,7 @@ Qiongkai Xu,Macquarie University,https://xuqiongkai.github.io,wCer2WUAAAAJ,0000-
 Qipeng Liu 0001,Univ. of California - San Diego,https://sites.google.com/view/qipengliu,oQPOdX0AAAAJ,0000-0002-3994-7061
 Qirong Ho,MBZUAI,https://mbzuai.ac.ae/study/faculty/qirong-ho,tR3AZbwAAAAJ,0000-0000-0000-0000
 Qirun Zhang,Georgia Institute of Technology,http://helloqirun.github.io,u0TKjhIAAAAJ,0000-0001-5367-9377
+Qisheng Wang,Shanghai Jiao Tong University,https://cs.sjtu.edu.cn/jiaoshiml/wangqisheng.html,t9NllbcAAAAJ,0000-0000-0000-0000
 Qishi Wu,NJIT,http://cs.njit.edu/people/wu.php,C__DNg8AAAAJ,0000-0000-0000-0000
 Qiu Shen,Nanjing University,https://shenqiu.njucite.cn,cFS40tMAAAAJ,0000-0000-0000-0000
 Qiuchi Li,University of Copenhagen,https://di.ku.dk/english/staff/vip/researchers_ml/?pure=en/persons/708176,vZ3-V8oAAAAJ,0000-0000-0000-0000

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -1133,6 +1133,7 @@ Shengyao Lu,University of Victoria,https://sluxsr.github.io,MSsab9EAAAAJ,0000-00
 Shengyu Zhang 0001,Zhejiang University,https://person.zju.edu.cn/shengyuzhang,l4Dyt7EAAAAJ,0000-0002-0030-8289
 Shengyu Zhang 0002,Chinese University of Hong Kong,http://www.cse.cuhk.edu.hk/~syzhang,h9_LPeAAAAAJ,0000-0001-5907-2277
 Shengyuan Wang,Tsinghua University,http://www.tsinghua.edu.cn/publish/csen/4623/2010/20101224194341363850614/20101224194341363850614_.html,o_XEptEAAAAJ,0000-0000-0000-0000
+Shengyun Liu,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/jiaoshiml/liushengyun.html,aY3qb2cAAAAJ,0000-0003-1219-786X
 Shenlong Wang,Univ. of Illinois at Urbana-Champaign,http://shenlong.web.illinois.edu,QFpswmcAAAAJ,0000-0002-7984-266X
 Sheqin Dong,Tsinghua University,http://www.tsinghua.edu.cn/publish/csen/4623/2010/20101223231437873460518/20101223231437873460518_.html,VxBX9CgAAAAJ,0000-0000-0000-0000
 Sherah Kurnia,University of Melbourne,https://findanexpert.unimelb.edu.au/display/person6535,vasVu8sAAAAJ,0000-0000-0000-0000

--- a/csrankings-t.csv
+++ b/csrankings-t.csv
@@ -67,8 +67,8 @@ Taisy Silva Weber,UFRGS,https://www.inf.ufrgs.br/site/docente/taisy-silva-weber,
 Taiyun Chi,Rice University,https://chilab.info/team,x7UY3lIAAAAJ,0000-0000-0000-0000
 Tajana Rosing,Univ. of California - San Diego,http://cseweb.ucsd.edu/~trosing,CeieiIgAAAAJ,0000-0002-6954-997X
 Tajana S. Rosing,Univ. of California - San Diego,http://cseweb.ucsd.edu/~trosing,CeieiIgAAAAJ,0000-0000-0000-0000
-Tajana Simunic,Univ. of California - San Diego,http://cseweb.ucsd.edu/~trosing,CeieiIgAAAAJ,0000-0002-6954-997X
 Tajana Simunic Rosing,Univ. of California - San Diego,http://cseweb.ucsd.edu/~trosing,CeieiIgAAAAJ,0000-0002-6954-997X
+Tajana Simunic,Univ. of California - San Diego,http://cseweb.ucsd.edu/~trosing,CeieiIgAAAAJ,0000-0002-6954-997X
 Tak Wah Lam,University of Hong Kong,https://i.cs.hku.hk/~twlam,wgvU0B8AAAAJ,0000-0003-4676-8587
 Tak Yeon Lee,KAIST,https://id.kaist.ac.kr/people,k2sjjrwAAAAJ,0000-0002-9235-9947
 Takaaki Ohnishi,University of Tokyo,http://www.canon-igs.org/en/fellows/takaaki_ohnishi.html,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -145,6 +145,7 @@ Tamás Vinkó,University of Szeged,http://www.inf.u-szeged.hu/~tvinko,XZFOFSwAAA
 Tanaya Guha,University of Warwick,https://warwick.ac.uk/fac/sci/dcs/people/tanaya_guha,GljtiSUAAAAJ,0000-0000-0000-0000
 Tandy J. Warnow,Univ. of Illinois at Urbana-Champaign,https://tandy.cs.illinois.edu,pPB_WK0AAAAJ,0000-0001-7717-3514
 Tanel Alumäe,Tallinn University of Technology,https://taltech.ee/en/person/tanel-alumae,Kdo-J_8AAAAJ,0000-0000-0000-0000
+Tanfeng Sun,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/jiaoshiml/suntanfeng.html,p5OtBwQAAAAJ,0000-0002-3253-5136
 Tangming Yuan,University of York,https://www-users.cs.york.ac.uk/~tommy,1fzy4fsAAAAJ,0000-0000-0000-0000
 Tanima Dutta,IIT (BHU) Varanasi,http://www.iitbhu.ac.in/cse/index.php/people/faculty.html,ofERjawAAAAJ,0000-0000-0000-0000
 Tanir Ozcelebi,TU Eindhoven,http://www.win.tue.nl/~tozceleb,3ryI7iEAAAAJ,0000-0001-7092-5998
@@ -196,8 +197,8 @@ Tao Xie 0001,Peking University,https://taoxiease.github.io,DhhH9J4AAAAJ,0000-000
 Tao Yang 0009,Univ. of California - Santa Barbara,http://www.cs.ucsb.edu/~tyang,NOSCHOLARPAGE,0000-0003-1902-3387
 Tao Yu 0009,University of Hong Kong,https://taoyds.github.io,5_Fn5CIAAAAJ,0000-0001-9939-2216
 Tao Yue 0002,Beihang University,https://scse.buaa.edu.cn/info/1078/10993.htm,zTDRGDcAAAAJ,0000-0003-3262-5577
-Tao Zhang,New York Tech,https://site.nyit.edu/bio/tzhang,9cMiSg4AAAAJ,0000-0000-0000-0000
 Tao Zhang 0001,MUST,https://cszhangtao.github.io,eMfANKoAAAAJ,0000-0002-6272-4069
+Tao Zhang,New York Tech,https://site.nyit.edu/bio/tzhang,9cMiSg4AAAAJ,0000-0000-0000-0000
 Tao Zhou 0001,UESTC,http://www.bigdata-research.org/people/faculty/4.html,MXgWgmEAAAAJ,0000-0003-0561-2316
 Taolue Chen 0001,Birkbeck University of London,https://www.dcs.bbk.ac.uk/about/people/academic-staff/taolue-chen,Qv_-WU4AAAAJ,0000-0002-5993-1665
 Tapan K. Saha,University of Queensland,http://researchers.uq.edu.au/researcher/83,v6njRnAAAAAJ,0000-0000-0000-0000
@@ -514,8 +515,8 @@ Thomas Martinetz,University of Lübeck,https://www.inb.uni-luebeck.de/mitarbeite
 Thomas Meyer 0002,University of Cape Town,https://people.cs.uct.ac.za/~tmeyer,Ua2MNSoAAAAJ,0000-0003-2204-6969
 Thomas Neele,TU Eindhoven,https://tneele.com,sDEqN78AAAAJ,0000-0001-6117-9129
 Thomas Neumann 0001,TU Munich,https://db.in.tum.de/~neumann,xSDfDpsAAAAJ,0000-0001-5787-142X
-Thomas Noll,RWTH Aachen University,https://moves.rwth-aachen.de/people/noll,KOrTdxMAAAAJ,0000-0000-0000-0000
 Thomas Noll 0001,RWTH Aachen University,https://moves.rwth-aachen.de/people/noll,jbGuWDwAAAAJ,0000-0002-1865-1798
+Thomas Noll,RWTH Aachen University,https://moves.rwth-aachen.de/people/noll,KOrTdxMAAAAJ,0000-0000-0000-0000
 Thomas Nolte,Mälardalen University,http://www.es.mdh.se/staff/48-Thomas_Nolte,vKIlvHIAAAAJ,0000-0000-0000-0000
 Thomas Nowotny,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/206151,W3T-i5AAAAAJ,0000-0000-0000-0000
 Thomas Olsson 0002,Tampere University,https://www.tuni.fi/en/thomas-olsson,_4wz2YAAAAAJ,0000-0002-1106-2544
@@ -713,15 +714,15 @@ Tim Bell,University of Canterbury,http://www.cosc.canterbury.ac.nz/tim.bell,NOSC
 Tim Bjørn Dyrby,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE,0000-0000-0000-0000
 Tim Blackwell,Goldsmiths University of London,https://www.gold.ac.uk/computing/staff/t-blackwell,NOSCHOLARPAGE,0000-0000-0000-0000
 Tim Brecht,University of Waterloo,https://cs.uwaterloo.ca/~brecht,74nBKe8AAAAJ,0000-0000-0000-0000
-Tim Chen,University of Technology Sydney,https://www.uts.edu.au/staff/tim.chen,UgJAkMgAAAAJ,0000-0000-0000-0000
 Tim Chen 0001,University of Technology Sydney,https://www.uts.edu.au/staff/tim.chen,UgJAkMgAAAAJ,0000-0000-0000-0000
+Tim Chen,University of Technology Sydney,https://www.uts.edu.au/staff/tim.chen,UgJAkMgAAAAJ,0000-0000-0000-0000
 Tim D. Barfoot,University of Toronto,http://asrl.utias.utoronto.ca/~tdb,N_vPIhoAAAAJ,0000-0000-0000-0000
 Tim Dwyer,Monash University,https://research.monash.edu/en/persons/tim-dwyer,cOEUhBAAAAAJ,0000-0002-9076-9571
 Tim Erhan Güneysu,Ruhr-University Bochum,http://www.seceng.rub.de/chair/staff/gueneysu,QrXiIS0AAAAJ,0000-0000-0000-0000
 Tim Fernando,Trinity College Dublin,https://www.scss.tcd.ie/Tim.Fernando,NOSCHOLARPAGE,0000-0000-0000-0000
 Tim Finin,Univ. of Maryland - Baltimore County,http://umbc.edu/~finin,p5oWQ0AAAAAJ,0000-0002-6593-1792
-Tim French,University of Western Australia,http://uwa.edu.au/people/tim.french,zcqX-AgAAAAJ,0000-0000-0000-0000
 Tim French 0001,University of Western Australia,http://uwa.edu.au/people/tim.french,zcqX-AgAAAAJ,0000-0000-0000-0000
+Tim French,University of Western Australia,http://uwa.edu.au/people/tim.french,zcqX-AgAAAAJ,0000-0000-0000-0000
 Tim Güneysu,Ruhr-University Bochum,http://www.seceng.rub.de/chair/staff/gueneysu,QrXiIS0AAAAJ,0000-0002-3293-4989
 Tim Hopkins,University of Kent,https://www.cs.kent.ac.uk/people/staff/trh,_Anf3acAAAAJ,0000-0000-0000-0000
 Tim Kovacs,University of Bristol,http://www.cs.bris.ac.uk/~kovacs,pil1zQsAAAAJ,0000-0000-0000-0000
@@ -770,8 +771,8 @@ Timothy M. Chan,Univ. of Illinois at Urbana-Champaign,http://tmc.web.engr.illino
 Timothy M. Hospedales,University of Edinburgh,http://homepages.inf.ed.ac.uk/thospeda,nHhtvqkAAAAJ,0000-0003-4867-7486
 Timothy M. Jones 0001,University of Cambridge,https://www.cl.cam.ac.uk/~tmj32,qnn3-gMAAAAJ,0000-0002-4114-7661
 Timothy McCarthy,Maynooth University,https://www.maynoothuniversity.ie/faculty-science-engineering/our-people/tim-mccarthy,fP6aKNEAAAAJ,0000-0000-0000-0000
-Timothy Merritt,Aalborg University,http://www.ixd.net,RBhmAmkAAAAJ,0000-0000-0000-0000
 Timothy Merritt 0001,Aalborg University,http://www.ixd.net,RBhmAmkAAAAJ,0000-0002-7851-7339
+Timothy Merritt,Aalborg University,http://www.ixd.net,RBhmAmkAAAAJ,0000-0000-0000-0000
 Timothy Oates 0001,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/people/faculty/tim-oates,NOSCHOLARPAGE,0000-0000-0000-0000
 Timothy Robert Merritt,Aalborg University,http://www.ixd.net,RBhmAmkAAAAJ,0000-0000-0000-0000
 Timothy Roscoe,ETH Zurich,http://people.inf.ethz.ch/troscoe,NOSCHOLARPAGE,0000-0002-8298-1126
@@ -789,8 +790,8 @@ Timothy Zhu,Pennsylvania State University,https://sites.psu.edu/timothyz,EhCg54E
 Tin Chi Nguyen,University of Nevada,https://www.cse.unr.edu/~tinn,WRyPP80AAAAJ,0000-0001-8001-9470
 Tin Lok James Ng,Trinity College Dublin,https://www.scss.tcd.ie/personnel/ngja,a2ahoJIAAAAJ,0000-0002-4405-4911
 Tin Lun Lam,CUHK (SZ),https://myweb.cuhk.edu.cn/tllam,YdOL0KUAAAAJ,0000-0002-6363-1446
-Tin Nguyen,Auburn University,https://tinnguyen-lab.com//home,WRyPP80AAAAJ,0000-0000-0000-0000
 Tin Nguyen 0001,University of Nevada,https://www.cse.unr.edu/~tinn,WRyPP80AAAAJ,0000-0001-8001-9470
+Tin Nguyen,Auburn University,https://tinnguyen-lab.com//home,WRyPP80AAAAJ,0000-0000-0000-0000
 Tina Eliassi-Rad,Northeastern University,http://www.ccis.northeastern.edu/people/tina-eliassi-rad,TXb5Ym8AAAAJ,0000-0000-0000-0000
 Ting Bai,BUPT,https://tbbaby.github.io/baiting_index.html,1mQvSPkAAAAJ,0000-0000-0000-0000
 Ting Chen 0002,UESTC,https://www.scse.uestc.edu.cn/info/1081/11931.htm,nkjaN4QAAAAJ,0000-0001-9165-8331
@@ -1026,8 +1027,8 @@ Toon Calders,University of Antwerp,https://www.uantwerpen.be/en/staff/toon-calde
 Tor Helleseth,University of Bergen,http://www.ii.uib.no/~torh,NOSCHOLARPAGE,0000-0000-0000-0000
 Tor M. Aamodt,University of British Columbia,https://www.ece.ubc.ca/~aamodt,zCsB5XsAAAAJ,0000-0003-1161-692X
 Tor-Arne Schmidt Nordmo,UiT The Arctic Univ. of Norway,https://uit.no/ansatte/tor-arne.s.nordmo,NOSCHOLARPAGE,0000-0000-0000-0000
-Torben Amtoft,Kansas State University,http://cis.ksu.edu/~tamtoft,NOSCHOLARPAGE,0009-0007-3273-7495
 Torben Amtoft Hansen,Kansas State University,http://cis.ksu.edu/~tamtoft,NOSCHOLARPAGE,0000-0000-0000-0000
+Torben Amtoft,Kansas State University,http://cis.ksu.edu/~tamtoft,NOSCHOLARPAGE,0009-0007-3273-7495
 Torben Bach Pedersen,Aalborg University,http://people.cs.aau.dk/~tbp,XGzPuKEAAAAJ,0000-0002-1615-777X
 Torben Hagerup,University of Augsburg,https://thiserver.informatik.uni-augsburg.de/personen/hagerup.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Torben Weis,University of Duisburg-Essen,https://www.vs.uni-due.de/mitarbeiter_weis.shtml,f2gnBw0AAAAJ,0000-0000-0000-0000

--- a/csrankings-w.csv
+++ b/csrankings-w.csv
@@ -281,6 +281,8 @@ Weiwei Liu 0003,Wuhan University,https://sites.google.com/site/weiweiliuhomepage
 Weiwei Sun 0008,Fudan University,http://www.cs.fudan.edu.cn/?page_id=1923,NOSCHOLARPAGE,0000-0000-0000-0000
 Weiwei Xu,Zhejiang University,http://www.cad.zju.edu.cn/home/weiweixu,qRXK__gAAAAJ,0000-0000-0000-0000
 Weiwen Jiang,George Mason University,https://www.gmu.edu/profiles/wjiang8,62oDIG4AAAAJ,0000-0002-9004-487X
+Weiwen Liu,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/jiaoshiml/liuweiwen.html,C7UzRGgAAAAJ,0000-0002-9148-3997
+Weixia Zhang,Shanghai Jiao Tong University,https://zwx8981.github.io/zhangweixia/,KK2nLnQAAAAJ,0000-0002-3634-2630
 Weixin Li 0001,Beihang University,http://irip.buaa.edu.cn/weixinli/index.html,ZRl2aAwAAAAJ,0000-0002-5093-5635
 Weixiong Rao,Tongji University,https://sse.tongji.edu.cn/wrao,7ubWTOMAAAAJ,0000-0000-0000-0000
 Weiyan Shi,Northeastern University,https://wyshi.github.io,xj666rUAAAAJ,0000-0003-0850-5831
@@ -334,8 +336,8 @@ Wendelin Boehmer,TU Delft,https://www.tudelft.nl/ewi/over-de-faculteit/afdelinge
 Wendelin Böhmer,TU Delft,https://www.tudelft.nl/ewi/over-de-faculteit/afdelingen/software-technology/algorithmics/people/wendelin-boehmer,wI5MV8IAAAAJ,0000-0000-0000-0000
 Wendi B. Heinzelman,University of Rochester,http://www2.ece.rochester.edu/~wheinzel,myYVVuYAAAAJ,0000-0000-0000-0000
 Wendi Beth Heinzelman,University of Rochester,http://www2.ece.rochester.edu/~wheinzel,myYVVuYAAAAJ,0000-0000-0000-0000
-Wendi Rabiner,University of Rochester,http://www2.ece.rochester.edu/~wheinzel,myYVVuYAAAAJ,0000-0000-0000-0000
 Wendi Rabiner Heinzelman,University of Rochester,http://www2.ece.rochester.edu/~wheinzel,myYVVuYAAAAJ,0000-0002-7541-4086
+Wendi Rabiner,University of Rochester,http://www2.ece.rochester.edu/~wheinzel,myYVVuYAAAAJ,0000-0000-0000-0000
 Wendy Hall 0001,University of Southampton,https://www.ecs.soton.ac.uk/people/wh,9NaDv3oAAAAJ,0000-0003-4327-7811
 Wendy Hui Wang,Stevens Institute of Technology,http://www.cs.stevens.edu/~hwang4,3pXvHPUAAAAJ,0000-0002-3913-815X
 Wendy Ju [Tech],Cornell University,https://wendyju.com,kjYhZYwAAAAJ,0000-0000-0000-0000
@@ -490,8 +492,8 @@ William D. Gropp,Univ. of Illinois at Urbana-Champaign,http://wgropp.cs.illinois
 William E. Skeith III,CUNY,http://www-cs.ccny.cuny.edu/~wes,NOSCHOLARPAGE,0000-0000-0000-0000
 William Eiers,Stevens Institute of Technology,https://william-eiers.github.io,shZGzBwAAAAJ,0009-0007-0235-2332
 William Enck,North Carolina State University,http://www.enck.org,KcM-4NsAAAAJ,0000-0002-3043-8092
-William F. Punch,Michigan State University,http://www.cse.msu.edu/~punch,U9HQ2qUAAAAJ,0000-0000-0000-0000
 William F. Punch III,Michigan State University,http://www.cse.msu.edu/~punch,U9HQ2qUAAAAJ,0000-0000-0000-0000
+William F. Punch,Michigan State University,http://www.cse.msu.edu/~punch,U9HQ2qUAAAAJ,0000-0000-0000-0000
 William Fornaciari,Politecnico di Milano,http://home.deib.polimi.it/fornacia,NOSCHOLARPAGE,0000-0001-8294-730X
 William G. J. Halfond,University of Southern California,https://viterbi-web.usc.edu/~halfond,98W28JoAAAAJ,0000-0003-4951-9367
 William G. Wee,University of Cincinnati,http://www.ece.uc.edu/%7Ewwee,NOSCHOLARPAGE,0000-0000-0000-0000

--- a/csrankings-x.csv
+++ b/csrankings-x.csv
@@ -382,6 +382,7 @@ Xiaoyuan Jing,Wuhan University,http://mla.whu.edu.cn,NOSCHOLARPAGE,0000-0000-000
 Xiaoyuan Xie,Wuhan University,http://xiaoyuanxie.github.io,VlHMPKoAAAAJ,0000-0003-2828-7165
 Xiaoyue Feng,Jilin University,https://ccst.jlu.edu.cn/info/1367/19980.htm,NOSCHOLARPAGE,0000-0003-3954-1333
 Xiaoyun Wang 0001,Tsinghua University,http://www.tsinghua.edu.cn/publish/casen/1695/2010/20101224093253705266640/20101224093253705266640_.html,5pUP56sAAAAJ,0000-0002-7846-269X
+Xiaoyun Yuan,Shanghai Jiao Tong University,https://xiaoyunyuan.net/,MrEV0uwAAAAJ,0000-0002-7914-3658
 Xiaozhong Liu 0001,Worcester Polytechnic Institute,https://www.wpi.edu/people/faculty/xliu14,1BUByMcAAAAJ,0000-0003-3477-8323
 Xiapu Luo,The Hong Kong Polytechnic Univ.,https://www4.comp.polyu.edu.hk/~csxluo,uvedrYMAAAAJ,0000-0002-9082-3208
 Xiatian Zhu,University of Surrey,https://xiatian-zhu.github.io,ZbA-z1cAAAAJ,0000-0002-9284-2955
@@ -460,6 +461,7 @@ Xingda Wei,Shanghai Jiao Tong University,https://ipads.se.sjtu.edu.cn/pub/member
 Xingfeng Li 0001,City University of Macau,https://fds.cityu.edu.mo/en/members/298,atfeiyYAAAAJ,0000-0000-0000-0000
 Xinggong Zhang,Peking University,http://www.icst.pku.edu.cn/vip/people-zhangxg_en.html,NOSCHOLARPAGE,0000-0003-0484-5951
 Xinghao Ding,Xiamen University,https://informatics.xmu.edu.cn/info/1018/3152.htm,k5hVBfMAAAAJ,0000-0000-0000-0000
+Xinghao Jiang,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/jiaoshiml/jiangxinghao.html,F6-ssMQAAAAJ,0000-0000-0000-0000
 Xinghua Mindy Shi,Temple University,https://cis.temple.edu/~mindyshi,vSDPGjcAAAAJ,0000-0000-0000-0000
 Xinghua Shi,Temple University,https://cis.temple.edu/~mindyshi,vSDPGjcAAAAJ,0000-0000-0000-0000
 Xingjun Zhang,Xi'an Jiaotong University,http://www.cs.xjtu.edu.cn/info/2639/1595.htm,m6QY7-wAAAAJ,0000-0003-1434-7016

--- a/csrankings-y.csv
+++ b/csrankings-y.csv
@@ -8,6 +8,7 @@ Y. Raghu Reddy,IIIT Hyderabad,http://faculty.iiit.ac.in/~raghu.reddy,NOSCHOLARPA
 Y. Tsiatouhas,University of Ioannina,https://cs.uoi.gr/~tsiatouhas,gHsE8pYAAAAJ,0009-0006-3922-7351
 Y. Y. Yao,University of Regina,http://www.cs.uregina.ca/People/Profiles/YiyuYao.html,_aL0fcQAAAAJ,0000-0000-0000-0000
 YE CAI,Shenzhen University,https://csse.szu.edu.cn/en/pages/user/index?id=551,5EFHwPkAAAAJ,0000-0000-0000-0000
+YUE WU,Shanghai Jiao Tong University,https://cs.sjtu.edu.cn/jiaoshiml/wuyue.html,YZyiCF3ihC0C,0000-0000-0000-0000
 Ya Zhang 0002,Shanghai Jiao Tong University,https://mediabrain.sjtu.edu.cn/yazhang,pbjw9sMAAAAJ,0000-0002-5390-9053
 Ya'akov (Kobi) Gal,Ben-Gurion University of the Negev,http://www.ise.bgu.ac.il/engineering/PersonalWebSite1main.aspx?id=djueVuMe,lNHuLiQAAAAJ,0000-0001-7187-8572
 Ya'akov Gal,Ben-Gurion University of the Negev,http://www.ise.bgu.ac.il/engineering/PersonalWebSite1main.aspx?id=djueVuMe,lNHuLiQAAAAJ,0000-0001-7187-8572
@@ -118,6 +119,7 @@ Yang Gao 0021,Royal Holloway Univ. of London,https://pure.royalholloway.ac.uk/po
 Yang Gao 0029,Tsinghua University,https://iiis.tsinghua.edu.cn/en/People/Faculty/GaoYang.htm,bo0P2qYAAAAJ,0000-0000-0000-0000
 Yang Hao 0001,Queen Mary University of London,http://www.eecs.qmul.ac.uk/~yang,W6hvCOAAAAAJ,0000-0000-0000-0000
 Yang Hua 0001,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=y.hua,N0tFi8MAAAAJ,0000-0001-5536-503X
+Yang Li 0116,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/jiaoshiml/l.html,msAmwaoAAAAJ,0000-0000-0000-0000
 Yang Li 0183,Iowa State University,https://www.cs.iastate.edu/people/yang-li,mes7IkwAAAAJ,0000-0002-9052-9308
 Yang Liu 0003,Nanyang Technological University,https://www3.ntu.edu.sg/home/yangliu,NOSCHOLARPAGE,0000-0001-7300-9215
 Yang Liu 0005,Tsinghua University,http://nlp.csai.tsinghua.edu.cn/~ly,NOSCHOLARPAGE,0000-0002-3087-242X
@@ -492,6 +494,7 @@ Yijun Wang 0002,Hunan University,http://csee.hnu.edu.cn/people/wangyijun,NOSCHOL
 Yijun Yu 0001,Open University UK,http://stem.open.ac.uk/people/yy66,E5Z63aUAAAAJ,0000-0002-7154-8570
 Yike Guo,HKUST,https://facultyprofiles.hkust.edu.hk/profiles.php?profile=yike-guo-yikeguo,-0q6cIYAAAAJ,0009-0005-8401-282X
 Yikun Ban,Beihang University,https://www.banyikun.com,oGa-XpMAAAAJ,0000-0003-3035-4849
+Yikun Hu,Shanghai Jiao Tong University,https://yikunh.github.io/,3hfq9_4AAAAJ,0000-0000-0000-0000
 Yikun Zhang 0001,Southeast University,https://cs.seu.edu.cn/yikun/main.htm,YdcGcQEAAAAJ,0000-0002-4048-4869
 Yile Wang 0001,Shenzhen University,https://ylwangy.github.io,v1YnW6gAAAAJ,0000-0000-0000-0000
 Yilei Chen 0001,Tsinghua University,https://iiis.tsinghua.edu.cn/en/People/Faculty/ChenYilei.htm,mJkYl8MAAAAJ,0000-0000-0000-0000


### PR DESCRIPTION
## Consolidated PR for Shanghai Jiao Tong University

This PR consolidates the following open PRs:

| PR | Score | Title |
|---|---|---|
| #12238 | 87% | Add 3 faculty from Shanghai Jiao Tong University (auto-batched) |
| #12249 | 90% | Add 3 faculty from Shanghai Jiao Tong University (auto-batched) |
| #12250 | 90% | Add 4 faculty from Shanghai Jiao Tong University |
| #12252 | 85% | Add 2 faculty from Shanghai Jiao Tong University |
| #12261 | 88% | Add 5 faculty from Shanghai Jiao Tong University (auto-batched) |

Total: 17 faculty additions.
Average individual score: 88%
Joint probability (all valid): 11.7%
