### PR TITLE
Add 6 faculty from University of Stuttgart (consolidated)

### DIFF
--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -1,4 +1,5 @@
 name,affiliation,homepage,scholarid,orcid
+"Boyang ""Albert"" Li",Nanyang Technological University,http://boyangli.org,QwL4z2UAAAAJ,0000-0002-6230-2376
 B. Aditya Prakash,Georgia Institute of Technology,http://www.cc.gatech.edu/~badityap,C-NftTgAAAAJ,0000-0002-3252-455X
 B. Ashutosh Holla,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/ashutosh-holla-b-/_jcr_content.html,0S83U1sAAAAJ,0009-0009-7995-4213
 B. Ashwath Rao,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/ashwath-rao/_jcr_content.html,bJA8hZQAAAAJ,0000-0001-8528-1646
@@ -58,8 +59,8 @@ Balaji Parthasarathy,IIIT Bangalore,http://citapp.iiitb.ac.in/staff-members/bala
 Balaji Prabhakar,Stanford University,http://web.stanford.edu/~balaji,TyPF9V4AAAAJ,0009-0006-3106-8720
 Balaji Raghavachari,University of Texas at Dallas,https://www.utdallas.edu/~rbk,NOSCHOLARPAGE,0000-0000-0000-0000
 Balakrishnan Chandrasekaran 0002,VU Amsterdam,https://balakrishnanc.github.io,wDjUEMMAAAAJ,0000-0002-5582-1223
-Balakrishnan Prabhakaran,University of Texas at Dallas,http://www.utdallas.edu/~praba,4yki88YAAAAJ,0000-0000-0000-0000
 Balakrishnan Prabhakaran 0001,University of Texas at Dallas,http://www.utdallas.edu/~praba,4yki88YAAAAJ,0000-0000-0000-0000
+Balakrishnan Prabhakaran,University of Texas at Dallas,http://www.utdallas.edu/~praba,4yki88YAAAAJ,0000-0000-0000-0000
 Balaprakasa Rao Killi,National Inst. of Tech. Warangal,https://wsdc.nitw.ac.in/facultynew/facultyprofile/id/17028,zpYxy98AAAAJ,0000-0000-0000-0000
 Balaraman Ravindran,IIT Madras,http://www.cse.iitm.ac.in/~ravi,nGUcGrYAAAAJ,0000-0002-5364-7639
 Balasubramaniam Srinivasan,Monash University,http://monash.edu/research/explore/en/persons/balasubramaniam-srinivasan(6a75b48c-6276-4090-90c9-0d784c16c78d).html,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -192,8 +193,8 @@ Bayu Anggorojati,Monash University Indonesia,https://www.monash.edu/indonesia/ab
 Bayyapu Neelima,Manipal Academy of Higher Education,https://bayyapu.github.io,_TPjGvcAAAAJ,0000-0002-7201-2217
 Beat D. Brüderlin,TU Ilmenau,https://www.tu-ilmenau.de/gdv/mitarbeiter/prof-beat-bruederlin,NOSCHOLARPAGE,0000-0000-0000-0000
 Beata Konikowska,IPI PAN,https://ipipan.waw.pl/instytut/pracownicy/beata-konikowska,EIJSiIIAAAAJ,0000-0001-8188-8344
-Beata Stahre,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/beata-wastberg.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Beata Stahre Wästberg,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/beata-wastberg.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
+Beata Stahre,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/beata-wastberg.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Beate Bollig,TU Dortmund,https://ls2-www.cs.tu-dortmund.de/grav/de/grav_files/people/bollig,NOSCHOLARPAGE,0000-0000-0000-0000
 Beatrice M. Ombuki,Brock University,http://www.cosc.brocku.ca/~bombuki,NOSCHOLARPAGE,0000-0000-0000-0000
 Beatrice M. Ombuki-Berman,Brock University,http://www.cosc.brocku.ca/~bombuki,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -224,9 +225,9 @@ Beijun Shen,Shanghai Jiao Tong University,https://base.sjtu.edu.cn/~bjshen,wnq7S
 Beiyu Lin,University of Oklahoma,https://beiyulincs.github.io,hou6waAAAAAJ,0000-0000-0000-0000
 Beki Grinter,Georgia Institute of Technology,http://www.cc.gatech.edu/~beki/Beki.html,PNalJ58AAAAJ,0000-0000-0000-0000
 Bela Gipp,University of Göttingen,https://gipplab.org,No2ot2YAAAAJ,0000-0001-6522-3019
-Belgin Ergenç,Izmir Institute of Technology,https://ceng.iyte.edu.tr/tr/people/belgin-ergenc-bostanoglu/,e00LSrIAAAAJ,0000-0001-6193-9853
-Belgin Ergenç,Izmir Institute of Technology,http://ceng.iyte.edu.tr/people/belgin-ergenc,e00LSrIAAAAJ,0000-0000-0000-0000
 Belgin Ergenç Bostanoglu,Izmir Institute of Technology,http://ceng.iyte.edu.tr/people/belgin-ergenc,e00LSrIAAAAJ,0000-0000-0000-0000
+Belgin Ergenç,Izmir Institute of Technology,http://ceng.iyte.edu.tr/people/belgin-ergenc,e00LSrIAAAAJ,0000-0000-0000-0000
+Belgin Ergenç,Izmir Institute of Technology,https://ceng.iyte.edu.tr/tr/people/belgin-ergenc-bostanoglu/,e00LSrIAAAAJ,0000-0001-6193-9853
 Belgin Ozakar,Izmir Institute of Technology,http://ceng.iyte.edu.tr/people/belgin-ergenc,e00LSrIAAAAJ,0000-0000-0000-0000
 Bella Bose,Oregon State University,http://eecs.oregonstate.edu/people/bose-bella,NOSCHOLARPAGE,0009-0009-4992-3184
 Belén Masiá,Universidad de Zaragoza,http://webdiis.unizar.es/~bmasia,d10sXc8AAAAJ,0000-0003-0060-7278
@@ -259,6 +260,7 @@ Ben Zhou,Arizona State University,https://search.asu.edu/profile/5107148,sO2ro4k
 Benedikt Ahrens,TU Delft,https://benediktahrens.gitlab.io,hdr4g6UAAAAJ,0000-0002-6786-4538
 Benedikt Bollig,Ecole Normale Superieure de Cachan,http://www.lsv.ens-cachan.fr/~bollig,dhayPjwAAAAJ,0000-0000-0000-0000
 Benedikt Bünz,New York University,http://crypto.stanford.edu/~buenz,Hj82r7MAAAAJ,0000-0003-2082-4480
+Benedikt V. Ehinger,University of Stuttgart,https://www.vis.uni-stuttgart.de/team/Ehinger-00001/,VKDX28YAAAAJ,0000-0002-6276-3332
 Beng Chin Ooi,National University of Singapore,http://www.comp.nus.edu.sg/~ooibc,9560QjYAAAAJ,0000-0003-4446-1100
 Bengt Carlsson,Uppsala University,http://www.it.uu.se/katalog/bc,WY1FerUAAAAJ,0000-0000-0000-0000
 Bengt J. Nilsson,Malmö University,https://mau.se/en/persons/bengt.nilsson.ts,aToIZSMAAAAJ,0000-0000-0000-0000
@@ -469,8 +471,8 @@ Bharat M. Deshpande,BITS Pilani-Goa,https://www.bits-pilani.ac.in/goa/bmd/Profil
 Bharath Hariharan,Cornell University,http://home.bharathh.info,TpglobcAAAAJ,0000-0002-2309-4703
 Bhargab B. Bhattacharya,IIT Kharagpur,https://www.isical.ac.in/~bhargab,udxFQnwAAAAJ,0000-0002-5890-2483
 Bhargav Narayanan,Rutgers University,https://sites.math.rutgers.edu/~narayanan,LRN9H2sAAAAJ,0000-0000-0000-0000
-Bharti,University of Delhi,http://people.du.ac.in/~bharti,4OuoFtAAAAAJ,0000-0000-0000-0000
 Bharti Rana,University of Delhi,http://people.du.ac.in/~bharti,4OuoFtAAAAAJ,0000-0000-0000-0000
+Bharti,University of Delhi,http://people.du.ac.in/~bharti,4OuoFtAAAAAJ,0000-0000-0000-0000
 Bhaskar DasGupta,University of Illinois at Chicago,https://www.cs.uic.edu/~dasgupta,V6ddZSkAAAAJ,0000-0000-0000-0000
 Bhaskar Krishnamachari,University of Southern California,http://ceng.usc.edu/~bkrishna,JHJozAYAAAAJ,0000-0002-9994-9931
 Bhaskar Mukhoty,IIT Delhi,https://sites.google.com/view/bhaskar-mukhoty,lJglnOQAAAAJ,0000-0002-8594-980X
@@ -670,8 +672,8 @@ Bo Dai 0001,Georgia Institute of Technology,https://bo-dai.github.io,TIKl_foAAAA
 Bo Dai 0002,University of Hong Kong,https://datascience.hku.hk/people/bo-dai,KNWTvgEAAAAJ,0000-0000-0000-0000
 Bo Dai 0006,UESTC,https://www.scse.uestc.edu.cn/info/1081/11208.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Bo Du 0001,Wuhan University,https://cs.whu.edu.cn/info/1019/2892.htm,Shy1gnMAAAAJ,0000-0002-0059-8458
-Bo Fang,University of Texas at Arlington,https://www.uta.edu/academics/faculty/profile?user=bo.fang,50k_hl8AAAAJ,0000-0000-0000-0000
 Bo Fang 0002,University of Texas at Arlington,https://www.uta.edu/academics/faculty/profile?user=bo.fang,50k_hl8AAAAJ,0000-0001-9721-3982
+Bo Fang,University of Texas at Arlington,https://www.uta.edu/academics/faculty/profile?user=bo.fang,50k_hl8AAAAJ,0000-0000-0000-0000
 Bo Friis Nielsen,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE,0000-0000-0000-0000
 Bo Han 0001,George Mason University,https://bohan00.github.io,BhRa314AAAAJ,0000-0001-7042-3322
 Bo Han 0003,Hong Kong Baptist University,https://bhanml.github.io,nTNjqHwAAAAJ,0000-0002-9226-0461
@@ -798,7 +800,6 @@ Bowen Weng,Iowa State University,https://www.cs.iastate.edu/people/bowen-weng-0,
 Bowen Xu,North Carolina State University,https://www.bowenxu.me,tLWbczIAAAAJ,0000-0002-1006-8493
 Boxin Shi,Peking University,http://www.shiboxin.com,K1LjZxcAAAAJ,0000-0001-6749-0364
 Boyana Norris,University of Oregon,https://ix.cs.uoregon.edu/~norris,prJFPwUAAAAJ,0000-0001-5811-9731
-"Boyang ""Albert"" Li",Nanyang Technological University,http://boyangli.org,QwL4z2UAAAAJ,0000-0002-6230-2376
 Boyang Li 0001,Nanyang Technological University,http://boyangli.org,QwL4z2UAAAAJ,0000-0002-6230-2376
 Boyang Wang,University of Cincinnati,https://researchdirectory.uc.edu/p/wang2ba,bKUDk2AAAAAJ,0000-0001-8973-2328
 Boyu Wang,Western University,https://sites.google.com/site/borriewang/home?authuser=0,qAZM5KcAAAAJ,0000-0002-7413-4162

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -82,6 +82,7 @@ Carina Alves 0001,UFPE,https://www.cin.ufpe.br/~cfa,qrsfaXoAAAAJ,0000-0000-0000-
 Carina F. Alves,UFPE,https://www.cin.ufpe.br/~cfa,qrsfaXoAAAAJ,0000-0000-0000-0000
 Carina Frota Alves,UFPE,https://www.cin.ufpe.br/~cfa,qrsfaXoAAAAJ,0000-0000-0000-0000
 Carina Frota,UFPE,https://www.cin.ufpe.br/~cfa,qrsfaXoAAAAJ,0000-0000-0000-0000
+Carina Silberer,University of Stuttgart,https://www.f05.uni-stuttgart.de/en/faculty/contactpersons/Silberer-00001/,tI5JvekAAAAJ,0000-0002-5047-1869
 Carl A. Gunter,Univ. of Illinois at Urbana-Champaign,http://web.engr.illinois.edu/~cgunter,3S5qpXsAAAAJ,0000-0000-0000-0000
 Carl A. Gutwin,University of Saskatchewan,https://www.cs.usask.ca/faculty/gutwin,ZWsIEYcAAAAJ,0000-0000-0000-0000
 Carl DiSalvo,Georgia Institute of Technology,https://www.carldisalvo.com,YR1EmaAAAAAJ,0000-0002-7344-8741
@@ -829,6 +830,7 @@ Christian Bachmeir,THWS,https://fiw.thws.de/fakultaet/personen/dozentinnen-und-d
 Christian Bartelt,TU Clausthal,https://www.isse.tu-clausthal.de/ueber-uns/team-neu/professoren-und-dozenten/prof-dr-christian-bartelt,9FcF1gwAAAAJ,0000-0003-0426-6714
 Christian Bauckhage,University of Bonn,https://www.iais.fraunhofer.de/de/institut/mitarbeiterprofile/christian-bauckhage.html,f9iP-80AAAAJ,0000-0001-6615-2128
 Christian Baumgartner,Graz University of Technology,http://www.hce.tugraz.at,NOSCHOLARPAGE,0000-0002-3763-5195
+Christian Becker 0001,University of Stuttgart,https://www.ipvs.uni-stuttgart.de/institute/team/Becker-00039/,kvDsx-8AAAAJ,0000-0002-9036-1410
 Christian Beecks,University of Münster,https://www.uni-muenster.de/DMA/team/beecks.shtml,kQcfLnMAAAAJ,0000-0000-0000-0000
 Christian Berger 0001,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/christian-berger.aspx,-5qMVbcAAAAJ,0000-0000-0000-0000
 Christian Bettstetter,University of Klagenfurt,https://bettstetter.com,ymlpYBYAAAAJ,0000-0002-6836-8034

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -821,6 +821,7 @@ Jenny Lin,University of Utah,https://jlin98.github.io,W_Kf130AAAAJ,0009-0000-861
 Jenny Waycott,University of Melbourne,http://findanexpert.unimelb.edu.au/display/person52243,kc5Fr-0AAAAJ,0000-0002-4634-0532
 Jenq Kuen Lee,National Tsing Hua University,http://pllab.cs.nthu.edu.tw/~jklee,cIxlQU4AAAAJ,0000-0000-0000-0000
 Jenq-Kuen Lee,National Tsing Hua University,http://pllab.cs.nthu.edu.tw/~jklee,cIxlQU4AAAAJ,0000-0000-0000-0000
+Jens Anders,University of Stuttgart,https://www.f05.uni-stuttgart.de/en/faculty/contactpersons/Anders-00001/,yXF1SeAAAAAJ,0000-0002-2498-0352
 Jens B. Schmitt,TU Kaiserslautern,https://disco.cs.uni-kl.de/index.php/people/jens-schmitt,lmEldBwAAAAJ,0000-0000-0000-0000
 Jens Christian Claussen,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/academic-staff/claussen-jens-christian.aspx,fCjDwsIAAAAJ,0000-0000-0000-0000
 Jens Dietrich 0001,Victoria University of Wellington,https://sites.google.com/site/jensdietrich,wMsX0w4AAAAJ,0000-0001-9019-6550
@@ -837,6 +838,7 @@ Jens H. Weber-Jahnke,University of Victoria,http://www.cs.uvic.ca/~jens/blog/pag
 Jens Harald Krüger,University of Duisburg-Essen,http://hpc.uni-due.de/krueger.html,w87pmH4AAAAJ,0000-0002-9197-0613
 Jens Haueisen,TU Ilmenau,https://www.tu-ilmenau.de/bmti/fachgebiete/biomedizinische-technik,u5SRjOwAAAAJ,0000-0000-0000-0000
 Jens Knoop,TU Wien,http://www.complang.tuwien.ac.at/knoop,NOSCHOLARPAGE,0000-0000-0000-0000
+Jens Kober,University of Stuttgart,https://www.f05.uni-stuttgart.de/en/faculty/contactpersons/Kober/,XOWZzUcAAAAJ,0000-0001-7257-5434
 Jens Krinke,University College London,http://www0.cs.ucl.ac.uk/staff/J.Krinke,y8MpLZwAAAAJ,0000-0003-1009-2861
 Jens Lagergren,KTH Royal Inst. of Technology,https://www.kth.se/profile/jensl,lS1rJKQAAAAJ,0000-0002-4552-0240
 Jens Lambrecht,TU Berlin,https://www.ignc.tu-berlin.de/menue/ueber_uns/team/parameter/de,LirFG6EAAAAJ,0000-0000-0000-0000

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -2574,6 +2574,7 @@ Mirella M. Moro,UFMG,http://homepages.dcc.ufmg.br/~mirella,MRbdeWkAAAAJ,0000-000
 Mirella Moura Moro,UFMG,http://homepages.dcc.ufmg.br/~mirella,MRbdeWkAAAAJ,0000-0002-0545-2001
 Miriam Backens,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/academic-staff/backens-miriam.aspx,yDlqLwsAAAAJ,0000-0000-0000-0000
 Miriam Mehl,University of Stuttgart,http://www.ipvs.uni-stuttgart.de/abteilungen/sgs/abteilung/mitarbeiter/Miriam.Mehl,DGIIXCEAAAAJ,0000-0000-0000-0000
+Miriam Schulte,University of Stuttgart,https://www.ipvs.uni-stuttgart.de/de/institut/team/Schulte-00010/,DGIIXCEAAAAJ,0000-0003-4594-6142
 Mirjam Minor,Goethe University Frankfurt,http://www.wi.informatik.uni-frankfurt.de/index.php?Itemid=494&lang=de,NOSCHOLARPAGE,0000-0002-6592-631X
 Mirjana Stojilovic,EPFL,https://mirjanastojilovic.github.io,wwEwOqwAAAAJ,0000-0001-5649-5020
 Mirko Marras,University of Cagliari,https://dblp.org/pid/208/4100.html,JZhqKBIAAAAJ,0000-0003-1989-6057


### PR DESCRIPTION
## Consolidated PR for University of Stuttgart

This PR consolidates the following open PRs:

| PR | Score | Title |
|---|---|---|
| #12364 | 80% | Add 2 faculty from University of Stuttgart (auto-batched) |
| #12370 | 80% | Add 3 faculty from University of Stuttgart (auto-batched) |
| #12371 | 80% | Add 1 faculty from University of Stuttgart |

Total: 6 faculty additions.
Average individual score: 80%
Joint probability (all valid): 26.2%
