### PR TITLE
Add 5 faculty from INRIA (consolidated)

### DIFF
--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -1470,6 +1470,7 @@ Constantinos Dovrolis,Georgia Institute of Technology,http://www.cc.gatech.edu/f
 Constantinos Lambrinoudakis,University of Piraeus,https://www.ds.unipi.gr/en/faculty/clam-en,D-mfQXsAAAAJ,0000-0000-0000-0000
 Constantinos Markantonakis,Royal Holloway Univ. of London,https://pure.royalholloway.ac.uk/portal/en/persons/konstantinos-markantonakis(61472f42-bf1d-44fa-9f10-856c99997d9e).html,NygekFcAAAAJ,0000-0000-0000-0000
 Constantinos Patsakis,University of Piraeus,https://www.cs.unipi.gr/kpatsak,wkHmlysAAAAJ,0000-0000-0000-0000
+Cordelia Schmid,INRIA,https://cordeliaschmid.github.io/,IvqCXP4AAAAJ,0009-0005-7239-3741
 Corey Baker,University of Kentucky,https://www.cs.uky.edu/~baker,PqWkFEYAAAAJ,0000-0003-4803-2530
 Corey E. Baker,University of Kentucky,https://www.cs.uky.edu/~baker,PqWkFEYAAAAJ,0000-0000-0000-0000
 Corey Tessler,University of Nevada Las Vegas,https://www.unlv.edu/people/chuck-tessler,_I-Buk8AAAAJ,0000-0001-6355-2740

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -677,6 +677,7 @@ Jean-Philippe Vandeborre,CRIStAL,https://www.cristal.univ-lille.fr/profil/vandeb
 Jean-Pierre Corriveau,Carleton University,http://www.scs.carleton.ca/~jeanpier,SmEIZO0AAAAJ,0000-0002-6570-3108
 Jean-Pierre Dussault,Université de Sherbrooke,https://www.usherbrooke.ca/informatique/personnel/corps-professoral/professeurs/jean-pierre-dussault,NOSCHOLARPAGE,0000-0001-7253-7462
 Jean-Pierre Hubaux,EPFL,https://people.epfl.ch/jean-pierre.hubaux,W7YBLlEAAAAJ,0000-0003-1533-6132
+Jean-Pierre Lozi,INRIA,https://jean-pierre.lozi.org/,EBBbAOoAAAAJ,0009-0002-2876-8292
 Jean-Pierre Seifert,TU Berlin,https://www.eecs.tu-berlin.de/menue/einrichtungen/professuren/professorinnen/seifert,aYbydEMAAAAJ,0000-0002-5372-4825
 Jean-Stéphane Varré,CRIStAL,http://cristal.univ-lille.fr/~varre,NOSCHOLARPAGE,0000-0001-6322-0519
 Jean-Sébastien Coron,University of Luxembourg,http://wwwen.uni.lu/recherche/fstc/laboratory_of_algorithmics_cryptology_and_security_lacs/members/jean_sebastien_coron,NOSCHOLARPAGE,0000-0003-1021-3344
@@ -2510,6 +2511,7 @@ Julia Hirschberg,Columbia University,http://www.cs.columbia.edu/~julia,Qrd7FCoAA
 Julia Hockenmaier,Univ. of Illinois at Urbana-Champaign,http://juliahmr.cs.illinois.edu,iIiVrrQAAAAJ,0000-0003-2796-1752
 Julia Kempe,New York University,https://cims.nyu.edu/~kempe,m9WZOV4AAAAJ,0009-0006-1984-0060
 Julia Klier,University of Regensburg,https://www.uni-regensburg.de/informatik-data-science/wi-klier/start/index.html,JhWXMQ4AAAAJ,0000-0000-0000-0000
+Julia Lawall,INRIA,https://who.paris.inria.fr/Julia.Lawall/,ufr0tvAAAAAJ,0000-0002-1684-1264
 Julia Len,University of North Carolina,https://julialen.github.io,YXafOYwAAAAJ,0000-0002-9625-6363
 Julia Mosin,University of British Columbia,https://www.ece.ubc.ca/faculty/julia-rubin,IQNUPWgRnRsC,0000-0000-0000-0000
 Julia Olkhovskaya,TU Delft,https://sites.google.com/view/julia-olkhovskaya/home,aBT52BsAAAAJ,0000-0000-0000-0000

--- a/csrankings-o.csv
+++ b/csrankings-o.csv
@@ -74,8 +74,8 @@ Olga Gadyatskaya,Leiden University,https://ogadyatskaya.github.io,QD3DU0wAAAAJ,0
 Olga Goussevskaia,UFMG,http://homepages.dcc.ufmg.br/~olga,2NbTEyYAAAAJ,0000-0000-0000-0000
 Olga Kupriianova,Ecole Normale Superieure de Lyon,http://kupriianova.info,NOSCHOLARPAGE,0000-0000-0000-0000
 Olga Marino Drews,Universidad de los Andes,https://sistemasacademico.uniandes.edu.co/~olmarino/dokuwiki/doku.php,TRujnBQAAAAJ,0000-0000-0000-0000
-Olga Mariño,Universidad de los Andes,https://sistemasacademico.uniandes.edu.co/~olmarino/dokuwiki/doku.php,TRujnBQAAAAJ,0000-0000-0000-0000
 Olga Mariño Drews,Universidad de los Andes,https://sistemasacademico.uniandes.edu.co/~olmarino/dokuwiki/doku.php,TRujnBQAAAAJ,0000-0000-0000-0000
+Olga Mariño,Universidad de los Andes,https://sistemasacademico.uniandes.edu.co/~olmarino/dokuwiki/doku.php,TRujnBQAAAAJ,0000-0000-0000-0000
 Olga Ohrimenko,University of Melbourne,https://people.eng.unimelb.edu.au/oohrimenko,lzfVm_8AAAAJ,0000-0002-9735-0538
 Olga Ormandjieva,Concordia University,http://www.cs.concordia.ca/~ormandj,NOSCHOLARPAGE,0000-0000-0000-0000
 Olga Papaemmanouil,Brandeis University,http://www.cs.brandeis.edu/~olga/home.html,JaAonb0AAAAJ,0000-0003-4526-3595
@@ -121,6 +121,7 @@ Oliver W. W. Yang,University of Ottawa,http://www.site.uottawa.ca/~yang,NOSCHOLA
 Oliver Yang,University of Ottawa,http://www.site.uottawa.ca/~yang,NOSCHOLARPAGE,0000-0000-0000-0000
 Oliver van Kaick,Carleton University,http://people.scs.carleton.ca/~olivervankaick,IfvyBBUAAAAJ,0000-0001-9869-6832
 Olivier Alata,Université Jean Monnet,http://perso.univ-st-etienne.fr/ao29170h,ClqgTp8AAAAJ,0000-0000-0000-0000
+Olivier Beaumont,INRIA,https://topal.gitlabpages.inria.fr/webpages/Olivier_Beaumont/OlivierBeaumont.html,XT007NgAAAAJ,0000-0003-2741-6228
 Olivier Caron,CRIStAL,https://www.cristal.univ-lille.fr/profil/carono,NOSCHOLARPAGE,0000-0000-0000-0000
 Olivier Danvy,National University of Singapore,https://www.yale-nus.edu.sg/faculty/olivier-danvy,OZJGoVoAAAAJ,0000-0002-3890-3630
 Olivier Glück,Ecole Normale Superieure de Lyon,http://perso.univ-lyon1.fr/olivier.gluck,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -229,8 +230,8 @@ Oscar González 0001,Universidad de los Andes,https://sistemasacademico.uniandes
 Oscar González Rojas,Universidad de los Andes,https://sistemasacademico.uniandes.edu.co/~o-gonza1,RPqeGp0AAAAJ,0000-0000-0000-0000
 Oscar H. Ibarra,Univ. of California - Santa Barbara,https://sites.cs.ucsb.edu/~ibarra,NOSCHOLARPAGE,0000-0000-0000-0000
 Oscar Mendez Maldonado,University of Surrey,http://oscarmendez.co.uk,BK3u-3EAAAAJ,0000-0000-0000-0000
-Oscar Meruvia,Memorial Univ. of Newfoundland,https://www.mun.ca/computerscience/people/omeruvia.php,fDH4lPYAAAAJ,0000-0000-0000-0000
 Oscar Meruvia Pastor,Memorial Univ. of Newfoundland,https://www.mun.ca/computerscience/people/omeruvia.php,fDH4lPYAAAAJ,0000-0000-0000-0000
+Oscar Meruvia,Memorial Univ. of Newfoundland,https://www.mun.ca/computerscience/people/omeruvia.php,fDH4lPYAAAAJ,0000-0000-0000-0000
 Oscar Nierstrasz,University of Bern,http://scg.unibe.ch/staff/oscar,Yi00hUYAAAAJ,0000-0002-9975-9791
 Oscar Pedreira,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=98,w_r4yFAAAAAJ,0000-0000-0000-0000
 Oscar Peter Buneman,University of Edinburgh,http://homepages.inf.ed.ac.uk/opb,d9bq04sAAAAJ,0000-0000-0000-0000
@@ -270,8 +271,8 @@ Ozgun Pinarer,Galatasaray University,https://avesis.gsu.edu.tr/opinarer,s0jOxwMA
 Ozgur Akgun,University of St Andrews,https://ozgurakgun.github.io,heG7k-gAAAAJ,0000-0000-0000-0000
 Ozlem O. Garibay,University of Central Florida,https://www.cecs.ucf.edu/faculty/ozlem-ozmen-garibay,0RKzNtIAAAAJ,0000-0000-0000-0000
 Oznur Tastan,Sabancı University,http://people.sabanciuniv.edu/otastan,8ljjXmEAAAAJ,0000-0000-0000-0000
-Óscar Cánovas,University of Murcia,http://webs.um.es/ocanovas/miwiki/doku.php,iAPkCb8AAAAJ,0000-0000-0000-0000
 Óscar Cánovas Reverte,University of Murcia,http://webs.um.es/ocanovas/miwiki/doku.php,iAPkCb8AAAAJ,0000-0000-0000-0000
+Óscar Cánovas,University of Murcia,http://webs.um.es/ocanovas/miwiki/doku.php,iAPkCb8AAAAJ,0000-0000-0000-0000
 Óscar Pedreira Fernández,University of A Coruña,https://lbd.udc.es/ShowResearcherInformation.do?id=98,w_r4yFAAAAAJ,0000-0000-0000-0000
 Özcan Özturk 0001,Bilkent University,http://www.cs.bilkent.edu.tr/~ozturk,YZQ0KIcAAAAJ,0000-0000-0000-0000
 Özgün Pinarer,Galatasaray University,https://avesis.gsu.edu.tr/opinarer,s0jOxwMAAAAJ,0000-0000-0000-0000

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -221,8 +221,8 @@ Samuel Fiorini,Université libre de Bruxelles,http://homepages.ulb.ac.be/~sfiori
 Samuel Hopkins 0001,Massachusetts Inst. of Technology,https://www.samuelbhopkins.com,E_a3VB4AAAAJ,0000-0000-0000-0000
 Samuel Horváth,MBZUAI,https://mbzuai.ac.ae/study/faculty/samuel-horvath,k252J7kAAAAJ,0000-0000-0000-0000
 Samuel Hym,CRIStAL,https://www.cristal.univ-lille.fr/profil/hym,NOSCHOLARPAGE,0000-0000-0000-0000
-Samuel J. Lomonaco,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~lomonaco,0PMb9xcAAAAJ,0000-0000-0000-0000
 Samuel J. Lomonaco Jr.,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~lomonaco,0PMb9xcAAAAJ,0000-0000-0000-0000
+Samuel J. Lomonaco,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~lomonaco,0PMb9xcAAAAJ,0000-0000-0000-0000
 Samuel Kadoury,Polytechnique Montreal,https://www.polymtl.ca/expertises/en/kadoury-samuel,HOov_S8AAAAJ,0000-0000-0000-0000
 Samuel Kaski,Aalto University,https://users.ics.aalto.fi/sami,uF6H9jMAAAAJ,0000-0000-0000-0000
 Samuel Kounev,University of Würzburg,https://se.informatik.uni-wuerzburg.de/software-engineering-group/staff/samuel-kounev,1iN71-YAAAAJ,0000-0000-0000-0000
@@ -298,8 +298,8 @@ Sandy Gould,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles
 Sandy Irani,Univ. of California - Irvine,https://www.ics.uci.edu/~irani,dBhm_oIAAAAJ,0000-0000-0000-0000
 Sandy J. J. Gould,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/gould-sandy.aspx,DF7FgAQAAAAJ,0000-0003-0476-4270
 Sanem Kabadayi,Istanbul Technical University,http://web.itu.edu.tr/kabadayi,NOSCHOLARPAGE,0000-0000-0000-0000
-Sanem Sariel,Istanbul Technical University,http://web.itu.edu.tr/sariel,Fw0RC2IAAAAJ,0000-0003-2993-6681
 Sanem Sariel Talay,Istanbul Technical University,http://web.itu.edu.tr/sariel,Fw0RC2IAAAAJ,0000-0000-0000-0000
+Sanem Sariel,Istanbul Technical University,http://web.itu.edu.tr/sariel,Fw0RC2IAAAAJ,0000-0003-2993-6681
 Sang Ho Yoon,KAIST,https://hcitech.org,ejaRQn8AAAAJ,0000-0002-3780-5350
 Sang Kil Cha,KAIST,http://softsec.kaist.ac.kr/~sangkilc,kV40DzcAAAAJ,0000-0002-6012-7228
 Sang Lyul Min,Seoul National University,http://archi.snu.ac.kr/symin,U4ewRr0AAAAJ,0000-0000-0000-0000
@@ -338,8 +338,8 @@ Sanjam Garg,Univ. of California - Berkeley,http://www.cs.berkeley.edu/~sanjamg,m
 Sanjay Bhattacherjee,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/sanjay.bhattacherjee,rpUwbWIAAAAJ,0000-0002-3367-6192
 Sanjay G. Rao,Purdue University,https://engineering.purdue.edu/~sanjay,v_uxLhgAAAAJ,0000-0003-4825-4352
 Sanjay Jain 0001,National University of Singapore,https://www.comp.nus.edu.sg/~sanjay,PYOH-4kAAAAJ,0000-0001-6798-8330
-Sanjay Jha,UNSW,http://www.cse.unsw.edu.au/~sjha,Hiv2PjEAAAAJ,0000-0000-0000-0000
 Sanjay Jha 0001,UNSW,http://www.cse.unsw.edu.au/~sjha,Hiv2PjEAAAAJ,0000-0002-1844-1520
+Sanjay Jha,UNSW,http://www.cse.unsw.edu.au/~sjha,Hiv2PjEAAAAJ,0000-0000-0000-0000
 Sanjay K. Bose,Plaksha University,https://user.plaksha.edu.in/sanjay-bose,BR6HchkAAAAJ,0000-0000-0000-0000
 Sanjay K. Jha,UNSW,http://www.cse.unsw.edu.au/~sjha,Hiv2PjEAAAAJ,0000-0002-1844-1520
 Sanjay K. Sahay,BITS Pilani-Goa,https://www.bits-pilani.ac.in/goa/ssahay/profile,i6lSvKEAAAAJ,0000-0000-0000-0000
@@ -394,8 +394,8 @@ Santanu Kumar Dash 0001,Royal Holloway Univ. of London,https://pure.royalhollowa
 Santhosh Kamath,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/santhosh-kamath/_jcr_content.html,1JciSa8AAAAJ,0000-0002-1956-1727
 Santhosha Rao,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/santhosha-rao/_jcr_content.html,NOSCHOLARPAGE,0000-0001-9511-3048
 Santhoshini Velusamy,University of Waterloo,https://uwaterloo.ca/computer-science/contacts/santhoshini-velusamy,GpxRFs4AAAAJ,0000-0002-0294-5425
-Santi Ontañón,Drexel University,http://drexel.edu/cci/contact/Faculty/Ontanon-Santiago,aS-DrOwAAAAJ,0000-0000-0000-0000
 Santi Ontañón Villar,Drexel University,http://drexel.edu/cci/contact/Faculty/Ontanon-Santiago,aS-DrOwAAAAJ,0000-0000-0000-0000
+Santi Ontañón,Drexel University,http://drexel.edu/cci/contact/Faculty/Ontanon-Santiago,aS-DrOwAAAAJ,0000-0000-0000-0000
 Santiago Ceria,University of Buenos Aires,https://twitter.com/santiagoceria?lang=en,NOSCHOLARPAGE,0000-0000-0000-0000
 Santiago Chumbe,Heriot-Watt University,https://researchportal.hw.ac.uk/en/persons/santiago-segundo-chumbe,4zoTdQMAAAAJ,0000-0000-0000-0000
 Santiago Figueira,University of Buenos Aires,http://www.glyc.dc.uba.ar/santiago,WzLmB-4AAAAJ,0000-0000-0000-0000
@@ -459,8 +459,8 @@ Sarah Pink,Monash University,https://research.monash.edu/en/persons/sarah-pink,f
 Sarah Preum,Dartmouth College,https://web.cs.dartmouth.edu/people/sarah-masud-preum,TyO23NgAAAAJ,0000-0002-7771-8323
 Sarah Scheffler,Carnegie Mellon University,https://www.sarahscheffler.net,YPq45Q0AAAAJ,0000-0003-1202-7502
 Sarah Sebo,University of Chicago,https://sarahsebo.com,6gWYMigAAAAJ,0000-0003-2211-6429
-Sarah Strohkorb,University of Chicago,https://sarahsebo.com,6gWYMigAAAAJ,0000-0000-0000-0000
 Sarah Strohkorb Sebo,University of Chicago,https://sarahsebo.com,6gWYMigAAAAJ,0000-0000-0000-0000
+Sarah Strohkorb,University of Chicago,https://sarahsebo.com,6gWYMigAAAAJ,0000-0000-0000-0000
 Sarah Wiegreffe,Univ. of Maryland - College Park,https://www.cs.umd.edu/people/sarahwie,YoR3IugAAAAJ,0000-0000-0000-0000
 Sarah Wiseman,Goldsmiths University of London,https://www.gold.ac.uk/computing/people/wiseman-sarah,NdRUEYIAAAAJ,0000-0000-0000-0000
 Sarah Zelikovitz,CUNY,http://www.cs.csi.cuny.edu/~zelikovi,JJvTMLsAAAAJ,0000-0000-0000-0000
@@ -561,8 +561,8 @@ Sayak Ray Chowdhury,IIT Kanpur,https://sites.google.com/view/sayakraychowdhury/h
 Sayak Saha Roy,Louisiana State University,https://www.lsu.edu/eng/cse/people/faculty/saha-roy.php,WwR6ZPQAAAAJ,0000-0000-0000-0000
 Sayako Shimizu,National Inst. of Informatics,https://www.nii.ac.jp/en/faculty/architecture/sayako_shimizu,NOSCHOLARPAGE,0000-0000-0000-0000
 Sayan Bhattacharya,University of Warwick,https://www.dcs.warwick.ac.uk/~u1671158,ca-urkIAAAAJ,0000-0003-1612-0296
-Sayan Mitra,Univ. of Illinois at Urbana-Champaign,http://mitras.ece.illinois.edu,dXUl8ewAAAAJ,0000-0000-0000-0000
 Sayan Mitra 0001,Univ. of Illinois at Urbana-Champaign,https://mitras.ece.illinois.edu/index.html,dXUl8ewAAAAJ,0000-0001-7082-5516
+Sayan Mitra,Univ. of Illinois at Urbana-Champaign,http://mitras.ece.illinois.edu,dXUl8ewAAAAJ,0000-0000-0000-0000
 Sayan Mukherjee 0001,University of Leipzig,https://sayanmuk.github.io,YPD04uIAAAAJ,0000-0002-6715-3920
 Sayan Ranu,IIT Delhi,http://www.cse.iitd.ac.in/~sayan,K4w5qYUAAAAJ,0000-0003-4147-9372
 Sayan Sarcar,University of Tsukuba,https://sayansarcar.github.io/index.html,bIkNGO4AAAAJ,0009-0003-1052-4633
@@ -613,7 +613,6 @@ Scott T. Leutenegger,University of Denver,http://www.cs.du.edu/~leut,UDOTNC0AAAA
 Scott. D. Goodwin,University of Windsor,http://www.uwindsor.ca/science/computerscience/1036/dr-scott-goodwin,NOSCHOLARPAGE,0000-0000-0000-0000
 Se Young Chun,Seoul National University,https://icl.snu.ac.kr/members,3jLuG64AAAAJ,0000-0001-8739-8960
 Se-Young Yun,KAIST,https://fbsqkd.github.io,X_IAjb8AAAAJ,0000-0000-0000-0000
-Sergey Goncharov 0001,University of Birmingham,https://sergey-goncharov.org/,O6as6pAAAAAJ,0000-0000-0000-0000
 SeYoung Yun,KAIST,https://fbsqkd.github.io,X_IAjb8AAAAJ,0000-0000-0000-0000
 Sea Ling,Monash University,http://monash.edu/research/explore/en/persons/chris-ling(12fc1dc1-ee0e-4294-a74d-7b6f2218dc2a).html,16YOBUgAAAAJ,0000-0000-0000-0000
 Seah Hock Soon,Nanyang Technological University,http://www.ntu.edu.sg/home/ashsseah,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -693,8 +692,8 @@ Sebastijan Dumančić,TU Delft,https://sebdumancic.github.io,besOUicAAAAJ,0000-0
 Sebastián Uchitel,University of Buenos Aires,http://lafhis.dc.uba.ar/en/~suchitel,v-rnR5UAAAAJ,0000-0001-9352-1478
 Sebastián Urrutia,UFMG,http://homepages.dcc.ufmg.br/~surrutia,mPBETD0AAAAJ,0000-0000-0000-0000
 Sebti Foufou,Qatar University,http://www.qu.edu.qa/engineering/computer/faculty/Sebti.php,E-8Pz2IAAAAJ,0000-0002-3555-9125
-Seda Ogrenci,Northwestern University,http://users.eecs.northwestern.edu/~seda,dojdbWYAAAAJ,0000-0000-0000-0000
 Seda Ogrenci Memik,Northwestern University,http://users.eecs.northwestern.edu/~seda,dojdbWYAAAAJ,0000-0001-8327-9585
+Seda Ogrenci,Northwestern University,http://users.eecs.northwestern.edu/~seda,dojdbWYAAAAJ,0000-0000-0000-0000
 Seda Ogrenci-Memik,Northwestern University,http://users.eecs.northwestern.edu/~seda,dojdbWYAAAAJ,0000-0000-0000-0000
 Sedat Akleylek,University of Tartu,https://sites.google.com/a/bil.omu.edu.tr/akleylek,plpKMjkAAAAJ,0000-0000-0000-0000
 Sedat Ozer,Özyeğin University,http://www.sedatozer.com,G8rbKi4AAAAJ,0000-0002-2069-3807
@@ -730,8 +729,8 @@ Sen Lin 0001,University of Houston,https://slin70.github.io,94-TbUsAAAAJ,0000-00
 Sen Su,BUPT,https://int.bupt.edu.cn/content/content.php?p=6_16_95,JaDhAfsAAAAJ,0000-0003-4266-7527
 Sencun Zhu,Pennsylvania State University,http://www.cse.psu.edu/~sxz16,5qwfn20AAAAJ,0000-0000-0000-0000
 Sendong Zhao,Harbin Institute of Technology,http://homepage.hit.edu.cn/stanzhao,ZtIhRvwAAAAJ,0000-0002-4676-1812
-Senem Velipasalar,Syracuse University,http://eng-cs.syr.edu/our-departments/electrical-engineering-and-computer-science/people/faculty,HEAE9XsAAAAJ,0000-0000-0000-0000
 Senem Velipasalar Gursoy,Syracuse University,http://eng-cs.syr.edu/our-departments/electrical-engineering-and-computer-science/people/faculty,HEAE9XsAAAAJ,0000-0000-0000-0000
+Senem Velipasalar,Syracuse University,http://eng-cs.syr.edu/our-departments/electrical-engineering-and-computer-science/people/faculty,HEAE9XsAAAAJ,0000-0000-0000-0000
 Senjuti Basu Roy,NJIT,https://web.njit.edu/~senjutib,O125w4cAAAAJ,0000-0003-3475-8138
 Sennur Ulukus,Univ. of Maryland - College Park,http://www.cyber.umd.edu/faculty/ulukus,nTG_TQMAAAAJ,0000-0000-0000-0000
 Senzhang Wang,Central South University,https://senzhangwangcsu.github.io/index.html,zdWyGRMAAAAJ,0000-0002-3615-4859
@@ -786,6 +785,7 @@ Sergei P. Gorlatch,University of Münster,https://www.uni-muenster.de/PVS/person
 Sergej Fatikow,University of Oldenburg,https://uol.de/informatik/amir/personen/prof-dr-ing-habil-sergej-fatikow,NOSCHOLARPAGE,0000-0000-0000-0000
 Sergey Bereg,University of Texas at Dallas,https://www.utdallas.edu/~besp,t0j3HjcAAAAJ,0000-0000-0000-0000
 Sergey Bratus,Dartmouth College,https://sergeybratus.gitlab.io,mufO1rkAAAAJ,0000-0000-0000-0000
+Sergey Goncharov 0001,University of Birmingham,https://sergey-goncharov.org/,O6as6pAAAAAJ,0000-0000-0000-0000
 Sergey Gorbunov 0001,University of Waterloo,https://cs.uwaterloo.ca/~sgorbuno,joZ7vIgAAAAJ,0000-0000-0000-0000
 Sergey Gorinsky,IMDEA Networks Institute,https://networks.imdea.org/team/imdea-networks-team/people/sergey-gorinsky,hiGGy0kAAAAJ,0000-0001-9612-8081
 Sergey Levine,Univ. of California - Berkeley,https://people.eecs.berkeley.edu/~svlevine,8R35rCwAAAAJ,0000-0001-6764-2743
@@ -793,8 +793,8 @@ Sergey M. Plis,Georgia State University,https://trendscenter.org/sergey-plis,nm3
 Sergey Mechtaev,University College London,http://mechtaev.com,XTFR93cAAAAJ,0000-0001-6088-4993
 Sergey O. Kuznetsov,HSE University,https://www.hse.ru/staff/skuznetsov,PK5Qz0cAAAAJ,0000-0000-0000-0000
 Sergey Sosnovsky,Utrecht University,http://www.staff.science.uu.nl/~sosno002,91gXaZUAAAAJ,0000-0000-0000-0000
-Sergio Alvarez,Boston College,http://www.cs.bc.edu/~alvarez,X8_J4FEAAAAJ,0000-0000-0000-0000
 Sergio Alvarez Pardo,Boston College,http://www.cs.bc.edu/~alvarez,X8_J4FEAAAAJ,0000-0000-0000-0000
+Sergio Alvarez,Boston College,http://www.cs.bc.edu/~alvarez,X8_J4FEAAAAJ,0000-0000-0000-0000
 Sergio Bampi,UFRGS,http://inf.ufrgs.br/gme,emFRxDUAAAAJ,0000-0002-9018-6309
 Sergio De Agostino,Sapienza University of Rome,http://twiki.di.uniroma1.it/twiki/view/Users/SergioDeAgostino,lll7oscAAAAJ,0000-0000-0000-0000
 Sergio F. Ochoa,Universidad de Chile,https://www.dcc.uchile.cl/sochoa,aUtukf4AAAAJ,0000-0000-0000-0000
@@ -820,8 +820,8 @@ Seth Flaxman,University of Oxford,https://www.cs.ox.ac.uk/people/seth.flaxman,Wn
 Seth Frey,Univ. of California - Davis,https://cs.ucdavis.edu/directory/seth-frey,DO4uc-kAAAAJ,0000-0002-5298-5089
 Seth Gilbert,National University of Singapore,http://www.comp.nus.edu.sg/~gilbert,bKN3mSsAAAAJ,0000-0003-3298-7412
 Seth Holladay,Brigham Young University,https://cs.byu.edu/faculty/srh43,FLK47OIAAAAJ,0000-0000-0000-0000
-Seth Hutchinson,Northeastern University,https://www.khoury.northeastern.edu/people/seth-hutchinson,-JPZ21IAAAAJ,0000-0000-0000-0000
 Seth Hutchinson 0001,Northeastern University,https://www.khoury.northeastern.edu/people/seth-hutchinson,-JPZ21IAAAAJ,0000-0002-3949-6061
+Seth Hutchinson,Northeastern University,https://www.khoury.northeastern.edu/people/seth-hutchinson,-JPZ21IAAAAJ,0000-0000-0000-0000
 Seth Lewis Gilbert,National University of Singapore,http://www.comp.nus.edu.sg/~gilbert,bKN3mSsAAAAJ,0000-0003-3298-7412
 Seth Pettie,University of Michigan,http://web.eecs.umich.edu/~pettie,ao_EFbUAAAAJ,0000-0002-2610-1630
 Seth Poulsen,Utah State University,https://www.usu.edu/cs/directory/faculty/poulsen-seth,yoEvwpsAAAAJ,0000-0001-6284-9972
@@ -888,11 +888,12 @@ Shabnam Kasra Kermanshahi,RMIT University,https://www.rmit.edu.au/contact/staff-
 Shachar Itzhaky,Technion,https://csaws.cs.technion.ac.il/~shachari,U7MFtRwAAAAJ,0000-0002-7276-7644
 Shachar Lovett,Univ. of California - San Diego,http://cseweb.ucsd.edu/~slovett,f6JF7BkAAAAJ,0000-0003-4552-1443
 Shachi Sharma,South Asian University,http://sau.int/faculty/faculty-profile.html?staff_id=87,TltIxw8AAAAJ,0000-0000-0000-0000
-Shadan Sadeghian,University of Siegen,https://www.mediacoop.uni-siegen.de/de/personen/sadedhian-shadan,DYGZQO0AAAAJ,0000-0002-8590-656X
 Shadan Sadeghian Borojeni,University of Siegen,https://www.mediacoop.uni-siegen.de/de/personen/sadedhian-shadan,DYGZQO0AAAAJ,0000-0000-0000-0000
+Shadan Sadeghian,University of Siegen,https://www.mediacoop.uni-siegen.de/de/personen/sadedhian-shadan,DYGZQO0AAAAJ,0000-0002-8590-656X
 Shadan Sadeghianborojeni,University of Siegen,https://www.mediacoop.uni-siegen.de/de/personen/sadedhian-shadan,DYGZQO0AAAAJ,0000-0000-0000-0000
 Shaddi Hasan,Virginia Tech,https://people.cs.vt.edu/shaddi,IHburiYAAAAJ,0000-0001-5432-6952
 Shaddin Dughmi,University of Southern California,https://viterbi-web.usc.edu/~shaddin,jn-B_MoAAAAJ,0000-0002-2784-1868
+Shadi Ibrahim,INRIA,https://people.rennes.inria.fr/Shadi.Ibrahim/index.html,wYsb_kUAAAAJ,0000-0000-0000-0000
 Shady Elbassuoni,American University of Beirut,https://www.aub.edu.lb/fas/cs/people/Pages/se58.aspx,Fe8iIHMAAAAJ,0000-0000-0000-0000
 Shafay Shamail,LUMS,https://lums.edu.pk/lums_employee/533,LEWgqDAAAAAJ,0000-0000-0000-0000
 Shafi Goldwasser,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/goldwasser.html,NOSCHOLARPAGE,0000-0003-4728-1535
@@ -912,8 +913,8 @@ Shahed Khan Mohammed,UNC - Charlotte,https://ece.charlotte.edu/directory/dr-shah
 Shahedur Rahman,Middlesex University,http://www.cs.mdx.ac.uk/people/shahedur-rahman,NOSCHOLARPAGE,0000-0000-0000-0000
 Shaheen Fatima,Loughborough University,https://www.lboro.ac.uk/departments/compsci/staff/academic-teaching/shaheen-fatima,KqRKHv4AAAAJ,0000-0000-0000-0000
 Shahid Raza,University of Glasgow,https://www.gla.ac.uk/schools/computing/staff/shahidraza,ivYcvvoAAAAJ,0000-0001-8192-0893
-Shahin Jabbari,Drexel University,https://shahin-jabbari.github.io,h60zIiUAAAAJ,0000-0000-0000-0000
 Shahin Jabbari Arfaee,Drexel University,https://shahin-jabbari.github.io,h60zIiUAAAAJ,0000-0000-0000-0000
+Shahin Jabbari,Drexel University,https://shahin-jabbari.github.io,h60zIiUAAAAJ,0000-0000-0000-0000
 Shahin Kamali,University of Manitoba,http://www.cs.umanitoba.ca/~kamalis,hQXlVLsAAAAJ,0000-0003-1404-2212
 Shahram Ghandeharizadeh,University of Southern California,https://www.flslab.org,FI5-sZEAAAAJ,0000-0002-1792-7879
 Shahram ShahbazPanahi,Ontario Tech University,https://engineering.ontariotechu.ca/people/ecse/shahram.shahbazpanahi.php,-kZ8x08AAAAJ,0000-0000-0000-0000
@@ -1340,8 +1341,8 @@ Shuai Li 0001,Beihang University,http://scse.buaa.edu.cn/info/1024/3022.htm,NOSC
 Shuai Li 0010,Shanghai Jiao Tong University,https://shuaili8.github.io,kMZgQxcAAAAJ,0000-0002-3935-0708
 Shuai Lü 0001,Jilin University,https://ccst.jlu.edu.cn/info/1367/19944.htm,S1T_HV0AAAAJ,0000-0002-8081-4498
 Shuai Ma 0001,Beihang University,http://mashuai.buaa.edu.cn,vJUjFpQAAAAJ,0000-0002-4050-0443
-Shuai Mu,Stony Brook University,http://mpaxos.com,wcbyR5UAAAAJ,0000-0000-0000-0000
 Shuai Mu 0001,Stony Brook University,http://mpaxos.com,wcbyR5UAAAAJ,0000-0001-8244-2109
+Shuai Mu,Stony Brook University,http://mpaxos.com,wcbyR5UAAAAJ,0000-0000-0000-0000
 Shuai Shao 0001,USTC,http://staff.ustc.edu.cn/~wwwucuc,Lh-UKzcAAAAJ,0000-0003-0935-2929
 Shuai Wang 0011,HKUST,https://home.cse.ust.hk/~shuaiw,POlWWAsAAAAJ,0000-0002-0866-0308
 Shuai Wang 0016,Nanjing University,https://shuaiwang-nju.github.io,vW1ZaucAAAAJ,0000-0000-0000-0000
@@ -1471,7 +1472,6 @@ Sichao Li,City University of Macau,https://fds.cityu.edu.mo/en/members/461,ylZQz
 Sicong Liu,NWPU,https://sicongliu-deep.github.io,_maZt1AAAAAJ,0000-0000-0000-0000
 Sicun Gao,Univ. of California - San Diego,https://scungao.github.io,UmyrEtcAAAAJ,0000-0000-0000-0000
 Sid Ray,Monash University,http://users.monash.edu/~sid/shadowfax,NOSCHOLARPAGE,0000-0000-0000-0000
-Siddharth,Plaksha University,https://ssiddharth.in/about-me,M3zP9NEAAAAJ,0000-0000-0000-0000
 Siddharth Barman,IISc Bangalore,http://www.csa.iisc.ac.in/~barman,HcGQSKIAAAAJ,0000-0001-9276-2181
 Siddharth Garg,New York University,http://engineering.nyu.edu/people/siddharth-garg,Yf8OqQQAAAAJ,0000-0002-6158-9512
 Siddharth Gupta 0002,BITS Pilani-Goa,https://guptasid.bitbucket.io,B_2PPFgAAAAJ,0000-0000-0000-0000
@@ -1479,6 +1479,7 @@ Siddharth Joshi 0001,University of Notre Dame,http://isn.ucsd.edu/~siddharth,Peg
 Siddharth Kaza,Towson University,https://www.towson.edu/fcsm/departments/computerinfosci/facultystaff/skaza.html,xj0-4yQAAAAJ,0000-0000-0000-0000
 Siddharth Krishnan,UNC - Charlotte,https://webpages.uncc.edu/~skrish21,I8HrLhQAAAAJ,0000-0000-0000-0000
 Siddharth Srivastava 0001,Arizona State University,http://siddharthsrivastava.net,H3ZnCqYAAAAJ,0000-0002-5217-2790
+Siddharth,Plaksha University,https://ssiddharth.in/about-me,M3zP9NEAAAAJ,0000-0000-0000-0000
 Siddhartha Banerjee,Cornell University,https://people.orie.cornell.edu/sbanerjee,_kqpoHIAAAAJ,0000-0002-8954-4578
 Siddhartha Jayanti,Dartmouth College,https://sites.google.com/view/siddhartha-jayanti,NKDBBGkAAAAJ,0000-0002-2681-1632
 Siddhartha Sarma,IIT Mandi,http://faculty.iitmandi.ac.in/~siddhartha/index.html,c-oFx5UAAAAJ,0000-0000-0000-0000
@@ -1517,8 +1518,8 @@ Silvia Regina Vergilio,UFPR,https://www.inf.ufpr.br/silvia,2bkThnAAAAAJ,0000-000
 Silvia S. C. Botelho,Federal University of Rio Grande,http://www.silviacb.c3.furg.br,XKt2OlEAAAAJ,0000-0002-8857-0221
 Silvia Santini,Università della Svizzera italiana,https://tu-dresden.de/die_tu_dresden/fakultaeten/fakultaet_informatik/tei/es/mitarbeiter/silvia-santini,RjTLqRwAAAAJ,0000-0002-0882-2004
 Silvia Silva da Costa Botelho,Federal University of Rio Grande,http://www.silviacb.c3.furg.br,XKt2OlEAAAAJ,0000-0002-8857-0221
-Silvia Takahashi,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/stakahas/es/inicio,x7gjZ04AAAAJ,0000-0000-0000-0000
 Silvia Takahashi Rodríguez,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/stakahas/es/inicio,x7gjZ04AAAAJ,0000-0000-0000-0000
+Silvia Takahashi,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/stakahas/es/inicio,x7gjZ04AAAAJ,0000-0000-0000-0000
 Silvina L. Ferradal,Indiana University,https://luddy.indiana.edu/contact/profile/?Silvina_Ferradal,2JcHy3wAAAAJ,0000-0000-0000-0000
 Silvio Amir,Northeastern University,https://www.khoury.northeastern.edu/people/silvio-amir,jhUQvC0AAAAJ,0000-0000-0000-0000
 Silvio Meira 0001,UFPE,https://www.cin.ufpe.br/~srlm,ycIwxqsAAAAJ,0000-0000-0000-0000
@@ -1668,8 +1669,8 @@ Sivaraman Balakrishnan,Carnegie Mellon University,http://www.stat.cmu.edu/~siva,
 Sivaraman K. Anirudh,New York University,https://cs.nyu.edu/~anirudh,z9em5msAAAAJ,0000-0000-0000-0000
 Siwei Feng,Soochow University,http://web.suda.edu.cn/fsw,_7xkHz8AAAAJ,0000-0000-0000-0000
 Siwei Lyu,University at Buffalo,https://cse.buffalo.edu/~siweilyu,wefAEM4AAAAJ,0000-0000-0000-0000
-Siwei Ma,Peking University,http://idm.pku.edu.cn/staff/masiwei/masiwei.htm,y3YqlaUAAAAJ,0000-0000-0000-0000
 Siwei Ma 0001,Peking University,https://cs.pku.edu.cn/info/1236/2106.htm,y3YqlaUAAAAJ,0000-0002-2731-5403
+Siwei Ma,Peking University,http://idm.pku.edu.cn/staff/masiwei/masiwei.htm,y3YqlaUAAAAJ,0000-0000-0000-0000
 Siwei Tan,Zhejiang University,http://person.zju.edu.cn/tansiwei,Wj7H4EUAAAAJ,0000-0002-0634-8089
 Siyao Guo,NYU Shanghai,https://sites.google.com/site/siyaoguo,nscLxl4AAAAJ,0009-0008-3664-3928
 Siyi Lv,Nankai University,https://cc.nankai.edu.cn/2021/0323/c13620a570392/page.htm,RbowLSoAAAAJ,0009-0007-1857-5186
@@ -1771,8 +1772,8 @@ Songul Albayrak,Yıldız Technical University,https://www.ce.yildiz.edu.tr/perso
 Songwu Lu,Univ. of California - Los Angeles,http://www.cs.ucla.edu/~slu,PVdTviYAAAAJ,0000-0003-3779-0918
 Songze Li,Southeast University,https://cyber.seu.edu.cn/lsz/list.htm,vcGuNDYAAAAJ,0000-0003-4282-3307
 Songül Albayrak,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/songul?lang=en,LF5HfgEAAAAJ,0000-0000-0000-0000
-Songül Varli,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/songul?lang=en,LF5HfgEAAAAJ,0000-0000-0000-0000
 Songül Varli Albayrak,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/songul?lang=en,LF5HfgEAAAAJ,0000-0000-0000-0000
+Songül Varli,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/songul?lang=en,LF5HfgEAAAAJ,0000-0000-0000-0000
 Sonia Berman,University of Cape Town,https://www.cs.uct.ac.za/research/research-interests-sonia-berman,NOSCHOLARPAGE,0000-0000-0000-0000
 Sonia Chernova,Georgia Institute of Technology,http://www.cc.gatech.edu/~chernova,EYo_WkEAAAAJ,0000-0001-6320-0825
 Sonia Chiasson,Carleton University,https://carleton.ca/scs/people/sonia-chiasson,wg8yZz8AAAAJ,0000-0000-0000-0000
@@ -1831,8 +1832,8 @@ Soumaya Cherkaoui,Polytechnique Montreal,https://www.polymtl.ca/expertises/en/ch
 Soumen Chakrabarti,IIT Bombay,https://www.cse.iitb.ac.in/~soumen,LfF2zfQAAAAJ,0000-0000-0000-0000
 Soumitra Roy Joy,UNC - Charlotte,https://ece.charlotte.edu/people/soumitra-r-joy-ph-d,sBjj4LgAAAAJ,0000-0000-0000-0000
 Soumya Dutta,IIT Kanpur,https://soumyadutta-cse.github.io,7CGMUB8AAAAJ,0000-0001-5030-9979
-Soumya K. Ghosh,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ,0000-0000-0000-0000
 Soumya K. Ghosh 0001,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ,0000-0000-0000-0000
+Soumya K. Ghosh,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ,0000-0000-0000-0000
 Soumya Kanti Ghosh 0001,IIT Kharagpur,http://www.facweb.iitkgp.ac.in/~skg,wTtdGd4AAAAJ,0000-0000-0000-0000
 Soumya Ray,Case Western Reserve University,http://engr.case.edu/ray_soumya,T3Wxu_AAAAAJ,0000-0002-7497-3281
 Soumyabrata Dev,University College Dublin,https://people.ucd.ie/soumyabrata.dev,_akXw8IAAAAJ,0000-0000-0000-0000
@@ -2448,8 +2449,8 @@ Suely Oliveira,University of Iowa,https://www.cs.uiowa.edu/~oliveira,eDMCSJwAAAA
 Suganya Devi K,National Inst. of Tech. Silchar,http://cs.nits.ac.in/suganya,AdtGcxoAAAAJ,0000-0000-0000-0000
 Sugata Gangopadhyay,IIT Roorkee,http://www.iitr.ac.in/departments/CSE/pages/Home+Departments_and_Centres+Mathematics+People+Faculty+Gangopadhyay_Sugata.html,J7_k8JEAAAAJ,0000-0000-0000-0000
 Sugih Jamin,University of Michigan,http://web.eecs.umich.edu/~sugih,NOSCHOLARPAGE,0000-0000-0000-0000
-Suguru Saito,Institute of Science Tokyo,https://www.img.cs.titech.ac.jp/en/,ZcOg_EMAAAAJ,0000-0000-0000-0000
 Suguman Bansal,Georgia Institute of Technology,https://suguman.github.io,bd9Rk1MAAAAJ,0000-0002-0405-073X
+Suguru Saito,Institute of Science Tokyo,https://www.img.cs.titech.ac.jp/en/,ZcOg_EMAAAAJ,0000-0000-0000-0000
 Suha Kwak,POSTECH,http://cvlab.postech.ac.kr/~suhakwak,-gscDIEAAAAJ,0000-0002-4567-9091
 Suhaib A. Fahmy,KAUST,https://cemse.kaust.edu.sa/accl/people/person/suhaib-fahmy,88wtbPwAAAAJ,0000-0003-0568-5048
 Suhang Wang,Pennsylvania State University,https://faculty.ist.psu.edu/szw494,cdT_WMMAAAAJ,0000-0003-3448-4878
@@ -2482,8 +2483,8 @@ Sukumar Nandi,IIT Guwahati,https://www.iitg.ernet.in/sukumar,ChtruacAAAAJ,0000-0
 Sukyoung Lee,Yonsei University,http://winet.yonsei.ac.kr/home/professor,NOSCHOLARPAGE,0000-0002-3497-3295
 Sukyoung Ryu,KAIST,http://plrg.kaist.ac.kr/ryu,c98U5D0AAAAJ,0000-0002-0019-9772
 Sulamita Klein,UFRJ,http://www.cos.ufrj.br/index.php/pt-BR/pessoas/details/18/1054-sula,r4ZrGiIAAAAJ,0000-0000-0000-0000
-Sule Gündüz,Istanbul Technical University,http://web.itu.edu.tr/sgunduz,E5OlkJMAAAAJ,0000-0000-0000-0000
 Sule Gündüz Ögüdücü,Istanbul Technical University,http://web.itu.edu.tr/sgunduz,E5OlkJMAAAAJ,0000-0000-0000-0000
+Sule Gündüz,Istanbul Technical University,http://web.itu.edu.tr/sgunduz,E5OlkJMAAAAJ,0000-0000-0000-0000
 Sule Ögüdücü,Istanbul Technical University,http://web.itu.edu.tr/sgunduz,E5OlkJMAAAAJ,0000-0000-0000-0000
 Suleman Shahid,LUMS,https://lums.edu.pk/lums_employee/4407,NOSCHOLARPAGE,0000-0000-0000-0000
 Suleyman Tosun,Hacettepe University,https://web.cs.hacettepe.edu.tr/~stosun,IiZP05YAAAAJ,0000-0000-0000-0000
@@ -2520,8 +2521,8 @@ Sun Kim,Seoul National University,http://biohealth.snu.ac.kr,lI_oWS8AAAAJ,0000-0
 Sun-Teck Tan,National University of Singapore,http://www.comp.nus.edu.sg/about/depts/cs/faculty,NOSCHOLARPAGE,0000-0000-0000-0000
 Sun-Yuan Hsieh,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/depmember/teacherdetail/id/15,xTcr9DoAAAAJ,0000-0000-0000-0000
 Sunbeom So,Korea University,https://ku-formal.github.io,UTug1PgAAAAJ,0009-0000-7005-1928
-Suncica Hadzidedic,Durham University,https://www.dur.ac.uk/computer.science/staff/profile/?id=18580,RYJDV5cAAAAJ,0000-0000-0000-0000
 Suncica Hadzidedic Bazdarevic,Durham University,https://www.dur.ac.uk/computer.science/staff/profile/?id=18580,RYJDV5cAAAAJ,0000-0000-0000-0000
+Suncica Hadzidedic,Durham University,https://www.dur.ac.uk/computer.science/staff/profile/?id=18580,RYJDV5cAAAAJ,0000-0000-0000-0000
 Sundar Balasubramaniam,BITS Pilani,http://www.bits-pilani.ac.in/pilani/sundarb/profile,2E9w-LgAAAAJ,0000-0000-0000-0000
 Sundar Vishwanathan,IIT Bombay,https://www.cse.iitb.ac.in/~sundar,8CK3IY4AAAAJ,0000-0000-0000-0000
 Sundaraja Sitharama Iyengar,Florida International University,http://users.cis.fiu.edu/~iyengar,eNONM8AAAAAJ,0000-0000-0000-0000
@@ -2610,8 +2611,8 @@ Surjya Ghosh,BITS Pilani-Goa,https://surjya-ghosh.github.io,jwQqy80AAAAJ,0000-00
 Surya P. N. Singh,University of Queensland,http://robotics.itee.uq.edu.au/~spns,GdBpqg4AAAAJ,0000-0000-0000-0000
 Surya Prakash 0001,IIT Indore,http://www.iiti.ac.in/~surya,6_PF2KEAAAAJ,0000-0000-0000-0000
 Suryadipta Majumdar,Concordia University,https://users.encs.concordia.ca/~majumdar,S4x0by4AAAAJ,0000-0000-0000-0000
-Sus Lundgren,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/sus-lundgren.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Sus Lundgren Lyckvi,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/sus-lundgren.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
+Sus Lundgren,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/sus-lundgren.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Sus Lyckvi,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/sus-lundgren.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Susan A. Mengel,Texas Tech University,https://www.depts.ttu.edu/cs/faculty/susan_a._mengel,SH_ZjnkAAAAJ,0000-0000-0000-0000
 Susan A. Murphy,Harvard University,https://www.seas.harvard.edu/directory/samurphy,q-DPFdUAAAAJ,0000-0002-2032-4286


### PR DESCRIPTION
## Consolidated PR for INRIA

This PR consolidates the following open PRs:

| PR | Score | Title |
|---|---|---|
| #12342 | 80% | Add 2 faculty from INRIA |
| #12346 | 80% | Add Cordelia Schmid (INRIA) |
| #12349 | 80% | Add 2 faculty from INRIA |

Total: 5 faculty additions.
Average individual score: 80%
Joint probability (all valid): 32.8%
