### PR TITLE
Add 4 faculty from Chinese Academy of Sciences (consolidated)

### DIFF
--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -4,8 +4,8 @@ C. B. Chandrakala,Manipal Academy of Higher Education,https://www.manipal.edu/mi
 C. Barry Jay,University of Technology Sydney,https://www.uts.edu.au/staff/barry.jay,Ml9nDYQAAAAJ,0000-0000-0000-0000
 C. Carvalho de Souza,UNICAMP,http://www.ic.unicamp.br/~cid,t_w8cAkAAAAJ,0000-0000-0000-0000
 C. Chandra Sekhar,IIT Madras,https://www.iitm.ac.in/info/fac/cchandra,rO5ZgW4AAAAJ,0000-0000-0000-0000
-C. David Page,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~dpage,aNh0te8AAAAJ,0000-0000-0000-0000
 C. David Page Jr.,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~dpage,aNh0te8AAAAJ,0000-0000-0000-0000
+C. David Page,University of Wisconsin - Madison,http://pages.cs.wisc.edu/~dpage,aNh0te8AAAAJ,0000-0000-0000-0000
 C. Edward Chow,UCCS,http://www.cs.uccs.edu/~chow,xLIQ4PYAAAAJ,0000-0000-0000-0000
 C. Estelle Smith,Colorado School of Mines,https://estellesmithphd.com,1YmwfXoAAAAJ,0000-0002-4981-7105
 C. Greg Plaxton,University of Texas at Austin,https://www.cs.utexas.edu/users/plaxton,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -25,9 +25,9 @@ C. V. Jawahar,IIIT Hyderabad,https://www.iiit.ac.in/~jawahar,U9dH-DoAAAAJ,0000-0
 C. Y. Roger Chen,Syracuse University,https://eng-cs.syr.edu/our-departments/electrical-engineering-and-computer-science/people/?peopleid=2970,NOSCHOLARPAGE,0000-0000-0000-0000
 C.-C. Jay Kuo,University of Southern California,http://mcl.usc.edu,81d60okAAAAJ,0000-0001-9474-5035
 C.-H. Luke Ong,Nanyang Technological University,https://dr.ntu.edu.sg/entities/person/Luke-Ong,gNFel3QAAAAJ,0000-0001-7509-680X
-Caetano Traina,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/caetano,h2ivd3AAAAAJ,0000-0002-6625-6047
 Caetano Traina Jr.,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/caetano,h2ivd3AAAAAJ,0000-0002-6625-6047
 Caetano Traina Júnior,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/caetano,h2ivd3AAAAAJ,0000-0000-0000-0000
+Caetano Traina,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/caetano,h2ivd3AAAAAJ,0000-0002-6625-6047
 Cagatay Turkay,City University of London,https://www.city.ac.uk/people/academics/cagatay-turkay#profile=overview,ho0I_1kAAAAJ,0000-0001-6788-251X
 Cagdas D. Onal,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/cdo.html,3symmLYAAAAJ,0000-0000-0000-0000
 Cagdas Denizel Onal,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/cdo.html,3symmLYAAAAJ,0000-0000-0000-0000
@@ -80,8 +80,8 @@ Carey L. Williamson,University of Calgary,http://www.cpsc.ucalgary.ca/~carey,NOS
 Carey Williamson,University of Calgary,http://www.cpsc.ucalgary.ca/~carey,NOSCHOLARPAGE,0000-0000-0000-0000
 Carina Alves 0001,UFPE,https://www.cin.ufpe.br/~cfa,qrsfaXoAAAAJ,0000-0000-0000-0000
 Carina F. Alves,UFPE,https://www.cin.ufpe.br/~cfa,qrsfaXoAAAAJ,0000-0000-0000-0000
-Carina Frota,UFPE,https://www.cin.ufpe.br/~cfa,qrsfaXoAAAAJ,0000-0000-0000-0000
 Carina Frota Alves,UFPE,https://www.cin.ufpe.br/~cfa,qrsfaXoAAAAJ,0000-0000-0000-0000
+Carina Frota,UFPE,https://www.cin.ufpe.br/~cfa,qrsfaXoAAAAJ,0000-0000-0000-0000
 Carl A. Gunter,Univ. of Illinois at Urbana-Champaign,http://web.engr.illinois.edu/~cgunter,3S5qpXsAAAAJ,0000-0000-0000-0000
 Carl A. Gutwin,University of Saskatchewan,https://www.cs.usask.ca/faculty/gutwin,ZWsIEYcAAAAJ,0000-0000-0000-0000
 Carl DiSalvo,Georgia Institute of Technology,https://www.carldisalvo.com,YR1EmaAAAAAJ,0000-0002-7344-8741
@@ -141,8 +141,8 @@ Carlos Caleiro,Universidade de Lisboa,http://sqig.math.ist.utl.pt/ccal,YnVAMh4AA
 Carlos Camarao de Figueiredo,UFMG,http://homepages.dcc.ufmg.br/~camarao,2LRi77IAAAAJ,0000-0000-0000-0000
 Carlos Camarão 0001,UFMG,http://homepages.dcc.ufmg.br/~camarao,2LRi77IAAAAJ,0000-0000-0000-0000
 Carlos Cid,Simula UiB,https://www.simula.no/people/carlos,yfL0oMkAAAAJ,0000-0001-5761-8694
-Carlos Dafonte,University of A Coruña,https://pdi.udc.es/en/File/Pdi/9K9AF,plU2iAkAAAAJ,0000-0000-0000-0000
 Carlos Dafonte Vázquez,University of A Coruña,https://pdi.udc.es/en/File/Pdi/9K9AF,plU2iAkAAAAJ,0000-0000-0000-0000
+Carlos Dafonte,University of A Coruña,https://pdi.udc.es/en/File/Pdi/9K9AF,plU2iAkAAAAJ,0000-0000-0000-0000
 Carlos Duarte,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/caduarte,I7hcyJgAAAAJ,0000-0003-1370-5379
 Carlos E. Ferreira,USP,http://www.ime.usp.br/~cef,cp2Bft4AAAAJ,0000-0000-0000-0000
 Carlos Eduardo Ferreira,USP,http://www.ime.usp.br/~cef,cp2Bft4AAAAJ,0000-0003-4804-5788
@@ -360,8 +360,8 @@ Changhee Joo,Korea University,https://rain.korea.ac.kr/members/professor,ZTvziRo
 Changhee Jung,Purdue University,https://www.cs.purdue.edu/homes/chjung,_sIzYHAAAAAJ,0000-0002-6422-6549
 Changhee Lee,Korea University,https://sites.google.com/view/actionable-intelligence,kSvJTg4AAAAJ,0000-0000-0000-0000
 Changho Suh,KAIST,https://sites.google.com/site/changhosuh,B1guGw8AAAAJ,0000-0002-3101-4291
-Changhun Kim,Korea University,http://kucg.korea.ac.kr/new/about/people.php,NOSCHOLARPAGE,0000-0000-0000-0000
 Changhun Kim 0001,Korea University,https://pure.korea.ac.kr/en/persons/chang-hun-kim,NOSCHOLARPAGE,0000-0000-0000-0000
+Changhun Kim,Korea University,http://kucg.korea.ac.kr/new/about/people.php,NOSCHOLARPAGE,0000-0000-0000-0000
 Changhyun Choi,University of Minnesota,https://choice.umn.edu/people,WOsQx6EAAAAJ,0000-0003-4715-3576
 Changick Kim,KAIST,https://cilabs.kaist.ac.kr/members/professor,ABH_2lcAAAAJ,0000-0001-9323-8488
 Changjian Chen,Hunan University,https://changjianchen.github.io,Q4pwU6sAAAAJ,0000-0003-2715-8839
@@ -445,8 +445,8 @@ Charles Anderson 0001,Colorado State University,http://www.cs.colostate.edu/~and
 Charles B. Owen,Michigan State University,http://www.cse.msu.edu/~cbowen,zBuDgD0AAAAJ,0009-0009-4255-4195
 Charles Border,Rochester Inst. of Technology,https://www.rit.edu/gccis/charlie-border,NOSCHOLARPAGE,0000-0000-0000-0000
 Charles Bouillaguet,CRIStAL,http://cristal.univ-lille.fr/~bouillag,5ov-TX4AAAAJ,0000-0001-9416-6244
-Charles C. Weems,Univ. of Massachusetts Amherst,https://people.cs.umass.edu/~weems,bkN-YUkAAAAJ,0000-0000-0000-0000
 Charles C. Weems Jr.,Univ. of Massachusetts Amherst,https://people.cs.umass.edu/~weems,bkN-YUkAAAAJ,0000-0000-0000-0000
+Charles C. Weems,Univ. of Massachusetts Amherst,https://people.cs.umass.edu/~weems,bkN-YUkAAAAJ,0000-0000-0000-0000
 Charles Dierbach,Towson University,https://www.towson.edu/fcsm/departments/computerinfosci/facultystaff/cdierbach.html,NOSCHOLARPAGE,0000-0002-3370-6291
 Charles E. Hughes,University of Central Florida,http://www.cs.ucf.edu/~ceh,pbb9CG4AAAAJ,0000-0002-2528-3380
 Charles E. Leiserson,Massachusetts Inst. of Technology,http://people.csail.mit.edu/cel,gWBoNCsAAAAJ,0000-0001-6386-5552
@@ -523,8 +523,8 @@ Chen Chen 0042,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/ac
 Chen Chen 0067,Shanghai Jiao Tong University,https://jhc.sjtu.edu.cn/~chen-chen,NOSCHOLARPAGE,0000-0001-9480-5632
 Chen Chen 0070,Florida International University,https://chen-chen.me,z--wnsUAAAAJ,0000-0001-7179-0861
 Chen Ding 0001,University of Rochester,http://www.cs.rochester.edu/~cding,SZuNhvQAAAAJ,0000-0003-4968-6659
-Chen Feng,Queen's University Belfast,https://pure.qub.ac.uk/en/persons/chen-feng,4VZhTYgAAAAJ,0000-0001-9199-559X
 Chen Feng 0002,New York University,https://engineering.nyu.edu/faculty/chen-feng,YeG8ZM0AAAAJ,0000-0003-3211-1576
+Chen Feng,Queen's University Belfast,https://pure.qub.ac.uk/en/persons/chen-feng,4VZhTYgAAAAJ,0000-0001-9199-559X
 Chen Greif,University of British Columbia,https://www.cs.ubc.ca/~greif,NOSCHOLARPAGE,0009-0006-4103-4364
 Chen Hajaj,Ariel University,https://www.ariel.ac.il/wp/chen-hajaj,Zy2cIskAAAAJ,0000-0001-9940-5654
 Chen Li 0001,Univ. of California - Irvine,https://chenli.ics.uci.edu,BRMbGhgAAAAJ,0000-0001-8015-6870
@@ -543,9 +543,9 @@ Chen Wei 0005,Rice University,https://profiles.rice.edu/faculty/chen-wei,LHQGpBU
 Chen Yu 0001,Indiana University,https://psych.indiana.edu/directory/faculty/yu-chen.html,SA3IoXwAAAAJ,0000-0003-1473-3179
 Chen Yu 0003,HUST,http://faculty.hust.edu.cn/yuchen1/en/index.htm,kIfNRN4AAAAJ,0000-0003-0782-0450
 Chen Yuan 0003,Shanghai Jiao Tong University,https://infosec.sjtu.edu.cn/DirectoryDetail.aspx?id=161,IETqP9EAAAAJ,0000-0000-0000-0000
-Chen Zhao,Harbin Institute of Technology,https://homepage.hit.edu.cn/zhaochen?lang=en,dUWdX5EAAAAJ,0000-0003-4993-5416
 Chen Zhao 0010,Baylor University,https://charliezhaoyinpeng.github.io/homepage,xebNvXQAAAAJ,0000-0002-6400-0048
 Chen Zhao 0013,NYU Shanghai,https://henryzhao5852.github.io,zehsvT8AAAAJ,0000-0001-7672-146X
+Chen Zhao,Harbin Institute of Technology,https://homepage.hit.edu.cn/zhaochen?lang=en,dUWdX5EAAAAJ,0000-0003-4993-5416
 Chen-Ching Liu,Washington State University,https://school.eecs.wsu.edu/people/faculty/chen-ching-liu,NOSCHOLARPAGE,0000-0000-0000-0000
 Chen-Nee Chuah,Univ. of California - Davis,https://www.ece.ucdavis.edu/~chuah/rubinet/people/chuah/bio.html,bZNRLNAAAAAJ,0000-0002-2772-387X
 Chen-Yu Wei,University of Virginia,https://bahh723.github.io,2L2cR-kAAAAJ,0000-0000-0000-0000
@@ -614,8 +614,9 @@ Chenren Xu,Peking University,http://soar.group/chenren,IFX5C-cAAAAJ,0000-0001-91
 Chenshu Wu,University of Hong Kong,https://cswu.me,q9llreMAAAAJ,0000-0002-9700-4627
 Chentao Wu,Shanghai Jiao Tong University,http://www.cs.sjtu.edu.cn/~wuct,RAs-wnEAAAAJ,0000-0002-6882-3754
 Chenxi Qiu,University of North Texas,https://computerscience.engineering.unt.edu/people/faculty/chenxi-qiu,Lj9jGZ8AAAAJ,0000-0002-3387-9758
-Chenxi Zhang,Tongji University,https://sse.tongji.edu.cn/Data/View/2825,NOSCHOLARPAGE,0000-0000-0000-0000
+Chenxi Wang,Chinese Academy of Sciences,https://people.ucas.ac.cn/~0074774,ESj_-bEAAAAJ,0000-0002-1451-3101
 Chenxi Zhang 0003,Xidian University,http://faculty.xidian.edu.cn/zhangchenxi/zh_CN/index.htm,Ds3dvEMAAAAJ,0009-0007-1432-9957
+Chenxi Zhang,Tongji University,https://sse.tongji.edu.cn/Data/View/2825,NOSCHOLARPAGE,0000-0000-0000-0000
 Chenxiong Qian,University of Hong Kong,https://i.cs.hku.hk/~cqian,AojtmP4AAAAJ,0000-0002-6201-6011
 Chenyan Xiong,Carnegie Mellon University,http://www.cs.cmu.edu/~cx,E9BaEBYAAAAJ,0000-0002-0392-4183
 Chenyang Lu 0001,Washington University in St. Louis,https://www.cs.wustl.edu/~lu,tCq7Wx0AAAAJ,0000-0003-1709-6769
@@ -753,8 +754,8 @@ Choonhwa Lee,Hanyang University,http://dcc.hanyang.ac.kr/members.htm,NOSCHOLARPA
 Chowdhury Farhan Ahmed,University of Dhaka,https://du.ac.bd/body/faculty_details/CSE/1770,0huuef0AAAAJ,0000-0002-6101-4591
 Chris Amato,Northeastern University,http://www.ccs.neu.edu/home/camato,-8-sD-sAAAAJ,0000-0000-0000-0000
 Chris Baber,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/academic-staff/baber-chris.aspx,MQ184fQAAAAJ,0000-0002-1830-2272
-Chris Bailey,University of York,https://www-users.cs.york.ac.uk/~chrisb,QQ_dWtcAAAAJ,0000-0000-0000-0000
 Chris Bailey 0002,University of York,https://www-users.cs.york.ac.uk/~chrisb,QQ_dWtcAAAAJ,0000-0000-0000-0000
+Chris Bailey,University of York,https://www-users.cs.york.ac.uk/~chrisb,QQ_dWtcAAAAJ,0000-0000-0000-0000
 Chris Bailey-Kellogg,Dartmouth College,http://www.cs.dartmouth.edu/~cbk,NOSCHOLARPAGE,0000-0003-1860-0912
 Chris Bartone,Ohio University,https://www.ohio.edu/engineering/about/people/profiles.cfm?profile=bartone,NOSCHOLARPAGE,0000-0000-0000-0000
 Chris Bevan,University of Bristol,http://www.chrisbevan.co.uk,oeU9peMAAAAJ,0000-0002-2823-420X
@@ -1245,8 +1246,8 @@ Chunyang Chen 0001,TU Munich,https://chunyang-chen.github.io,3tyGlPsAAAAJ,0000-0
 Chunyao Song,Nankai University,https://cc.nankai.edu.cn/2021/0323/c13620a549970/page.htm,8q8-yYcAAAAJ,0000-0002-5715-5092
 Chunyi Peng 0001,Purdue University,https://www.cs.purdue.edu/homes/chunyi,7QF1eF4AAAAJ,0000-0003-2945-4981
 Chunyu Lin,Beijing Jiaotong University,http://faculty.bjtu.edu.cn/8549,t8xkhscAAAAJ,0000-0003-2847-0349
-Chunyu Wang,Harbin Institute of Technology,http://homepage.hit.edu.cn/chunyu,1BBVb2wAAAAJ,0000-0001-6348-2455
 Chunyu Wang 0002,Harbin Institute of Technology,http://homepage.hit.edu.cn/chunyu,1BBVb2wAAAAJ,0000-0002-2965-9920
+Chunyu Wang,Harbin Institute of Technology,http://homepage.hit.edu.cn/chunyu,1BBVb2wAAAAJ,0000-0001-6348-2455
 Chunyu Wei,Renmin University of China,http://weicy15.github.io,qECtMnkAAAAJ,0000-0002-5802-5759
 Chuxu Zhang,University of Connecticut,https://chuxuzhang.github.io,ZbZ0l0oAAAAJ,0000-0002-8349-7926
 Chuyu Wang,Nanjing University,http://cs.nju.edu.cn/chuyu,yb3PUaoAAAAJ,0000-0002-1479-9023
@@ -1259,8 +1260,8 @@ Cicek Cavdar,KTH Royal Inst. of Technology,https://www.kth.se/profile/cavdar,9Dj
 Cid C. de Souza,UNICAMP,http://www.ic.unicamp.br/~cid,t_w8cAkAAAAJ,0000-0002-5945-0845
 Cid Carvalho de Souza,UNICAMP,http://www.ic.unicamp.br/~cid,t_w8cAkAAAAJ,0000-0000-0000-0000
 Cigdem Demir,Bilkent University,http://www.cs.bilkent.edu.tr/~gunduz,d1I0jcAAAAAJ,0000-0000-0000-0000
-Cigdem Gunduz,Bilkent University,http://www.cs.bilkent.edu.tr/~gunduz,d1I0jcAAAAAJ,0000-0000-0000-0000
 Cigdem Gunduz Demir,Bilkent University,http://www.cs.bilkent.edu.tr/~gunduz,d1I0jcAAAAAJ,0000-0000-0000-0000
+Cigdem Gunduz,Bilkent University,http://www.cs.bilkent.edu.tr/~gunduz,d1I0jcAAAAAJ,0000-0000-0000-0000
 Cigdem Sengul,Brunel University London,https://www.brunel.ac.uk/people/cigdem-sengul,dvmxdpEAAAAJ,0000-0002-6011-9690
 Cihan Tunc,University of North Texas,https://computerscience.engineering.unt.edu/people/faculty/cihan-tunc,b2Re4qYAAAAJ,0000-0001-5200-1097
 Cihang Xie,Univ. of California - Santa Cruz,https://cihangxie.github.io,X3vVZPcAAAAJ,0000-0003-1243-8045
@@ -1272,8 +1273,8 @@ Cindy Marling,Ohio University,http://oucsace.cs.ohiou.edu/~marling,zeBniq4AAAAJ,
 Cindy Rubio-González,Univ. of California - Davis,http://web.cs.ucdavis.edu/~rubio,AMeXAmQAAAAJ,0000-0002-0861-3763
 Cindy X. Chen,University of Massachusetts Lowell,http://www.cs.uml.edu/~cchen,dtaR0JYAAAAJ,0000-0000-0000-0000
 Cindy Xinmin Chen,University of Massachusetts Lowell,http://www.cs.uml.edu/~cchen,dtaR0JYAAAAJ,0000-0000-0000-0000
-Cindy Xiong,Georgia Institute of Technology,http://cyxiong.com,fFc3ezYAAAAJ,0000-0002-1451-4083
 Cindy Xiong Bearfield,Georgia Institute of Technology,http://cyxiong.com,fFc3ezYAAAAJ,0000-0002-1451-4083
+Cindy Xiong,Georgia Institute of Technology,http://cyxiong.com,fFc3ezYAAAAJ,0000-0002-1451-4083
 Cindy Ya Xiong,Georgia Institute of Technology,http://cyxiong.com,fFc3ezYAAAAJ,0000-0000-0000-0000
 Cinzia Cappiello,Politecnico di Milano,http://home.deib.polimi.it/cappiell,NOSCHOLARPAGE,0000-0001-6062-5174
 Claes Strannegård,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/claes-strannegard.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -1402,8 +1403,8 @@ Cláudio Rosito Jung,UFRGS,http://inf.ufrgs.br/~crjung,3hU1tEkAAAAJ,0000-0002-47
 Cláudio Sant'Anna,Federal University of Bahia,https://computacao.ufba.br/pt-br/claudio-nogueira-santanna,jJVb7rMAAAAJ,0000-0000-0000-0000
 Cláudio T. Silva,New York University,https://ctsilva.github.io,YIwiAAsAAAAJ,0000-0003-2452-2295
 Cláudio Teixeira Silva,New York University,https://ctsilva.github.io,YIwiAAsAAAAJ,0000-0000-0000-0000
-Cláudio Toledo,USP-ICMC,http://icmc.usp.br/pessoas?id=14662391,oiW7E1IAAAAJ,0000-0000-0000-0000
 Cláudio Toledo 0001,USP-ICMC,http://icmc.usp.br/pessoas?id=14662391,oiW7E1IAAAAJ,0000-0000-0000-0000
+Cláudio Toledo,USP-ICMC,http://icmc.usp.br/pessoas?id=14662391,oiW7E1IAAAAJ,0000-0000-0000-0000
 Clément Aubert,Augusta University,https://spots.augusta.edu/caubert,mV9zWOoAAAAJ,0000-0001-6346-3043
 Clément Ballabriga,CRIStAL,https://www.cristal.univ-lille.fr/profil/ballabri,NOSCHOLARPAGE,0000-0000-0000-0000
 Clément L. Canonne,University of Sydney,https://www.sydney.edu.au/engineering/about/our-people/academic-staff/clement-canonne.html,gjLr_FgAAAAJ,0000-0001-7153-5211

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -3,8 +3,8 @@ D. C. Douglas Hung,NJIT,http://cs.njit.edu/people/hung.php,NOSCHOLARPAGE,0000-00
 D. Caleb Rucker,University of Tennessee,https://mabe.utk.edu/people/d-caleb-rucker,swKSAGAAAAAJ,0000-0001-7181-1933
 D. Cenitta,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/d-cenitta/_jcr_content.html,949MilMAAAAJ,0000-0003-3715-6941
 D. Ellis Hershkowitz,Brown University,https://dhershko.github.io,JR_KR7MAAAAJ,0000-0003-0862-3715
-D. F. Wong,Chinese University of Hong Kong,https://www.erg.cuhk.edu.hk/erg/DeanMessage,WPhoQiUAAAAJ,0000-0000-0000-0000
 D. F. Wong 0001,Chinese University of Hong Kong,https://www.erg.cuhk.edu.hk/erg/DeanMessage,WPhoQiUAAAAJ,0000-0001-8274-9688
+D. F. Wong,Chinese University of Hong Kong,https://www.erg.cuhk.edu.hk/erg/DeanMessage,WPhoQiUAAAAJ,0000-0000-0000-0000
 D. Hemkumar,VNIT Nagpur,https://vnit.ac.in/engineering/cse/dr-hemkumar-d,QzZ4IDcAAAAJ,0000-0000-0000-0000
 D. J. Soudris,NTUA,https://microlab.ntua.gr/academics/dimitrios-soudris,lWuTmpEAAAAJ,0000-0000-0000-0000
 D. Janaki Ram,IIT Madras,http://dos.iitm.ac.in/djwebsite,zxpFxq8AAAAJ,0000-0000-0000-0000
@@ -279,8 +279,8 @@ Daniel Harabor,Monash University,https://research.monash.edu/en/persons/daniel-h
 Daniel Hershcovich,University of Copenhagen,https://danielhers.github.io,479qIucAAAAJ,0000-0002-3966-8708
 Daniel Hirschkoff,Ecole Normale Superieure de Lyon,https://perso.ens-lyon.fr/daniel.hirschkoff,NOSCHOLARPAGE,0000-0000-0000-0000
 Daniel Hsu 0001,Columbia University,http://www.cs.columbia.edu/~djhsu,jj0Evx0AAAAJ,0000-0002-3495-7113
-Daniel Hughes,KU Leuven,https://distrinet.cs.kuleuven.be/people/dannyh,PhAY-GwAAAAJ,0000-0000-0000-0000
 Daniel Hughes 0001,KU Leuven,https://distrinet.cs.kuleuven.be/people/dannyh,PhAY-GwAAAAJ,0000-0000-0000-0000
+Daniel Hughes,KU Leuven,https://distrinet.cs.kuleuven.be/people/dannyh,PhAY-GwAAAAJ,0000-0000-0000-0000
 Daniel J. Abadi,Univ. of Maryland - College Park,https://www.cs.umd.edu/people/abadi,zxeEF2gAAAAJ,0000-0003-3771-2995
 Daniel J. Dougherty,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/djd.html,6dDd-M4AAAAJ,0000-0000-0000-0000
 Daniel J. Finnegan,Cardiff University,https://www.cardiff.ac.uk/people/view/1496260-finnegan-daniel,YxCvjCoAAAAJ,0000-0003-1169-2842
@@ -307,8 +307,8 @@ Daniel Keren,University of Haifa,https://cs.haifa.ac.il/~dkeren,NOSCHOLARPAGE,00
 Daniel Khashabi,Johns Hopkins University,https://danielkhashabi.com,pK2kQvgAAAAJ,0009-0009-7664-2230
 Daniel Kifer,Pennsylvania State University,http://www.cse.psu.edu/~duk17,7PQN6r4AAAAJ,0000-0002-4611-7066
 Daniel Klein 0001,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/klein.html,jJRiZR8AAAAJ,0000-0000-0000-0000
-Daniel Král,Masaryk University,https://www.muni.cz/en/people/44742,crv1hRwAAAAJ,0000-0001-8680-0890
 Daniel Král',Masaryk University,https://www.muni.cz/en/people/44742,crv1hRwAAAAJ,0000-0000-0000-0000
+Daniel Král,Masaryk University,https://www.muni.cz/en/people/44742,crv1hRwAAAAJ,0000-0001-8680-0890
 Daniel L. Chester,University of Delaware,https://www.eecis.udel.edu/~chester,f1rXXY8AAAAJ,0000-0000-0000-0000
 Daniel L. Pimentel-Alarcón,Georgia State University,https://danielpimentel.github.io/index.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Daniel Leithinger,University of Colorado Boulder,http://www.leithinger.com,OsJr4BMAAAAJ,0000-0003-4342-7082
@@ -350,8 +350,8 @@ Daniel Penazzi,Universidad Nacional de Córdoba,https://www.famaf.unc.edu.ar/~pe
 Daniel Pieter Saakes,University of Twente,http://people.utwente.nl/d.p.saakes,NOSCHOLARPAGE,0000-0000-0000-0000
 Daniel Prince,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/people/daniel-prince,aDfoLUUAAAAJ,0000-0003-0962-8569
 Daniel R. Catchpoole,University of Technology Sydney,https://www.uts.edu.au/staff/daniel.catchpoole,K9dgaRgAAAAJ,0000-0000-0000-0000
-Daniel R. Figueiredo,UFRJ,http://www.land.ufrj.br/~daniel,j4YbANwAAAAJ,0000-0000-0000-0000
 Daniel R. Figueiredo 0001,UFRJ,http://www.land.ufrj.br/~daniel,j4YbANwAAAAJ,0000-0001-9341-6619
+Daniel R. Figueiredo,UFRJ,http://www.land.ufrj.br/~daniel,j4YbANwAAAAJ,0000-0000-0000-0000
 Daniel R. Sheldon,Univ. of Massachusetts Amherst,https://people.cs.umass.edu/~sheldon,P1bHFuoAAAAJ,0000-0000-0000-0000
 Daniel R. Thomas,University of Strathclyde,https://pureportal.strath.ac.uk/en/persons/daniel-thomas/publications,Tq1LRo2DuUIC,0000-0001-8936-0683
 Daniel Rakita,Yale University,https://cpsc.yale.edu/people/daniel-rakita,1Y-cnCUAAAAJ,0000-0000-0000-0000
@@ -404,8 +404,8 @@ Daniela Barreiro Claro,Federal University of Bahia,https://computacao.ufba.br/pt
 Daniela Chudá,Kempelen Institute - KInIT,https://kinit.sk/member/daniela-chuda,7AaHqcYAAAAJ,0000-0000-0000-0000
 Daniela Damian,University of Victoria,https://www.uvic.ca/ecs/software/research/our-researchers/damiandaniela.php,B-1karUAAAAJ,0000-0000-0000-0000
 Daniela E. Damian,University of Victoria,http://www.uvic.ca/engineering/prospective/undergrad/research/people/?searchstring=&expertid=116&researchtopic=,B-1karUAAAAJ,0000-0003-0826-5460
-Daniela E. Herlea,University of Victoria,http://www.uvic.ca/engineering/prospective/undergrad/research/people/?searchstring=&expertid=116&researchtopic=,B-1karUAAAAJ,0000-0000-0000-0000
 Daniela E. Herlea Damian,University of Victoria,http://www.uvic.ca/engineering/prospective/undergrad/research/people/?searchstring=&expertid=116&researchtopic=,B-1karUAAAAJ,0000-0000-0000-0000
+Daniela E. Herlea,University of Victoria,http://www.uvic.ca/engineering/prospective/undergrad/research/people/?searchstring=&expertid=116&researchtopic=,B-1karUAAAAJ,0000-0000-0000-0000
 Daniela G. Trevisan,UFF,http://www2.ic.uff.br/~daniela,Jr1C8ZIAAAAJ,0000-0000-0000-0000
 Daniela Gorski Trevisan,UFF,http://www2.ic.uff.br/~daniela,Jr1C8ZIAAAAJ,0000-0000-0000-0000
 Daniela Grigori,Université Paris Dauphine,https://www.lamsade.dauphine.fr/~grigori,uOpbfVsAAAAJ,0000-0000-0000-0000
@@ -413,8 +413,8 @@ Daniela Marghitu,Auburn University,http://www.eng.auburn.edu/~daniela,d2w-SswAAA
 Daniela Nicklas,University of Bamberg,https://www.uni-bamberg.de/mobi/team/daniela-nicklas,BpfYffYAAAAJ,0000-0001-7012-6010
 Daniela Raicu,DePaul University,http://facweb.cs.depaul.edu/Dstan,NOSCHOLARPAGE,0000-0002-2165-7234
 Daniela Rus,Massachusetts Inst. of Technology,https://www.csail.mit.edu/user/876,910z20QAAAAJ,0000-0001-5473-3566
-Daniela Stan,DePaul University,http://facweb.cs.depaul.edu/Dstan,NOSCHOLARPAGE,0000-0000-0000-0000
 Daniela Stan Raicu,DePaul University,http://facweb.cs.depaul.edu/Dstan,NOSCHOLARPAGE,0000-0000-0000-0000
+Daniela Stan,DePaul University,http://facweb.cs.depaul.edu/Dstan,NOSCHOLARPAGE,0000-0000-0000-0000
 Daniela Trevisan,UFF,http://www2.ic.uff.br/~daniela,Jr1C8ZIAAAAJ,0000-0000-0000-0000
 Daniele Antonioli,EURECOM,https://francozappa.github.io,RkX4eFsAAAAJ,0000-0002-9342-3920
 Daniele Braga,Politecnico di Milano,http://home.deib.polimi.it/braga,yIEvxuoAAAAJ,0000-0000-0000-0000
@@ -432,8 +432,8 @@ Daniele Panozzo,New York University,http://cs.nyu.edu/~panozzo,XUp6qhMAAAAJ,0000
 Daniele Riboni,University of Cagliari,https://web.unica.it/unica/page/it/daniele_riboni,D0PowGAAAAAJ,0000-0002-0695-2040
 Daniele Sgandurra,Royal Holloway Univ. of London,https://pure.royalholloway.ac.uk/portal/en/persons/daniele-sgandurra(caa1bd38-d6af-42fa-8a63-51d475f10220).html,Hw2Idxu9yLsC,0000-0000-0000-0000
 Daniele Venturi 0001,Sapienza University of Rome,http://danieleventuri.altervista.org,dCsqhREAAAAJ,0000-0003-2379-8564
-Danielle Albers,University of North Carolina,https://cs.unc.edu/person/danielle-szafir,CGb88B0AAAAJ,0000-0000-0000-0000
 Danielle Albers Szafir,University of North Carolina,https://cs.unc.edu/person/danielle-szafir,CGb88B0AAAAJ,0000-0003-3634-8597
+Danielle Albers,University of North Carolina,https://cs.unc.edu/person/danielle-szafir,CGb88B0AAAAJ,0000-0000-0000-0000
 Danielle Azar,Lebanese American University,http://sas.lau.edu.lb/csm/people/danielle-azar.php,lcd1FHgAAAAJ,0000-0002-6159-3714
 Danielle Szafir,University of Colorado Boulder,http://www.colorado.edu/cmci/people/information-science/danielle-albers-szafir,CGb88B0AAAAJ,0000-0003-3634-8597
 Danilo Ardagna,Politecnico di Milano,http://home.deib.polimi.it/ardagna,2S6m-oYAAAAJ,0000-0003-4224-927X
@@ -717,8 +717,8 @@ David Kristjanson Duvenaud,University of Toronto,http://www.cs.toronto.edu/~duve
 David Kung,University of Texas at Arlington,http://ranger.uta.edu/~kung/kung.html,cgO5XwcAAAAJ,0000-0000-0000-0000
 David L. Dowe,Monash University,https://research.monash.edu/en/persons/david-dowe,8ZlclUsAAAAJ,0000-0000-0000-0000
 David L. Poole,University of British Columbia,https://www.cs.ubc.ca/~poole,CeWswygAAAAJ,0000-0000-0000-0000
-David L. Roberts,North Carolina State University,https://www.csc.ncsu.edu/faculty/robertsd,vXYrNiIAAAAJ,0000-0000-0000-0000
 David L. Roberts 0001,North Carolina State University,https://www.csc.ncsu.edu/faculty/robertsd,vXYrNiIAAAAJ,0000-0000-0000-0000
+David L. Roberts,North Carolina State University,https://www.csc.ncsu.edu/faculty/robertsd,vXYrNiIAAAAJ,0000-0000-0000-0000
 David L. Spooner,Rensselaer Polytechnic Institute,http://faculty.rpi.edu/node/34623,NOSCHOLARPAGE,0000-0000-0000-0000
 David L. Wehlau,Royal Military College of Canada,https://www.rmc-cmr.ca/en/mathematics-and-computer-science/dr-david-wehlau,40oEP74AAAAJ,0000-0000-0000-0000
 David Lazer,Northeastern University,https://lazerlab.net,gMndACUAAAAJ,0000-0000-0000-0000
@@ -754,8 +754,8 @@ David McG. Squire,Monash University,https://www.researchgate.net/profile/David_S
 David McNeill,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=dw.mcneill,L_gCkX8AAAAJ,0000-0000-0000-0000
 David Meger,McGill University,http://www.cim.mcgill.ca/~dmeger,gFwEytkAAAAJ,0009-0008-6180-0032
 David Menoti,UFPR,https://web.inf.ufpr.br/menotti,Ipu5_-gAAAAJ,0000-0000-0000-0000
-David Menotti,UFPR,https://web.inf.ufpr.br/menotti,Ipu5_-gAAAAJ,0000-0000-0000-0000
 David Menotti Gomes,UFPR,https://web.inf.ufpr.br/menotti,Ipu5_-gAAAAJ,0000-0000-0000-0000
+David Menotti,UFPR,https://web.inf.ufpr.br/menotti,Ipu5_-gAAAAJ,0000-0000-0000-0000
 David Miller,DePaul University,http://www.depaul.edu/about/administration/Pages/miller.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 David Mimno,Cornell University,https://mimno.infosci.cornell.edu,uBFV6SUAAAAJ,0000-0001-7510-9404
 David Mohaisen,University of Central Florida,http://cs.ucf.edu/~mohaisen,q387AywAAAAJ,0000-0003-3227-2505
@@ -1111,8 +1111,8 @@ Dezhen Song,MBZUAI,https://mbzuai.ac.ae/study/faculty/dezhen-song,jdSlREMAAAAJ,0
 Dezhong Peng,Sichuan University,https://cs.scu.edu.cn/info/1249/10284.htm,0gupif8AAAAJ,0000-0002-0533-4515
 Dezhong Yao 0002,HUST,http://faculty.hust.edu.cn/dezhong/en/index.htm,SFBHGr0AAAAJ,0000-0003-0336-0522
 Dhabaleswar K. D. K. Panda,Ohio State University,http://web.cse.ohio-state.edu/~panda,7FXtL98AAAAJ,0000-0000-0000-0000
-Dhabaleswar K. Panda,Ohio State University,http://web.cse.ohio-state.edu/~panda,7FXtL98AAAAJ,0000-0000-0000-0000
 Dhabaleswar K. Panda 0001,Ohio State University,http://web.cse.ohio-state.edu/~panda,7FXtL98AAAAJ,0000-0002-0356-1781
+Dhabaleswar K. Panda,Ohio State University,http://web.cse.ohio-state.edu/~panda,7FXtL98AAAAJ,0000-0000-0000-0000
 Dhabaleswar Kumar Panda 0001,Ohio State University,http://web.cse.ohio-state.edu/~panda,7FXtL98AAAAJ,0000-0000-0000-0000
 Dhammika Elkaduwe,University of Peradeniya,https://people.ce.pdn.ac.lk/staff/academic/dhammika-elkaduwe,zLUPMFkAAAAJ,0000-0000-0000-0000
 Dhananjay M. Dhamdhere,IIT Bombay,https://www.cse.iitb.ac.in/~dmd,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -1171,8 +1171,8 @@ Dianne Foreback,Kent State University,https://www.kent.edu/ehhs/hs/profile/dr-di
 Dianqi Han,University of Texas at Arlington,https://www.uta.edu/academics/faculty/profile?user=dianqi.han,9t5M1bsAAAAJ,0000-0002-0105-5869
 Dibyayan Chakraborty,University of Leeds,https://eps.leeds.ac.uk/computing/staff/14032/dr-dibyayan-chakraborty,HjcuaaQAAAAJ,0000-0003-0534-6417
 Dick H. J. Epema,TU Delft,http://www.ds.ewi.tudelft.nl/epema,NOSCHOLARPAGE,0000-0000-0000-0000
-Didem Unat,Koç University,https://parcorelab.ku.edu.tr,NR70RpYAAAAJ,0000-0002-2351-0770
 Didem Unat Erten,Koç University,https://parcorelab.ku.edu.tr,NR70RpYAAAAJ,0000-0000-0000-0000
+Didem Unat,Koç University,https://parcorelab.ku.edu.tr,NR70RpYAAAAJ,0000-0002-2351-0770
 Didier Remy,INRIA,https://cambium.inria.fr/~remy,LTGX-Y0AAAAJ,0000-0000-0000-0000
 Didier Stricker,TU Kaiserslautern,https://av.dfki.de/members/stricker,ImhXfxgAAAAJ,0009-0004-8794-6858
 Diedrich Wolter,University of Lübeck,https://www.isp.uni-luebeck.de/staff/d-wolter,pxX08x8AAAAJ,0000-0001-9185-0147
@@ -1195,8 +1195,8 @@ Diego Hernán Peluffo-Ordóñez,Mohammed VI Polytechnic University,https://cc.um
 Diego Martinez Plasencia,University College London,https://uclic.ucl.ac.uk/people/diego-martinez-plasencia,KKh8PWYAAAAJ,0000-0000-0000-0000
 Diego Martínez 0001,University College London,https://uclic.ucl.ac.uk/people/diego-martinez-plasencia,KKh8PWYAAAAJ,0000-0002-5815-8236
 Diego Martínez Plasencia,University College London,https://uclic.ucl.ac.uk/people/diego-martinez-plasencia,KKh8PWYAAAAJ,0000-0002-5815-8236
-Diego Mollá,Macquarie University,https://researchers.mq.edu.au/en/persons/diego-molla-aliod,FZhJRQUAAAAJ,0000-0000-0000-0000
 Diego Mollá Aliod,Macquarie University,https://researchers.mq.edu.au/en/persons/diego-molla-aliod,FZhJRQUAAAAJ,0000-0000-0000-0000
+Diego Mollá,Macquarie University,https://researchers.mq.edu.au/en/persons/diego-molla-aliod,FZhJRQUAAAAJ,0000-0000-0000-0000
 Diego Perez Liebana,Queen Mary University of London,http://www.diego-perez.net,bMLr-zgAAAAJ,0000-0003-1958-0212
 Diego Pérez-Liébana,Queen Mary University of London,http://www.diego-perez.net,bMLr-zgAAAAJ,0000-0000-0000-0000
 Diego R. Amancio,USP-ICMC,http://icmc.usp.br/pessoas?id=10793181,WHdCNq0AAAAJ,0000-0000-0000-0000
@@ -1517,6 +1517,7 @@ Dong-Jun Han,Yonsei University,https://sites.google.com/view/djhan930/home,-YR-G
 Dong-Ming Yan 0001,Chinese Academy of Sciences,https://sites.google.com/site/yandongming,xAFSO3AAAAAJ,0000-0003-2209-2404
 Dong-Sun Kim 0001,Kyungpook National University,http://www.darkrsw.net,Rmzs0QIAAAAJ,0000-0000-0000-0000
 DongGyun Han,Royal Holloway Univ. of London,https://pure.royalholloway.ac.uk/en/persons/donggyun-han,gfAdVBwAAAAJ,0000-0002-8599-2197
+Dongbin Zhao,Chinese Academy of Sciences,https://people.ucas.ac.cn/~zhaodongbin,RxvYlNQAAAAJ,0000-0001-8218-9633
 Dongbing Gu,University of Essex,https://www.essex.ac.uk/people/gudon81301/dongbing-gu,U-3knAUAAAAJ,0000-0002-0986-2921
 Dongdong She,HKUST,https://home.cse.ust.hk/~dongdong,CAd3jhcAAAAJ,0000-0001-6655-0468
 Dongfang Li 0002,Harbin Institute of Technology,https://homepage.hit.edu.cn/lidongfang,_OOzj40AAAAJ,0000-0000-0000-0000

--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -1149,6 +1149,7 @@ Huijia Lin,University of Washington,http://www.cs.ucsb.edu/~rachel.lin,h3gpLYAAA
 Huijing Zhao,Peking University,http://www.cis.pku.edu.cn/faculty/vision/zhaohj/index-e.htm,q-aZF-kAAAAJ,0000-0000-0000-0000
 Huijuan Wang,TU Delft,https://www.nas.ewi.tudelft.nl/people/Huijuan,d8o43k0AAAAJ,0000-0002-9204-7265
 Huijuan Xu 0001,Pennsylvania State University,https://www.eecs.psu.edu/departments/directory-detail-g.aspx?q=hkx5063,eml8HfQAAAAJ,0000-0002-4778-5584
+Huimin Cui,Chinese Academy of Sciences,https://people.ucas.ac.cn/~huimin,kzC1bFIAAAAJ,0000-0002-2491-7679
 Huining Li,North Carolina State University,https://huining-li.github.io,fAZqlmgAAAAJ,0000-0003-3865-3587
 Huiping Cao,New Mexico State University,http://www.cs.nmsu.edu/~hcao,M6UHVQwAAAAJ,0000-0002-1350-1846
 Huiqiang Chen,City University of Macau,https://fds.cityu.edu.mo/en/members/459,q3QIFZ0AAAAJ,0000-0003-4811-6742

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -1,4 +1,5 @@
 name,affiliation,homepage,scholarid,orcid
+"Jan ""Matt"" Pedersen",University of Nevada Las Vegas,http://www.egr.unlv.edu/~matt,Oh3z3nEAAAAJ,0000-0002-2800-5095
 J. A. dos Santos,UFMG,http://homepages.dcc.ufmg.br/~jefersson,wXQnnTUAAAAJ,0000-0000-0000-0000
 J. Alex Halderman,University of Michigan,https://jhalderm.com,h6yXnyEAAAAJ,0000-0002-9116-5390
 J. Andreas Bærentzen,DTU,https://people.compute.dtu.dk/janba,if2X4wkAAAAJ,0000-0003-2583-0660
@@ -109,8 +110,8 @@ Jacob W. Crandall,Brigham Young University,http://www.jacobcrandall.net,FHGBC58A
 Jacob White 0001,Massachusetts Inst. of Technology,http://www.rle.mit.edu/cpg/people_faculty.htm,4lpSV-8AAAAJ,0000-0000-0000-0000
 Jacob Whitehill,Worcester Polytechnic Institute,https://www.wpi.edu/academics/facultydir/200331.htm,PGyMqU0AAAAJ,0000-0000-0000-0000
 Jacob William Crandall,Brigham Young University,http://www.jacobcrandall.net,FHGBC58AAAAJ,0000-0000-0000-0000
-Jacobo Torán,University of Ulm,https://www.uni-ulm.de/toran1,9tCatQwAAAAJ,0000-0000-0000-0000
 Jacobo Torán Romero,University of Ulm,https://www.uni-ulm.de/toran1,9tCatQwAAAAJ,0000-0000-0000-0000
+Jacobo Torán,University of Ulm,https://www.uni-ulm.de/toran1,9tCatQwAAAAJ,0000-0000-0000-0000
 Jacobus E. van der Merwe,University of Utah,https://www.cs.utah.edu/~kobus,PEki4LgAAAAJ,0000-0000-0000-0000
 Jacopo Urbani,VU Amsterdam,http://www.jacopourbani.it,5o88MDIAAAAJ,0000-0002-0717-3559
 Jacqueline Christmas,University of Exeter,http://emps.exeter.ac.uk/computer-science/staff/jtc202,IQRq0CYAAAAJ,0000-0000-0000-0000
@@ -176,8 +177,8 @@ Jaideep Vaidya,Rutgers University,https://www.business.rutgers.edu/faculty/jaide
 Jaijeet Roychowdhury,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/jr.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Jaijeet S. Roychowdhury,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Faculty/Homepages/jr.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Jaime Arguello,University of North Carolina,https://sils.unc.edu/people/faculty/profiles/Jaime-Arguello,q7foMK4AAAAJ,0000-0002-7645-0556
-Jaime Delgado,Polytechnic Univ. of Catalonia,http://ieeexplore.ieee.org/document/6214725/?section=abstract,RSDAEdAAAAAJ,0000-0000-0000-0000
 Jaime Delgado Merce,Polytechnic Univ. of Catalonia,http://ieeexplore.ieee.org/document/6214725/?section=abstract,RSDAEdAAAAAJ,0000-0000-0000-0000
+Jaime Delgado,Polytechnic Univ. of Catalonia,http://ieeexplore.ieee.org/document/6214725/?section=abstract,RSDAEdAAAAAJ,0000-0000-0000-0000
 Jaime Fernández Fisac,Princeton University,https://ece.princeton.edu/people/jaime-fernandez-fisac,HvjirogAAAAJ,0000-0000-0000-0000
 Jaime Navon,UC Chile,https://www.ing.uc.cl/academicos-e-investigadores/jaime-navon-cohen,NOSCHOLARPAGE,0000-0000-0000-0000
 Jaime Ruiz,University of Florida,https://www.jaimeruiz.com,K1O-ZPIAAAAJ,0000-0002-9139-6172
@@ -278,8 +279,8 @@ James H. Elder,York University,http://elderlab.yorku.ca/~elder,wSBFrb8AAAAJ,0000
 James H. Hill,IUPUI,http://sebox.cs.iupui.edu,NOSCHOLARPAGE,0000-0001-8336-9855
 James H. Martin,University of Colorado Boulder,http://www.cs.colorado.edu/~martin,ZVxO6IIAAAAJ,0000-0002-9654-3864
 James H. Moore,University of Pennsylvania,http://epistasis.org/jason-h-moore-phd,mE1Te78AAAAJ,0000-0000-0000-0000
-James H. Morris,Carnegie Mellon University,http://www.cs.cmu.edu/~jhm,Y9cRdbIAAAAJ,0000-0000-0000-0000
 James H. Morris Jr.,Carnegie Mellon University,http://www.cs.cmu.edu/~jhm,Y9cRdbIAAAAJ,0000-0000-0000-0000
+James H. Morris,Carnegie Mellon University,http://www.cs.cmu.edu/~jhm,Y9cRdbIAAAAJ,0000-0000-0000-0000
 James Harland,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/h/harland-associate-professor-james,46pt7TgAAAAJ,0000-0001-8640-5137
 James Harold Davenport,University of Bath,http://people.bath.ac.uk/masjhd,bxOyjTUAAAAJ,0000-0000-0000-0000
 James Hays,Georgia Institute of Technology,http://www.cc.gatech.edu/~hays,vjZrDKQAAAAJ,0000-0001-7016-4252
@@ -376,10 +377,9 @@ Jamie Twycross,University of Nottingham,https://www.nottingham.ac.uk/computersci
 Jamie Vicary,University of Cambridge,https://www.cl.cam.ac.uk/~jv258,9LG1IeMAAAAJ,0000-0002-0998-1701
 Jamilson Dantas,UFPE,https://sites.google.com/cin.ufpe.br/jamilsondantas,p-6fez4AAAAJ,0000-0000-0000-0000
 Jamuna Kanta Sing,Jadavpur University,https://jaduniv.irins.org/profile/57038,rf_-dsUAAAAJ,0000-0000-0000-0000
-"Jan ""Matt"" Pedersen",University of Nevada Las Vegas,http://www.egr.unlv.edu/~matt,Oh3z3nEAAAAJ,0000-0002-2800-5095
 Jan Arne Telle,University of Bergen,http://www.ii.uib.no/~telle,NOSCHOLARPAGE,0000-0000-0000-0000
-Jan B. Pedersen,University of Nevada Las Vegas,http://www.egr.unlv.edu/~matt,Oh3z3nEAAAAJ,0000-0000-0000-0000
 Jan B. Pedersen 0001,University of Nevada Las Vegas,http://www.egr.unlv.edu/~matt,Oh3z3nEAAAAJ,0000-0000-0000-0000
+Jan B. Pedersen,University of Nevada Las Vegas,http://www.egr.unlv.edu/~matt,Oh3z3nEAAAAJ,0000-0000-0000-0000
 Jan Baumbach,University of Hamburg,https://www.zbh.uni-hamburg.de/personen/csb/jbaumbach.html,PWV8xOoAAAAJ,0000-0002-0282-0462
 Jan Bender,RWTH Aachen University,https://www.animation.rwth-aachen.de,POEoFagAAAAJ,0000-0002-1908-4027
 Jan Beutel,University of Innsbruck,https://www.uibk.ac.at/informatik/forschung/professorinnen.html.de,LRkwAAAAJ,0000-0003-0879-2455
@@ -563,8 +563,8 @@ Jason Jue,University of Texas at Dallas,http://www.utdallas.edu/~jjue,8EDESdwAAA
 Jason L. Pacheco,University of Arizona,https://www2.cs.arizona.edu/~pachecoj,71ZEsnEAAAAJ,0000-0000-0000-0000
 Jason Leigh,University of Hawaii at Manoa,http://www2.hawaii.edu/~leighj,5KgriYAAAAAJ,0000-0001-7693-2814
 Jason Li 0006,Carnegie Mellon University,https://q3r.github.io,NOSCHOLARPAGE,0000-0003-3644-0879
-Jason Liu,Florida International University,http://www.cis.fiu.edu/~liux,l8b0bfcAAAAJ,0009-0007-6157-8841
 Jason Liu 0001,Florida International University,http://www.cis.fiu.edu/~liux,l8b0bfcAAAAJ,0000-0001-8222-4013
+Jason Liu,Florida International University,http://www.cis.fiu.edu/~liux,l8b0bfcAAAAJ,0009-0007-6157-8841
 Jason Lowe-Power,Univ. of California - Davis,https://faculty.engineering.ucdavis.edu/lowepower,7m7TYQsAAAAJ,0000-0002-8880-8703
 Jason M. Bindewald,Air Force Inst. of Technology,https://scholar.afit.edu/docs/21,NOSCHOLARPAGE,0000-0000-0000-0000
 Jason M. O'Kane,Texas A&M University,https://jokane.net,ETFTMZMAAAAJ,0000-0002-1536-4822
@@ -597,8 +597,8 @@ Javed A. Aslam,Northeastern University,http://www.ccs.neu.edu/home/jaa,-spRnaQAA
 Javed Khan,Kent State University,http://www.cs.kent.edu/~javed,NOSCHOLARPAGE,0000-0000-0000-0000
 Javen Shi,Adelaide University,https://cs.adelaide.edu.au/~javen,h6O9vYkAAAAJ,0000-0002-9126-2107
 Javid Taheri,Queen's University Belfast,https://pure.qub.ac.uk/en/persons/javid-taheri,QTNsnbAAAAAJ,0000-0001-9194-010X
-Javier Andrade,University of A Coruña,https://pdi.udc.es/en/File/Pdi/7379E,NOSCHOLARPAGE,0000-0000-0000-0000
 Javier Andrade Garda,University of A Coruña,https://pdi.udc.es/en/File/Pdi/7379E,NOSCHOLARPAGE,0000-0000-0000-0000
+Javier Andrade,University of A Coruña,https://pdi.udc.es/en/File/Pdi/7379E,NOSCHOLARPAGE,0000-0000-0000-0000
 Javier Andreu-Perez,University of Essex,https://www.essex.ac.uk/people/andre09407/javier-andreu-perez,1m4DHQQAAAAJ,0000-0002-7421-4808
 Javier Andréu Pérez,University of Essex,https://www.essex.ac.uk/people/andre09407/javier-andreu-perez,1m4DHQQAAAAJ,0000-0000-0000-0000
 Javier Andréu-Pérez,University of Essex,https://www.essex.ac.uk/people/andre09407/javier-andreu-perez,1m4DHQQAAAAJ,0000-0000-0000-0000
@@ -710,8 +710,8 @@ Jeff Clune,University of British Columbia,https://www.cs.ubc.ca/people/jeff-clun
 Jeff Dalton 0001,University of Edinburgh,http://www.inf.ed.ac.uk/people/staff/Jeff_Dalton.html,mgwLi-EAAAAJ,0000-0003-2422-8651
 Jeff Edmonds,York University,http://www.cs.yorku.ca/~jeff,AjD7zfgAAAAJ,0000-0003-4803-3365
 Jeff Erickson 0001,Univ. of Illinois at Urbana-Champaign,http://jeffe.cs.illinois.edu,02_kT4YAAAAJ,0000-0002-5253-2282
-Jeff Gray,The University of Alabama,http://gray.cs.ua.edu,83an8lYAAAAJ,0000-0003-0082-6753
 Jeff Gray 0001,The University of Alabama,http://gray.cs.ua.edu,83an8lYAAAAJ,0000-0003-0082-6753
+Jeff Gray,The University of Alabama,http://gray.cs.ua.edu,83an8lYAAAAJ,0000-0003-0082-6753
 Jeff Heflin,Lehigh University,http://www.cse.lehigh.edu/~heflin,IKKQHqkAAAAJ,0000-0002-7290-1495
 Jeff Huang 0001,Texas A&M University,https://parasol.tamu.edu/~jeff,UmrxW60AAAAJ,0000-0003-1393-0752
 Jeff Huang 0002,Brown University,http://jeffhuang.com,o8oJ6s4AAAAJ,0000-0002-3453-5666
@@ -902,8 +902,8 @@ Jerzy Tiuryn,University of Warsaw,https://www.mimuw.edu.pl/~tiuryn,1iFPnFwAAAAJ,
 Jerzy Tyszkiewicz,University of Warsaw,http://www.mimuw.edu.pl/~jty,5B5PToIAAAAJ,0000-0003-2858-3124
 Jerzy W. Grzymala-Busse,University of Kansas,http://people.eecs.ku.edu/~jerzy,NOSCHOLARPAGE,0000-0000-0000-0000
 Jerzy W. Jaromczyk,University of Kentucky,http://www.cs.uky.edu/~jurek,NOSCHOLARPAGE,0000-0000-0000-0000
-Jerónimo Castrillón,TU Dresden,https://cfaed.tu-dresden.de/ccc-about,Vez2G1kAAAAJ,0000-0002-5007-445X
 Jerónimo Castrillón Mazo,TU Dresden,https://cfaed.tu-dresden.de/ccc-about,Vez2G1kAAAAJ,0000-0000-0000-0000
+Jerónimo Castrillón,TU Dresden,https://cfaed.tu-dresden.de/ccc-about,Vez2G1kAAAAJ,0000-0002-5007-445X
 Jerônimo Grandi,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=JGRANDI,VOUOkLYAAAAJ,0000-0000-0000-0000
 Jes Frellsen,DTU,https://frellsen.org,Yj2sBWkAAAAJ,0000-0001-9224-1271
 Jesper Bengtson,IT University of Copenhagen,http://www.itu.dk/people/jebe,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -946,8 +946,8 @@ Jesús A. De Loera,Univ. of California - Davis,https://www.math.ucdavis.edu/~del
 Jesús Labarta,Polytechnic Univ. of Catalonia,https://www.bsc.es/labarta-mancho-jesus,6vj6TdsAAAAJ,0000-0002-7489-4727
 Jesús M. González-Barahona,Universidad Rey Juan Carlos,https://gsyc.urjc.es/jgb,vYIPWB0AAAAJ,0000-0000-0000-0000
 Jesús Martínez del Rincón,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=j.martinez-del-rincon,jEJdlX8AAAAJ,0000-0002-9574-4138
-Jesús Vilares,University of A Coruña,http://www.grupolys.org/~jvilares,fZHz0B0AAAAJ,0000-0000-0000-0000
 Jesús Vilares Ferro,University of A Coruña,http://www.grupolys.org/~jvilares,fZHz0B0AAAAJ,0000-0000-0000-0000
+Jesús Vilares,University of A Coruña,http://www.grupolys.org/~jvilares,fZHz0B0AAAAJ,0000-0000-0000-0000
 Jetty Kleijn,Leiden University,https://liacs.leidenuniv.nl/~kleijnhcm,NOSCHOLARPAGE,0000-0001-9506-4071
 Jevgenijs Vihrovs,University of Latvia,https://scholar.google.com/citations?user=3F4yQG4AAAAJ&hl=en,3F4yQG4AAAAJ,0000-0000-0000-0000
 Jey Han Lau,University of Melbourne,https://findanexpert.unimelb.edu.au/profile/385601-jey-han-lau,MFi65f4AAAAJ,0000-0002-1647-4628
@@ -985,18 +985,19 @@ Jia Yu 0001,Washington State University,https://jiayuasu.github.io,CHOjvFIAAAAJ,
 Jia Zou 0001,Arizona State University,https://sites.google.com/view/jiazou-web/home,7Dnxbj0AAAAJ,0000-0001-9849-0711
 Jia-Bin Huang 0001,Univ. of Maryland - College Park,https://jbhuang0604.github.io,pp848fYAAAAJ,0000-0002-0536-3658
 Jia-Fu Xu,Nanjing University,https://cs.nju.edu.cn/58/2b/c2639a153643/page.htm,NOSCHOLARPAGE,0000-0000-0000-0000
-Jia-Guang Sun,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2010/20101219095105462245998/20101219095105462245998_.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Jia-Guang Sun 0001,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2010/20101219095105462245998/20101219095105462245998_.html,NOSCHOLARPAGE,0009-0003-0179-317X
+Jia-Guang Sun,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2010/20101219095105462245998/20101219095105462245998_.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Jia-Huai You,University of Alberta,https://webdocs.cs.ualberta.ca/~you,NOSCHOLARPAGE,0000-0001-9372-4371
 Jia-Jie Xu 0001,Soochow University,http://jwsy.suda.edu.cn/69/bf/c9398a223679/page.htm,HYURJ-0AAAAJ,0000-0000-0000-0000
 Jia-Shung Wang,National Tsing Hua University,http://vc.cs.nthu.edu.tw/home/vc_html/member/jswang_e.html,NOSCHOLARPAGE,0000-0003-2157-6108
 Jiachen Li 0001,Univ. of California - Riverside,https://jiachenli94.github.io,1_f79vUAAAAJ,0000-0000-0000-0000
+Jiacheng Zhao,Chinese Academy of Sciences,https://people.ucas.ac.cn/~0055535,pNVRhGcAAAAJ,0000-0001-5228-8972
 Jiachi Chen,Zhejiang University,https://person.zju.edu.cn/en/chenjiachi,FpdgEZMAAAAJ,0000-0002-0192-9992
 Jiadi Yu,Shanghai Jiao Tong University,https://www.cs.sjtu.edu.cn/~jdyu,2e7_jEoAAAAJ,0000-0002-0207-9643
 Jiafeng Guo,Chinese Academy of Sciences,http://teacher.ucas.ac.cn/~0023936,nD0I3PUAAAAJ,0000-0002-9509-8674
 Jiafeng Zhou,University of Liverpool,https://liverpool.ac.uk/electrical-engineering-and-electronics/staff/jiafeng-zhou,NOSCHOLARPAGE,0000-0000-0000-0000
-Jiaguang Sun,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2010/20101219095105462245998/20101219095105462245998_.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Jiaguang Sun 0001,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2010/20101219095105462245998/20101219095105462245998_.html,NOSCHOLARPAGE,0000-0002-5884-7939
+Jiaguang Sun,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2010/20101219095105462245998/20101219095105462245998_.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Jiahai Yang,Tsinghua University,http://nmgroup.tsinghua.edu.cn/yang/index_en.htm,NOSCHOLARPAGE,0000-0001-6109-6737
 Jiaheng Liu,Nanjing University,https://is.nju.edu.cn/ljh/main.htm,yFI_RjUAAAAJ,0000-0000-0000-0000
 Jiaheng Lu,University of Helsinki,https://www.cs.helsinki.fi/u/jilu,EVNolAkAAAAJ,0000-0003-2067-454X
@@ -1097,8 +1098,8 @@ Jianfu Zhang 0003,Shanghai Jiao Tong University,http://www.qingyuan.sjtu.edu.cn/
 Jiang Hu,Texas A&M University,http://cesg.tamu.edu/faculty/jiang-hu,TWw91rQAAAAJ,0009-0005-8842-7811
 Jiang Liu 0001,SUSTech,https://faculty.sustech.edu.cn/liuj,NOSCHOLARPAGE,0000-0001-6281-6505
 Jiang Ming 0002,Tulane University,https://cs.tulane.edu/~jming,i4VFYKAAAAAJ,0000-0001-9682-0502
-Jiang Yu,Tsinghua University,https://sites.google.com/site/jiangyu198964/home,NOSCHOLARPAGE,0000-0000-0000-0000
 Jiang Yu Zheng,IUPUI,http://cs.iupui.edu/~jzheng,Gih-kpUAAAAJ,0000-0000-0000-0000
+Jiang Yu,Tsinghua University,https://sites.google.com/site/jiangyu198964/home,NOSCHOLARPAGE,0000-0000-0000-0000
 Jiangchuan Liu,Simon Fraser University,http://www.cs.sfu.ca/~jcliu,VU2Jw1YAAAAJ,0000-0001-6592-1984
 Jiangfan Yi,Peking University,http://eecs.pku.edu.cn/EN/People/Faculty/Detail/?ID=6016,NOSCHOLARPAGE,0000-0000-0000-0000
 Jiangfan Yu,CUHK (SZ),https://www.imlyu.com,2rMKEG0AAAAJ,0000-0002-7981-6744
@@ -1238,8 +1239,8 @@ Jiaxin Zhu,Chinese Academy of Sciences,http://www.tcse.cn/~zhujiaxin,2NTaUWsAAAA
 Jiaxing Song,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/csen/4623/2010/20101224171300777933176/20101224171300777933176_.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Jiaxuan You,Univ. of Illinois at Urbana-Champaign,https://cs.stanford.edu/people/jiaxuan,NDbMl7oAAAAJ,0000-0003-1812-7598
 Jiaya Jia,HKUST,https://cse.hkust.edu.hk/admin/people/faculty/profile/jia,XPAkzTEAAAAJ,0000-0002-1246-553X
-Jiayi Huang,HKUST,https://jyhuang91.github.io,LAqRzrMAAAAJ,0000-0003-4011-6668
 Jiayi Huang 0001,HKUST,https://jyhuang91.github.io,LAqRzrMAAAAJ,0000-0003-4011-6668
+Jiayi Huang,HKUST,https://jyhuang91.github.io,LAqRzrMAAAAJ,0000-0003-4011-6668
 Jiayi Ma 0001,Wuhan University,http://eis.whu.edu.cn/ryDetail.shtml?rsh=00030884,73trMQkAAAAJ,0000-0003-3264-3265
 Jiayi Meng,University of Texas at Arlington,https://ranger.uta.edu/~jmeng,IlZs8_oAAAAJ,0000-0003-3091-8894
 Jiaying Liu 0001,Peking University,http://www.icst.pku.edu.cn/struct/people/liujiaying.html,NOSCHOLARPAGE,0000-0002-0468-9576
@@ -1359,8 +1360,8 @@ Jim Laird,University of Bath,http://www.bath.ac.uk/comp-sci/contacts/academics/j
 Jim Lathrop,Iowa State University,https://www.cs.iastate.edu/people/jim-lathrop,NOSCHOLARPAGE,0000-0000-0000-0000
 Jim Leone,Rochester Inst. of Technology,http://www.ist.rit.edu/~leone,ivIz4JYAAAAJ,0000-0000-0000-0000
 Jim Little 0001,University of British Columbia,http://www.cs.ubc.ca/~little,a0za4V8AAAAJ,0000-0000-0000-0000
-Jim Martin,Clemson University,https://people.cs.clemson.edu/~jmarty,66VE-3MAAAAJ,0000-0000-0000-0000
 Jim Martin 0001,Clemson University,https://people.cs.clemson.edu/~jmarty,66VE-3MAAAAJ,0000-0000-0000-0000
+Jim Martin,Clemson University,https://people.cs.clemson.edu/~jmarty,66VE-3MAAAAJ,0000-0000-0000-0000
 Jim McCann,Carnegie Mellon University,http://www.cs.cmu.edu/~jmccann,NOSCHOLARPAGE,0000-0000-0000-0000
 Jim Purtilo,Univ. of Maryland - College Park,https://seam.cs.umd.edu/purtilo,5-O2lzIAAAAJ,0000-0000-0000-0000
 Jim R. Davies,University of Oxford,http://www.cs.ox.ac.uk/jim.davies,w_UPj9YAAAAJ,0000-0000-0000-0000
@@ -1443,8 +1444,8 @@ Jing Ma 0002,Case Western Reserve University,https://jma712.github.io,VLElvX8AAA
 Jing Ma 0004,Hong Kong Baptist University,https://majingcuhk.github.io,78Jby0EAAAAJ,0000-0002-7464-8331
 Jing Ren 0003,Ontario Tech University,https://engineering.ontariotechu.ca/people/ecse/jing.ren.php,NOSCHOLARPAGE,0000-0000-0000-0000
 Jing Selena He,Old Dominion University,http://www.cs.odu.edu/~jhe,r4WtU2oAAAAJ,0000-0000-0000-0000
-Jing Sun,City University of Macau,https://fds.cityu.edu.mo/en/members/299,4XbYJisAAAAJ,0000-0000-0000-0000
 Jing Sun 0002,University of Auckland,https://www.cs.auckland.ac.nz/~jingsun,GUXAGAYAAAAJ,0000-0002-1979-6622
+Jing Sun,City University of Macau,https://fds.cityu.edu.mo/en/members/299,4XbYJisAAAAJ,0000-0000-0000-0000
 Jing Tang 0004,HKUST,https://sites.google.com/view/jtang,0S4cpyoAAAAJ,0000-0002-0785-707X
 Jing Wang 0055,Renmin University of China,http://info.ruc.edu.cn/jsky/szdw/ajxjgcx/jsjkxyjsx1/fjs2/c6cd7c6a13334e3da59f08920941bf56.htm,NOSCHOLARPAGE,0000-0003-3653-7013
 Jing Wu 0004,Cardiff University,https://www.cardiff.ac.uk/people/view/118177-wu-jing,ms46emIAAAAJ,0000-0001-5123-9861
@@ -1625,8 +1626,8 @@ Joachim Spoerhase,University of Liverpool,https://sites.google.com/view/joachim-
 Joachim Weickert,Saarland University,http://www.mia.uni-saarland.de/weickert/index.shtml,IWwCuGAAAAAJ,0000-0002-8494-0045
 Joachim von Hacht,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/joachim-hacht.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Joakim Lilliesköld,KTH Royal Inst. of Technology,https://www.kth.se/profile/joakiml,4ki0Nk4AAAAJ,0000-0003-0724-2283
-Joan Bruna,New York University,http://www.cs.nyu.edu/~bruna,L4bNmsMAAAAJ,0000-0000-0000-0000
 Joan Bruna Estrach,New York University,http://www.cs.nyu.edu/~bruna,L4bNmsMAAAAJ,0000-0000-0000-0000
+Joan Bruna,New York University,http://www.cs.nyu.edu/~bruna,L4bNmsMAAAAJ,0000-0000-0000-0000
 Joan Daemen,Radboud University,https://cs.ru.nl/~joan,onY4i0oAAAAJ,0000-0002-4102-0775
 Joan Espasa Arxer,University of St Andrews,https://www.st-andrews.ac.uk/computer-science/people/jea20,g4H0JuYAAAAJ,0000-0000-0000-0000
 Joan Feigenbaum,Yale University,http://www.cs.yale.edu/~jf,IAeKTGsAAAAJ,0000-0002-3735-6022
@@ -1879,16 +1880,16 @@ John Mariani,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/peopl
 John Mark Bishop,Goldsmiths University of London,https://www.gold.ac.uk/computing/staff/m-bishop,48y80igAAAAJ,0000-0000-0000-0000
 John Mark Smotherman,Clemson University,https://people.cs.clemson.edu/~mark,KADbB0cAAAAJ,0000-0000-0000-0000
 John McAllister,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=jp.mcallister,CZerWWQAAAAJ,0000-0000-0000-0000
-John McDonald,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=643,NOSCHOLARPAGE,0000-0000-0000-0000
 John McDonald 0001,Maynooth University,https://www.maynoothuniversity.ie/faculty-science-engineering/our-people/john-mcdonald,MrI1EV4AAAAJ,0000-0001-9225-673X
+John McDonald,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=643,NOSCHOLARPAGE,0000-0000-0000-0000
 John McGregor,Clemson University,https://people.cs.clemson.edu/~johnmc,Tw739kgAAAAJ,0000-0000-0000-0000
 John Millar Carroll,Pennsylvania State University,https://jcarroll.ist.psu.edu,7Mg8JZMAAAAJ,0000-0001-5189-337X
 John Murphy 0001,University College Dublin,https://people.ucd.ie/j.murphy,hRzqMboAAAAJ,0000-0000-0000-0000
 John Murray-Bruce,University of South Florida,https://www.cse.usf.edu/~murraybruce,lQkw3IoAAAAJ,0000-0002-1416-4175
 John Musacchio,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~johnm,NOSCHOLARPAGE,0009-0006-2504-1759
 John N. Tsitsiklis,Massachusetts Inst. of Technology,http://www.mit.edu/~jnt/home.html,bWTPrLEAAAAJ,0000-0000-0000-0000
-John O'Donnell,University of Glasgow,http://www.dcs.gla.ac.uk/~jtod,NOSCHOLARPAGE,0000-0000-0000-0000
 John O'Donnell 0001,University of Glasgow,http://www.dcs.gla.ac.uk/~jtod,NOSCHOLARPAGE,0000-0000-0000-0000
+John O'Donnell,University of Glasgow,http://www.dcs.gla.ac.uk/~jtod,NOSCHOLARPAGE,0000-0000-0000-0000
 John P. Collomosse,University of Surrey,http://personal.ee.surrey.ac.uk/Personal/J.Collomosse,yVnCUg0AAAAJ,0000-0003-3580-4685
 John P. Conley,Oregon State University,http://eecs.oregonstate.edu/~jconley,Q-LRVgpXOHcC,0000-0000-0000-0000
 John P. Lalor,University of Notre Dame,https://jplalor.github.io,d7r0R14AAAAJ,0000-0000-0000-0000
@@ -2089,8 +2090,8 @@ Jordan Kodner,Stony Brook University,https://jkodner05.github.io,hYxTJEcAAAAJ,00
 Jordan L. Boyd-Graber,Univ. of Maryland - College Park,http://www.umiacs.umd.edu/~jbg,BT4XTP4AAAAJ,0000-0000-0000-0000
 Jordan Pollack,Brandeis University,http://www.cs.brandeis.edu/~pollack,NOSCHOLARPAGE,0009-0008-0819-3819
 Jordi Domingo-Pascual,Polytechnic Univ. of Catalonia,http://personals.ac.upc.edu/jordid,sPD_L5YAAAAJ,0000-0000-0000-0000
-Jordi Garcia,Polytechnic Univ. of Catalonia,https://www.facebook.com/public/Jordi-Garcia/school/Polytechnic-University-of-Catalonia-109077209117931,S76yu0YAAAAJ,0000-0000-0000-0000
 Jordi Garcia Almiñana,Polytechnic Univ. of Catalonia,http://personals.ac.upc.edu/jordig,S76yu0YAAAAJ,0000-0000-0000-0000
+Jordi Garcia,Polytechnic Univ. of Catalonia,https://www.facebook.com/public/Jordi-Garcia/school/Polytechnic-University-of-Catalonia-109077209117931,S76yu0YAAAAJ,0000-0000-0000-0000
 Jordi Guitart,Polytechnic Univ. of Catalonia,https://www.facebook.com/public/Jordi-Guitart/school/Polytechnic-University-of-Catalonia-109077209117931,gq_W4DwAAAAJ,0000-0003-0751-3100
 Jordi Perello Muntan,Polytechnic Univ. of Catalonia,http://people.ccaba.upc.edu/perello,N3Xy7m0AAAAJ,0000-0000-0000-0000
 Jordi Torres,Polytechnic Univ. of Catalonia,https://www.facebook.com/public/Jordi-Torres-Sanchez/school/Polytechnic-University-of-Catalonia-109077209117931,waODsw0AAAAJ,0000-0003-1963-7418
@@ -2107,12 +2108,12 @@ Jorge Fandinno,University of Nebraska - Omaha,https://www.unomaha.edu/college-of
 Jorge Fernandes,Universidade de Lisboa,http://fcsh.unl.pt/faculdade/docentes/pfernandes,DGDFIzgAAAAJ,0000-0000-0000-0000
 Jorge Garcia Vidal,Polytechnic Univ. of Catalonia,http://people.ac.upc.edu/jorge,NOSCHOLARPAGE,0000-0000-0000-0000
 Jorge Gonçalves 0001,University of Melbourne,http://www.jorgegoncalves.com,SkQ6OisAAAAJ,0000-0002-0117-0322
-Jorge Graña,University of A Coruña,https://pdi.udc.es/en/File/Pdi/WY69E,NOSCHOLARPAGE,0000-0001-9952-1778
 Jorge Graña Gil,University of A Coruña,https://pdi.udc.es/en/File/Pdi/WY69E,NOSCHOLARPAGE,0000-0000-0000-0000
+Jorge Graña,University of A Coruña,https://pdi.udc.es/en/File/Pdi/WY69E,NOSCHOLARPAGE,0000-0001-9952-1778
 Jorge Marx Gómez,University of Oldenburg,https://uol.de/jorge-marx-gomez,NOSCHOLARPAGE,0000-0000-0000-0000
 Jorge Munoz-Gama,UC Chile,https://haplab.org/team/jorge,3Og-qpwAAAAJ,0000-0002-6908-3911
-Jorge Novo,University of A Coruña,http://www.varpa.es/~jnovo,6mRipmwAAAAJ,0000-0002-0125-3064
 Jorge Novo Buján,University of A Coruña,http://www.varpa.es/~jnovo,6mRipmwAAAAJ,0000-0000-0000-0000
+Jorge Novo,University of A Coruña,http://www.varpa.es/~jnovo,6mRipmwAAAAJ,0000-0002-0125-3064
 Jorge Pérez 0001,Universidad de Chile,https://users.dcc.uchile.cl/~jperez,a6lUuiwAAAAJ,0000-0000-0000-0000
 Jorge S. Marques,Universidade de Lisboa,http://users.isr.ist.utl.pt/~jsm,8Vwg-7sAAAAJ,0000-0000-0000-0000
 Jorge Stolfi,UNICAMP,https://twitter.com/jorgestolfi?lang=en,mLo7gCEAAAAJ,0000-0000-0000-0000
@@ -2173,8 +2174,8 @@ Joseph Hallett,University of Bristol,https://research-information.bris.ac.uk/en/
 Joseph Hummel,University of Illinois at Chicago,https://www.cs.uic.edu/~jhummel,NOSCHOLARPAGE,0000-0000-0000-0000
 Joseph Izraelevitz,University of Colorado Boulder,https://www.colorado.edu/faculty/izraelevitz,CtQUnFUAAAAJ,0009-0002-1267-5024
 Joseph J. Boutros,Texas A&M at Qatar,http://www.josephboutros.org,lyjl3nMAAAAJ,0000-0000-0000-0000
-Joseph J. LaViola,University of Central Florida,https://www.cs.ucf.edu/~jjl,kXZaMu8AAAAJ,0000-0003-1186-4130
 Joseph J. LaViola Jr.,University of Central Florida,https://www.cs.ucf.edu/~jjl,kXZaMu8AAAAJ,0000-0000-0000-0000
+Joseph J. LaViola,University of Central Florida,https://www.cs.ucf.edu/~jjl,kXZaMu8AAAAJ,0000-0003-1186-4130
 Joseph J. Lim,KAIST,https://www.clvrai.com,jTnQTBoAAAAJ,0000-0000-0000-0000
 Joseph Jaeger,Georgia Institute of Technology,https://faculty.cc.gatech.edu/~josephjaeger,r9K3MQwAAAAJ,0000-0002-4934-3405
 Joseph Jay Williams,University of Toronto,http://www.josephjaywilliams.com,Gdow0U4AAAAJ,0000-0002-9122-5242
@@ -2250,8 +2251,8 @@ José A. Ramos,Nova Southeastern University,https://cec.nova.edu/faculty/ramos-j
 José A. S. Monteiro,UFPE,http://www.di.ufpe.br/~suruagy,xCIQf-QAAAAJ,0000-0000-0000-0000
 José Alberto R. P. Sardinha,PUC-RIO,https://www-di.inf.puc-rio.br/~sardinha/Publications.html,ki58SvAAAAAJ,0000-0002-5782-3142
 José Alberto Rodrigues Pereira Sardinha,PUC-RIO,https://www-di.inf.puc-rio.br/~sardinha/Publications.html,ki58SvAAAAAJ,0000-0000-0000-0000
-José Antonio Becerra,University of A Coruña,https://pdi.udc.es/es/File/Pdi/EU69E,QTPUBioAAAAJ,0000-0000-0000-0000
 José Antonio Becerra Permuy,University of A Coruña,https://pdi.udc.es/es/File/Pdi/EU69E,QTPUBioAAAAJ,0000-0000-0000-0000
+José Antonio Becerra,University of A Coruña,https://pdi.udc.es/es/File/Pdi/EU69E,QTPUBioAAAAJ,0000-0000-0000-0000
 José António Beltran Gerald,Universidade de Lisboa,http://ieeexplore.ieee.org/document/7845358,NOSCHOLARPAGE,0000-0000-0000-0000
 José Augusto Suruagy Monteiro,UFPE,http://www.di.ufpe.br/~suruagy,xCIQf-QAAAAJ,0000-0000-0000-0000
 José Bento 0001,Boston College,http://www.jbento.net,8K6Z0lEAAAAJ,0000-0000-0000-0000
@@ -2307,9 +2308,9 @@ José Monteiro 0001,Universidade de Lisboa,http://algos.inesc-id.pt/~jcm,tkeh3OA
 José N. Amaral,University of Alberta,https://webdocs.cs.ualberta.ca/~amaral,NOSCHOLARPAGE,0000-0000-0000-0000
 José Nelson Amaral,University of Alberta,https://webdocs.cs.ualberta.ca/~amaral,NOSCHOLARPAGE,0000-0000-0000-0000
 José Nicoletti Junior,UFRGS,https://www.inf.ufrgs.br/site/docente/jose-nicoletti-junior,NOSCHOLARPAGE,0000-0000-0000-0000
-José Oramas,University of Antwerp,https://www.uantwerpen.be/en/staff/jose-oramas,FurBYlUAAAAJ,0000-0002-8607-5067
 José Oramas M.,University of Antwerp,https://www.uantwerpen.be/en/staff/jose-oramas,FurBYlUAAAAJ,0000-0002-8607-5067
 José Oramas Mogrovejo,University of Antwerp,https://www.uantwerpen.be/en/staff/jose-oramas,FurBYlUAAAAJ,0000-0000-0000-0000
+José Oramas,University of Antwerp,https://www.uantwerpen.be/en/staff/jose-oramas,FurBYlUAAAAJ,0000-0002-8607-5067
 José Palazzo M. de Oliveira,UFRGS,http://www.inf.ufrgs.br/~palazzo,8Xw1b6oAAAAJ,0000-0000-0000-0000
 José Palazzo Moreira de Oliveira,UFRGS,http://www.inf.ufrgs.br/~palazzo,8Xw1b6oAAAAJ,0000-0000-0000-0000
 José R. A. Torreão,UFF,http://www2.ic.uff.br/~jrat,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -2323,12 +2324,12 @@ José Rufino,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/jmrufino,
 José Santos Reyes,University of A Coruña,https://www.dc.fi.udc.es/ai/~santos,NOSCHOLARPAGE,0000-0000-0000-0000
 José Santos-Victor,Universidade de Lisboa,http://users.isr.ist.utl.pt/~jasv,ZMuNAXQAAAAJ,0000-0002-9036-1728
 José T. Hernández,Universidad de los Andes,http://imagine.uniandes.edu.co,-gUUc7oAAAAJ,0000-0000-0000-0000
-José Tiberio Hernández,Universidad de los Andes,http://imagine.uniandes.edu.co,-gUUc7oAAAAJ,0000-0000-0000-0000
 José Tiberio Hernández Peñaloza,Universidad de los Andes,http://imagine.uniandes.edu.co,-gUUc7oAAAAJ,0000-0000-0000-0000
+José Tiberio Hernández,Universidad de los Andes,http://imagine.uniandes.edu.co,-gUUc7oAAAAJ,0000-0000-0000-0000
 José Tribolet,Universidade de Lisboa,https://fenix.tecnico.ulisboa.pt/homepage/ist10876,dzslQ5MAAAAJ,0000-0003-1903-4561
 José Valdeni de Lima,UFRGS,https://www.inf.ufrgs.br/site/docente/jose-valdeni-de-lima,0ROMJ0YAAAAJ,0000-0000-0000-0000
-José Viterbo,UFF,http://www.ic.uff.br/index.php/en-GB/people/317-faculty-ic?docente=36,twAYAPsAAAAJ,0000-0000-0000-0000
 José Viterbo Filho,UFF,http://www.ic.uff.br/index.php/en-GB/people/317-faculty-ic?docente=36,twAYAPsAAAAJ,0000-0000-0000-0000
+José Viterbo,UFF,http://www.ic.uff.br/index.php/en-GB/people/317-faculty-ic?docente=36,twAYAPsAAAAJ,0000-0000-0000-0000
 Jouko Lampinen,Aalto University,https://people.aalto.fi/new/jouko.lampinen,Hk0Q8TkAAAAJ,0000-0000-0000-0000
 Jovan Stojkovic,University of Texas at Austin,https://jovans2.github.io,1BcJ5ZAAAAAJ,0009-0007-4914-336X
 Jovita Lukasik,University of Siegen,https://www.vsa.informatik.uni-siegen.de/en/lukasik-jovita-0,TpsZenwAAAAJ,0000-0003-4243-9188
@@ -2356,8 +2357,8 @@ João Bimbo,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/jmbimbo,jj
 João Coelho Garcia,Universidade de Lisboa,http://www.gsd.inesc-id.pt/~jog,hYb5gDYAAAAJ,0000-0000-0000-0000
 João Comba,UFRGS,http://www.inf.ufrgs.br/~comba,jyeX-1sAAAAJ,0000-0003-2921-2130
 João Costa Seco,Universidade NOVA de Lisboa,https://docentes.fct.unl.pt/jrcs,EPFxA8YAAAAJ,0000-0002-2840-3966
-João Dias,Universidade de Lisboa,https://pt-br.facebook.com/public/Joao-Dias/school/fac.ciencias.ul,NOSCHOLARPAGE,0000-0000-0000-0000
 João Dias Pereira,Universidade de Lisboa,http://ihc.fcsh.unl.pt/pt/ihc/investigadores/item/1161-jdpereira,IREJZj4AAAAJ,0000-0000-0000-0000
+João Dias,Universidade de Lisboa,https://pt-br.facebook.com/public/Joao-Dias/school/fac.ciencias.ul,NOSCHOLARPAGE,0000-0000-0000-0000
 João Eduardo Ferreira,USP,http://www.ime.usp.br/~jef,wR2O6I0AAAAJ,0000-0001-9607-2014
 João F. Ferreira 0001,Universidade de Lisboa,https://joaoff.com,WurhenEAAAAJ,0000-0002-6612-9013
 João Fernando Ferreira,Universidade de Lisboa,https://joaoff.com,WurhenEAAAAJ,0000-0000-0000-0000
@@ -2410,14 +2411,14 @@ Ju Ren 0001,Tsinghua University,https://juren1987.github.io,QvqnU8wAAAAJ,0000-00
 Ju Sun,University of Minnesota,https://sunju.org,V6FaD-UAAAAJ,0000-0002-2017-5903
 Ju Wang 0003,Northwest University,https://faculty.nwu.edu.cn/ju/en/index.htm,NOSCHOLARPAGE,0000-0001-8026-9787
 Ju-yeon Jo,University of Nevada Las Vegas,http://joj5.faculty.unlv.edu,hqccsn8AAAAJ,0000-0000-0000-0000
-Juan A. Botía,University of Murcia,http://webs.um.es/juanbot/miwiki/doku.php,IFiSPE4AAAAJ,0000-0000-0000-0000
 Juan A. Botía Blaya,University of Murcia,http://webs.um.es/juanbot/miwiki/doku.php,IFiSPE4AAAAJ,0000-0000-0000-0000
+Juan A. Botía,University of Murcia,http://webs.um.es/juanbot/miwiki/doku.php,IFiSPE4AAAAJ,0000-0000-0000-0000
 Juan A. Fraire,Universidad Nacional de Córdoba,https://depend.cs.uni-saarland.de/~jfraire,YXq56tgAAAAJ,0000-0001-9816-6989
 Juan A. Garay 0001,Texas A&M University,https://engineering.tamu.edu/cse/profiles/garay-juan.html,pOCh6eAAAAAJ,0000-0003-0366-7110
 Juan A. Sánchez-Laguna,University of Murcia,https://ants.inf.um.es/staff/jlaguna,Ka4v6PIAAAAJ,0000-0000-0000-0000
 Juan Andres Fraire,Universidad Nacional de Córdoba,https://depend.cs.uni-saarland.de/~jfraire,YXq56tgAAAAJ,0000-0000-0000-0000
-Juan Ares,University of A Coruña,https://pdi.udc.es/en/File/Pdi/P679E,NOSCHOLARPAGE,0000-0000-0000-0000
 Juan Ares Casal,University of A Coruña,https://pdi.udc.es/en/File/Pdi/P679E,NOSCHOLARPAGE,0000-0000-0000-0000
+Juan Ares,University of A Coruña,https://pdi.udc.es/en/File/Pdi/P679E,NOSCHOLARPAGE,0000-0000-0000-0000
 Juan C. Caicedo,University of Wisconsin - Madison,https://datascience.wisc.edu/staff/caicedo-juan,U50zLvkAAAAJ,0000-0002-1277-4631
 Juan Caballero,IMDEA Software Institute,http://software.imdea.org/people/juan.caballero,6QjUClkAAAAJ,0000-0003-2962-1348
 Juan Cao 0001,Chinese Academy of Sciences,https://people.ucas.ac.cn/~caojuan,fSBdNg0AAAAJ,0000-0003-4256-6830
@@ -2541,8 +2542,8 @@ Julian Togelius,New York University,http://engineering.nyu.edu/people/julian-tog
 Juliana Bowles,University of St Andrews,https://juliana.host.cs.st-andrews.ac.uk,JstYoqcAAAAJ,0000-0002-5918-9114
 Juliana Freire,New York University,http://engineering.nyu.edu/user/4254,sSzAlq0AAAAJ,0000-0003-3915-7075
 Juliana Freitag Borin,UNICAMP,http://www.ic.unicamp.br/~juliana,MoEzFxoAAAAJ,0000-0000-0000-0000
-Juliana Küster Filipe,University of St Andrews,https://juliana.host.cs.st-andrews.ac.uk,JstYoqcAAAAJ,0000-0000-0000-0000
 Juliana Küster Filipe Bowles,University of St Andrews,https://juliana.host.cs.st-andrews.ac.uk,JstYoqcAAAAJ,0000-0000-0000-0000
+Juliana Küster Filipe,University of St Andrews,https://juliana.host.cs.st-andrews.ac.uk,JstYoqcAAAAJ,0000-0000-0000-0000
 Juliane Krämer,University of Regensburg,https://www.uni-regensburg.de/informatics-data-science/qpc/team/prof-dr-juliane-kraemer/index.html,Hebnan8AAAAJ,0000-0000-0000-0000
 Juliano Araujo Wickboldt,UFRGS,https://www.inf.ufrgs.br/site/docente/juliano-wickboldt,bqxkwSQAAAAJ,0000-0000-0000-0000
 Juliano Iyoda,UFPE,http://www.cin.ufpe.br/~jmi,ZF4EXI8AAAAJ,0000-0000-0000-0000
@@ -2561,8 +2562,8 @@ Julie Greensmith,University of Nottingham,https://www.nottingham.ac.uk/computers
 Julie Jacques,CRIStAL,https://www.cristal.univ-lille.fr/profil/jacques,NOSCHOLARPAGE,0000-0000-0000-0000
 Julie Porteous,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/p/porteous-dr-julie,B3AVEIoAAAAJ,0000-0003-4618-2359
 Julie R. Williamson,University of Glasgow,http://juliericowilliamson.com,qUtAKFQAAAAJ,0000-0002-1816-1393
-Julie Rico,University of Glasgow,http://juliericowilliamson.com,qUtAKFQAAAAJ,0000-0000-0000-0000
 Julie Rico Williamson,University of Glasgow,http://juliericowilliamson.com,qUtAKFQAAAAJ,0000-0000-0000-0000
+Julie Rico,University of Glasgow,http://juliericowilliamson.com,qUtAKFQAAAAJ,0000-0000-0000-0000
 Julie Shah,Massachusetts Inst. of Technology,http://people.csail.mit.edu/julie_a_shah,NOSCHOLARPAGE,0000-0003-1338-8107
 Julie Weeds,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/116624,goWjVPQAAAAJ,0000-0002-3831-4019
 Julie Williamson 0001,University of Glasgow,http://juliericowilliamson.com,qUtAKFQAAAAJ,0000-0002-1816-1393
@@ -2674,8 +2675,8 @@ Jung-Chun Kao,National Tsing Hua University,http://www.cs.nthu.edu.tw/~jungchuk,
 Jung-Eun Kim,North Carolina State University,https://jungeunkim.wordpress.ncsu.edu,8HpZmN0AAAAJ,0000-0001-9780-2947
 Jung-Hong Chuang,National Chiao Tung University,http://cggmwww.csie.nctu.edu.tw/index.php/8-member/10-faculty,NOSCHOLARPAGE,0000-0002-9038-6124
 Jung-Hsien Chiang,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/depmember/teacherdetail/id/10,NaNxyQgAAAAJ,0000-0002-4657-6705
-Jung-Hwan Oh,University of North Texas,http://www.cse.unt.edu/~jhoh,NOSCHOLARPAGE,0000-0000-0000-0000
 Jung-Hwan Oh 0001,University of North Texas,http://www.cse.unt.edu/~jhoh,alNk_OkAAAAJ,0000-0000-0000-0000
+Jung-Hwan Oh,University of North Texas,http://www.cse.unt.edu/~jhoh,NOSCHOLARPAGE,0000-0000-0000-0000
 JungHyun Han,Korea University,https://media.korea.ac.kr,51TWc5UAAAAJ,0000-0001-6438-2974
 Jungbeom Lee,Korea University,https://dcai-lab.github.io/DCAI-Lab,6qTcgH0AAAAJ,0000-0000-0000-0000
 Jungdam Won,Seoul National University,https://sites.google.com/view/jungdam,mUWAgvgAAAAJ,0000-0001-5510-6425
@@ -2857,8 +2858,8 @@ Jürgen Hesser,Heidelberg University,http://medphyssrv1.medma.uni-heidelberg.de/
 Jürgen Peissig,University of Hannover,https://www.ikt.uni-hannover.de/321.html?&no_cache=1&tx_tkinstpersonen_pi1%5Balias%5D=pei,asWSO9QAAAAJ,0000-0000-0000-0000
 Jürgen Prestin,University of Lübeck,https://www.math.uni-luebeck.de/mitarbeiter/prestin,0SzrmIMAAAAJ,0000-0000-0000-0000
 Jürgen Sachau,University of Luxembourg,http://wwwen.uni.lu/snt/people/juergen_sachau,NOSCHOLARPAGE,0000-0000-0000-0000
-Jürgen Sauer,University of Oldenburg,https://uol.de/sao/personen/apl-prof-dr-ing-juergen-sauer,E6w1sCMAAAAJ,0000-0000-0000-0000
 Jürgen Sauer 0001,University of Oldenburg,https://uol.de/sao/personen/apl-prof-dr-ing-juergen-sauer,E6w1sCMAAAAJ,0000-0000-0000-0000
+Jürgen Sauer,University of Oldenburg,https://uol.de/sao/personen/apl-prof-dr-ing-juergen-sauer,E6w1sCMAAAAJ,0000-0000-0000-0000
 Jürgen Schmidhuber,KAUST,https://cemse.kaust.edu.sa/people/person/jurgen-schmidhuber,gLnCTgIAAAAJ,0000-0002-1468-6758
 Jürgen Schönwälder,Jacobs University Bremen,https://www.jacobs-university.de/directory/jschoenwaelder,YaiOokwAAAAJ,0000-0000-0000-0000
 Jürgen Steimle,Saarland University,https://hci.cs.uni-saarland.de/people/juergen-steimle,Cz_S3u8AAAAJ,0000-0003-3493-8745


### PR DESCRIPTION
## Consolidated PR for Chinese Academy of Sciences

This PR consolidates the following open PRs:

| PR | Score | Title |
|---|---|---|
| #12103 | 75% | Add 3 faculty from Chinese Academy of Sciences |
| #12491 | 70% | Add 1 faculty from Chinese Academy of Sciences |

Total: 4 faculty additions.
Average individual score: 80%
Joint probability (all valid): 41.0%
