### PR TITLE
Add 2 faculty from Chung-Ang University (consolidated)

### DIFF
--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -48,8 +48,8 @@ Haggai Maron,Technion,https://haggaim.github.io,4v8uJrIAAAAJ,0009-0001-4088-6286
 Hagit Attiya,Technion,http://hagit.net.technion.ac.il,eoMK92MAAAAJ,0000-0002-8017-6457
 Hagit Hel-Or,University of Haifa,http://cs.haifa.ac.il/~hagit,GMM3-EUAAAAJ,0000-0001-8488-0380
 Hagit Shatkay,University of Delaware,https://www.eecis.udel.edu/~shatkay,NOSCHOLARPAGE,0000-0000-0000-0000
-Hagit Zabrodsky,University of Haifa,http://cs.haifa.ac.il/~hagit,GMM3-EUAAAAJ,0000-0000-0000-0000
 Hagit Zabrodsky Hel-Or,University of Haifa,http://cs.haifa.ac.il/~hagit,GMM3-EUAAAAJ,0000-0000-0000-0000
+Hagit Zabrodsky,University of Haifa,http://cs.haifa.ac.il/~hagit,GMM3-EUAAAAJ,0000-0000-0000-0000
 Hai (Helen) Li,Duke University,https://ece.duke.edu/people/hai-helen-li,E6Tpfq8AAAAJ,0000-0003-3228-6544
 Hai Dong,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/d/dong-dr-hai,ENWFU4gAAAAJ,0000-0002-7033-5688
 Hai Helen Li,Duke University,https://ece.duke.edu/people/hai-helen-li,E6Tpfq8AAAAJ,0000-0003-3228-6544
@@ -101,8 +101,8 @@ Hainan Zhang,Beihang University,https://zhanghainan.github.io,D22QG1557LgC,0000-
 Haining Fan,Tsinghua University,http://www.cs.tsinghua.edu.cn/publish/cs/4616/2017/20170303112105728431532/20170303112105728431532_.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Haining Zhang,Nankai University,https://cs.nankai.edu.cn/szdw/js/zhn.htm,NOSCHOLARPAGE,0009-0007-1320-3981
 Haipeng Cai,University at Buffalo,https://chapering.github.io,Ru4B_wkAAAAJ,0000-0002-5224-9970
-Haipeng Chen,College of William and Mary,https://haipeng-chen.github.io,YT-b72QAAAAJ,0000-0000-0000-0000
 Haipeng Chen 0002,Jilin University,https://ccst.jlu.edu.cn/info/1367/20675.htm,NOSCHOLARPAGE,0000-0002-9410-4120
+Haipeng Chen,College of William and Mary,https://haipeng-chen.github.io,YT-b72QAAAAJ,0000-0000-0000-0000
 Haipeng Dai 0001,Nanjing University,https://cs.nju.edu.cn/daihp,fb9R-QgAAAAJ,0000-0003-0545-8187
 Haipeng Luo,University of Southern California,https://haipeng-luo.net,ct2hw4UAAAAJ,0000-0001-8056-6271
 Haipeng Peng,BUPT,https://scss.bupt.edu.cn/info/1063/1188.htm,pZqxzFoAAAAJ,0000-0000-0000-0000
@@ -603,8 +603,8 @@ Helen Xu 0001,Georgia Institute of Technology,https://itshelenxu.github.io,ZcguQ
 Helen Yannakoudakis,King's College London,https://www.kcl.ac.uk/people/helen-yannakoudakis,B3WGvRsAAAAJ,0000-0000-0000-0000
 Helena Cristina da Gama Leitão,UFF,http://www2.ic.uff.br/~hcgl,NOSCHOLARPAGE,0000-0000-0000-0000
 Helena Galhardas,Universidade de Lisboa,http://web.ist.utl.pt/helena.galhardas,oBY_WrMAAAAJ,0000-0000-0000-0000
-Helena Holmström,Malmö University,https://mau.se/en/persons/helena.holmstrom.olsson,bjGw_5QAAAAJ,0000-0000-0000-0000
 Helena Holmström Olsson,Malmö University,https://mau.se/en/persons/helena.holmstrom.olsson,bjGw_5QAAAAJ,0000-0000-0000-0000
+Helena Holmström,Malmö University,https://mau.se/en/persons/helena.holmstrom.olsson,bjGw_5QAAAAJ,0000-0000-0000-0000
 Helena Karasti,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/helena-karasti(fdbd5c94-bf35-463a-ab70-1224809bbbf4).html,oEzi1K0AAAAJ,0000-0000-0000-0000
 Helena M. Mentis,Drexel University,https://drexel.edu/cci/about/directory/M/Mentis-Helena,_VdWyEcAAAAJ,0000-0002-0142-3529
 Helena Sarmento,Universidade de Lisboa,http://lisboa.academia.edu/HelenaSarmento,cn9nh7UAAAAJ,0000-0000-0000-0000
@@ -1205,6 +1205,7 @@ Huzur Saran,IIT Delhi,http://www.cse.iitd.ernet.in/~saran,NOSCHOLARPAGE,0000-000
 Hwa-Chun Lin,National Tsing Hua University,http://alpha5.cs.nthu.edu.tw/labweb/advisor.html,NOSCHOLARPAGE,0000-0002-8811-8331
 Hwangjun Song,POSTECH,http://mcnl.postech.ac.kr,3w4oYn8AAAAJ,0000-0000-0000-0000
 Hwangnam Kim,Korea University,https://wine.korea.ac.kr,T4lnatcAAAAJ,0000-0000-0000-0000
+Hwanhee Lee,Chung-Ang University,https://hwanheelee1993.github.io,eRM8zHkAAAAJ,0000-0002-9367-9811
 Hwanjo Yu,POSTECH,http://hwanjoyu.org,LbrCa7EAAAAJ,0000-0002-7510-0255
 Hwann-Tzong Chen,National Tsing Hua University,http://www.cs.nthu.edu.tw/~htchen,mwFy9kkAAAAJ,0000-0003-2806-7090
 Hwee Tou Ng,National University of Singapore,https://www.comp.nus.edu.sg/~nght,FABZCeAAAAAJ,0000-0000-0000-0000

--- a/csrankings-y.csv
+++ b/csrankings-y.csv
@@ -772,6 +772,7 @@ Yongpan Zou,Shenzhen University,https://yongpanzou.github.io,RO4w5pAAAAAJ,0000-0
 Yongqian Sun,Nankai University,https://nkcs.iops.ai/yongqiansun,NOSCHOLARPAGE,0000-0003-0266-7899
 Yongqiang Tian 0001,Monash University,https://yqtian.com,51iYgNAAAAAJ,0000-0003-1644-2965
 Yongqiang zhao,NWPU,https://teacher.nwpu.edu.cn/m/en/2001000069.html,FsJyR8QAAAAJ,0000-0000-0000-0000
+Yongseok Son,Chung-Ang University,https://sites.google.com/view/syslab-cau,uSquPgoAAAAJ,0000-0003-4512-0121
 Yongshan Ding 0001,Yale University,https://seas.yale.edu/faculty-research/faculty-directory/yongshan-ding,pIFh3c0AAAAJ,0000-0002-2338-1315
 Yongsheng Bai,Indiana State University,http://isu.indstate.edu/ybai2,NOSCHOLARPAGE,0000-0000-0000-0000
 Yongsheng Gao 0001,Griffith University,https://experts.griffith.edu.au/19112-yongsheng-gao,IqazXu4AAAAJ,0000-0002-5382-5351


### PR DESCRIPTION
## Consolidated PR for Chung-Ang University

This PR consolidates the following open PRs:

| PR | Score | Title |
|---|---|---|
| #12444 | 80% | Add Yongseok Son (Chung-Ang University) |
| #12481 | 80% | Add 1 faculty from Chung-Ang University |

Total: 2 faculty additions.
Average individual score: 80%
Joint probability (all valid): 64.0%
