### PR TITLE
Update Kunpeng Liu affiliation: Portland State University → Clemson University

### DIFF
--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -1069,7 +1069,7 @@ Kunihiko Sadakane,University of Tokyo,http://www.tkl.iis.u-tokyo.ac.jp/FIRST/mem
 Kunitake Kaneko,Keio University,https://www.inl.ics.keio.ac.jp,pVpmX2sAAAAJ,0009-0001-6107-6151
 Kunle Olukotun,Stanford University,http://arsenalfc.stanford.edu/kunle,IzXDyR8AAAAJ,0000-0002-8779-0636
 Kunpeng He,Nankai University,https://ai.nankai.edu.cn/info/1279/6253.htm,NOSCHOLARPAGE,0009-0005-1618-4726
-Kunpeng Liu 0001,Portland State University,https://www.kunpengliu.com,wfF30KMAAAAJ,0000-0002-6053-5977
+Kunpeng Liu 0001,Clemson University,https://www.kunpengliu.com,wfF30KMAAAAJ,0000-0002-6053-5977
 Kunpeng Yao,University of Leeds,https://eps.leeds.ac.uk/computing/staff/16237/dr-kunpeng-yao,YN1iXY4AAAAJ,0000-0002-5839-081X
 Kunqing Xie,Peking University,http://www.cis.pku.edu.cn/faculty/system/xiekunqing/english.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Kunsoo Park,Seoul National University,http://theory.snu.ac.kr/?page_id=982,StNl-UAAAAAJ,0000-0001-5225-0907


### PR DESCRIPTION
Updates the affiliation for `Kunpeng Liu 0001` from **Portland State University** to **Clemson University**. Kunpeng Liu joined Clemson's School of Computing as a tenure-track Assistant Professor in August 2025.

**Diff:**
```diff
-Kunpeng Liu 0001,Portland State University,https://www.kunpengliu.com,wfF30KMAAAAJ,0000-0002-6053-5977
+Kunpeng Liu 0001,Clemson University,https://www.kunpengliu.com,wfF30KMAAAAJ,0000-0002-6053-5977
```

**Evidence:**
- Clemson School of Computing faculty page (lists him as Assistant Professor, McAdams 221C, kunpenl@clemson.edu): https://www.clemson.edu/cecas/departments/computing/people/
- Clemson News, 2025 College of Engineering, Computing and Applied Sciences new faculty hires: https://news.clemson.edu/2025-college-of-engineering-computing-and-applied-sciences-new-faculty-hires/
- Personal website (now shows Clemson): https://www.kunpengliu.com/

Homepage, Google Scholar ID, and ORCID are unchanged. Clemson University already exists in CSrankings (64 entries across 20 files), so no new institution is being added.

## Required Checklist

### Identity & Format
- [x] My GitHub profile shows my full name
- [x] PR title is descriptive (not "Update csrankings-x.csv")
- [x] One PR per institution, all changes combined
- [x] Only modified `csrankings-[a-z].csv` or `old/industry.csv`
- [x] Did NOT use Excel
- [x] No spaces after commas, no missing fields
- [x] Entries in alphabetical order by full name

### Data Accuracy
- [x] Name matches [DBLP](https://dblp.org/pid/265/3303.html) exactly (including 0001 suffix)
- [x] Homepage URL works and shows name + affiliation
- [x] Google Scholar ID is the 12-character code only

### Eligibility
- [x] Faculty is full-time, tenure-track
- [x] Can **solely** advise CS PhD students