### PR TITLE
Update SeungJun Kim → Seungjun Kim 0001 (GIST)

### DIFF
--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -842,7 +842,6 @@ Seung-Jae Han,Yonsei University,http://mnet.yonsei.ac.kr/#professor,NOSCHOLARPAG
 Seung-Jong Park,Missouri S&T,https://sites.mst.edu/sjpark,AEJSH4UAAAAJ,0000-0001-7821-7793
 Seung-Jun Kim 0002,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/people/faculty/seung-jun-kim,AsHKhcsAAAAJ,0000-0000-0000-0000
 Seung-won Hwang,Seoul National University,http://seungwonh.github.io,63bBmc3mYrAC,0000-0000-0000-0000
-SeungJun Kim,GIST,https://sites.google.com/view/gist-hcis-lab/people?authuser=0,AjfRd6wAAAAJ,0000-0000-0000-0000
 Seungbae Kim,University of South Florida,https://sites.google.com/site/sbkimcv,gFZlotAAAAAJ,0000-0001-5667-3560
 Seunggeun Lee,Seoul National University,https://www.leelabsg.org/personnel,8GohEw0AAAAJ,0000-0002-8097-3878
 Seunghee Shin,Binghamton University,https://sites.google.com/binghamton.edu/seunghee,wpGg2O4AAAAJ,0009-0003-0226-9951
@@ -850,6 +849,7 @@ Seunghoon Hong,KAIST,http://cvlab.postech.ac.kr/~maga33,hvr3ALkAAAAJ,0000-0000-0
 Seunghoon Woo,Korea University,https://ssp.korea.ac.kr/ ,vm77ejwAAAAJ,0000-0002-5455-0804
 Seungjin Choi,POSTECH,http://mlg.postech.ac.kr/~seungjin,_3O0RcUAAAAJ,0000-0000-0000-0000
 Seungjoo Kim,Korea University,http://KimLab.net,MjJzWJEAAAAJ,0000-0000-0000-0000
+Seungjun Kim 0001,GIST,https://sites.google.com/view/gist-hcis-lab/people?authuser=0,AjfRd6wAAAAJ,0000-0000-0000-0000
 Seungmoon Choi,POSTECH,http://choism71.wixsite.com/home,YpaI-NkAAAAJ,0000-0002-5889-1083
 Seungryong Kim,KAIST,https://cvlab.kaist.ac.kr/members/faculty,cIK1hS8AAAAJ,0000-0003-2927-6273
 Seungryoul Maeng,KAIST,http://camars.kaist.ac.kr/~maeng,NOSCHOLARPAGE,0000-0000-0000-0000


### PR DESCRIPTION
## Summary
- Renames the GIST entry `SeungJun Kim` to `Seungjun Kim 0001` so it matches the canonical DBLP name at https://dblp.org/pid/39/465-1.html (the page heading and PID metadata use lowercase `j` and the `0001` disambiguator, even though the publication byline shows `SeungJun Kim`).
- Without the `0001` suffix, publications are not attributed correctly.
- Re-sorted into the correct alphabetical position (between `Seungjoo Kim` and `Seungmoon Choi`).

## Required Checklist

### Identity & Format
- [x] My GitHub profile shows my full name
- [x] PR title is descriptive (not "Update csrankings-x.csv")
- [x] One PR per institution, all changes combined
- [x] Only modified `csrankings-[a-z].csv` or `old/industry.csv`
- [x] Did NOT use Excel
- [x] No spaces after commas, no missing fields
- [x] Entries in alphabetical order by full name

### Data Accuracy
- [x] Name matches [DBLP](https://dblp.org) exactly (including 0001 suffixes)
- [x] Homepage URL works and shows name + affiliation
- [x] Google Scholar ID is the 12-character code only