### PR TITLE
Add Kangil Kim (GIST)

### DIFF
--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -177,6 +177,7 @@ Kang Wook Lee 0001,University of Wisconsin - Madison,https://kangwooklee.com,sCE
 Kang-Min Kim,Kyung Hee University,https://cuknlp.com,PQsJWfsAAAAJ,0000-0003-2335-7072
 KangKang Yin,Simon Fraser University,https://www.cs.sfu.ca/~kkyin,5P2jxPQAAAAJ,0000-0000-0000-0000
 Kangfei Zhao,Beijing Institute of Technology,https://kangfei.github.io,ZPCRhOsAAAAJ,0000-0000-0000-0000
+Kangil Kim,GIST,https://irrlab.github.io/people/professor/,RZggOtkAAAAJ,0000-0003-3220-6401
 Kangjie Lu,University of Minnesota,https://www.cs.umn.edu/people/kangjie-lu,1F9N6icAAAAJ,0000-0002-4763-7354
 Kangkook Jee,University of Texas at Dallas,https://kangkookjee.github.io,x-ApqMUAAAAJ,0000-0003-3797-4637
 Kangning Wang 0001,Rutgers University,https://sites.google.com/view/kangningwang/home,tK_Ty_IAAAAJ,0000-0001-8688-2478


### PR DESCRIPTION
## Summary
- Adds Kangil Kim (GIST) to `csrankings-k.csv`.
- DBLP: https://dblp.org/pid/45/8372.html — canonical name `Kangil Kim`, no disambiguation suffix (ORCID `0000-0003-3220-6401` matches).
- Inserted in correct alphabetical position between `Kangfei Zhao` and `Kangjie Lu`.

## Required Checklist

### Identity & Format
- [x] My GitHub profile shows my full name
- [x] PR title is descriptive (not "Update csrankings-x.csv")
- [x] One PR per institution, all changes combined
- [x] Only modified `csrankings-[a-z].csv` or `old/industry.csv`
- [x] Did NOT use Excel
- [x] No spaces after commas, no missing fields
- [x] Entries in alphabetical order by full name

### Data Accuracy
- [x] Name matches [DBLP](https://dblp.org) exactly (including 0001 suffixes)
- [x] Homepage URL works and shows name + affiliation
- [x] Google Scholar ID is the 12-character code only

### Eligibility
- [x] Faculty is full-time, tenure-track
- [x] Can **solely** advise CS PhD students