### PR TITLE
Add Fazl Barez (University of Oxford)

### DIFF
--- a/csrankings-f.csv
+++ b/csrankings-f.csv
@@ -206,6 +206,7 @@ Faysal Hossain Shezan,University of Texas at Arlington,https://fhshezan.github.i
 Fayyaz A. Afsar,University of Warwick,https://sites.google.com/view/fayyaz,cQ6eO_kAAAAJ,0000-0000-0000-0000
 Fayyaz ul Amir Afsar Minhas,University of Warwick,https://sites.google.com/view/fayyaz,cQ6eO_kAAAAJ,0000-0001-9129-1189
 Fazhi He,Wuhan University,https://cs.whu.edu.cn/info/1019/2497.htm,AAEd6CkAAAAJ,0000-0001-7016-3698
+Fazl Barez,University of Oxford,https://fbarez.github.io/,EAjpNIMAAAAJ,0009-0008-1889-6577
 Fazli Can,Bilkent University,http://www.cs.bilkent.edu.tr/~canf,u1-_lGIAAAAJ,0000-0003-0016-4278
 Federica Arrigoni,Politecnico di Milano,https://federica-arrigoni.github.io,bzBtqfQAAAAJ,0000-0003-0331-4032
 Federica Mandreoli,Univ. of Modena and Reggio Emilia,https://personale.unimore.it/rubrica/dettaglio/fmandreoli,S52hANkAAAAJ,0000-0002-8043-8787


### PR DESCRIPTION
Add Fazl Barez to `csrankings-f.csv`, inserted alphabetically between Fazhi He and Fazli Can.

**Entry:**
```
Fazl Barez,University of Oxford,https://fbarez.github.io/,EAjpNIMAAAAJ,0009-0008-1889-6577
```

**Checklist:**
- [x] Entry inserted in alphabetical order
- [x] Name matches DBLP exactly: https://dblp.org/pid/308/2550.html
- [x] Homepage verified and shows name/affiliation: https://fbarez.github.io/
- [x] Google Scholar ID verified: https://scholar.google.com/citations?user=EAjpNIMAAAAJ
- [x] ORCID verified: https://orcid.org/0009-0008-1889-6577
- [x] Full-time faculty who can solely advise CS PhD students at University of Oxford
- [x] No spaces after commas, no missing fields

Closes #13033