### PR TITLE
Update TOBB ETÜ faculty

### DIFF
--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -2715,6 +2715,7 @@ Ayoung Kim,Seoul National University,https://rpm.snu.ac.kr/index.php/Main/People
 Ayse K. Coskun,Boston University,https://www.bu.edu/eng/profile/ayse-coskun,euIQ_RkAAAAJ,0000-0002-6554-088X
 Ayse Kivilcim Coskun,Boston University,https://www.bu.edu/eng/profile/ayse-coskun,euIQ_RkAAAAJ,0000-0000-0000-0000
 Ayse Küçükyilmaz,University of Nottingham,https://www.nottingham.ac.uk/computerscience/people/ayse.kucukyilmaz,NOSCHOLARPAGE,0000-0003-3202-6750
+Ayse Mutlu Derya,TOBB ETÜ,https://www.etu.edu.tr/en/bolum/computer-engineering/akademik-kadro?l=1#ayse-mutlu-derya,51n7f5kAAAAJ,0000-0000-0000-0000
 Ayse Nur Zincir-Heywood,Dalhousie University,https://www.cs.dal.ca/~zincir,F9nG0F4AAAAJ,0000-0000-0000-0000
 Ayse Tosun,Istanbul Technical University,http://web.itu.edu.tr/tosunay,KktAed0AAAAJ,0000-0003-1859-7872
 Ayse Tosun Misirli,Istanbul Technical University,http://web.itu.edu.tr/tosunay,KktAed0AAAAJ,0000-0003-1859-7872

--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -30,6 +30,7 @@ Badri N. Vellambi,University of Cincinnati,https://researchdirectory.uc.edu/p/
 Badrul H. Chowdhury,UNC - Charlotte,https://ece.charlotte.edu/directory/dr-badrul-chowdhury-phd,03NaljoAAAAJ,0000-0000-0000-0000
 Baek-Young Choi,Missouri S&T,https://www.choiby.net,Ce0nO6wAAAAJ,0000-0003-4449-2425
 BaekGyu Kim,DGIST,https://sites.google.com/view/hass-dgist/professor,pZ9VYeUAAAAJ,0000-0001-7892-5191
+Bahaeddin Eravci,TOBB ETÜ,https://beravci.github.io/,PRy1_YUAAAAJ,0000-0002-9006-917X
 Bahar Asgari,Univ. of Maryland - College Park,https://www.umiacs.umd.edu/people/baharasgari,19grMJMAAAAJ,0000-0003-2305-9892
 Baharak Rastegari,University of Southampton,https://www.ecs.soton.ac.uk/people/br1e18,C2wWMqsAAAAJ,0000-0002-0985-573X
 Baharan Mirzasoleiman,Univ. of California - Los Angeles,https://cs.stanford.edu/~baharanm,x63j7HEAAAAJ,0000-0000-0000-0000

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -31,7 +31,6 @@ Caetano Traina Júnior,USP-ICMC,http://conteudo.icmc.usp.br/pessoas/caetano,h2iv
 Cagatay Turkay,City University of London,https://www.city.ac.uk/people/academics/cagatay-turkay#profile=overview,ho0I_1kAAAAJ,0000-0001-6788-251X
 Cagdas D. Onal,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/cdo.html,3symmLYAAAAJ,0000-0000-0000-0000
 Cagdas Denizel Onal,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/cdo.html,3symmLYAAAAJ,0000-0000-0000-0000
-Cagdas Evren Gerede,TOBB ETÜ,http://cegerede.etu.edu.tr,JMTNP1MAAAAJ,0000-0000-0000-0000
 Caifeng Shan,Nanjing University,https://caifeng-shan.github.io,fIXA_SsAAAAJ,0000-0002-2131-1671
 Caigui Jiang,Xi'an Jiaotong University,http://gr.xjtu.edu.cn/web/jiang,5uDZVvgAAAAJ,0000-0002-1342-4094
 Cairong Zhao,Tongji University,https://vill.tongji.edu.cn/info/1067/1396.htm,z-XzWZcAAAAJ,0000-0000-0000-0000
@@ -1627,3 +1626,4 @@ César Torres 0001,University of Texas at Arlington,http://cearto.com,9CJbh1MAAA
 Çagdas D. Önal,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/cdo.html,3symmLYAAAAJ,0000-0000-0000-0000
 Çaglar Gülçehre,EPFL,https://people.epfl.ch/caglar.gulcehre?lang=en,7hwJ2ckAAAAJ,0009-0003-4124-1687
 Çigdem Aslay,Aarhus University,https://pure.au.dk/portal/da/persons/cigdem-aslay(921b00ac-c233-4813-be49-89852a83f6bc).html,aVRi34QAAAAJ,0000-0002-5556-8977
+Çigdem Avci Salma,TOBB ETÜ,https://www.etu.edu.tr/en/bolum/computer-engineering/akademik-kadro?l=1#cigdem-avci-salma,NOSCHOLARPAGE,0000-0001-7030-0533

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -15,7 +15,6 @@ M. Ehsan Abbasnejad,Adelaide University,https://ehsanabb.github.io,OdlVfTsAAAAJ,
 M. Elif Karsligil,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/elifk?lang=en,NOSCHOLARPAGE,0000-0000-0000-0000
 M. Engin Tozal,Univ. of Louisiana - Lafayette,https://people.cmix.louisiana.edu/tozal,NOSCHOLARPAGE,0000-0000-0000-0000
 M. Fatih Amasyali,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/mfatih?lang=en,qTUSAy0AAAAJ,0000-0000-0000-0000
-M. Fatih Demirci,TOBB ETÜ,http://mfdemirci.etu.edu.tr,qShOHtsAAAAJ,0000-0000-0000-0000
 M. Frans Kaashoek,Massachusetts Inst. of Technology,https://pdos.csail.mit.edu/archive/kaashoek,NOSCHOLARPAGE,0000-0001-7098-586X
 M. Furkan Kiraç,Özyeğin University,http://www.fkirac.net,kdJBxv8AAAAJ,0000-0000-0000-0000
 M. G. J. van den Brand,TU Eindhoven,http://www.win.tue.nl/~mvdbrand,CZt-AsoAAAAJ,0000-0000-0000-0000
@@ -1646,7 +1645,6 @@ Mehdi Soltanolkotabi,University of Southern California,https://viterbi-web.usc.e
 Mehmed Kantardzic,University of Louisville,http://louisville.edu/speed/people/faculty/kantardzicMehmed,RKnDA7oAAAAJ,0000-0002-6861-4434
 Mehmed M. Kantardzic,University of Louisville,http://louisville.edu/speed/people/faculty/kantardzicMehmed,RKnDA7oAAAAJ,0000-0002-6861-4434
 Mehmet A. Orgun,Macquarie University,http://web.science.mq.edu.au/~mehmet,FpZlwKUAAAAJ,0000-0002-7873-1562
-Mehmet Aksit,TOBB ETÜ,https://people.utwente.nl/m.aksit,8lwFYb0AAAAJ,0000-0000-0000-0000
 Mehmet Ali Orgun,Macquarie University,http://web.science.mq.edu.au/~mehmet,FpZlwKUAAAAJ,0000-0000-0000-0000
 Mehmet Amaç Güvensan,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/amacg?lang=en,YPbvk4gAAAAJ,0000-0000-0000-0000
 Mehmet Burak Akgun,TOBB ETÜ,https://www.etu.edu.tr/en/bolum/computer-engineering/akademik-kadro?l=1#mehmet-burak-akgun,u3z2zsgAAAAJ,0000-0000-0000-0000
@@ -1667,7 +1665,6 @@ Mehmet Remzi Dogar,University of Leeds,https://eps.leeds.ac.uk/computing/staff/7
 Mehmet S. Aktas,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/maktas?lang=en,ocHB_6gAAAAJ,0000-0000-0000-0000
 Mehmet Siddik Aktas,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/maktas?lang=en,ocHB_6gAAAAJ,0000-0000-0000-0000
 Mehmet Tahir Sandikkaya,Istanbul Technical University,http://akademi.itu.edu.tr/en/sandikkaya,_d7K3TkAAAAJ,0000-0002-9756-603X
-Mehmet Tan,TOBB ETÜ,http://mtan.etu.edu.tr,Ztz_N_gAAAAJ,0000-0000-0000-0000
 Mehmet Turan,Boğaziçi University,https://deepmia.bogazici.edu.tr,Ba0lRIwAAAAJ,0000-0000-0000-0000
 Mehmet Önder Efe,Hacettepe University,https://web.cs.hacettepe.edu.tr/~onderefe,OityWEAAAAAJ,0000-0002-5992-895X
 Mehran Alidoost Nia,Shahid Beheshti University,https://facultymembers.sbu.ac.ir/alidoost,Gx87T8wAAAAJ,0000-0000-0000-0000

--- a/csrankings-o.csv
+++ b/csrankings-o.csv
@@ -237,7 +237,6 @@ Oscar Pedreira,University of A Coruña,https://lbd.udc.es/ShowResearcherInformat
 Oscar Peter Buneman,University of Edinburgh,http://homepages.inf.ed.ac.uk/opb,d9bq04sAAAAJ,0000-0000-0000-0000
 Oskar Skibski,University of Warsaw,http://www.mimuw.edu.pl/~oski,1mk4ZnUAAAAJ,0000-0002-3978-416X
 Oskar von Stryk,TU Darmstadt,http://www.sim.informatik.tu-darmstadt.de,TmbrLRMAAAAJ,0000-0000-0000-0000
-Osman Abul,TOBB ETÜ,http://osmanabul.etu.edu.tr,fG9v1bwAAAAJ,0000-0002-9284-6112
 Osman Balci,Virginia Tech,http://manta.cs.vt.edu/balci,NOSCHOLARPAGE,0000-0000-0000-0000
 Osmar Norberto de Souza,PUC-RS,http://www.inf.pucrs.br/~osmarns,W7Qu_twAAAAJ,0000-0000-0000-0000
 Osmar R. Zaïane,University of Alberta,https://webdocs.cs.ualberta.ca/~zaiane,j-W_RNYAAAAJ,0000-0002-0060-5988

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -895,6 +895,7 @@ Shadan Sadeghian Borojeni,University of Siegen,https://www.mediacoop.uni-siegen.
 Shadan Sadeghianborojeni,University of Siegen,https://www.mediacoop.uni-siegen.de/de/personen/sadedhian-shadan,DYGZQO0AAAAJ,0000-0000-0000-0000
 Shaddi Hasan,Virginia Tech,https://people.cs.vt.edu/shaddi,IHburiYAAAAJ,0000-0001-5432-6952
 Shaddin Dughmi,University of Southern California,https://viterbi-web.usc.edu/~shaddin,jn-B_MoAAAAJ,0000-0002-2784-1868
+Shadi Bikas,TOBB ETÜ,https://www.etu.edu.tr/en/bolum/computer-engineering/akademik-kadro?l=1#shadi-bikas,ejRGYLsAAAAJ,0000-0000-0000-0000
 Shadi Ibrahim,INRIA,https://people.rennes.inria.fr/Shadi.Ibrahim/index.html,wYsb_kUAAAAJ,0000-0000-0000-0000
 Shady Elbassuoni,American University of Beirut,https://www.aub.edu.lb/fas/cs/people/Pages/se58.aspx,Fe8iIHMAAAAJ,0000-0000-0000-0000
 Shafay Shamail,LUMS,https://lums.edu.pk/lums_employee/533,LEWgqDAAAAAJ,0000-0000-0000-0000

--- a/csrankings-y.csv
+++ b/csrankings-y.csv
@@ -1061,6 +1061,7 @@ Yubei Chen,Univ. of California - Davis,https://cs.ucdavis.edu/directory/yubei-ch
 Yubin Xia,Shanghai Jiao Tong University,https://ipads.se.sjtu.edu.cn/yubin_xia,jHYNM6QAAAAJ,0000-0001-6558-5298
 Yubin Yang,Nanjing University,https://cs.nju.edu.cn/yangyubin,kLOKBgUAAAAJ,0000-0000-0000-0000
 Yubo Tao,Zhejiang University,http://www.cad.zju.edu.cn/home/ybtao,NOSCHOLARPAGE,0000-0002-2283-6437
+Yucel Cimtay,TOBB ETÜ,https://www.etu.edu.tr/en/bolum/computer-engineering/akademik-kadro?l=1#yucel-cimtay,sfAsF9MAAAAJ,0000-0000-0000-0000
 Yucel Yemez,Koç University,http://network.ku.edu.tr/~yyemez,12csu04AAAAJ,0000-0000-0000-0000
 Yuchao Dai,NWPU,https://teacher.nwpu.edu.cn/m/en/2017010207.html,fddAbqsAAAAJ,0000-0000-0000-0000
 Yuchen Cui,Univ. of California - Los Angeles,https://yuchencui.cc,qQz2cm8AAAAJ,0000-0001-7417-1222


### PR DESCRIPTION
## Summary

Updates TOBB ETÜ Computer Engineering faculty list to reflect departures and new hires (verified against the department's official faculty page).

### Added (5)
- **Ayse Mutlu Derya** — Asst. Prof. (visiting). DBLP: `Ayse Mutlu Derya`
- **Bahaeddin Eravci** — Asst. Prof., deputy department chair. DBLP: `Bahaeddin Eravci`
- **Çigdem Avci Salma** — Asst. Prof. DBLP: `Çigdem Avci Salma`
- **Shadi Bikas** — Asst. Prof., education coordinator. DBLP: `Shadi Bikas`
- **Yucel Cimtay** — Assoc. Prof. DBLP: `Yucel Cimtay`

### Removed (5, no longer at TOBB ETÜ)
- Cagdas Evren Gerede
- M. Fatih Demirci
- Mehmet Aksit
- Mehmet Tan
- Osman Abul

### Files changed
csrankings-a.csv, csrankings-b.csv, csrankings-c.csv, csrankings-m.csv, csrankings-o.csv, csrankings-s.csv, csrankings-y.csv (7 files; +5 / -5).

All entries inserted in alphabetical order; DBLP names match existing author entries; Google Scholar IDs verified (one entry uses NOSCHOLARPAGE where no profile exists).