### PR TITLE
Surface sponsor banner in the issue PR-Created comment

### DIFF
--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -808,7 +808,7 @@ jobs:
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issue.number,
-                    body: `## ✅ PR Created\n\nYour batch submission has been processed and a pull request has been created:\n\n**PR #${pr.number}**: ${pr.html_url}\n\nA maintainer will review and merge the PR. Thank you for contributing to CSRankings!`
+                    body: `${submitterIsSponsor ? sponsorBanner : ''}## ✅ PR Created\n\nYour batch submission has been processed and a pull request has been created:\n\n**PR #${pr.number}**: ${pr.html_url}\n\nA maintainer will review and merge the PR. Thank you for contributing to CSRankings!`
                   });
 
                   await github.rest.issues.addLabels({
@@ -1517,7 +1517,7 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issue.number,
-                  body: `## ✅ PR Created\n\nYour submission has been processed and a pull request has been created:\n\n**PR #${pr.number}**: ${pr.html_url}\n\nA maintainer will review and merge the PR. Thank you for contributing to CSRankings!`
+                  body: `${submitterIsSponsor ? sponsorBanner : ''}## ✅ PR Created\n\nYour submission has been processed and a pull request has been created:\n\n**PR #${pr.number}**: ${pr.html_url}\n\nA maintainer will review and merge the PR. Thank you for contributing to CSRankings!`
                 });
 
                 // Add processed label


### PR DESCRIPTION
## Problem
Sponsors submit faculty changes via the form, which opens a GitHub **issue** they get email notifications about. The `💛 CSrankings Sponsor` thank-you banner is only added to the **PR body** the bot creates — but sponsors aren't notified about that bot-authored PR, so the acknowledgment was invisible to them both in email and on the issue they were watching.

## Fix
Prepend the existing `sponsorBanner` (gated by `submitterIsSponsor`) to the `✅ PR Created` comment that's posted back **on the issue** — in both the batch path (line ~811) and the single-submission path (line ~1520). This is the message that actually emails the sponsor.

No new logic or data: reuses the existing `sponsorBanner` constant and `submitterIsSponsor` check already computed in both code paths. Verified the affected sponsors (#13315 → @nguyenthanhvuh, #13209 → @gaperez64) are genuine entries in `sponsors.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)