### PR TITLE
Revert reinstatement of Junchen Jiang (University of Chicago)

### DIFF
--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -2672,7 +2672,6 @@ Junaed Sattar,University of Minnesota,http://www-users.cs.umn.edu/~junaed,cgaU4U
 Junaid Haroon Siddiqui,LUMS,https://www.junaidharoonsiddiqui.com,dvKylVEAAAAJ,0000-0002-6674-7727
 Junbeom Hur,Korea University,https://sites.google.com/korea.ac.kr/isslab/home,N2TGY7gAAAAJ,0000-0002-4823-4194
 Junchen,University of Chicago,https://people.cs.uchicago.edu/~junchenj,_8wfjeAAAAAJ,0000-0000-0000-0000
-Junchen Jiang,University of Chicago,https://people.cs.uchicago.edu/~junchenj,_8wfjeAAAAAJ,0000-0002-6877-1683
 Juncheng Li 0006,Zhejiang University,https://person.zju.edu.cn/juncheng,lm9s-QgAAAAJ,0000-0000-0000-0000
 Juncheng Wang 0001,Hong Kong Baptist University,https://www.juncheng-wang.com,sxZvGpIAAAAJ,0000-0003-1375-8382
 Juncheng Yang,Harvard University,https://seas.harvard.edu/person/juncheng-yang,P8HaQPoAAAAJ,0000-0002-0412-1139

--- a/old/industry.csv
+++ b/old/industry.csv
@@ -164,6 +164,7 @@ Jo Vermeulen,Aarhus University,http://www.jovermeulen.com,mLqdIdoAAAAJ,TBA,0000-
 John Dickerson 0001,Univ. of Maryland - College Park,http://jpdickerson.com,QgDpfCQAAAAJ,Arthur,0000-0000-0000-0000
 Joseph Austerweil,University of Wisconsin - Madison,http://alab.psych.wisc.edu,Jrn-jxQAAAAJ,Chiba Tech,0000-0000-0000-0000
 Joshua G. Tanenbaum,Univ. of California - Irvine,https://tesstanen.com/,rRJ9wTJMUB8C,TBD,0000-0000-0000-0000
+Junchen Jiang,University of Chicago,https://people.cs.uchicago.edu/~junchenj,_8wfjeAAAAAJ,Tensormesh,0000-0002-6877-1683
 Jur P. van den Berg,University of Utah,http://arl.cs.utah.edu,VjsNXysAAAAJ,TBD,0000-0000-0000-0000
 Jur van den Berg,University of Utah,http://arl.cs.utah.edu,VjsNXysAAAAJ,TBD,0000-0000-0000-0000
 Jure Leskovec,Stanford University,https://cs.stanford.edu/people/jure,Q_kKkIUAAAAJ,Chan Zuckerberg Biohub,0000-0002-5411-923X


### PR DESCRIPTION
Reverts the effect of #12953. Junchen Jiang is at **Tensormesh** (industry), so this moves the entry back from active rankings to `old/industry.csv`:

- **Remove** from `csrankings-j.csv`: `Junchen Jiang,University of Chicago,…,_8wfjeAAAAAJ,0000-0002-6877-1683`
- **Restore** to `old/industry.csv`: same entry with the `Tensormesh` company field

Net change: −1 line in csrankings-j.csv, +1 line in old/industry.csv (plus a trailing-newline fix on industry.csv's last line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)