### PR TITLE
Update University of Michigan (supersedes #12866)

### DIFF
--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -246,7 +246,6 @@ Daniel David Campbell Prince,Lancaster University,https://www.lancaster.ac.uk/sc
 Daniel Deutch,Tel Aviv University,https://www.cs.tau.ac.il/~danielde,2BnMsFIAAAAJ,0009-0001-0838-0162
 Daniel Dominic Kaplan Sleator,Carnegie Mellon University,http://www.cs.cmu.edu/~sleator,NOSCHOLARPAGE,0000-0000-0000-0000
 Daniel Dominic Sleator,Carnegie Mellon University,http://www.cs.cmu.edu/~sleator,NOSCHOLARPAGE,0000-0000-0000-0000
-Daniel E. Atkins,University of Michigan,https://www.si.umich.edu/people/daniel-atkins-iii,txEgjecAAAAJ,0000-0001-9002-9613
 Daniel E. Koditschek,University of Pennsylvania,http://www.seas.upenn.edu/~kod,K_PZFhEAAAAJ,0000-0000-0000-0000
 Daniel E. Krutz,Rochester Inst. of Technology,https://dan7800.github.io/index.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Daniel Engels,Southern Methodist University,https://datascience.smu.edu/about/leadership-and-faculty/profile/daniel-engels,NOSCHOLARPAGE,0000-0003-0761-8017
@@ -993,7 +992,6 @@ Demetrios G. Sampson,University of Piraeus,https://www.ds.unipi.gr/en/faculty/sa
 Demetrios-Dionysios Koutsouris,NTUA,http://www2.biomed.ntua.gr/%CE%B4%CE%B9%CE%B5%CF%85%CE%B8%CF%85%CE%BD%CF%84%CE%AE%CF%82,tTm7CCAAAAAJ,0000-0000-0000-0000
 Demetris Trihinas,University of Nicosia,https://www.unic.ac.cy/trihinas-demetris,FVQ4sW4AAAAJ,0000-0002-9540-7342
 Deming Chen,Univ. of Illinois at Urbana-Champaign,https://www.ece.illinois.edu/directory/profile/dchen,A_A_LrsAAAAJ,0000-0002-3016-0270
-Demosthenis Teneketzis,University of Michigan,http://web.eecs.umich.edu/~teneket,NOSCHOLARPAGE,0000-0002-0450-5992
 Deng Cai 0001,Zhejiang University,http://www.cad.zju.edu.cn/home/dengcai,vzxDyJoAAAAJ,0000-0001-9817-4065
 Deng Pan 0002,Florida International University,http://www.cs.fiu.edu/~pand,o0lXy-UAAAAJ,0000-0000-0000-0000
 Deng Tang,Shanghai Jiao Tong University,https://cs.sjtu.edu.cn/jiaoshiml/tangdeng.html,Fhn_DMsAAAAJ,0000-0002-8373-9200

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -169,7 +169,6 @@ Kanchan Manna,BITS Pilani-Goa,https://www.bits-pilani.ac.in/goa/kanchanm/Profile
 Kanchana Thilakarathna,University of Sydney,https://sydney.edu.au/engineering/people/kanchana.thilakarathna.php,V-YM7ecAAAAJ,0000-0003-4332-0082
 Kanchi Gopinath,Plaksha University,https://plaksha.edu.in/faculty-details/dr-k-gopinath,ribzpr4AAAAJ,0000-0000-0000-0000
 Kang Chen,Tsinghua University,http://madsys.cs.tsinghua.edu.cn/~kangchen,fXtFkIoAAAAJ,0000-0002-8368-1109
-Kang G. Shin,University of Michigan,http://web.eecs.umich.edu/~kgshin,vY7MdLYAAAAJ,0000-0003-0086-8777
 Kang Hao Cheong,Nanyang Technological University,https://dr.ntu.edu.sg/entities/person/Kang-Hao-Cheong,neaUULMAAAAJ,0000-0002-4475-5451
 Kang Li 0001,University of Georgia,http://cobweb.cs.uga.edu/~kangli,LLcNeeYAAAAJ,0000-0000-0000-0000
 Kang Liu 0001,Chinese Academy of Sciences,http://www.nlpr.ia.ac.cn/cip/~liukang/index.html,DtZCfl0AAAAJ,0000-0000-0000-0000
@@ -661,7 +660,6 @@ Kevin Desai,University of Texas at San Antonio,https://sites.google.com/site/kev
 Kevin Elphinstone,UNSW,http://www.cse.unsw.edu.au/~kevine,iv6Rw20AAAAJ,0000-0000-0000-0000
 Kevin Fu,Northeastern University,https://web.eecs.umich.edu/~kevinfu,pZQuSyUAAAAJ,0000-0000-0000-0000
 Kevin G. Stanley,University of Victoria,https://www.uvic.ca/ecs/computerscience/people/faculty/profiles/stanley-kevin.php,ZDM1VzwAAAAJ,0000-0000-0000-0000
-Kevin J. Compton,University of Michigan,http://web.eecs.umich.edu/~kjc,NOSCHOLARPAGE,0000-0000-0000-0000
 Kevin Jamieson 0001,University of Washington,https://homes.cs.washington.edu/~jamieson/about.html,dq3yXjkAAAAJ,0000-0003-2054-2985
 Kevin Jeffay,University of North Carolina,http://jeffay.web.unc.edu,J12C3nYAAAAJ,0000-0000-0000-0000
 Kevin K. Y. Kuan,University of Sydney,http://sydney.edu.au/engineering/people/kevin.kuan.php,nxiGa3EAAAAJ,0000-0000-0000-0000

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -792,7 +792,7 @@ Mario Szegedy,Rutgers University,https://people.cs.rutgers.edu/~szegedy/homepage
 Mario Sánchez 0001,Universidad de los Andes,http://profesores.virtual.uniandes.edu.co/mar-san1,M1CE-nIAAAAJ,0000-0000-0000-0000
 Mario Vento,University of Salerno,http://mivia.unisa.it/people/vento,3PwXGpgAAAAJ,0000-0002-2948-741X
 Mariofanna Milanova,Univ. of Arkansas - Little Rock,http://ualr.academia.edu/MariofannaMilanova,oJr0BfEAAAAJ,0000-0003-0995-1921
-Marios C. Papaefthymiou,University of Michigan,http://web.eecs.umich.edu/~marios,NOSCHOLARPAGE,0000-0000-0000-0000
+Marios C. Papaefthymiou,Univ. of California - Irvine,https://ics.uci.edu/~marios/,NOSCHOLARPAGE,0000-0000-0000-0000
 Marios Christou,University of Nicosia,https://www.unic.ac.cy/christou-marios,NOSCHOLARPAGE,0000-0000-0000-0000
 Marios Fokaefs,Polytechnique Montreal,https://www.polymtl.ca/expertises/en/fokaefs-marios-eleftherios,CFKjCQQAAAAJ,0000-0000-0000-0000
 Marios Kogias,Imperial College London,https://marioskogias.github.io,DYzTOKYAAAAJ,0009-0006-7034-5284

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -2383,7 +2383,6 @@ Stéphane Ducasse,CRIStAL,http://stephane.ducasse.free.fr,7fHNqtoAAAAJ,0000-0000
 Stéphane Huot,CRIStAL,https://www.cristal.univ-lille.fr/profil/huot,hSznLJ8AAAAJ,0000-0003-2300-0815
 Stéphane Janot,CRIStAL,https://www.cristal.univ-lille.fr/profil/janot,NOSCHOLARPAGE,0000-0000-0000-0000
 Stéphane Julia,UFU,http://www.ppgco.facom.ufu.br/pt-br/pessoas/stephane-julia,NOSCHOLARPAGE,0000-0000-0000-0000
-Stéphane Lafortune,University of Michigan,https://wiki.eecs.umich.edu/stephane/index.php/St%C3%A9phane_Lafortune,5wgTi1AAAAAJ,0000-0002-7526-6642
 Stéphane Mallat,Ecole Normale Superieure,https://www.di.ens.fr/~mallat,g_YTmSgAAAAJ,0000-0000-0000-0000
 Stéphane S. Somé,University of Ottawa,http://www.site.uottawa.ca/~ssome,gZvSWooAAAAJ,0000-0000-0000-0000
 Stéphane Sotèg Somé,University of Ottawa,http://www.site.uottawa.ca/~ssome,gZvSWooAAAAJ,0000-0000-0000-0000

--- a/old/emeritus.csv
+++ b/old/emeritus.csv
@@ -54,6 +54,7 @@ Costas J. Spanos,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/F
 Dan Gusfield,Univ. of California - Davis,http://www.cs.ucdavis.edu/~gusfield,VoAHydgAAAAJ,0000-0000-0000-0000
 Dana Angluin,Yale University,http://cpsc.yale.edu/people/dana-angluin,bxi6JXYAAAAJ,0000-0000-0000-0000
 Dana S. Scott,Carnegie Mellon University,http://www.cs.cmu.edu/~scott,EsIyIQsAAAAJ,0000-0000-0000-0000
+Daniel E. Atkins,University of Michigan,https://www.si.umich.edu/people/daniel-atkins-iii,txEgjecAAAAJ,0000-0001-9002-9613
 Daniel Gusfield,Univ. of California - Davis,http://www.cs.ucdavis.edu/~gusfield,VoAHydgAAAAJ,0000-0000-0000-0000
 Daoxu Chen,Nanjing University,https://cs.nju.edu.cn/58/29/c2639a153641/page.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 David A. Padua,Univ. of Illinois at Urbana-Champaign,http://polaris.cs.uiuc.edu/~padua,QaLf6bEAAAAJ,0000-0000-0000-0000
@@ -64,6 +65,7 @@ David P. Dobkin,Princeton University,https://www.cs.princeton.edu/people/profile
 David R. Cheriton,Stanford University,http://web.stanford.edu/~cheriton,NOSCHOLARPAGE,0000-0000-0000-0000
 Deborah G. Tatar,Virginia Tech,https://thirdlab.cs.vt.edu/people/deborah-tatar,LWcEVAIAAAAJ,0000-0000-0000-0000
 Debra J. Richardson,Univ. of California - Irvine,http://www.ics.uci.edu/~djr,vL6ubpMAAAAJ,0000-0002-8202-9274
+Demosthenis Teneketzis,University of Michigan,http://web.eecs.umich.edu/~teneket,NOSCHOLARPAGE,0000-0002-0450-5992
 Dennis G. Kafura,Virginia Tech,http://people.cs.vt.edu/~kafura,rWuQTEcAAAAJ,0000-0000-0000-0000
 Derek G. Corneil,University of Toronto,http://www.cs.toronto.edu/theory/Corneil-bio.htm/,XiTfJCsAAAAJ,0000-0000-0000-0000
 Dexter Campbell Kozen,Cornell University,http://www.cs.cornell.edu/~kozen,LV1qWjgAAAAJ,0000-0000-0000-0000
@@ -161,6 +163,7 @@ Judea Pearl,Univ. of California - Los Angeles,http://bayes.cs.ucla.edu/jp_home.h
 Judith S. Olson,Univ. of California - Irvine,https://judithsolson.com,xfwOz_kAAAAJ,0000-0000-0000-0000
 K. Mani Chandy,California Inst. of Technology,https://www.eas.caltech.edu/people/mani,_e1E9DQAAAAJ,0000-0000-0000-0000
 Kai H. Chang,Auburn University,http://www.eng.auburn.edu/~kchang,NOSCHOLARPAGE,0000-0000-0000-0000
+Kang G. Shin,University of Michigan,http://web.eecs.umich.edu/~kgshin,vY7MdLYAAAAJ,0000-0003-0086-8777
 Kang Zhang 0001,University of Texas at Dallas,http://www.utdallas.edu/~kzhang,cdzVY_QAAAAJ,0000-0003-3802-7535
 Karl N. Levitt,Univ. of California - Davis,http://faculty.engineering.ucdavis.edu/levitt,NOSCHOLARPAGE,0000-0000-0000-0000
 Keh-Hsun Chen,UNC - Charlotte,https://webpages.uncc.edu/chen,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -168,6 +171,7 @@ Ken Baclawski,Northeastern University,http://www.ccs.neu.edu/home/kenb,Vwi6Ya8AA
 Kendra Cooper,University of Texas at Dallas,https://www.utdallas.edu/~kcooper,mwSaet0AAAAJ,0000-0000-0000-0000
 Kendra M. L. Cooper,University of Texas at Dallas,https://www.utdallas.edu/~kcooper,mwSaet0AAAAJ,0000-0000-0000-0000
 Kenneth Salisbury,Stanford University,https://med.stanford.edu/profiles/john-salisbury,FmrDR68AAAAJ,0000-0000-0000-0000
+Kevin J. Compton,University of Michigan,http://web.eecs.umich.edu/~kjc,NOSCHOLARPAGE,0000-0000-0000-0000
 Kok-Ming Leung,New York University,http://engineering.nyu.edu/people/kok-ming-leung,NOSCHOLARPAGE,0000-0000-0000-0000
 Kurt Keutzer,Univ. of California - Berkeley,https://people.eecs.berkeley.edu/~keutzer,IzaagZkAAAAJ,0000-0000-0000-0000
 Kwong-Sak Leung,Chinese University of Hong Kong,http://www.cs.cuhk.edu.hk/~ksleung,x--r9cIAAAAJ,0000-0000-0000-0000
@@ -301,6 +305,7 @@ Steven M. Nowick,Columbia University,http://www.cs.columbia.edu/~nowick,gaXiAekA
 Steven P. Reiss,Brown University,http://cs.brown.edu/~spr,fn3HR4YAAAAJ,0000-0003-0942-1883
 Stuart A. Kurtz,University of Chicago,http://people.cs.uchicago.edu/~stuart,VvszaMQAAAAJ,0000-0000-0000-0000
 Stuart Smith,University of Massachusetts Lowell,https://www.uml.edu/Sciences/computer-science/faculty/emeritus-faculty/smith-stuart.aspx,PLH8f6MAAAAJ,0000-0000-0000-0000
+Stéphane Lafortune,University of Michigan,https://wiki.eecs.umich.edu/stephane/index.php/St%C3%A9phane_Lafortune,5wgTi1AAAAAJ,0000-0002-7526-6642
 Susanne E. Hambrusch,Purdue University,https://www.cs.purdue.edu/people/seh,NOSCHOLARPAGE,0000-0000-0000-0000
 Thomas H. Cormen,Dartmouth College,http://www.cs.dartmouth.edu/~thc,V5FJ6pIAAAAJ,0000-0000-0000-0000
 Todd F. Dupont,University of Chicago,http://people.cs.uchicago.edu/~dupont,BCRISEEAAAAJ,0000-0000-0000-0000


### PR DESCRIPTION
Re-applies the intent of #12866 ("Update University of Michigan", by @andrewcrotty) cleanly onto the current `gh-pages`. The original PR became unmergeable because `gh-pages` moved on (e.g. `Debra J. Richardson` was inserted into `old/emeritus.csv` adjacent to one of its anchors).

## Changes
Retire 5 Michigan emeritus faculty — removed from the active `csrankings-[d/k/s].csv` files and added to `old/emeritus.csv` in alphabetical order:
- Daniel E. Atkins
- Demosthenis Teneketzis
- Kang G. Shin
- Kevin J. Compton
- Stéphane Lafortune

Institution move (stays active):
- Marios C. Papaefthymiou: University of Michigan → `Univ. of California - Irvine`

The original PR's unrelated reorder of two duplicate `Rajsekar Manokaran` rows in `old/industry.csv` was intentionally omitted (a no-op).

Net diff: `5 files changed, 6 insertions(+), 6 deletions(-)`; CRLF line endings preserved.

Closes #12866.
