### PR TITLE
Update Georgia Institute of Technology (supersedes #13069)

### DIFF
--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -370,7 +370,6 @@ Afsaneh Doryab,University of Virginia,https://www.afsanehdoryab.com,O0lONMkAAAAJ
 Afsaneh Razi,Drexel University,https://www.afsanehrazi.com,sV43f5AAAAAJ,0000-0001-5829-8004
 Afzel Noore,West Virginia University,https://www.statler.wvu.edu/faculty-staff/adjunct-faculty/afzel-noore,rEopbiMAAAAJ,0000-0000-0000-0000
 Agata Ciabattoni,TU Wien,https://www.logic.at/staff/agata,pAyqI0wAAAAJ,0000-0001-6947-8772
-Agata Rozga,Georgia Institute of Technology,http://www.agatarozga.org,LAuxzv0AAAAJ,0000-0002-5558-9786
 Agathoniki Trigoni,University of Oxford,https://www.cs.ox.ac.uk/niki.trigoni,185g9ckAAAAJ,0000-0000-0000-0000
 Aggeliki Arapoyanni,University of Athens,http://www.di.uoa.gr/eng/staff/1012,NOSCHOLARPAGE,0000-0000-0000-0000
 Aggelos K. Katsaggelos,Northwestern University,http://www.mccormick.northwestern.edu/research-faculty/directory/profiles/katsaggelos-aggelos.html,aucB85kAAAAJ,0000-0003-4554-0070

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -454,13 +454,13 @@ Charles E. Hughes,University of Central Florida,http://www.cs.ucf.edu/~ceh,pbb9C
 Charles E. Leiserson,Massachusetts Inst. of Technology,http://people.csail.mit.edu/cel,gWBoNCsAAAAJ,0000-0001-6386-5552
 Charles E. McDowell,Univ. of California - Santa Cruz,https://www.soe.ucsc.edu/people/charlie,vizwcbsAAAAJ,0000-0000-0000-0000
 Charles Gretton,Australian National University,https://cecs.anu.edu.au/people/charles-gretton,C6mgJ_QAAAAJ,0000-0001-9803-0168
-Charles Isbell,Georgia Institute of Technology,http://www.cc.gatech.edu/fac/Charles.Isbell,NOSCHOLARPAGE,0000-0000-0000-0000
+Charles Isbell,Univ. of Illinois at Urbana-Champaign,https://chancellor.illinois.edu/about/,NOSCHOLARPAGE,0000-0000-0000-0000
 Charles J. Colbourn,Arizona State University,http://www.public.asu.edu/~ccolbou,NOSCHOLARPAGE,0000-0000-0000-0000
 Charles Joseph Colbourn,Arizona State University,http://www.public.asu.edu/~ccolbou,NOSCHOLARPAGE,0000-0000-0000-0000
 Charles K. Nicholas,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~nicholas/charles_nicholas.html,i3uLKmkAAAAJ,0000-0000-0000-0000
 Charles L. A. Clarke,University of Waterloo,https://plg.uwaterloo.ca/~claclark,TkVleDIAAAAJ,0000-0001-8178-9194
-Charles L. Isbell Jr.,Georgia Institute of Technology,http://www.cc.gatech.edu/fac/Charles.Isbell,NOSCHOLARPAGE,0000-0000-0000-0000
-Charles Lee Isbell Jr.,Georgia Institute of Technology,http://www.cc.gatech.edu/fac/Charles.Isbell,NOSCHOLARPAGE,0000-0000-0000-0000
+Charles L. Isbell Jr.,Univ. of Illinois at Urbana-Champaign,https://chancellor.illinois.edu/about/,NOSCHOLARPAGE,0000-0000-0000-0000
+Charles Lee Isbell Jr.,Univ. of Illinois at Urbana-Champaign,https://chancellor.illinois.edu/about/,NOSCHOLARPAGE,0000-0000-0000-0000
 Charles Markham,Maynooth University,https://www.maynoothuniversity.ie/faculty-science-engineering/our-people/charles-markham,YCBu9rkAAAAJ,0000-0003-2447-2611
 Charles Martin 0001,Australian National University,http://cs.anu.edu.au/people/charles-martin,mTlH4G8AAAAJ,0000-0001-5683-7529
 Charles Nicholas,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~nicholas/charles_nicholas.html,i3uLKmkAAAAJ,0000-0001-9494-7139
@@ -1608,7 +1608,6 @@ Cássio V. S. Prazeres,Federal University of Bahia,https://computacao.ufba.br/pt
 Cécile Murat,Université Paris Dauphine,https://www.lamsade.dauphine.fr/~murat,NOSCHOLARPAGE,0000-0000-0000-0000
 Cédric Dumoulin,CRIStAL,http://cristal.univ-lille.fr/~dumoulin,mmKnPuMAAAAJ,0000-0000-0000-0000
 Cédric Lhoussaine,CRIStAL,https://www.cristal.univ-lille.fr/profil/lhoussai,NOSCHOLARPAGE,0000-0000-0000-0000
-Cédric Pradalier,Georgia Institute of Technology,https://research.gatech.edu/people/cedric-pradalier,4_1DZoYAAAAJ,0000-0000-0000-0000
 Célia A. Z. Barcelos,UFU,http://www.ppgco.facom.ufu.br/en/pessoas/celia-aparecida-zorzo-barcelos,f9fPNbsAAAAJ,0000-0000-0000-0000
 Célia A. Zorzo Barcelos,UFU,http://www.ppgco.facom.ufu.br/en/pessoas/celia-aparecida-zorzo-barcelos,f9fPNbsAAAAJ,0000-0000-0000-0000
 Célia G. Ralha,Universidade de Brasília,http://cic.unb.br/~ghedini,c6JLbaUAAAAJ,0000-0000-0000-0000

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -700,7 +700,6 @@ David Jackson 0001,University of Liverpool,https://cgi.csc.liv.ac.uk/~dave,NOSCH
 David Jao,University of Waterloo,https://djao.math.uwaterloo.ca,uj3Xx8IAAAAJ,0000-0002-8073-1692
 David John Hawkes,University College London,http://cmic.cs.ucl.ac.uk/staff/dave_hawkes,O42T24CT_GwC,0000-0000-0000-0000
 David Jones,University College London,http://www.cs.ucl.ac.uk/staff/D.Jones,yRb0DnQAAAAJ,0000-0002-8152-6818
-David Joyner,Georgia Institute of Technology,https://www.ic.gatech.edu/people/david-joyner,yaCigtkAAAAJ,0000-0000-0000-0000
 David Juedes,Ohio University,http://oucsace.cs.ohiou.edu/~juedes,eTFiw7wAAAAJ,0000-0002-1656-5781
 David Jurgens,University of Michigan,https://www.si.umich.edu/node/15080,sGFFr5kAAAAJ,0000-0002-2135-9878
 David K. Duvenaud,University of Toronto,http://www.cs.toronto.edu/~duvenaud,ZLpO3XQAAAAJ,0000-0000-0000-0000

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -1940,7 +1940,6 @@ John T. Hale,Johns Hopkins University,https://cogsci.jhu.edu/directory/john-t-ha
 John T. Minor,University of Nevada Las Vegas,https://www.unlv.edu/people/dr-john-minor,NOSCHOLARPAGE,0000-0000-0000-0000
 John T. O'Donnell,University of Glasgow,http://www.dcs.gla.ac.uk/~jtod,NOSCHOLARPAGE,0000-0000-0000-0000
 John T. Paxton,Montana State University,https://www.cs.montana.edu/directory/1524459/john-paxton,gkIyoEQAAAAJ,0000-0000-0000-0000
-John T. Stasko,Georgia Institute of Technology,http://www.cc.gatech.edu/~john.stasko,2PxFftgAAAAJ,0000-0003-4129-7659
 John Tang Boyland,Univ. of Wisconsin - Milwaukee,http://www.cs.uwm.edu/faculty/boyland,I4lFc4IAAAAJ,0000-0002-1048-8850
 John Thangarajah,RMIT University,http://john.agentprojects.com,bGu9cEsAAAAJ,0000-0002-7699-6444
 John Thickstun,Cornell University,https://johnthickstun.com,RkuzIZMAAAAJ,0000-0003-1268-8677

--- a/old/emeritus.csv
+++ b/old/emeritus.csv
@@ -153,6 +153,7 @@ John Mylopoulos,University of Toronto,http://www.cs.toronto.edu/~jm/,mQ6mh20AAAA
 John P. Hayes,University of Michigan,http://web.eecs.umich.edu/~jhayes,a-qMWpwAAAAJ,0000-0002-4747-492X
 John Patrick Hayes,University of Michigan,http://web.eecs.umich.edu/~jhayes,a-qMWpwAAAAJ,0000-0000-0000-0000
 John R. Kender,Columbia University,http://www.cs.columbia.edu/~jrk,RBuoCYEAAAAJ,0000-0000-0000-0000
+John T. Stasko,Georgia Institute of Technology,http://www.cc.gatech.edu/~john.stasko,2PxFftgAAAAJ,0000-0003-4129-7659
 Jonathan Turner,Washington University in St. Louis,http://www.arl.wustl.edu/~jst,Cgx9W6UAAAAJ,0000-0000-0000-0000
 Joseph J. DiStefano III,Univ. of California - Los Angeles,http://www.cs.ucla.edu/joseph-distefano-iii,NOSCHOLARPAGE,0000-0000-0000-0000
 Joseph L. Zachary,University of Utah,https://www.cs.utah.edu/~zachary,hOCBMzIAAAAJ,0000-0000-0000-0000


### PR DESCRIPTION
Re-applies the intent of #13069 ("Update Georgia Institute of Technology", by @andrewcrotty) cleanly onto the current `gh-pages`. The original PR became unmergeable because `gh-pages` moved on since it was opened.

## Changes
Remove (not tenure-track / not main campus) from the active CSVs:
- Agata Rozga (`csrankings-a.csv`)
- Cédric Pradalier (`csrankings-c.csv`)
- David Joyner (`csrankings-d.csv`)

Retire to emeritus:
- John T. Stasko (`csrankings-j.csv` → `old/emeritus.csv`)

Institution move:
- Charles Isbell / Charles L. Isbell Jr. / Charles Lee Isbell Jr.: Georgia Institute of Technology → `Univ. of Illinois at Urbana-Champaign`

The original PR's regenerated `csrankings.min.js` (build artifact, rebuilt by CI) and its unrelated reorder of two duplicate `Rajsekar Manokaran` rows in `old/industry.csv` were intentionally omitted.

Net diff: `5 files changed, 4 insertions(+), 7 deletions(-)`; CRLF line endings preserved.

Closes #13069.
