### PR TITLE
Require valid ORCID for all new and updated entries

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,7 @@ Delete any lines that don't apply to your PR.
 - [ ] Name matches [DBLP](https://dblp.org) exactly (including 0001 suffixes)[^8]
 - [ ] Homepage URL works and shows name + affiliation[^9]
 - [ ] Google Scholar ID is the 12-character code only[^10]
+- [ ] Valid ORCID provided (not placeholder zeros)[^16]
 
 ### Eligibility
 - [ ] Faculty is full-time, tenure-track[^11]
@@ -45,3 +46,4 @@ Delete any lines that don't apply to your PR.
 [^13]: E.g., courtesy appointment in CS, or graduate program membership. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#non-cs-dept)
 [^14]: Institution must be added to `institutions.csv` first by maintainer. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#new-institution)
 [^15]: Partial departments skew rankings; all-or-nothing ensures fairness. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#entire-dept)
+[^16]: ORCID is required for all new and updated entries. [Register for an ORCID iD](https://support.orcid.org/hc/en-us/articles/360006897454-How-do-I-register-for-an-ORCID-ID) if you don't have one. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#orcid)

--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -400,6 +400,11 @@ jobs:
                   const scholarid = parseField(body, 'Google Scholar ID') || parseField(body, 'Scholar ID');
                   const orcid = parseField(body, 'ORCID') || '0000-0000-0000-0000';
 
+                  if (orcid === '0000-0000-0000-0000') {
+                    core.warning(`Issue #${issue.number}: Missing required ORCID — skipping`);
+                    continue;
+                  }
+
                   if (name && homepage && scholarid) {
                     entries.push({
                       name,
@@ -983,12 +988,13 @@ jobs:
                     }
                   }
 
-                  if (!institution || !homepage || !scholarid) {
+                  if (!institution || !homepage || !scholarid || !orcid || orcid === '0000-0000-0000-0000') {
+                    const orcidMissing = !orcid || orcid === '0000-0000-0000-0000';
                     await github.rest.issues.createComment({
                       owner: context.repo.owner,
                       repo: context.repo.repo,
                       issue_number: issue.number,
-                      body: `## ❌ Missing required fields\n\nCould not parse all required fields:\n- Name: ${name || '❌ missing'}\n- Institution: ${institution || '❌ missing'}\n- Homepage: ${homepage || '❌ missing'}\n- Scholar ID: ${scholarid || '❌ missing'}`
+                      body: `## ❌ Missing required fields\n\nCould not parse all required fields:\n- Name: ${name || '❌ missing'}\n- Institution: ${institution || '❌ missing'}\n- Homepage: ${homepage || '❌ missing'}\n- Scholar ID: ${scholarid || '❌ missing'}\n- ORCID: ${orcidMissing ? '❌ missing — [Register for an ORCID iD](https://support.orcid.org/hc/en-us/articles/360006897454-How-do-I-register-for-an-ORCID-ID)' : orcid}`
                     });
                     await github.rest.issues.addLabels({
                       owner: context.repo.owner,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,12 @@ Insert new faculty **in alphabetical order** (not at the end) in the appropriate
 <a id="csv-format"></a>
 ### CSV formatting
 
-Check to make sure that you have no spaces after commas, or any missing fields. Each line must have exactly four comma-separated values.
+Check to make sure that you have no spaces after commas, or any missing fields. Each line must have exactly five comma-separated values (name, affiliation, homepage, Google Scholar ID, ORCID).
+
+<a id="orcid"></a>
+### ORCID (required)
+
+A valid ORCID iD is required for all new and updated entries. The placeholder value `0000-0000-0000-0000` is not accepted. If you do not have an ORCID, [register for one here](https://support.orcid.org/hc/en-us/articles/360006897454-How-do-I-register-for-an-ORCID-ID) — it only takes a few seconds. ORCID enables reliable name disambiguation and links publications across systems.
 
 <a id="homepage"></a>
 ### Homepage
@@ -92,7 +97,7 @@ Faculty must be able to *solely* advise PhD students for a degree in Computer Sc
 
 <a id="updating"></a>
 
-Update affiliations, home pages, and Google Scholar entries by modifying `csrankings-[a-z].csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put `NOSCHOLARPAGE`.
+Update affiliations, home pages, and Google Scholar entries by modifying `csrankings-[a-z].csv`. For the Google Scholar entry, just use the alphanumeric identifier in the middle of the URL. If none is there, put `NOSCHOLARPAGE`. A valid ORCID is required for all updates — [register for one](https://support.orcid.org/hc/en-us/articles/360006897454-How-do-I-register-for-an-ORCID-ID) if you don't have one.
 
 ---
 

--- a/submit/index.html
+++ b/submit/index.html
@@ -172,15 +172,15 @@
                     <!-- ORCID Field -->
                     <div class="form-group" id="orcid-group">
                         <label for="orcid" class="col-sm-3 control-label">
-                            ORCID
+                            ORCID <span class="required">*</span>
                         </label>
                         <div class="col-sm-9">
                             <input type="text" class="form-control" id="orcid"
-                                   placeholder="0000-0000-0000-0000">
+                                   placeholder="0000-0000-0000-0000" required>
                             <span id="orcid-status" class="help-block status"></span>
                             <p class="help-block">
-                                16-digit identifier from <a href="https://orcid.org" target="_blank">orcid.org</a>.
-                                Leave as 0000-0000-0000-0000 if you don't have one.
+                                A valid ORCID is required for all submissions.
+                                <a href="https://support.orcid.org/hc/en-us/articles/360006897454-How-do-I-register-for-an-ORCID-ID" target="_blank">Register for an ORCID iD</a> if you don't have one.
                                 <a href="#" id="search-orcid-link" target="_blank" style="display:none;">Search ORCID for your name</a>
                                 <a href="#" id="test-orcid-link" target="_blank" style="display:none;">Verify on ORCID</a>
                             </p>

--- a/submit/submit.js
+++ b/submit/submit.js
@@ -1629,13 +1629,9 @@ function validateOrcid() {
         return;
     }
     const orcid = document.getElementById('orcid').value.trim();
-    // Empty or placeholder is valid (ORCID is optional)
+    // ORCID is required - empty or placeholder is not accepted
     if (!orcid || orcid === '0000-0000-0000-0000') {
-        // Set to placeholder if empty
-        if (!orcid) {
-            document.getElementById('orcid').value = '0000-0000-0000-0000';
-        }
-        setFieldStatus('orcid', 'valid', 'Optional - no ORCID provided');
+        setFieldStatus('orcid', 'error', 'A valid ORCID is required. <a href="https://support.orcid.org/hc/en-us/articles/360006897454-How-do-I-register-for-an-ORCID-ID" target="_blank">Register for an ORCID iD</a> if you don\'t have one.');
         updatePreview();
         return;
     }

--- a/util/validate_commit.py
+++ b/util/validate_commit.py
@@ -78,9 +78,10 @@ def has_valid_google_scholar_id(s: str) -> bool:
     return s == 'NOSCHOLARPAGE' or bool(re.fullmatch(r'^[a-zA-Z0-9_-]{11}[CJ]$', s))
 
 def has_valid_orcid(s: str) -> bool:
-    """Check if ORCID has valid format (0000-0000-0000-000X where X is 0-9 or X)."""
+    """Check if ORCID has valid format (0000-0000-0000-000X where X is 0-9 or X).
+    Note: placeholder 0000-0000-0000-0000 passes format check but is rejected at the call site."""
     if s == '0000-0000-0000-0000':
-        return True  # Placeholder for no ORCID
+        return True  # Valid format, but rejected as insufficient by caller
     return bool(re.fullmatch(r'^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$', s))
 
 def check_excel_corruption(line: str) -> Optional[str]:
@@ -558,11 +559,14 @@ def process_csv_diff(diff_path: str) -> bool:
                             else:
                                 pass
                                 # print(f"{index}.\t{INFO}\tName ({name}) found on given Google Scholar page ({gs_url}).")
-                    # Validate ORCID format
+                    # Validate ORCID format (ORCID is required for all new/updated entries)
                     if not has_valid_orcid(orcid):
                         print(f"{index}.\t{ERROR}\t{CHECKBOX_REFS['orcid']} Invalid ORCID format: {orcid}")
                         valid = False
-                    elif orcid != '0000-0000-0000-0000':
+                    elif orcid == '0000-0000-0000-0000':
+                        print(f"{index}.\t{ERROR}\t{CHECKBOX_REFS['orcid']} A valid ORCID is required. Register at https://support.orcid.org/hc/en-us/articles/360006897454-How-do-I-register-for-an-ORCID-ID")
+                        valid = False
+                    else:
                         print(f"{index}.\t{INFO}\tORCID ({orcid}) has valid format.")
                 except Exception as e:
                     print(f"{index}.\tProcessing error: {e}")

--- a/util/validate_prs.py
+++ b/util/validate_prs.py
@@ -368,8 +368,8 @@ def check_red_flags(person: dict) -> list[str]:
             flags.append("NOSCHOLARPAGE with no ORCID")
         else:
             flags.append("NOSCHOLARPAGE (but ORCID provided)")
-    if person.get("orcid") == "0000-0000-0000-0000":
-        flags.append("Placeholder ORCID (all zeros)")
+    if person.get("orcid", "0000-0000-0000-0000") == "0000-0000-0000-0000":
+        flags.append("MISSING ORCID (required) — register at https://support.orcid.org/hc/en-us/articles/360006897454-How-do-I-register-for-an-ORCID-ID")
     if re.search(r'\d{4}$', person.get("name", "")):
         flags.append("DBLP disambiguated name")
     return flags

--- a/util/validate_submission.py
+++ b/util/validate_submission.py
@@ -27,9 +27,10 @@ def has_valid_google_scholar_id(scholar_id: str) -> bool:
 
 
 def has_valid_orcid(orcid: str) -> bool:
-    """Check if ORCID has valid format (0000-0000-0000-000X where X is 0-9 or X)."""
+    """Check if ORCID has valid format (0000-0000-0000-000X where X is 0-9 or X).
+    Note: placeholder 0000-0000-0000-0000 passes format check but is rejected at the call site."""
     if orcid == '0000-0000-0000-0000':
-        return True  # Placeholder for no ORCID
+        return True  # Valid format, but rejected as insufficient by caller
     return bool(re.fullmatch(r'^\d{4}-\d{4}-\d{4}-\d{3}[\dX]$', orcid))
 
 
@@ -408,12 +409,12 @@ def main():
     else:
         print("  ✓ Found exact match")
 
-    # 5. Check ORCID (optional field)
+    # 5. Check ORCID (required field)
     print("Checking ORCID...")
     if not has_valid_orcid(args.orcid):
-        errors.append(f"- **ORCID**: Invalid format. Must be `0000-0000-0000-0000` format or placeholder. Got: `{args.orcid}`")
+        errors.append(f"- **ORCID**: Invalid format. Must be `0000-0000-0000-000X` format (16 digits with dashes). Got: `{args.orcid}`")
     elif args.orcid == '0000-0000-0000-0000':
-        print("  ✓ Placeholder (no ORCID)")
+        errors.append("- **ORCID**: A valid ORCID is required for all submissions. [Register for an ORCID iD](https://support.orcid.org/hc/en-us/articles/360006897454-How-do-I-register-for-an-ORCID-ID) if you don't have one.")
     else:
         print(f"  ✓ Valid format: {args.orcid}")
 


### PR DESCRIPTION
## Summary
- ORCID is now a **required** field for all new submissions and updates (placeholder `0000-0000-0000-0000` rejected)
- Enforced across: submission form, `validate_commit.py`, `validate_submission.py`, `validate_prs.py`, and the `process-submission` GitHub Actions workflow
- Contributors without an ORCID are directed to register: https://support.orcid.org/hc/en-us/articles/360006897454-How-do-I-register-for-an-ORCID-ID
- PR template and CONTRIBUTING.md updated to document the policy

## Motivation
ORCID enables reliable name disambiguation and links publications across systems. Making it mandatory improves data quality and reduces manual verification burden for ambiguous entries.

## Test plan
- [ ] Submit form rejects empty/placeholder ORCID with error message and registration link
- [ ] Submit form accepts valid ORCID format (e.g., `0000-0002-8295-9252`)
- [ ] `validate_commit.py` fails PRs with placeholder ORCID in added CSV lines
- [ ] `validate_submission.py` reports error for placeholder ORCID
- [ ] GitHub Actions workflow skips batch entries without ORCID; single submissions get "missing fields" comment
- [ ] Existing entries with placeholder ORCID are NOT affected (only new/changed lines validated)