### PR TITLE
Remove Buğra Çaşkurlu from TOBB ETÜ faculty

### DIFF
--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -993,7 +993,6 @@ Brygg Ullmer,Clemson University,https://people.computing.clemson.edu/~bullmer,Jx
 Bu-Sung Lee,Nanyang Technological University,https://dr.ntu.edu.sg/cris/rp/rp00531,TyytTfQAAAAJ,0000-0001-7828-7900
 Bud Mishra,New York University,https://cs.nyu.edu/mishra,kXVBr20AAAAJ,0000-0000-0000-0000
 Budi Arief,University of Kent,https://www.cs.kent.ac.uk/people/staff/ba284,bSZk250AAAAJ,0000-0002-1830-1587
-Bugra Çaskurlu,TOBB ETÜ,http://bugracaskurlu.etu.edu.tr,yLgnAu0AAAAJ,0000-0000-0000-0000
 Bui Quang Minh,Australian National University,https://cecs.anu.edu.au/people/minh-bui,UI0xN_QAAAAJ,0000-0002-5535-6560
 Bulat Ibragimov,University of Copenhagen,https://di.ku.dk/english/staff/vip/researchers_image/?pure=en/persons/644987,IPQZ4bkAAAAJ,0000-0001-8540-0684
 Bumsub Ham,Yonsei University,https://cvlab.yonsei.ac.kr,agL5G5wAAAAJ,0000-0002-3443-8161
@@ -1015,7 +1014,6 @@ Burton Rosenberg,University of Miami,http://www.cs.miami.edu/~burt,NOSCHOLARPAGE
 Buru Chang,Korea University,https://lilab.korea.ac.kr,5Qa2Uw0AAAAJ,0000-0002-7595-9035
 Buser Say,Monash University,https://research.monash.edu/en/persons/buser-say,2PIZ6xUAAAAJ,0000-0003-2822-5909
 Buzhou Tang,Harbin Institute of Technology,http://faculty.hitsz.edu.cn/tangbuzhou,5oGXsxUAAAAJ,0000-0003-0271-8246
-Buğra Çaşkurlu,TOBB ETÜ,http://bugracaskurlu.etu.edu.tr,yLgnAu0AAAAJ,0000-0000-0000-0000
 Byonghyo Shim,Seoul National University,https://isl.snu.ac.kr/members_1/professor,pL1HDE8AAAAJ,0000-0001-5051-1763
 Byoung-Tak Zhang,Seoul National University,https://bi.snu.ac.kr/~btzhang,sYTUOu8AAAAJ,0000-0001-9890-0389
 Byoungyoung Lee,Seoul National University,https://lifeasageek.github.io,AoDgrKIAAAAJ,0000-0001-7746-0572


### PR DESCRIPTION
## Summary

Removes two rows for **Buğra Çaşkurlu** (ASCII + Turkish spellings) from `csrankings-b.csv`. He is no longer at TOBB ETÜ Computer Engineering.

### Removed
- `Bugra Çaskurlu,TOBB ETÜ,http://bugracaskurlu.etu.edu.tr,yLgnAu0AAAAJ,0000-0000-0000-0000`
- `Buğra Çaşkurlu,TOBB ETÜ,http://bugracaskurlu.etu.edu.tr,yLgnAu0AAAAJ,0000-0000-0000-0000`

Follow-up to #13054 (which updated the rest of the TOBB ETÜ roster).