### PR TITLE
Add 5 faculty from HKUST (consolidated: #13509, #13606, #13607, #13619)

### DIFF
--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -2501,6 +2501,7 @@ Mingxing Zhang,Tsinghua University,https://madsys.cs.tsinghua.edu.cn/~zhangmx,ak
 Mingxuan Sun,Louisiana State University,https://csc.lsu.edu/~msun,1oQ3NnEAAAAJ,0000-0000-0000-0000
 Mingxue Zhang 0001,Zhejiang University,https://zhangmx1997.github.io,73M-epsAAAAJ,0000-0001-8863-8751
 Mingxun Wang,Univ. of California - Riverside,https://www.cs.ucr.edu/~mingxunw,jMvg4eMAAAAJ,0000-0000-0000-0000
+Mingxun Zhou,HKUST,https://wuwuz.github.io/,N3k-0vsAAAAJ,0000-0001-6034-9245
 Mingyan Liu,University of Michigan,http://web.eecs.umich.edu/~mingyan,WiIM-MgAAAAJ,0000-0003-3295-9200
 Mingyang Yi,Renmin University of China,https://mingyangyi.github.io,RlOZiPUAAAAJ,0009-0005-2336-0687
 Mingyi He,NWPU,http://dianzi.nwpu.edu.cn/info/1269/5955.htm,gLnLpAsAAAAJ,0000-0003-2051-6955

--- a/csrankings-x.csv
+++ b/csrankings-x.csv
@@ -305,6 +305,7 @@ Xiaoman Shawn Li,University of Central Florida,https://www.cs.ucf.edu/~xiaoman,O
 Xiaomeng Li 0001,HKUST,https://facultyprofiles.hkust.edu.hk/profiles.php?profile=xiaomeng-li-eexmli,uVTzPpoAAAAJ,0000-0003-1105-8083
 Xiaomin Chu,Soochow University,http://web.suda.edu.cn/xmchu,xZm0oOEAAAAJ,0000-0000-0000-0000
 Xiaomin Lin 0002,University of South Florida,https://xiaominlin.github.io,nudP80UAAAAJ,0009-0009-6452-785X
+Xiaomin Ouyang,HKUST,https://xmouyang.github.io/,y7oUVucAAAAJ,0000-0003-0710-0963
 Xiaomin Sun,Tsinghua University,http://www.carch.ac.cn/~xmsun/xmsun.htm,_G0EETMAAAAJ,0000-0000-0000-0000
 Xiaoming Deng 0001,Chinese Academy of Sciences,https://www.idengxm.com/index.html,NX_oVR0AAAAJ,0000-0001-8576-1201
 Xiaoming Fu 0001,University of Göttingen,http://www.net.informatik.uni-goettingen.de/?q=people/prof-dr-xiaoming-fu,Gu7gTTEAAAAJ,0000-0002-8012-4753

--- a/csrankings-y.csv
+++ b/csrankings-y.csv
@@ -295,6 +295,7 @@ Yaohui Jin,Shanghai Jiao Tong University,http://front.sjtu.edu.cn/~jinyh/index.h
 Yaojie Lu 0001,Chinese Academy of Sciences,https://luyaojie.github.io,s0mCSI0AAAAJ,0000-0002-5842-7715
 Yaojing Yang,Dartmouth College,https://sites.google.com/site/yangyaoqingcmu,LYvugWgAAAAJ,0000-0000-0000-0000
 Yaoliang Yu,University of Waterloo,https://cs.uwaterloo.ca/~y328yu,zbXIQMsAAAAJ,0000-0000-0000-0000
+Yaonan Jin,HKUST,https://cse.hkust.edu.hk/admin/people/faculty/profile/jinyaonan,4qW5L2AAAAAJ,0000-0001-6256-7625
 Yaonan Wang 0001,Hunan University,http://robotics.hnu.edu.cn/info/1071/1157.htm,NOSCHOLARPAGE,0000-0002-0519-6458
 Yaoqing (Lamar) Yang,Dartmouth College,https://sites.google.com/site/yangyaoqingcmu,LYvugWgAAAAJ,0000-0000-0000-0000
 Yaoqing Yang 0001,Dartmouth College,https://sites.google.com/site/yangyaoqingcmu,LYvugWgAAAAJ,0000-0001-9908-5531
@@ -587,6 +588,7 @@ Yingcai Wu,Zhejiang University,http://www.ycwu.org,2eQFlqsAAAAJ,0000-0002-1119-3
 Yingcheng Sun,UNC - Greensboro,https://yingchengsun.github.io/academic,VCxrWbsAAAAJ,0000-0000-0000-0000
 Yingcong Li,NJIT,https://yingcong-li.github.io,9uWgjIUAAAAJ,0009-0000-2667-6752
 Yingfei Xiong 0001,Peking University,http://sei.pku.edu.cn/~xiongyf04,kiG3fBsAAAAJ,0000-0001-8991-747X
+Yinghao Xu,HKUST,https://justimyhxu.github.io/,I_7PXKEAAAAJ,0000-0003-2696-9664
 Yinghuan Shi,Nanjing University,http://cs.nju.edu.cn/shiyh,m6BKDUMAAAAJ,0000-0000-0000-0000
 Yinghui Pan,Shenzhen University,https://csse.szu.edu.cn/staff/panyh,Y7UBrUAAAAAJ,0009-0008-5003-4109
 Yinghui Wu 0001,Case Western Reserve University,https://yinghwu.github.io,9u7wNjUAAAAJ,0000-0003-3991-5155

--- a/csrankings-z.csv
+++ b/csrankings-z.csv
@@ -456,6 +456,7 @@ Zifei Nie,Jilin University,https://www.researchgate.net/profile/Zifei-Nie,G7mwUV
 Zigui Jiang,Sun Yat-sen University,https://ziguijiang.github.io,qkPuihoAAAAJ,0000-0002-3349-5383
 Zih-Yun Chiu,Johns Hopkins University,https://sarahchiu.github.io,6ZEE3pUAAAAJ,0000-0000-0000-0000
 Zihan Tan,University of Minnesota,https://cse.umn.edu/cs/zihan-tan,1Z0cFgMAAAAJ,0000-0003-4844-8480
+Zihan Zhang,HKUST,https://cse.hkust.edu.hk/admin/people/faculty/profile/zihanz,un0eGzEAAAAJ,0000-0000-0000-0000
 Zihao Li,UESTC,https://zzzihao-li.github.io,B-Vg8FYAAAAJ,0000-0002-4382-577X
 Zihao Zhan,Texas Tech University,https://zihaozhan.github.io,rEukSdgAAAAJ,0000-0002-1467-9056
 Zihe Wang 0001,Renmin University of China,http://ai.ruc.edu.cn/academicfaculty/898f1ad173bf48eabc5c94d1b615938b.htm,SL1QGDoAAAAJ,0000-0001-7752-4687


### PR DESCRIPTION
## Consolidated HKUST CSE additions

This PR consolidates four overlapping open PRs that collectively add HKUST CSE faculty. Three people appeared in **multiple** PRs (creating duplicate rows if merged separately), and #13509 misspelled one name. This PR contains each person **exactly once**, using the highest-quality data variant.

| Name | File | Homepage | Scholar | ORCID | Source PR |
|------|------|----------|---------|-------|-----------|
| Mingxun Zhou | -m | wuwuz.github.io | N3k-0vsAAAAJ | 0000-0001-6034-9245 | #13607 (had ORCID) |
| Xiaomin Ouyang | -x | xmouyang.github.io | y7oUVucAAAAJ | 0000-0003-0710-0963 | #13619 (correct spelling + ORCID; #13509 had 'Xiaoming') |
| Yinghao Xu | -y | justimyhxu.github.io | I_7PXKEAAAAJ | 0000-0003-2696-9664 | #13606 (had ORCID + homepage) |
| Yaonan Jin | -y | cse.hkust.edu.hk/…/jinyaonan | 4qW5L2AAAAAJ | 0000-0001-6256-7625 | #13606 |
| Zihan Zhang | -z | cse.hkust.edu.hk/…/zihanz | un0eGzEAAAAJ | (none) | #13509 |

### Overlap resolved
- **Xiaomin Ouyang** (Scholar `y7oUVucAAAAJ`) appeared in #13509 (as "Xiaoming"), #13606, and #13619 → included once, correct spelling.
- **Mingxun Zhou** (`N3k-0vsAAAAJ`) appeared in #13509 and #13607 → included once.
- **Yinghao Xu** (`I_7PXKEAAAAJ`) appeared in #13509 and #13606 → included once.

All five were validated as tenure-track Assistant Professors in the HKUST Dept. of Computer Science & Engineering (verified via cse.hkust.edu.hk). Supersedes #13509, #13606, #13607, #13619.