### PR TITLE
Fix: cannot remove faculty via self-service form (hidden required ORCID field)

### DIFF
--- a/src/submit.ts
+++ b/src/submit.ts
@@ -752,10 +752,13 @@ function updateUIForAction(action: ActionType): void {
     const institutionInput = document.getElementById('institution') as HTMLInputElement;
     const homepageInput = document.getElementById('homepage') as HTMLInputElement;
     const scholaridInput = document.getElementById('scholarid') as HTMLInputElement;
+    const orcidInput = document.getElementById('orcid') as HTMLInputElement;
 
     institutionInput.required = action !== 'remove';
     homepageInput.required = action !== 'remove';
     scholaridInput.required = action !== 'remove';
+    // ORCID field is hidden for remove; clear required so hidden control doesn't block submission
+    orcidInput.required = action !== 'remove';
 
     // Toggle required on eligibility checkboxes (only required for 'add' action)
     document.querySelectorAll('#eligibility-section input[type="checkbox"]').forEach(cb => {

--- a/submit/submit.js
+++ b/submit/submit.js
@@ -1,4 +1,3 @@
-"use strict";
 /**
  * CSRankings Faculty Submission Form
  * Client-side validation and GitHub Issue creation
@@ -680,9 +679,12 @@ function updateUIForAction(action) {
     const institutionInput = document.getElementById('institution');
     const homepageInput = document.getElementById('homepage');
     const scholaridInput = document.getElementById('scholarid');
+    const orcidInput = document.getElementById('orcid');
     institutionInput.required = action !== 'remove';
     homepageInput.required = action !== 'remove';
     scholaridInput.required = action !== 'remove';
+    // ORCID field is hidden for remove; clear required so hidden control doesn't block submission
+    orcidInput.required = action !== 'remove';
     // Toggle required on eligibility checkboxes (only required for 'add' action)
     document.querySelectorAll('#eligibility-section input[type="checkbox"]').forEach(cb => {
         cb.required = action === 'add';


### PR DESCRIPTION
## Problem

Fixes #13977. Submitting the self-service form at `/submit/` to **remove** faculty fails with a JavaScript console error and never submits:

```
An invalid form control with name='' is not focusable.
<input type="text" class="form-control" id="orcid" ... required>
```

## Root cause

The `orcid` input is marked `required` in `submit/index.html`. When the **Remove** action is selected, `updateUIForAction()` hides the ORCID field's group (`orcid-group` is in `hideForRemove`) but only cleared `required` on the institution, homepage, and scholarid inputs — not on `orcid`. HTML5 form validation then tries to focus the still-`required`, now-hidden ORCID control on submit, which throws and aborts the submission.

## Fix

Toggle `orcid.required` off for the remove action alongside the other hidden fields, in `src/submit.ts`, and rebuild `submit/submit.js`.