### PR TITLE
Update ORCID for Veronica Lachi (UiT)

### DIFF
--- a/csrankings-v.csv
+++ b/csrankings-v.csv
@@ -205,7 +205,7 @@ Vernon Asuncion,Western Sydney University,https://www.westernsydney.edu.au/staff
 Vernon Rego,Purdue University,https://www.cs.purdue.edu/people/rego,NOSCHOLARPAGE,0000-0000-0000-0000
 Vero Vanden Abeele,KU Leuven,https://iiw.kuleuven.be/onderzoek/emedia/people/verovandenabeele,4ujvHaEAAAAJ,0000-0002-3031-9579
 Veronica Cateté,North Carolina State University,https://www.csc.ncsu.edu/people/vmcatete,TxIMXZoAAAAJ,0000-0002-7620-7708
-Veronica Lachi,UiT The Arctic Univ. of Norway,https://en.uit.no/ansatte/person?p_document_id=917512,uly8D-sAAAAJ,0000-0000-0000-0000
+Veronica Lachi,UiT The Arctic Univ. of Norway,https://en.uit.no/ansatte/person?p_document_id=917512,uly8D-sAAAAJ,0000-0002-6947-7304
 Veronica Teichrieb,UFPE,http://www.cin.ufpe.br/voxarlabs,6YwOT_QAAAAJ,0000-0003-4685-3634
 Veronika A. Vanden Abeele,KU Leuven,https://iiw.kuleuven.be/onderzoek/emedia/people/verovandenabeele,4ujvHaEAAAAJ,0000-0000-0000-0000
 Veronika Cheplygina,IT University of Copenhagen,https://veronikach.com,4x1y2bwAAAAJ,0000-0000-0000-0000


### PR DESCRIPTION
## Summary

Replaces the placeholder ORCID (`0000-0000-0000-0000`) with the real iD for **Veronica Lachi** (UiT The Arctic Univ. of Norway).

This is the follow-up to #13495. The submitter (@Wickstrom) supplied the correct ORCID in the PR thread, but #13495 was merged before that correction was pushed to the branch, so the placeholder landed on `gh-pages`.

## Change

```diff
-Veronica Lachi,UiT The Arctic Univ. of Norway,https://en.uit.no/ansatte/person?p_document_id=917512,uly8D-sAAAAJ,0000-0000-0000-0000
+Veronica Lachi,UiT The Arctic Univ. of Norway,https://en.uit.no/ansatte/person?p_document_id=917512,uly8D-sAAAAJ,0000-0002-6947-7304
```

One line in `csrankings-v.csv`. No entries added or removed; name, affiliation, homepage, and Google Scholar ID are unchanged.

## Verification

Checked against the ORCID public API rather than taken on trust:

| Field | Value for `0000-0002-6947-7304` |
|---|---|
| Name | **Veronica Lachi** |
| Works | 10, including *"The expressive power of pooling in Graph Neural Networks"* and *"Graph Neural Networks for temporal graphs: State of the art, open challenges"* |

The publication record is graph machine learning, matching her research profile in the [UiT Machine Learning Group](https://en.uit.no/ansatte/person?p_document_id=917512&p_dimension_id=88136), where she is listed as Associate Professor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)