### PR TITLE
Fix OOM that has broken every monthly DBLP update

### DIFF
--- a/util/generate-uids.py
+++ b/util/generate-uids.py
@@ -77,10 +77,13 @@ def parse_dblp_homepages(
     """
     with gzip.open(gz_path, "rb") as f:
         seen_uids = set()
+        # NOTE: do *not* pass tag="www" here -- see the same note in
+        # new-name-detector.py. DBLP puts its <www> homepage records at the end of
+        # the file, so filtering by tag defers all freeing to the end of the parse
+        # and retains the entire document in memory (~14GB on current DBLP).
         context = ET.iterparse(
             f,
             events=("end",),
-            tag="www",
             load_dtd=False,         # stay offline
             no_network=True,
             recover=True,           # be tolerant of minor issues
@@ -89,7 +92,14 @@ def parse_dblp_homepages(
             resolve_entities=False, # we expand &name; ourselves
         )
         for _, node in context:
+            # Only top-level records are processed and freed; child elements are
+            # left intact so their parent can be read, and are released with it.
+            parent = node.getparent()
+            if parent is None or parent.getparent() is not None:
+                continue
             try:
+                if node.tag != "www":
+                    continue
                 key = node.get("key") or ""
                 if not key.startswith("homepages/"):
                     continue

--- a/util/new-name-detector.py
+++ b/util/new-name-detector.py
@@ -107,10 +107,15 @@ def parse_canonical_names(
     """
     result: Dict[str, str] = {}
     with gzip.open(gz_path, "rb") as f:
+        # NOTE: do *not* pass tag="www" here. DBLP clusters its <www> homepage
+        # records at the end of the file, and iterparse only emits events for the
+        # filtered tag -- so the freeing below would not run until the very end,
+        # by which point the whole document (~10M records) is retained in memory.
+        # That OOMs a 16GB CI runner. Iterating every element and freeing each
+        # top-level record keeps memory flat (~30MB) regardless of input size.
         context = ET.iterparse(
             f,
             events=("end",),
-            tag="www",
             load_dtd=False,          # offline
             no_network=True,
             recover=True,            # tolerant of minor issues
@@ -119,7 +124,15 @@ def parse_canonical_names(
             resolve_entities=False,  # expand entities ourselves via entmap
         )
         for _, node in context:
+            # Only top-level records (direct children of <dblp>) are processed and
+            # freed. Child elements are skipped without clearing them, so the parent
+            # record can still be read; they are released with their parent below.
+            parent = node.getparent()
+            if parent is None or parent.getparent() is not None:
+                continue
             try:
+                if node.tag != "www":
+                    continue
                 key = node.get("key") or ""
                 if not key.startswith("homepages/"):
                     continue


### PR DESCRIPTION
## The failure is real, and it has never worked

`Monthly DBLP Update` was added on 2025-12-31 and **has not completed successfully once** — 7 runs, all failed:

```
2026-06-28  failure     2026-03-28  failure     2025-12-31  failure
2026-05-28  failure     2026-02-28  failure     2025-12-31  cancelled
2026-04-28  failure     2026-01-28  failure     2025-12-31  cancelled
```

This is why `dblp.xml.xz` is a hand-made May 11 snapshot rather than a monthly automatic one.

**It is not a timeout.** The June job ran for only 13 minutes of the 6-hour limit. Both runs with surviving logs die at the same place:

```
Step 6/8: Detecting and applying author name changes...
make: *** [Makefile:206: update-dblp-full] Terminated
##[error]The runner has received a shutdown signal.
```

Killed ~40–60s into `util/new-name-detector.py`, with the runner shut down out from under the job — the signature of an OOM kill, not a nonzero exit.

## Cause

Both DBLP homepage parsers call `iterparse(..., tag="www")`. lxml only emits events for the filtered tag, so the element-freeing code — which is correct, and does run — is not reached until the first `<www>` record arrives. DBLP clusters `<www>` homepage records at the **end** of the file, so effectively the whole document accumulates in memory before anything is released.

## Measurements

Synthetic files with DBLP's layout (publication records first, homepages last):

| publication records | peak RSS before | peak RSS after |
|---|---|---|
| 100,000 | 190 MB | 27 MB |
| 200,000 | 355 MB | 28 MB |
| 400,000 | 686 MB | 30 MB |

Before: **~1.65 KB retained per record, growing linearly.** `dblp.xml.gz` is now 1.09 GB compressed, which projects to roughly **13–16 GB** against a **16 GB** runner. After: flat, independent of input size.

The control confirms the mechanism — with homepages *interleaved* instead of at the end, the old code stays flat at ~26 MB. It is the file layout, not the volume, that triggers it.

## Fix

Iterate every element and free each **top-level** record instead of filtering by tag.

The subtlety worth noting: child elements must be skipped *without* being cleared. The obvious version of this fix clears every element as it ends, which destroys `<author>` before its parent `<www>` is read and silently returns **zero** homepages — a passing run producing an empty result. Guarding on "parent is the root" avoids that.

`util/generate-uids.py` has the identical bug and is fixed the same way.

`util/filter-dblp.py` and `util/regenerate_data.py` use the same idiom but filter on `('article', 'inproceedings')`, which are dense throughout the file, so freeing happens continuously. Not affected — and they demonstrably work today.

## Verification

Both parsers produce **byte-identical output** to the previous code on a fixture covering mixed content (`<sup>0001</sup>`), multiple `<author>` entries per homepage, and non-homepage `<www>` records.

## What this does not prove

Step 6 is the first failure, not necessarily the only one. Steps 7–8 (`generated-author-info.csv`, `update-dblp-date`) have never executed in CI, so further problems may surface once this unblocks. Suggest merging and then triggering the workflow manually via `workflow_dispatch` to find out, rather than waiting for the 28th.

🤖 Generated with [Claude Code](https://claude.com/claude-code)