### PR TITLE
Remove 15 stale rows duplicating a person across two institutions

### DIFF
--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -813,7 +813,6 @@ Chris Piech,Stanford University,https://stanford.edu/~cpiech/bio/index.html,fpT4
 Chris Preist,University of Bristol,https://research-information.bris.ac.uk/en/persons/chris-w-preist,rfoJfMgAAAAJ,0000-0002-5094-5294
 Chris R. Johnson 0001,University of Utah,http://www.cs.utah.edu/~crj,SS3tE_MAAAAJ,0000-0001-5673-5338
 Chris Reed 0001,University of Dundee,https://www.computing.dundee.ac.uk/about/staff/25,4uzzI5YAAAAJ,0000-0002-6849-1374
-Chris Russell 0001,University of Surrey,https://www.surrey.ac.uk/cvssp/people/russell_christopher,RM2sHhYAAAAJ,0000-0003-1665-1759
 Chris S. Crawford,The University of Alabama,http://www.chrissmithcrawford.com,3V9Nf8QAAAAJ,0000-0003-3127-308X
 Chris Schwiegelshohn,Aarhus University,https://cs.au.dk/~schwiegelshohn,X9Hl0LcAAAAJ,0009-0008-9114-0661
 Chris Smith Crawford Jr.,The University of Alabama,http://www.chrissmithcrawford.com,3V9Nf8QAAAAJ,0000-0000-0000-0000

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -556,7 +556,6 @@ David Amar,Tel Aviv University,https://english.tau.ac.il/profile/davidama,UHz2UM
 David Andersen,Carnegie Mellon University,https://www.cs.cmu.edu/~dga,wUArfPgAAAAJ,0000-0000-0000-0000
 David Andrew Ross,University of Queensland,http://www.itee.uq.edu.au/contacts/show.ephp/uqdross,RqOzJR0AAAAJ,0000-0000-0000-0000
 David Andrews,University of Arkansas,http://www.csce.uark.edu/~dandrews,NOSCHOLARPAGE,0000-0000-0000-0000
-David Anthony Parker,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/parker-david.aspx,nEKbXSMAAAAJ,0000-0000-0000-0000
 David Arnott,Monash University,http://monash.edu/research/explore/en/persons/david-arnott(fcc08d5c-a8cd-45ce-9cac-f2bfbbbb6dfe).html,A2fkR3QAAAAJ,0000-0002-6527-8527
 David Arthur Eppstein,Univ. of California - Irvine,https://www.ics.uci.edu/~eppstein,QSY7ufMAAAAJ,0000-0000-0000-0000
 David Aspinall 0001,University of Edinburgh,http://homepages.inf.ed.ac.uk/da,_pT1xEwAAAAJ,0000-0002-6073-9013
@@ -1205,7 +1204,6 @@ Diego R. Amancio,USP-ICMC,http://icmc.usp.br/pessoas?id=10793181,WHdCNq0AAAAJ,00
 Diego Raphael Amancio,USP-ICMC,http://icmc.usp.br/pessoas?id=10793181,WHdCNq0AAAAJ,0000-0000-0000-0000
 Diego Reforgiato Recupero,University of Cagliari,https://web.unica.it/unica/page/it/diego_reforgiato,kgY5Gn4AAAAJ,0000-0001-8646-6183
 Diego Vaggione,Universidad Nacional de Córdoba,http://ual.famaf.unc.edu.ar/index.php/home/diego-vaggione,NOSCHOLARPAGE,0000-0000-0000-0000
-Diego de Freitas Aranha,UNICAMP,https://twitter.com/dfaranha?lang=en,FF26-mIAAAAJ,0000-0000-0000-0000
 Dieter A. Fensel,University of Innsbruck,http://www.fensel.com,MKgl6f4AAAAJ,0000-0000-0000-0000
 Dieter August Kranzlmüller,LMU Munich,http://www.nm.ifi.lmu.de/~kranzlm,NOSCHOLARPAGE,0000-0002-8319-0123
 Dieter Fensel,University of Innsbruck,http://www.fensel.com,MKgl6f4AAAAJ,0000-0000-0000-0000

--- a/csrankings-f.csv
+++ b/csrankings-f.csv
@@ -263,7 +263,6 @@ Felipe M. G. França,UFRJ,http://www.cos.ufrj.br/~felipe,An-l3DsAAAAJ,0000-0002-
 Felipe Maia Galvão França,UFRJ,http://www.cos.ufrj.br/~felipe,An-l3DsAAAAJ,0000-0000-0000-0000
 Felipe Meneguzzi,University of Aberdeen,http://www.meneguzzi.eu/felipe,uFEbojwAAAAJ,0000-0003-3549-6168
 Felipe Orihuela-Espina,University of Birmingham,https://www.birmingham.ac.uk/staff/profiles/computer-science/academic-staff/orihuela-espina-felipe.aspx,Yj2_-7kAAAAJ,0000-0001-8963-7283
-Felipe Rech Meneguzzi,PUC-RS,http://www.meneguzzi.eu/felipe,uFEbojwAAAAJ,0000-0000-0000-0000
 Felipe W. Trevizan,Australian National University,https://comp.anu.edu.au/people/felipe-trevizan,AG1PRG4AAAAJ,0000-0000-0000-0000
 Felisa J. Vázquez-Abad,CUNY,http://www.hunter.cuny.edu/csci/people/faculty,NOSCHOLARPAGE,0000-0000-0000-0000
 Felix A. Wichmann,University of Tübingen,https://uni-tuebingen.de/en/faculties/faculty-of-science/departments/computer-science/lehrstuehle/neural-information-processing/people/members,NxrQ794AAAAJ,0000-0000-0000-0000

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -919,7 +919,6 @@ Guillermo Suarez-Tangil,IMDEA Networks Institute,https://networks.imdea.org/team
 Guiming Luo,Tsinghua University,http://www.thss.tsinghua.edu.cn/publish/soften/3131/2010/20101219105703907330347/20101219105703907330347_.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Guixin Ye,Northwest University,https://faculty.nwu.edu.cn/yeguixin/en/index.htm,dvbIcXgAAAAJ,0000-0003-2074-4253
 Guiying Li,SUSTech,http://www.liguiying.cn,Pdj79icAAAAJ,0000-0000-0000-0000
-Gul Calikli,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/calikli.aspx,lShgfvwAAAAJ,0000-0003-4578-1747
 Gul Çalikli,University of Glasgow,https://gulcalikli.github.io,lShgfvwAAAAJ,0000-0000-0000-0000
 Gultekin Özsoyoglu,Case Western Reserve University,http://engineering.case.edu/eecs/faculty-staff,NOSCHOLARPAGE,0000-0000-0000-0000
 Gunes Acar,Radboud University,https://gunesacar.net,B6yKiPQAAAAJ,0000-0002-1621-8333

--- a/csrankings-i.csv
+++ b/csrankings-i.csv
@@ -309,7 +309,6 @@ Irene Amerini,Sapienza University of Rome,http://www.diag.uniroma1.it/users/iren
 Irene Cheng 0001,University of Alberta,https://webdocs.cs.ualberta.ca/~crome/mrc/people/irene_cheng,76DyMqoAAAAJ,0000-0000-0000-0000
 Irene Loiseau,University of Buenos Aires,https://www.dc.uba.ar/People/loiseau,NOSCHOLARPAGE,0000-0000-0000-0000
 Irene M. Kaplow,Carnegie Mellon University,https://imk1.github.io,_IfiZD4AAAAJ,0000-0002-8924-8269
-Irene Ntoutsi,Freie Universitaet Berlin,https://www.mi.fu-berlin.de/inf/groups/ag-KIML/members/Professoren/Ntoutsi.html,RdA9uxYAAAAJ,0000-0000-0000-0000
 Irene Y. Chen,Univ. of California - Berkeley,https://irenechen.net,Du51uRIAAAAJ,0000-0000-0000-0000
 Irfan A. Essa,Georgia Institute of Technology,http://prof.irfanessa.com,XM97iScAAAAJ,0000-0000-0000-0000
 Irfan Ahmed,Virginia Commonwealth University,http://www.people.vcu.edu/~iahmed3,JXrXUC4AAAAJ,0000-0000-0000-0000

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -30,7 +30,6 @@ J. Mark Bishop,Goldsmiths University of London,https://www.gold.ac.uk/computing/
 J. Maurice Rojas,Texas A&M University,http://www.math.tamu.edu/~rojas,gValByUAAAAJ,0000-0002-1657-2674
 J. Michael Herrmann,University of Edinburgh,http://www.research.ed.ac.uk/portal/en/persons/michael-herrmann(cf1b7c31-3a87-4812-bf0a-05cf49b0120e).html,MJiOEy0AAAAJ,0000-0000-0000-0000
 J. Montgomery,Georgetown University,http://explore.georgetown.edu/people/jm985,XQYNoekAAAAJ,0000-0002-2706-2370
-J. Nathan Foster,Cornell University,http://www.cs.cornell.edu/~jnfoster,AH5j40kAAAAJ,0000-0000-0000-0000
 J. Nelson Rushton,Texas Tech University,http://www.depts.ttu.edu/cs/department/seminars.php,NOSCHOLARPAGE,0000-0000-0000-0000
 J. P. Lewis 0001,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/JohnLewis,wC_k2-4AAAAJ,0000-0002-6835-7263
 J. P. Misra,BITS Pilani,http://www.bits-pilani.ac.in/pilani/computerscience/Faculty,7HBV4QwAAAAJ,0000-0000-0000-0000
@@ -960,7 +959,6 @@ Ji Guan 0001,Chinese Academy of Sciences,https://www.researchgate.net/profile/Ji
 Ji Hwan Park,Rochester Inst. of Technology,https://people.rit.edu/jhpigm,LVJWinQAAAAJ,0000-0002-7971-2419
 Ji Liu 0002,University of Rochester,http://www.cs.rochester.edu/u/jliu,UpbJ4CMAAAAJ,0000-0000-0000-0000
 Ji Ming,Queen's University Belfast,https://www.qub.ac.uk/schools/eeecs/Connect/Staff/BusinessCard/?name=j.ming,NOSCHOLARPAGE,0000-0000-0000-0000
-Ji Won Seo,Hanyang University,http://bdsl.hanyang.ac.kr/members/jiwonseo,O1WC6TAAAAAJ,0000-0000-0000-0000
 Ji Won Yoon,Korea University,https://signal.korea.ac.kr,jDLHy60AAAAJ,0000-0000-0000-0000
 Ji Wu 0002,Tsinghua University,https://www.tsinghua.edu.cn/publish/eeen/3784/2010/20101219135614305780920/20101219135614305780920_.html,1V8LxbYAAAAJ,0000-0001-6170-726X
 Ji-Hyun Lee,KAIST,http://gsct3237.kaist.ac.kr,io8xhtgAAAAJ,0000-0001-6420-5150

--- a/csrankings-l.csv
+++ b/csrankings-l.csv
@@ -858,7 +858,6 @@ Louis Salvail,University of Montreal,http://www.iro.umontreal.ca/~salvail,NOSCHO
 Louis-Noël Pouchet,Colorado State University,https://www.cs.colostate.edu/~pouchet,TCppIZYAAAAJ,0000-0000-0000-0000
 Louis-Philippe Morency,Carnegie Mellon University,https://www.cs.cmu.edu/~morency,APgaFK0AAAAJ,0000-0001-6376-7696
 Louise A. Dennis,University of Manchester,https://personalpages.manchester.ac.uk/staff/louise.dennis,5d8ouI8AAAAJ,0000-0003-1426-1896
-Louise Abigail Dennis,University of Liverpool,https://www.liverpool.ac.uk/computer-science/staff/louise-dennis,5d8ouI8AAAAJ,0000-0000-0000-0000
 Louise Barkhuus,IT University of Copenhagen,https://barkhu.us,dAeFXDcAAAAJ,0000-0003-1306-249X
 Louise Knight,Cardiff University,https://www.cardiff.ac.uk/people/view/1235342-knight-louise,hdQxi5cAAAAJ,0000-0003-1431-197X
 Louise Laforest,Université du Québec à Montréal,https://professeurs.uqam.ca/professeur/Y%252bVnHzE%252bja4_,NOSCHOLARPAGE,0000-0000-0000-0000

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -2283,7 +2283,6 @@ Mike Bailey,Oregon State University,http://eecs.oregonstate.edu/people/bailey-mi
 Mike Barley,University of Auckland,https://www.cs.auckland.ac.nz/people/m-barley,QwAxKoEAAAAJ,0000-0000-0000-0000
 Mike Brooks,Adelaide University,http://www.adelaide.edu.au/directory/michael.brooks,IRsRrroAAAAJ,0000-0000-0000-0000
 Mike Burmester,Florida State University,http://www.cs.fsu.edu/~burmeste,GwirM_8AAAAJ,0000-0001-5094-5668
-Mike C. Fraser 0001,University of Bath,https://researchportal.bath.ac.uk/en/persons/mike-fraser,qxnHlVYAAAAJ,0000-0000-0000-0000
 Mike Chantler,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/mike-chantler.htm,oBixg1wAAAAJ,0000-0002-8381-1751
 Mike Conway,University of Melbourne,https://findanexpert.unimelb.edu.au/profile/886714-mike-conway,uiJso6MAAAAJ,0000-0000-0000-0000
 Mike D. Atkinson,University of Otago,http://www.cs.otago.ac.nz/staffpriv/mike/HomePages/newhome.html,C2oYWqgAAAAJ,0000-0000-0000-0000

--- a/csrankings-n.csv
+++ b/csrankings-n.csv
@@ -195,7 +195,6 @@ Nathalie Revol,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/nathali
 Nathalie Rose Lim,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742667036&command=GETPROFILE,Y--J7f8AAAAJ,0000-0000-0000-0000
 Nathalie Rose T. Lim,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742667036&command=GETPROFILE,Y--J7f8AAAAJ,0000-0000-0000-0000
 Nathaly Verwaal,University of Calgary,http://contacts.ucalgary.ca/info/cpsc/profiles/102-3419,NOSCHOLARPAGE,0000-0000-0000-0000
-Nathan B. Jacobs,University of Kentucky,https://jacobsn.github.io,ZBgGyh8AAAAJ,0000-0000-0000-0000
 Nathan Beckmann,Carnegie Mellon University,http://www.cs.cmu.edu/~beckmann,zkdjit0AAAAJ,0000-0001-6301-714X
 Nathan Blanchard,Colorado State University,https://sites.google.com/view/nathanieltblanchard,9ctSmkYAAAAJ,0000-0000-0000-0000
 Nathan D. Cahill,Rochester Inst. of Technology,https://people.rit.edu/ndcsma,O7uS3IUAAAAJ,0000-0002-6164-3291

--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -22,7 +22,6 @@ P. Sreenivasa Kumar 0001,IIT Madras,http://www.cse.iitm.ac.in/~psk,FbCn7fkAAAAJ,
 P. Takis Mathiopoulos,University of Athens,http://gain.di.uoa.gr/index.php/the-group-members/faculty-members/p-takis-mathiopoulos,NOSCHOLARPAGE,0000-0000-0000-0000
 P. Thomas Fletcher,University of Virginia,https://engineering.virginia.edu/faculty/tom-fletcher,7pRRhkkAAAAJ,0000-0000-0000-0000
 P. Ubaidulla,IIIT Hyderabad,https://www.iiit.ac.in/people/faculty/pubaidulla,JpIWSI4AAAAJ,0000-0000-0000-0000
-P. V. Skums,Georgia State University,http://alan.cs.gsu.edu/compbel,h5ZxsFAAAAAJ,0000-0000-0000-0000
 P. Vassalos,AUEB,http://pubs.dbs.uni-leipzig.de/aa/aff/Greece/Athens/Athens%20University%20of%20Economics%20and%20Business,NOSCHOLARPAGE,0000-0000-0000-0000
 P. Venkata Subba Reddy 0001,National Inst. of Tech. Warangal,https://wsdc.nitw.ac.in/facultynew/facultyprofile/id/16338,LSGPBhoAAAAJ,0000-0000-0000-0000
 P. Vijay Kumar,IISc Bangalore,http://ece.iisc.ernet.in/~vijay,Wx5neQQAAAAJ,0000-0000-0000-0000

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -1911,7 +1911,6 @@ Sri Devi Ravana,University of Malaya,https://umexpert.um.edu.my/sdevi,mZVfEWgAAA
 Sri Hastuti Kurniawan,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~srikur,NOSCHOLARPAGE,0000-0000-0000-0000
 Sri Kurniawan,Univ. of California - Santa Cruz,https://users.soe.ucsc.edu/~srikur,NOSCHOLARPAGE,0000-0000-0000-0000
 Sri Parameswaran,University of Sydney,https://profiles.sydney.edu.au/sri.parameswaran,IM4wtocAAAAJ,0000-0003-0435-9080
-Sridevan Parameswaran,UNSW,http://www.cse.unsw.edu.au/~sridevan,IM4wtocAAAAJ,0000-0003-0435-9080
 Sridhar Adepu,University of Bristol,https://adepu-phd.github.io,sSAQkAgAAAAJ,0000-0000-0000-0000
 Sridhar Chimalakonda,IIT Tirupati,https://researchweb.iiit.ac.in/~sridhar_ch,X3AR0HgAAAAJ,0000-0003-0818-8178
 Sridhar Iyer,IIT Bombay,http://www.it.iitb.ac.in/~sri,I7pOhHsAAAAJ,0000-0000-0000-0000

--- a/csrankings-w.csv
+++ b/csrankings-w.csv
@@ -543,7 +543,6 @@ William Mansky,University of Illinois at Chicago,https://www.cs.uic.edu/~mansky,
 William Moloney,University of Massachusetts Lowell,https://www.uml.edu/Sciences/computer-science/faculty/moloney-william.aspx,gHYMJZ0AAAAJ,0000-0000-0000-0000
 William N. L. Browne,Queensland Univ. of Technology,https://research.qut.edu.au/qcr/people/will-browne,syWBlr8AAAAJ,0000-0000-0000-0000
 William N. Sumner,Simon Fraser University,http://http://www.cs.sfu.ca/~wsumner,NOSCHOLARPAGE,0000-0001-8592-033X
-William Perkins 0001,University of Illinois at Chicago,http://willperkins.org,5HJzWMUAAAAJ,0000-0000-0000-0000
 William R. Michalson,Worcester Polytechnic Institute,http://www.wpi.edu/academics/facultydir/wzm.html,rau-pbUAAAAJ,0000-0000-0000-0000
 William Rhodes,Florida Atlantic University,http://www.fau.edu/ufsgov/standing-committees.php,NOSCHOLARPAGE,0000-0000-0000-0000
 William Robertson 0002,Northeastern University,http://www.ccis.northeastern.edu/people/william-robertson,VxWLGyoAAAAJ,0000-0000-0000-0000

--- a/csrankings-y.csv
+++ b/csrankings-y.csv
@@ -479,7 +479,6 @@ Yiannis Aloimonos,Univ. of Maryland - College Park,http://www.cfar.umd.edu/~yian
 Yiannis Cotronis,University of Athens,http://www.di.uoa.gr/eng/staff/1022,9IbOFmMAAAAJ,0000-0000-0000-0000
 Yiannis Giannakopoulos,University of Glasgow,https://www.gla.ac.uk/schools/computing/staff/yiannisgiannakopoulos,YtYCHGIAAAAJ,0000-0003-2382-1779
 Yiannis Koutis,NJIT,https://web.njit.edu/~ikoutis,ONXC8_gAAAAJ,0000-0000-0000-0000
-Yiannis Rekleitis,University of South Carolina,http://www.cse.sc.edu/~yiannisr,KjfpioYAAAAJ,0000-0000-0000-0000
 Yiannis Tselekounis,Royal Holloway Univ. of London,https://www.yiannistselekounis.com,FvBTv6wAAAAJ,0000-0000-0000-0000
 Yibiao Yang,Nanjing University,https://yangyibiao.github.io,-7PoE6MAAAAJ,0000-0003-1153-2013
 Yibo Lin,Peking University,http://yibolin.com.cn,155hQCcAAAAJ,0000-0002-0977-2774


### PR DESCRIPTION
## Background

Follow-up to the sweep suggested in #14028. Scanning all 32,290 faculty rows for repeated Google Scholar IDs:

| | count |
|---|---|
| distinct real Scholar IDs | 23,278 |
| IDs used by more than one row | 3,188 |
| ...spanning **different** institutions | **58** ← this sweep |
| ...within the same institution | 3,130 (alias rows; separate issue) |

A Scholar ID shared across two institutions means both institutions are receiving credit for the same publication record.

## Not all 58 are the same defect

Two distinct problems are mixed together, and they need opposite fixes:

- **Same person, stale row after a move** → remove the row at the former institution. *This PR.*
- **Different people, one carrying another's Scholar ID** → correct the Scholar ID; deleting would drop a real faculty member. Separate PR.

Conflating them would delete legitimate entries — e.g. `John Doyle` (Caltech) and `Jon Doyle` (NC State) share `C6DtGmMAAAAJ`, but they are two different researchers.

## This PR: 15 removals

| removed (former) | retained (current) |
|---|---|
| William Perkins 0001, UIC | Will Perkins 0001, Georgia Tech |
| Louise Abigail Dennis, Liverpool | Louise A. Dennis, Manchester |
| J. Nathan Foster, Cornell | Nate Foster, EPFL |
| Diego de Freitas Aranha, UNICAMP | Diego F. Aranha, Aarhus |
| Sridevan Parameswaran, UNSW | Sri Parameswaran, Sydney |
| Yiannis Rekleitis, South Carolina | Ioannis M. Rekleitis, Delaware |
| Ji Won Seo, Hanyang | Jiwon Seo 0002, SNU |
| Chris Russell 0001, Surrey | Christopher Russell 0001, Oxford |
| Irene Ntoutsi, FU Berlin | Eirini Ntoutsi, Bundeswehr Munich |
| Nathan B. Jacobs, Kentucky | Nathan Jacobs, WashU |
| P. V. Skums, Georgia State | Pavel Skums, UConn |
| Gul Calikli, Chalmers/GU | Gül Çalikli, Glasgow |
| David Anthony Parker, Birmingham | David Parker 0001, Oxford |
| Felipe Rech Meneguzzi, PUC-RS | Felipe Meneguzzi, Aberdeen |
| Mike C. Fraser 0001, Bath | Mike Fraser 0001, Bristol |

**Evidence**: ORCID public API current employment (no end-date), corroborated by homepage checks where ORCID looked ambiguous or stale. Two examples where the homepage was decisive:

- **Nate Foster** — the EPFL directory lists him as Professeur ordinaire with no Cornell affiliation.
- **Mike Fraser** — the Bath row's homepage returns **HTTP 404**, and ORCID shows Bristol as current.

**Post-edit check**: all 15 people still have exactly one row, at their current institution. Nobody is dropped from CSRankings.

## Deliberately excluded — needs a human call

**Dual appointments (8).** ORCID lists *both* institutions as current, so these may be legitimate joint appointments rather than stale rows: Paul Groth (Amsterdam/VU), Katja Mombaur (KIT/Waterloo), Anthony Tang (SMU/Calgary), Dongsun Kim (Korea Univ./Kyungpook), Martin D. F. Wong (CUHK/HKBU), Kai Kunze (Keio/Clausthal), Kobi Gal (BGU/Edinburgh), Mariëlle Stoelinga (Twente/Radboud). The >=75%-time criterion applies, but which institution to keep is a judgment call.

**Ehsan Abbasnejad** — excluded because the sources conflict. ORCID says Adelaide is current, but his Monash profile shows an active Associate Professor appointment with projects running to 2027. ORCID appears stale here, which would invert the removal. Worth resolving directly.

**Francis Bach (ENS/INRIA)** and **David Zhang (PolyU/CUHK-SZ)** — both rows plausible; INRIA-hosted-at-ENS and emeritus/chair arrangements are conventions this dataset may already handle deliberately.

**23 undetermined** — no current ORCID employment recorded, so no basis to pick. Listed in the sweep output; can be worked through if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)