### PR TITLE
Fix 4 Google Scholar IDs attributed to the wrong person

### DIFF
--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -763,7 +763,7 @@ Bolei Zhou,Univ. of California - Los Angeles,https://boleizhou.github.io,9D4aG8A
 Boleslaw K. Szymanski,Rensselaer Polytechnic Institute,http://www.cs.rpi.edu/~szymansk,2OJOZTUAAAAJ,0000-0002-0307-6743
 Bolette S. Pedersen,University of Copenhagen,https://nors.ku.dk/english/staff/?pure=en/persons/134967,NOSCHOLARPAGE,0000-0000-0000-0000
 Bolette Sandford Pedersen,University of Copenhagen,https://nors.ku.dk/english/staff/?pure=en/persons/134967,NOSCHOLARPAGE,0000-0000-0000-0000
-Bolong Zeng,Washington State University,https://school.eecs.wsu.edu/people/faculty/bolong-zeng,kp0baVYAAAAJ,0000-0000-0000-0000
+Bolong Zeng,Washington State University,https://school.eecs.wsu.edu/people/faculty/bolong-zeng,NOSCHOLARPAGE,0000-0000-0000-0000
 Bolong Zheng,HUST,http://faculty.hust.edu.cn/BOLONGZHENG/en/index.htm,kp0baVYAAAAJ,0000-0001-8639-4570
 Bon K. Sy,CUNY,https://www.gc.cuny.edu/Page-Elements/Academics-Research-Centers-Initiatives/Doctoral-Programs/Computer-Science/Faculty-Bios/Bon-K-Sy,GLjNiI4AAAAJ,0000-0000-0000-0000
 Bongki Moon,Seoul National University,http://dbs.snu.ac.kr/bkmoon,Uk9v1BQAAAAJ,0000-0001-9382-8306

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -889,7 +889,7 @@ Dazhen Deng,Zhejiang University,https://person.zju.edu.cn/en/dengdazhen,opQZa-EA
 De-Chuan Zhan,Nanjing University,http://lamda.nju.edu.cn/zhandc,mYJf4TcAAAAJ,0000-0002-3533-2078
 DeLiang L. Wang,Ohio State University,http://web.cse.ohio-state.edu/~dwang,yO59sggAAAAJ,0000-0000-0000-0000
 DeLiang Wang,Ohio State University,http://web.cse.ohio-state.edu/~dwang,yO59sggAAAAJ,0000-0000-0000-0000
-Dean C. Barratt,University College London,http://cmic.cs.ucl.ac.uk/staff/dean_barratt,7OtfUxcAAAAJ,0000-0000-0000-0000
+Dean C. Barratt,University College London,http://cmic.cs.ucl.ac.uk/staff/dean_barratt,NOSCHOLARPAGE,0000-0000-0000-0000
 Dean F. Hougen,University of Oklahoma,https://cs.ou.edu/~hougen,zVMLl_cAAAAJ,0000-0001-5393-1480
 Dean Hendrix,Auburn University,http://www.auburn.edu/~hendrtd,NOSCHOLARPAGE,0000-0000-0000-0000
 Dean Knudson,North Dakota State University,http://www.cs.ndsu.nodak.edu/~deaknuds,NOSCHOLARPAGE,0000-0000-0000-0000

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -1985,7 +1985,7 @@ Jon Bird,University of Bristol,https://research-information.bris.ac.uk/en/person
 Jon Calhoun 0001,Clemson University,https://jonccal.people.clemson.edu,6E6YpoMAAAAJ,0000-0001-7191-4422
 Jon Chamberlain,University of Essex,https://www.essex.ac.uk/people/chamb94408/jon-chamberlain,JJN-i1cAAAAJ,0000-0002-6947-8964
 Jon Crowcroft,University of Cambridge,https://www.cl.cam.ac.uk/~jac22,qnMs-XYAAAAJ,0000-0002-7013-0121
-Jon Doyle,North Carolina State University,https://www.csc.ncsu.edu/faculty/doyle,C6DtGmMAAAAJ,0000-0002-5553-3790
+Jon Doyle,North Carolina State University,https://www.csc.ncsu.edu/faculty/doyle,NOSCHOLARPAGE,0000-0002-5553-3790
 Jon E. Froehlich,University of Washington,http://www.cs.umd.edu/~jonf,nExKrpsAAAAJ,0000-0001-8291-3353
 Jon Froehlich,University of Washington,http://www.cs.umd.edu/~jonf,nExKrpsAAAAJ,0000-0001-8291-3353
 Jon G. Hall,Open University UK,http://stem.open.ac.uk/people/jgh23,Zd3QZkaH0hYJ,0000-0002-5619-820X

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -1801,7 +1801,7 @@ Michael A. Bauer 0001,Western University,http://www.csd.uwo.ca/~bauer,NOSCHOLARP
 Michael A. Bender,Stony Brook University,http://www3.cs.stonybrook.edu/~bender,B1_1mR8AAAAJ,0000-0001-7639-530X
 Michael A. Casey,Dartmouth College,http://dartmouth.edu/faculty-directory/michael-casey,2dTrwzAAAAAJ,0000-0001-6937-0104
 Michael A. DeVito,Northeastern University,https://www.khoury.northeastern.edu/people/michael-ann-devito,aPZtVrkAAAAJ,0000-0003-1001-2307
-Michael A. E. Wright,University of Bath,http://bath.academia.edu/MichaelWright,2dTrwzAAAAAJ,0000-0000-0000-0000
+Michael A. E. Wright,University of Bath,http://bath.academia.edu/MichaelWright,NOSCHOLARPAGE,0000-0000-0000-0000
 Michael A. Forbes 0001,Univ. of Illinois at Urbana-Champaign,http://miforbes.cs.illinois.edu,NOSCHOLARPAGE,0000-0000-0000-0000
 Michael A. Gennert,Worcester Polytechnic Institute,http://www.wpi.edu/~michaelg,zrxS5YsAAAAJ,0000-0002-3170-2190
 Michael A. Goodrich,Brigham Young University,https://faculty.cs.byu.edu/~mike,7LTGov4AAAAJ,0000-0002-2489-5705


### PR DESCRIPTION
## Companion to #14029

Same sweep, opposite fix. #14029 handles Scholar IDs shared because **one person** is listed at two institutions. These four are shared because **two different people** are involved and one row carries an ID that isn't theirs.

Deleting a row would be wrong here — these are real faculty whose entries are fine apart from the identifier.

## Ownership confirmed from the Scholar profiles

Read directly rather than inferred:

| Scholar ID | Profile says | Correct row | Row corrected |
|---|---|---|---|
| `C6DtGmMAAAAJ` | "John Doyle — Caltech" | John Doyle, Caltech | **Jon Doyle**, NC State |
| `2dTrwzAAAAAJ` | "Michael A. Casey — Professor, Dartmouth College" | Michael A. Casey, Dartmouth | **Michael A. E. Wright**, Bath |
| `kp0baVYAAAAJ` | "Bolong Zheng — Huazhong Univ. of Science and Technology" | Bolong Zheng, HUST | **Bolong Zeng**, Washington State |
| `7OtfUxcAAAAJ` | "Hugh Barrett — Adjunct Professor, Univ. of Western Australia" | Hugh R. Barrett, UWA | **Dean C. Barratt**, UCL |

The four mismatched rows are set to `NOSCHOLARPAGE`.

## Why the profile check mattered

The **Doyle** case inverts what ORCID alone implied. The NC State row carries a valid ORCID (`0000-0002-5553-3790`, Jon Doyle, SAS Institute Distinguished Professor at NC State), which made it look like the authoritative row — my first pass had it that way. But the Scholar profile for `C6DtGmMAAAAJ` reads "John Doyle, Caltech". Two different researchers; the NC State row simply has the wrong Scholar ID. Jon Doyle keeps his ORCID and loses only the misattributed identifier.

Had this gone by ORCID alone, the fix would have landed on the wrong row.

## Follow-up

Locating the correct Scholar IDs for these four would be better than `NOSCHOLARPAGE`, but blanking is the accurate value until each is verified. Separately, `7OtfUxcAAAAJ`'s profile describes Hugh Barrett as *Adjunct Professor, School of Biomedical Sciences* — an eligibility question for that row independent of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)