### PR TITLE
Resolve 7 more cross-institution Scholar ID duplicates

### DIFF
--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -2108,7 +2108,6 @@ Anthony D. Joseph,Univ. of California - Berkeley,https://www.eecs.berkeley.edu/F
 Anthony Finkelstein,City University of London,https://finkelstein.uk,n8xuCVkAAAAJ,0000-0003-2167-9844
 Anthony G. Cohn 0001,University of Leeds,https://eps.leeds.ac.uk/computing/staff/76/professor-anthony-g-cohn-freng-ceng-citp,tal4mMkAAAAJ,0000-0000-0000-0000
 Anthony Gitter,University of Wisconsin - Madison,https://www.biostat.wisc.edu/~gitter,j0_fn9oAAAAJ,0000-0002-5324-9833
-Anthony Hoi Tin Tang,University of Calgary,http://hcitang.org,RG1EQowAAAAJ,0000-0000-0000-0000
 Anthony Hunter,University College London,http://www0.cs.ucl.ac.uk/staff/a.hunter,N7ETYzcAAAAJ,0000-0001-5602-7446
 Anthony Ian Wirth,University of Sydney,https://www.sydney.edu.au/engineering/about/our-people/academic-staff/anthony-wirth.html,qVuN4MIAAAAJ,0000-0000-0000-0000
 Anthony J. Bonner,University of Toronto,http://www.cs.toronto.edu/~bonner,NOSCHOLARPAGE,0000-0000-0000-0000

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -3,8 +3,6 @@ D. C. Douglas Hung,NJIT,http://cs.njit.edu/people/hung.php,NOSCHOLARPAGE,0000-00
 D. Caleb Rucker,University of Tennessee,https://mabe.utk.edu/people/d-caleb-rucker,swKSAGAAAAAJ,0000-0001-7181-1933
 D. Cenitta,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/d-cenitta/_jcr_content.html,949MilMAAAAJ,0000-0003-3715-6941
 D. Ellis Hershkowitz,Brown University,https://dhershko.github.io,JR_KR7MAAAAJ,0000-0003-0862-3715
-D. F. Wong,Chinese University of Hong Kong,https://www.erg.cuhk.edu.hk/erg/DeanMessage,WPhoQiUAAAAJ,0000-0000-0000-0000
-D. F. Wong 0001,Chinese University of Hong Kong,https://www.erg.cuhk.edu.hk/erg/DeanMessage,WPhoQiUAAAAJ,0000-0001-8274-9688
 D. Hemkumar,VNIT Nagpur,https://vnit.ac.in/engineering/cse/dr-hemkumar-d,QzZ4IDcAAAAJ,0000-0000-0000-0000
 D. J. Soudris,NTUA,https://microlab.ntua.gr/academics/dimitrios-soudris,lWuTmpEAAAAJ,0000-0000-0000-0000
 D. Janaki Ram,IIT Madras,http://dos.iitm.ac.in/djwebsite,zxpFxq8AAAAJ,0000-0000-0000-0000
@@ -1517,7 +1515,6 @@ Dong-Guk Shin,University of Connecticut,http://profiles.uconn.edu/display/64589,
 Dong-Hong Ji,Wuhan University,https://cse.whu.edu.cn/info/1258/3290.htm,2Q-7u3AAAAAJ,0000-0000-0000-0000
 Dong-Jun Han,Yonsei University,https://sites.google.com/view/djhan930/home,-YR-GxUAAAAJ,0000-0003-2970-7336
 Dong-Ming Yan 0001,Chinese Academy of Sciences,https://sites.google.com/site/yandongming,xAFSO3AAAAAJ,0000-0003-2209-2404
-Dong-Sun Kim 0001,Kyungpook National University,http://www.darkrsw.net,Rmzs0QIAAAAJ,0000-0000-0000-0000
 DongGyun Han,Royal Holloway Univ. of London,https://pure.royalholloway.ac.uk/en/persons/donggyun-han,gfAdVBwAAAAJ,0000-0002-8599-2197
 Dongbao Yang,Nankai University,https://cs.nankai.edu.cn/info/1223/3579.htm,NOSCHOLARPAGE,0000-0001-8628-411X
 Dongbin Zhao,Chinese Academy of Sciences,https://people.ucas.ac.cn/~zhaodongbin,RxvYlNQAAAAJ,0000-0001-8218-9633

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -378,7 +378,6 @@ Katie Atkinson,University of Liverpool,https://www.csc.liv.ac.uk/~katie,fvQicksA
 Katie Bentley,King's College London,https://www.kcl.ac.uk/people/katie-bentley,vCDdIT4AAAAJ,0000-0002-9391-659X
 Katie Moor,Indiana University,http://wphomes.soic.indiana.edu/ksiek,-R9W7IkAAAAJ,0000-0000-0000-0000
 Katinka Wolter,Freie Universitaet Berlin,https://www.mi.fu-berlin.de/inf/groups/ag-tech/staff/0Current/wolter.html,JqtocLYAAAAJ,0000-0000-0000-0000
-Katja Daniela Mombaur,University of Waterloo,https://uwaterloo.ca/robohub/profile/kmombaur,HuN7dvgAAAAJ,0000-0000-0000-0000
 Katja Hose,TU Wien,https://www.dbai.tuwien.ac.at/staff/khose/About_me.html,LbXvZUoAAAAJ,0000-0001-7025-8099
 Katja Mombaur,Karlsruhe Inst. of Technology,https://hcr.iar.kit.edu/team_KMombaur.php,HuN7dvgAAAAJ,0000-0003-1353-0943
 Katja Nieselt,University of Tübingen,https://uni-tuebingen.de/en/faculties/faculty-of-science/departments/computer-science/lehrstuehle/integrative-transcriptomics/group,Ty-5Q7sAAAAJ,0000-0000-0000-0000

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -11,7 +11,6 @@ M. Brian Blake,Drexel University,http://drexel.edu/cci/contact/Faculty/Blake-MBr
 M. Cecília C. Baranauskas,UNICAMP,http://bv.fapesp.br/pt/pesquisador/3391/maria-cecilia-calani-baranauskas,NOSCHOLARPAGE,0000-0000-0000-0000
 M. D. Atkinson,University of Otago,http://www.cs.otago.ac.nz/staffpriv/mike/HomePages/newhome.html,C2oYWqgAAAAJ,0000-0000-0000-0000
 M. Eduard Gröller,TU Wien,https://www.cg.tuwien.ac.at/staff/EduardGroeller.html,eBsjFlIAAAAJ,0000-0002-8569-4149
-M. Ehsan Abbasnejad,Adelaide University,https://ehsanabb.github.io,OdlVfTsAAAAJ,0000-0002-7126-317X
 M. Elif Karsligil,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/elifk?lang=en,NOSCHOLARPAGE,0000-0000-0000-0000
 M. Engin Tozal,Univ. of Louisiana - Lafayette,https://people.cmix.louisiana.edu/tozal,NOSCHOLARPAGE,0000-0000-0000-0000
 M. Fatih Amasyali,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/mfatih?lang=en,qTUSAy0AAAAJ,0000-0000-0000-0000
@@ -815,7 +814,6 @@ Marivic S. Tangkeko,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/
 Mariya Toneva [SWS],Max Planck Society,https://mtoneva.com,a61sk-4AAAAJ,0000-0000-0000-0000
 Mariya Zheleva,University at Albany - SUNY,https://www.albany.edu/ceas/mariya-zheleva.php,eEqTPcwAAAAJ,0000-0000-0000-0000
 Marián Simko,Kempelen Institute - KInIT,https://kinit.sk/member/marian-simko,t0WixXUAAAAJ,0000-0000-0000-0000
-Mariëlle I. A. Stoelinga,Radboud University,https://wwwhome.ewi.utwente.nl/~marielle,po_MgfcAAAAJ,0000-0000-0000-0000
 Mariëlle Stoelinga,University of Twente,https://research.utwente.nl/en/persons/00c4dbae-73d0-4715-88c6-5203b1280f2a,po_MgfcAAAAJ,0000-0001-6793-8165
 Marjan Sirjani,Mälardalen University,https://marjansirjani.github.io/Marjan-Sirjani,TKnSrTQAAAAJ,0000-0001-5478-0987
 Marjo Kauppinen,Aalto University,https://people.aalto.fi/new/marjo.kauppinen,Wo8x6EUAAAAJ,0000-0000-0000-0000
@@ -2686,7 +2684,6 @@ Mohamed Younis,Univ. of Maryland - Baltimore County,http://www.csee.umbc.edu/~yo
 Mohammad A. Alsmirat,JUST,http://www.just.edu.jo/eportfolio/Pages/Default.aspx?email=masmirat,c1S0wzQAAAAJ,0000-0000-0000-0000
 Mohammad A. Islam 0001,University of Texas at Arlington,http://crystal.uta.edu/~mislam,rxKWd1cAAAAJ,0000-0002-5778-4366
 Mohammad A. M. Abushariah,University of Jordan,http://ju-jo.academia.edu/MohammadAbdAlrahmanMahmoudAbushariah/CurriculumVitae,NOSCHOLARPAGE,0000-0000-0000-0000
-Mohammad Abbasnejad,Adelaide University,https://ehsanabb.github.io,OdlVfTsAAAAJ,0000-0000-0000-0000
 Mohammad Abd-Alrahman Mahmoud Abushariah,University of Jordan,http://ju-jo.academia.edu/MohammadAbdAlrahmanMahmoudAbushariah/CurriculumVitae,NOSCHOLARPAGE,0000-0000-0000-0000
 Mohammad Abdollahi Azgomi,IUST,http://www.iust.ac.ir/content/8313/Dr.-Abdollahi-Azgomi,OcWAFjcAAAAJ,0000-0000-0000-0000
 Mohammad Abdulaziz,King's College London,https://www.kcl.ac.uk/people/mohammad-abdulaziz,x5z4rRkAAAAJ,0000-0002-8244-518X

--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -404,7 +404,6 @@ Paul Richmond,University of Sheffield,https://www.sheffield.ac.uk/dcs/people/aca
 Paul Rosen 0001,University of Utah,http://www.cspaul.com/wordpress,6iv6AEcAAAAJ,0000-0002-0873-9518
 Paul Schweizer,University of Edinburgh,https://www.inf.ed.ac.uk/people/staff/Paul_Schweizer.html,M0uLiP0AAAAJ,0000-0000-0000-0000
 Paul Siebert,University of Glasgow,http://www.dcs.gla.ac.uk/~psiebert,DoEOa80AAAAJ,0000-0000-0000-0000
-Paul T. Groth,VU Amsterdam,https://www.nbic.nl/about-nbic/nbic-faculty/pages1/4/details/groth-paul-t-dr,0tHSHCIAAAAJ,0000-0000-0000-0000
 Paul T. Tymann,Rochester Inst. of Technology,https://www.cs.rit.edu/~ptt,NOSCHOLARPAGE,0000-0000-0000-0000
 Paul Tarau,University of North Texas,http://www.cse.unt.edu/~tarau,JUMRc-oAAAAJ,0000-0000-0000-0000
 Paul Teal,Victoria University of Wellington,http://ecs.victoria.ac.nz/Main/PaulTeal,wS0ittUAAAAJ,0000-0000-0000-0000


### PR DESCRIPTION
Follow-up to #14029 / #14030, working the cases I held back as possible dual appointments.

**Method change**: verified against **departmental pages and LinkedIn first**, using ORCID only as a hint. ORCID lists *both* institutions as current for every case below, so it could not have resolved any of them — and it was outright wrong on two.

cc @hcitang @darkrsw @ehsan-aiml — your entries are involved; please correct me if any of this is wrong.

## Resolved to a single primary appointment (9 rows removed)

| Person | Removed | Evidence |
|---|---|---|
| **Paul Groth** | VU Amsterdam | Professor of Algorithmic Data Science at [UvA](https://www.uva.nl/en/profile/g/r/p.t.groth/p.t.groth.html), leads INDElab; VU listed as prior |
| **Katja Mombaur** | Waterloo | Leads the Institute for Anthropomatics and Robotics at KIT. At [Waterloo](https://uwaterloo.ca/robohub/profiles/katja-mombaur) she is now the **former** Canada Excellence Research Chair and only an **Adjunct Professor** |
| **Anthony Tang** | Calgary | Tenured Associate Professor, [SMU School of Computing and Information Systems](https://hcitang.github.io/cv/). Calgary is **two moves back** — Calgary → Toronto → SMU |
| **Dongsun Kim** | Kyungpook | Associate Professor, **Korea University** — stated on [@darkrsw's GitHub profile](https://github.com/darkrsw), which is the account that has submitted Korea University entries to this repo |
| **Martin D. F. Wong** | CUHK (**2 rows**) | [Provost and Chair Professor of CS at HKBU **since Aug 2023**](https://www.hkbu.edu.hk/en/about/university-officers/professor-martin-wong.html); the CUHK deanship ran Jan 2019 – **July 2023**. Both CUHK rows pointed at a CUHK dean's-message page |
| **Mariëlle Stoelinga** | Radboud | Full professor at [Twente](https://people.utwente.nl/m.i.a.stoelinga) (primary); Radboud is an explicit **0.2 FTE** appointment — below the >=75% bar in VALIDATION.md |
| **Ehsan Abbasnejad** | Adelaide (**2 rows**) | **He submitted the move himself** — [#9027 "Move to Monash University"](https://github.com/emeryberger/CSrankings/pull/9027) by @ehsan-aiml. Monash confirms an active Associate Professorship with projects to 2027 |

Three of these also collapse a **same-institution** duplicate pair as a side effect (Wong ×2 at CUHK, Abbasnejad ×2 at Adelaide).

**Post-edit check**: all seven people retain exactly one row, at their primary institution.

## Where ORCID would have got it wrong

- **Abbasnejad** — ORCID says Adelaide is current, which would have inverted this removal. In #14029 I excluded him for exactly that reason. The repo's own PR history settles it: he filed the Monash move.
- **Mombaur** — ORCID lists Waterloo as a current professorship with no end date. The Waterloo page says *former* CERC, now adjunct.

## Left alone — genuinely dual, needs a policy call

| Person | Appointments |
|---|---|
| **Kai Kunze** (@kkai) | Full professor at **both** Keio (Graduate School of Media Design) and **TU Clausthal** |
| **Kobi Gal** | Faculty at **Ben-Gurion** (SISE) and **Reader** at Edinburgh Informatics |

Neither source states an FTE split, so the >=75% criterion can't be applied from public information. @kkai — if you can say which appointment is your primary one, that would settle yours. Kobi Gal additionally has **two** Ben-Gurion rows (`Ya'akov (Kobi) Gal` and `Ya'akov Gal`), which is a same-institution duplicate worth collapsing regardless of the outcome.

## On the @-mentions

Only accounts I could positively tie to the person are tagged: @hcitang ("Tony Tang", homepage `hcitang.org` matching the CSRankings row), @darkrsw ("Dongsun Kim", Korea University, `darkrsw.github.io` matching the row), @ehsan-aiml ("Ehsan Abbasnejad", author of the Monash move PRs), @kkai ("Kai Kunze", `kaikunze.de` matching the row). Where a name matched a GitHub account but I could not confirm it was the same person, I left them untagged rather than risk notifying a stranger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)