### PR TITLE
Resolve 20 more cross-institution Scholar ID duplicates (23 rows)

### DIFF
--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -841,7 +841,6 @@ Alexander Leitsch,TU Wien,https://www.logic.at/staff/leitsch,NOSCHOLARPAGE,0000-
 Alexander Lex,Graz University of Technology,http://alexander-lex.net,JFNLCUcAAAAJ,0000-0001-6930-5468
 Alexander M. Barg,Univ. of Maryland - College Park,https://www.cs.umd.edu/people/abarg,nvU3IvEAAAAJ,0000-0000-0000-0000
 Alexander M. Bronstein,Technion,http://www.cs.technion.ac.il/~bron,lafKN0sAAAAJ,0000-0000-0000-0000
-Alexander M. Fraser,LMU Munich,https://www.cis.uni-muenchen.de/~fraser,4ZIZK08AAAAJ,0000-0000-0000-0000
 Alexander M. Rush [Tech],Cornell University,http://rush.seas.harvard.edu,LIjnUGgAAAAJ,0000-0000-0000-0000
 Alexander Marder,Johns Hopkins University,https://alexmarder.github.io,htWC_lMAAAAJ,0000-0003-3327-1571
 Alexander May 0001,Ruhr-University Bochum,http://www.cits.rub.de/personen/may.html,oD5v0XoAAAAJ,0000-0001-5965-5675
@@ -1647,7 +1646,6 @@ Andrej Bogdanov,University of Ottawa,https://andrejb.net,MCZpAkEAAAAJ,0000-0000-
 Andrej Risteski,Carnegie Mellon University,https://www.andrew.cmu.edu/user/aristesk,NWPDSEsAAAAJ,0000-0000-0000-0000
 Andrej Scedrov,University of Pennsylvania,https://www.cis.upenn.edu/~scedrov,F-kvxQoAAAAJ,0000-0000-0000-0000
 Andres Goens,TU Darmstadt,https://www.informatik.tu-darmstadt.de/fb20/professuren_und_gruppenleitungen/fb20professuren_und_gruppenleitungen_detailseite_154560.de.jsp,vjVhbJoAAAAJ,0000-0002-0409-1363
-Andres Wilhelm Goens Jokisch,University of Amsterdam,https://www.uva.nl/en/profile/g/o/a.w.goens-jokisch/a.w.goens-jokisch.html,vjVhbJoAAAAJ,0000-0000-0000-0000
 Andrew A. Chien,University of Chicago,http://people.cs.uchicago.edu/~aachien,zkqz0_0AAAAJ,0000-0000-0000-0000
 Andrew B. Kahng,Univ. of California - San Diego,http://vlsicad.ucsd.edu/~abk,zCO_h3cAAAAJ,0000-0002-4490-5018
 Andrew Begel,Carnegie Mellon University,https://s3d.cmu.edu/people/core-faculty/begel-andrew1.html,H_oWiFsAAAAJ,0000-0002-7425-4818
@@ -1821,7 +1819,6 @@ Andrés A. Lucero,Aalto University,http://funkydesignspaces.com,YdNEAwoAAAAJ,000
 Andrés Abeliuk,Universidad de Chile,https://aabeliuk.github.io,qKqH1lcAAAAJ,0000-0002-8158-4647
 Andrés Bruhn,University of Stuttgart,https://worldbeat.visus.uni-stuttgart.de/cvis/index.shtml,PtIe6OkAAAAJ,0000-0003-0423-7411
 Andrés Faiña,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/andres-faina(7dd48cfe-3069-4563-bef4-ef661c18387a).html,KxfaneoAAAAJ,0000-0001-7288-6988
-Andrés Goens,University of Amsterdam,https://www.uva.nl/en/profile/g/o/a.w.goens-jokisch/a.w.goens-jokisch.html,vjVhbJoAAAAJ,0000-0002-0409-1363
 Andrés Lucero,Aalto University,http://funkydesignspaces.com,YdNEAwoAAAAJ,0000-0002-7176-2884
 Andrés Martínez-Fernández,Universidad Rey Juan Carlos,http://www.tsc.urjc.es/profiles/andres_martinez.html,T8fmqcAAAAAJ,0000-0000-0000-0000
 Andrés Monroy-Hernández,Princeton University,https://www.cs.princeton.edu/people/profile/andresmh,WDSU0ucAAAAJ,0000-0003-4889-9484
@@ -2599,8 +2596,6 @@ Atakan Aral,University of Vienna,https://cs.univie.ac.at/Atakan.Aral,hyRRNqgAAAA
 Atanas P. Gotchev,Tampere University,https://www.tuni.fi/en/atanas-gotchev,quqBZjUAAAAJ,0000-0000-0000-0000
 Atanas Rountev,Ohio State University,http://web.cse.ohio-state.edu/~rountev,Y9Jw4lcAAAAJ,0000-0003-4556-4937
 Atau Tanaka,University of Bristol,http://ataut.net,4mgdxrUAAAAJ,0000-0000-0000-0000
-Atay Ozgovde,Galatasaray University,https://avesis.gsu.edu.tr/aozgovde,obp2euEAAAAJ,0000-0000-0000-0000
-Atay Özgövde,Galatasaray University,https://avesis.gsu.edu.tr/aozgovde,obp2euEAAAAJ,0000-0000-0000-0000
 Athanasios D. Panagopoulos,NTUA,http://users.ntua.gr/thanpan,RGuFDFIAAAAJ,0000-0000-0000-0000
 Athanasios G. Georgiadis,Trinity College Dublin,https://sites.google.com/site/nasosmath,RZ_2x8gAAAAJ,0000-0000-0000-0000
 Athanasios G. Kanatas,University of Piraeus,https://www.ds.unipi.gr/en/faculty/kanatas-en,9SbmI0YAAAAJ,0000-0000-0000-0000

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -502,7 +502,6 @@ Chee K. Yap,New York University,http://cs.nyu.edu/yap,NOSCHOLARPAGE,0000-0000-00
 Chee Keong Kwoh 0001,Nanyang Technological University,http://www.ntu.edu.sg/home/asckkwoh,jVn0wDMAAAAJ,0000-0000-0000-0000
 Chee Keong Tan,Monash University Malaysia,https://research.monash.edu/en/persons/tan-chee-keong,hlGeZ4MAAAAJ,0000-0001-5551-1017
 Chee Seng Chan,University of Malaya,http://web.fsktm.um.edu.my/~cschan,hKfga9oAAAAJ,0000-0000-0000-0000
-Chee Wei Tan 0001,City University of Hong Kong,https://www.cs.cityu.edu.hk/~cheewtan,G2CBtcAAAAAJ,0000-0002-6624-9752
 Chee Yap,New York University,http://cs.nyu.edu/yap,NOSCHOLARPAGE,0000-0000-0000-0000
 Chee Yong Chan,National University of Singapore,https://www.comp.nus.edu.sg/~chancy,mcz6T78AAAAJ,0000-0001-5925-6041
 Chee-Hung Henry Chu,Univ. of Louisiana - Lafayette,https://www.louisiana.edu/academics/awards-recognition/faculty-achievements/distinguished-professor-awards,NOSCHOLARPAGE,0000-0002-5817-8798
@@ -706,7 +705,6 @@ Ching-Ju Lin,National Chiao Tung University,http://people.cs.nctu.edu.tw/~kateli
 Ching-Kuang Shene,Michigan Technological University,https://www.mtu.edu/cs/department/faculty-staff/faculty/shene,NOSCHOLARPAGE,0000-0000-0000-0000
 Ching-Te Chiu,National Tsing Hua University,http://www.cs.nthu.edu.tw/~ctchiu,NOSCHOLARPAGE,0000-0000-0000-0000
 Chingfang Hsu,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/depmember/teacherdetail/id/19,NOSCHOLARPAGE,0000-0000-0000-0000
-Chinmay Eishan Kulkarni,Carnegie Mellon University,https://hcii.cmu.edu/people/chinmay-kulkarni,ZDatV6MAAAAJ,0000-0000-0000-0000
 Chinmay Hegde,New York University,https://engineering.nyu.edu/faculty/chinmay-hegde,eJAV17IAAAAJ,0000-0003-4574-8066
 Chinmay Kulkarni 0001,Emory University,https://hcii.cmu.edu/people/chinmay-kulkarni,ZDatV6MAAAAJ,0000-0003-4922-6601
 Chinmaya Misra,KIIT Bhubaneswar,https://ksca.kiit.ac.in/profiles/chinmaya-misra,_mmOoQIAAAAJ,0000-0000-0000-0000

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -294,7 +294,6 @@ Daniel J. Rigden,University of Liverpool,https://liverpool.ac.uk/integrative-bio
 Daniel J. Rough,University of Dundee,https://discovery.dundee.ac.uk/en/persons/daniel-rough,RCkETH8AAAAJ,0000-0003-1545-5377
 Daniel J. Simon,Cleveland State University,https://academic.csuohio.edu/simond,hZV3PngAAAAJ,0000-0000-0000-0000
 Daniel J. Sorin,Duke University,http://people.ee.duke.edu/~sorin,bsoRFLAAAAAJ,0000-0001-7013-8986
-Daniel J. Szafir,University of Colorado Boulder,http://danszafir.com,WxmhtyMAAAAJ,0000-0000-0000-0000
 Daniel J. Wigdor,University of Toronto,http://www.dgp.toronto.edu/~dwigdor,x3hvdTsAAAAJ,0000-0000-0000-0000
 Daniel Jackson 0001,Massachusetts Inst. of Technology,http://people.csail.mit.edu/dnj,_hAP7BgAAAAJ,0000-0003-4864-078X
 Daniel Jiménez-González,Polytechnic Univ. of Catalonia,http://personals.ac.upc.edu/djimenez,NOSCHOLARPAGE,0000-0001-6064-7883
@@ -438,7 +437,6 @@ Daniele Venturi 0001,Sapienza University of Rome,http://danieleventuri.altervist
 Danielle Albers,University of North Carolina,https://cs.unc.edu/person/danielle-szafir,CGb88B0AAAAJ,0000-0000-0000-0000
 Danielle Albers Szafir,University of North Carolina,https://cs.unc.edu/person/danielle-szafir,CGb88B0AAAAJ,0000-0003-3634-8597
 Danielle Azar,Lebanese American University,http://sas.lau.edu.lb/csm/people/danielle-azar.php,lcd1FHgAAAAJ,0000-0002-6159-3714
-Danielle Szafir,University of Colorado Boulder,http://www.colorado.edu/cmci/people/information-science/danielle-albers-szafir,CGb88B0AAAAJ,0000-0003-3634-8597
 Danilo Ardagna,Politecnico di Milano,http://home.deib.polimi.it/ardagna,2S6m-oYAAAAJ,0000-0003-4224-927X
 Danilo Avola,Sapienza University of Rome,http://visionlab.di.uniroma1.it/node/9,9R03Bl0AAAAJ,0000-0001-9437-6217
 Danilo Barbosa Coimbra,Federal University of Bahia,https://computacao.ufba.br/pt-br/danilo-barbosa-coimbra,aF-83tAAAAAJ,0000-0000-0000-0000

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -357,7 +357,6 @@ Georgios Portokalidis,IMDEA Software Institute,https://www.portokalidis.net,pGz5
 Georgios S. Zervas,Boston University,https://www.bu.edu/cs/profiles/zg,5L8vEA4AAAAJ,0000-0000-0000-0000
 Georgios Smaragdakis,TU Delft,https://gsmaragd.github.io,wytGMWcAAAAJ,0000-0002-4127-3617
 Georgios Theodoropoulos 0001,SUSTech,http://www.gtheodoropoulos.com,pr69a6YAAAAJ,0000-0000-0000-0000
-Georgios Tzimpragos,University of Michigan,https://www.georgetzimpragos.com,KxsspL0AAAAJ,0000-0002-0127-4703
 Georgios Tziritas,University of Crete,https://www.csd.uoc.gr/~tziritas,mIh2JWAAAAAJ,0000-0002-1802-1825
 Georgios Zervakis 0001,NTUA,https://giozerv.github.io,hZtfPegAAAAJ,0000-0001-8110-7122
 Georgios Zervas,Boston University,https://www.bu.edu/cs/profiles/zg,5L8vEA4AAAAJ,0000-0000-0000-0000
@@ -965,7 +964,6 @@ Guohui Xiao 0001,Southeast University,https://cs.seu.edu.cn/guohuixiao/main.htm,
 Guojie Luo,Peking University,http://ceca.pku.edu.cn/guojie,8-mT29YAAAAJ,0000-0003-4932-3655
 Guojie Song,Peking University,http://www.klmp.pku.edu.cn/Faculty/FacultyDetail.aspx?FacultyID=44,a832IIMAAAAJ,0000-0001-8295-2520
 Guojun Peng,Wuhan University,https://cse.whu.edu.cn/info/3301/37331.htm,NOSCHOLARPAGE,0000-0001-5731-8958
-Guojun Qi,University of Central Florida,http://www.cs.ucf.edu/~gqi,Nut-uvoAAAAJ,0000-0003-3508-1851
 Guolei Sun,Nankai University,https://cc.nankai.edu.cn/2021/0323/c13619a572933/page.htm,qd8Blw0AAAAJ,0000-0001-8667-9656
 Guoliang He,Wuhan University,http://cs.whu.edu.cn/teacherinfo.aspx?id=207,NOSCHOLARPAGE,0000-0000-0000-0000
 Guoliang Jin,North Carolina State University,https://www.csc.ncsu.edu/people/gjin2,Z2-LnXgAAAAJ,0000-0000-0000-0000

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -1,5 +1,4 @@
 name,affiliation,homepage,scholarid,orcid
-J. A. dos Santos,UFMG,http://homepages.dcc.ufmg.br/~jefersson,wXQnnTUAAAAJ,0000-0000-0000-0000
 J. Alex Halderman,University of Michigan,https://jhalderm.com,h6yXnyEAAAAJ,0000-0002-9116-5390
 J. Andreas Bærentzen,DTU,https://people.compute.dtu.dk/janba,if2X4wkAAAAJ,0000-0003-2583-0660
 J. Andrew Bagnell,Carnegie Mellon University,http://www.ri.cmu.edu/person.html?person_id=689,7t4jbPQAAAAJ,0000-0000-0000-0000
@@ -741,7 +740,6 @@ Jeffrey C. Dill,Ohio University,https://www.ohio.edu/engineering/about/people/pr
 Jeffrey C. Trinkle,Lehigh University,http://www.cse.lehigh.edu/~trink,Dl0vAp8AAAAJ,0000-0000-0000-0000
 Jeffrey Carver,The University of Alabama,http://carver.cs.ua.edu,qGe7nJ0AAAAJ,0000-0002-7824-9151
 Jeffrey Chan,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/c/chan-dr-jeffrey,I9mDeiYAAAAJ,0000-0002-7865-072X
-Jeffrey Clune,University of Wyoming,http://www.uwyo.edu/profiles/extras/playing-with-robots.html,5TZ7f5wAAAAJ,0000-0000-0000-0000
 Jeffrey D. Morris,Augusta University,https://www.augusta.edu/ccs/faculty.php,VWQQYTcAAAAJ,0000-0000-0000-0000
 Jeffrey Dalton 0001,University of Edinburgh,http://www.inf.ed.ac.uk/people/staff/Jeff_Dalton.html,mgwLi-EAAAAJ,0000-0003-2422-8651
 Jeffrey E. Boyd,University of Calgary,http://pages.cpsc.ucalgary.ca/~boyd,C285XCoAAAAJ,0000-0000-0000-0000

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -337,7 +337,6 @@ Katharina Kohls,Ruhr-University Bochum,https://kkohls.info,HQ8HblYAAAAJ,0000-000
 Katharina Krombholz,CISPA Helmholtz Center,https://cispa.saarland/people/katharina.krombholz,BkeawyUAAAAJ,0000-0003-2425-3013
 Katharina Morik,TU Dortmund,https://www-ai.cs.tu-dortmund.de/PERSONAL/morik.html,LfmjF2UAAAAJ,0000-0003-1153-5986
 Katharina Reinecke,University of Washington,https://www.cs.washington.edu/people/faculty/reinecke,_4EISRwAAAAJ,0000-0001-7897-9325
-Katharina Siobhan Kohls,Radboud University,https://kkohls.org/index.html,HQ8HblYAAAAJ,0000-0000-0000-0000
 Katharina Spiel,TU Wien,http://katta.mere.st,C9dueLMAAAAJ,0000-0000-0000-0000
 Katherine A. Daniell,Australian National University,https://cybernetics.anu.edu.au/people/katherine-daniell,TIQVsWEAAAAJ,0000-0000-0000-0000
 Katherine A. Yelick,Univ. of California - Berkeley,https://www.cs.berkeley.edu/~yelick,93yNuV0AAAAJ,0000-0003-0957-701X

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -1103,7 +1103,6 @@ Martin Jaggi,EPFL,https://people.epfl.ch/martin.jaggi,r1TJBr8AAAAJ,0000-0003-157
 Martin James Chorley,Cardiff University,https://www.cardiff.ac.uk/people/view/118120-chorley-martin,t3R1ZLgAAAAJ,0000-0001-8744-260X
 Martin Johns,TU Braunschweig,http://www.martinjohns.com,a-_ZVzEAAAAJ,0000-0003-2574-5060
 Martin Jägersand,University of Alberta,https://webdocs.cs.ualberta.ca/~jag,kxAlIY4AAAAJ,0000-0000-0000-0000
-Martin Karl Hoefer,Goethe University Frankfurt,http://algo.cs.uni-frankfurt.de/~mhoefer,PBCXFY8AAAAJ,0000-0000-0000-0000
 Martin Karsten,University of Waterloo,https://cs.uwaterloo.ca/~mkarsten,ieXJpBkAAAAJ,0009-0009-9389-8510
 Martin Kellogg,NJIT,https://web.njit.edu/~mjk76,KicmjV0AAAAJ,0000-0002-3185-2340
 Martin Kleppmann,University of Cambridge,https://www.cst.cam.ac.uk/people/mk428,TbyvU7oAAAAJ,0000-0001-7252-6958
@@ -1686,7 +1685,6 @@ Mei-Hwa Chen,University at Albany - SUNY,https://www.albany.edu/ceas/mei-hwa-che
 Meibao Yao,Jilin University,http://www.inrobotslab.com,8j2UgWwAAAAJ,0000-0002-7069-6782
 Meihui Zhang,Beijing Institute of Technology,https://zmeihui.github.io,DuLgpaQAAAAJ,0000-0000-0000-0000
 Meikang Qiu,Augusta University,https://www.augusta.edu/faculty/directory/view.php?id=MQIU,smMVdtwAAAAJ,0000-0002-1004-0140
-Meike Albrecht,University of Rostock,https://www.informatik.uni-rostock.de/ueber-uns/bereich/homepages/meike-klettke/startseite,Rj6p8R8AAAAJ,0000-0000-0000-0000
 Meike Klettke,University of Regensburg,https://www.uni-regensburg.de/informatik-data-science/data-engineering/startseite/index.html,Rj6p8R8AAAAJ,0000-0003-0551-8389
 Meiling Fang,Yangzhou University,https://xxgcxy.yzu.edu.cn/info/1022/7726.htm,S_RV3L4AAAAJ,0000-0000-0000-0000
 Meina Kan,Chinese Academy of Sciences,http://vipl.ict.ac.cn/homepage/mnkan/index.html,4AKCKKEAAAAJ,0000-0001-9483-875X

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -111,7 +111,6 @@ Sainyam Galhotra,Cornell University,http://sainyamgalhotra.com,0_9V8PgAAAAJ,0000
 Saiph Savage,Northeastern University,http://www.saiph.org,GHGHYZAAAAAJ,0000-0001-9020-8929
 Sajal K. Das 0001,Missouri S&T,https://isc.mst.edu/people/ri/sdas,mbaG-mQAAAAJ,0000-0002-9471-0868
 Sajda Qureshi,University of Nebraska - Omaha,https://www.unomaha.edu/college-of-information-science-and-technology/it-for-development/faculty/faculty.php,_7Rne6cAAAAJ,0000-0002-7407-8148
-Sajedul Rahim Talukder,SIU Carbondale,https://www2.cs.siu.edu/~stalukder,VJl925AAAAAJ,0000-0000-0000-0000
 Sajedul Talukder,University of Texas - El Paso,https://www.cs.utep.edu/stalukder,VJl925AAAAAJ,0000-0000-0000-0000
 Sajin Koroth,University of Victoria,https://web.uvic.ca/~skoroth,Tf_natAAAAAJ,0000-0000-0000-0000
 Sajin Sasy,CISPA Helmholtz Center,https://ssasy.github.io,rrJTgX0AAAAJ,0000-0003-3447-1006
@@ -435,7 +434,6 @@ Sara Khalifa,Queensland Univ. of Technology,https://www.qut.edu.au/about/our-peo
 Sara Ljungblad,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/sara-ljungblad.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
 Sara McAllister,University of Wisconsin - Madison,https://saramcallister.github.io,6FV_p28AAAAJ,0000-0001-5253-7094
 Sara Mostafavi,University of Washington,http://saramostafavi.github.io,nBL0J6kAAAAJ,0000-0000-0000-0000
-Sara Nadi,University of Alberta,https://www.ualberta.ca/science/about-us/contact-us/faculty-directory/sarah-nadi,PxNO2g8AAAAJ,0000-0000-0000-0000
 Sara Rampazzi,University of Florida,https://sararampazzi.com,I9d0CrAAAAAJ,0000-0002-3630-6269
 Sara Shurin,Hebrew University of Jerusalem,http://www.cs.huji.ac.il/~sara,J2sg9BwAAAAJ,0000-0002-8482-9435
 Sara Silva,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/sgsilva,g15oqi0AAAAJ,0000-0000-0000-0000
@@ -678,7 +676,6 @@ Sebastian Siebertz,University of Bremen,https://www.mimuw.edu.pl/~siebertz,B2g3q
 Sebastian Stein 0001,University of Southampton,https://www.ecs.soton.ac.uk/people/ss1y07,6TuZKj4AAAAJ,0000-0003-2858-8857
 Sebastian Steinhorst,TU Munich,https://www.ce.cit.tum.de/esi/mitarbeiter/steinhorst,nUd33p4AAAAJ,0000-0002-4096-2584
 Sebastian Stober,University of Magdeburg,http://ai.ovgu.de,OPyztE0AAAAJ,0000-0000-0000-0000
-Sebastian Thore Erdweg,University of Mainz,https://www.informatik.uni-marburg.de/~seba/index.html,2jCQrk4AAAAJ,0000-0000-0000-0000
 Sebastian Trimpe,RWTH Aachen University,https://www.dsme.rwth-aachen.de/cms/DSME/das-institut/Team/~jlolt/Prof-Sebastian-Trimpe/?allou=1,9kzHZssAAAAJ,0000-0002-2785-2487
 Sebastian Tschiatschek,University of Vienna,https://dm.cs.univie.ac.at/team/person/109359,NOSCHOLARPAGE,0000-0002-2592-0108
 Sebastian U. Stich,CISPA Helmholtz Center,https://www.sstich.ch,8l-mDfQAAAAJ,0000-0000-0000-0000
@@ -1052,7 +1049,6 @@ Sharon Mason,Rochester Inst. of Technology,http://ist.rit.edu/~spm,_03eTDYAAAAJ,
 Sharon Shoham,Tel Aviv University,http://www.tau.ac.il/~sharonshoham,SCP6RcEAAAAJ,0000-0002-7226-3526
 Sharon Wood,University of Sussex,http://www.sussex.ac.uk/informatics/people/peoplelists/person/2974,NOSCHOLARPAGE,0000-0000-0000-0000
 Sharon X. Huang,Pennsylvania State University,https://faculty.ist.psu.edu/suh972,iTtzc1UAAAAJ,0000-0003-2338-6535
-Sharon Xianghua Ding,Fudan University,http://www.xianghuading.com,B9M48i8AAAAJ,0000-0001-8122-6252
 Sharon Xiaolei Huang,Pennsylvania State University,https://faculty.ist.psu.edu/suh972,iTtzc1UAAAAJ,0000-0000-0000-0000
 Shasha Mao,Xidian University,https://web.xidian.edu.cn/ssmao,QLCqaOwAAAAJ,0000-0000-0000-0000
 Shashank Sonkar,University of Central Florida,https://www.cecs.ucf.edu/faculty/shashank-sonkar,4Rv56n4AAAAJ,0000-0000-0000-0000
@@ -2359,7 +2355,6 @@ Steven W. Zucker,Yale University,http://www.cs.yale.edu/~vision/zucker/steve.htm
 Steven Whang,KAIST,http://stevenwhang.com,w6hts30AAAAJ,0000-0000-0000-0000
 Steven Wu 0001,Carnegie Mellon University,https://zstevenwu.com,MbF6rTEAAAAJ,0000-0002-8125-8227
 Steven Y. Ko,Simon Fraser University,https://www.sfu.ca/computing/people/faculty/steven-ko.html,SsRxrX4AAAAJ,0000-0003-3771-0156
-Steven Z. Wu,University of Minnesota,https://www-users.cs.umn.edu/~zsw,MbF6rTEAAAAJ,0000-0000-0000-0000
 Stevie Chancellor,University of Minnesota,http://steviechancellor.com,Q_rTsewAAAAJ,0000-0003-0620-0903
 Stian Soiland-Reyes,University of Manchester,https://s11.no,OeBjonkAAAAJ,0000-0000-0000-0000
 Stig Høgh,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE,0000-0000-0000-0000

--- a/csrankings-x.csv
+++ b/csrankings-x.csv
@@ -87,7 +87,6 @@ Xiangdong Li,CUNY,http://www.gc.cuny.edu/Page-Elements/Academics-Research-Center
 Xiangdong Zhou,Fudan University,http://homepage.fudan.edu.cn/xdzhou,QUrLihYAAAAJ,0000-0002-5538-7367
 Xiangguo Sun,Southeast University,https://cs.seu.edu.cn/sunxiangguo/main.htm,rKfYQwEAAAAJ,0000-0002-2224-4634
 Xianghai Cao,Xidian University,https://web.xidian.edu.cn/caoxh/index.html,q4GKoagAAAAJ,0000-0000-0000-0000
-Xianghua Ding,Fudan University,http://www.xianghuading.com,B9M48i8AAAAJ,0000-0001-8122-6252
 Xianghua Ying,Peking University,http://www.cis.pku.edu.cn/vision/Visual&Robot/people/ying/index.htm,27o9L1wAAAAJ,0000-0000-0000-0000
 Xiangjie Sui,City University of Macau,https://fds.cityu.edu.mo/en/members/390,IAnTG2cAAAAJ,0009-0008-7604-3281
 Xiangjiu Che,Jilin University,https://ccst.jlu.edu.cn/info/1367/19062.htm,NOSCHOLARPAGE,0000-0003-3799-1963

--- a/csrankings-y.csv
+++ b/csrankings-y.csv
@@ -462,7 +462,6 @@ Yi-Fei Pu,Sichuan University,https://cs.scu.edu.cn/info/1288/13622.htm,NOSCHOLAR
 Yi-Jen Chiang,New York University,http://engineering.nyu.edu/people/yi-jen-chiang,ZcDNvvEAAAAJ,0000-0001-7822-6200
 Yi-Jun Chang,National University of Singapore,https://sites.google.com/a/umich.edu/yi-jun-chang,JhoyupQAAAAJ,0000-0002-0109-2432
 Yi-Jun Yang,Xi'an Jiaotong University,http://gr.xjtu.edu.cn/web/yangyijun/english,NOSCHOLARPAGE,0000-0000-0000-0000
-Yi-Ke Guo,Imperial College London,http://www.imperial.ac.uk/people/y.guo,-0q6cIYAAAAJ,0000-0002-3075-2161
 Yi-King Choi,University of Hong Kong,https://i.cs.hku.hk/~ykchoi,NOSCHOLARPAGE,0000-0001-7668-7599
 Yi-Ling Chen,Harvard University,http://yiling.seas.harvard.edu,Q8vaKmUAAAAJ,0000-0000-0000-0000
 Yi-Ping Hung,National Taiwan University,https://www.csie.ntu.edu.tw/~hung,gUYquw0AAAAJ,0000-0000-0000-0000


### PR DESCRIPTION
Third and final pass over the cross-institution duplicate Scholar IDs from #14029. These are the cases where ORCID had **no current-employment data at all**, so every one was resolved from departmental pages, university news, and LinkedIn.

## Resolved (23 rows)

| Person | Removed | Evidence |
|---|---|---|
| **Yike Guo** | Imperial College London | [HKUST Provost](https://hkustprovost.hkust.edu.hk/meet-provost) + Chair Professor of CSE since Dec 2022 |
| **Sebastian Erdweg** | Mainz | [Professor at KIT IPD](https://pl.ipd.kit.edu/staff_erdweg.php); previously led the PL team at Mainz |
| **Alexander Fraser** | LMU Munich | [Full Professor at TUM](https://www.professoren.tum.de/en/fraser-alexander) **from 2024**; LMU 2013–2024 |
| **Jeff Clune** | Wyoming | [UBC CS since January 2021](https://www.cs.ubc.ca/news/2021/06/associate-professor-jeff-clune-joins-ubc-cs-department) |
| **Katharina Kohls** | Radboud | Assoc. Prof. at [RUB since March 2024](https://informatik.rub.de/en/syssec/); Radboud 2020–2024 |
| **Chee Wei Tan** | City Univ. of Hong Kong | [NTU College of Computing and Data Science](https://cheewtan.github.io/) |
| **Danielle Szafir** | Colorado Boulder | [UNC Chapel Hill](https://cs.unc.edu/person/danielle-szafir/); Colorado prior |
| **Daniel Szafir** | Colorado Boulder | [UNC Chapel Hill](https://cs.unc.edu/person/daniel-szafir/); Colorado 2015–2021 |
| **Steven Wu** | Minnesota | CMU since Sept 2020 (Associate Professor from July 2025); Minnesota 2018–2020 |
| **Guo-Jun Qi** | UCF | [Full Professor of AI, Westlake](https://en.westlake.edu.cn/faculty/guojun-qi.html), 2024 |
| **Martin Hoefer** | Goethe Frankfurt | [RWTH Aachen since 2024](https://algo.rwth-aachen.de/team/hoefer/index.en.shtml); Frankfurt 2017–2024 |
| **Sarah Nadi** | Alberta | [Assoc. Prof., NYU Abu Dhabi](https://nyuad.nyu.edu/en/academics/divisions/science/faculty/sarah-nadi.html); Alberta is now **adjunct** |
| **Meike Klettke** | Rostock | [W3 chair for Data Engineering at Regensburg since 1 Apr 2022](https://www.uni-regensburg.de/informatik-data-science/fakultaet/einrichtungen/data-engineering/team/meike-klettke) |
| **George Tzimpragos** | Michigan | [UW–Madison since January 2025](https://engineering.wisc.edu/directory/profile/georgios-tzimpragos/); Michigan 2022–2025 |
| **Sajedul Talukder** | SIU Carbondale | [Asst. Prof., UTEP](https://www.cs.utep.edu/stalukder/) |
| **Atay Özgövde** | Galatasaray (**2 rows**) | Asst. Prof., [Boğaziçi Computer Engineering](https://swe.bogazici.edu.tr/en/atay-ozgovde); Galatasaray was **2002–2009** |
| **Andrés Goens** | Amsterdam (**2 rows**) | [Professor at TU Darmstadt](https://www.informatik.tu-darmstadt.de/fb20/ueber_uns_details_326656.de.jsp); UvA assistant professorship prior |
| **Jefersson dos Santos** | UFMG | [Sheffield](https://sheffield.ac.uk/cs/people/academic/jefersson-alex-dos-santos); UFMG 2013–2022 |
| **Xianghua (Sharon) Ding** | Fudan (**2 rows**) | [Glasgow since end of 2021](https://www.gla.ac.uk/schools/computing/staff/xianghuading/); Fudan prior |
| **Chinmay Kulkarni** | CMU only | CMU → Emory. See below. |

**Post-edit check**: all 20 people retain a row at their current institution.

## Left for a separate decision

**Chinmay Kulkarni** — only the CMU row is removed. He has since left Emory for **Microsoft AI**, so the Emory row likely belongs in `old/industry.csv`. That is an eligibility decision, not a de-duplication, so I have not made it.

**Tin Nguyen** (3 rows: Nevada ×2, Auburn) — the trail is Nevada 2017–2023 → Auburn 2023–2025 → **Wayne State School of Medicine, Professor in Oncology, 2026**. All three rows are stale and his current post is not a CS department, so this needs a removal decision rather than a merge.

**Gautam Kamath** (Waterloo / NYU) — he **starts at NYU in September 2026**, about five weeks out. Under VALIDATION.md §D both rows are momentarily defensible; worth revisiting after the move.

## Genuine dual appointments — policy call, untouched

| Person | Appointments |
|---|---|
| **Tieniu Tan** | Professor & President of the CPC Council, Nanjing Univ. **and** Director of NLPR, CAS Institute of Automation |
| **Xuan Song** | Assoc. Prof. at SUSTech **and** Dean/Professor of the School of AI, Jilin University |
| **Kai Kunze** (@kkai) | Full professor at both Keio (KMD) and TU Clausthal |
| **Kobi Gal** | Ben-Gurion (SISE) and Reader at Edinburgh Informatics |

## Not yet investigated (5)

`Francis Bach` (ENS/INRIA), `David Zhang` (PolyU ×2 / CUHK-SZ), `Hsiang-Ting "Tim" Chen` (Adelaide / UTS ×2), `Chris Ding` (CUHK-SZ / CUHK), `Kun Yang` (Nanjing / Essex — the two may well be **different people**, as with the cases in #14030).

## Eligibility flags noticed in passing

Not acted on, but visible now: **Guo-Jun Qi** is also Chief AI Scientist at OPPO Research (industry split), and **George Tzimpragos**'s Wisconsin appointment is in ECE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)