### PR TITLE
Remove 3 stale rows found by de-duplicating on ORCID

### DIFF
--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -678,7 +678,6 @@ Chien-Yi Roger Chen,Syracuse University,https://eng-cs.syr.edu/our-departments/e
 Chiew Tong Lau,Nanyang Technological University,https://dr.ntu.edu.sg/cris/rp/rp00670,NOSCHOLARPAGE,0000-0000-0000-0000
 Chiew-Lan Tai,HKUST,https://www.cse.ust.hk/~taicl,DORzgBQAAAAJ,0000-0002-1486-1974
 Chifumi Nishioka,National Inst. of Informatics,https://www.nii.ac.jp/en/faculty/digital_content/nishioka_chifumi,NOSCHOLARPAGE,0000-0000-0000-0000
-Chih-Hao Luke Ong,University of Oxford,https://www.cs.ox.ac.uk/luke.ong,NOSCHOLARPAGE,0000-0001-7509-680X
 Chih-Hong Cheng,University of Oldenburg,https://uol.de/en/suels/team,e3RTgfMAAAAJ,0000-0002-7265-8413
 Chih-Jen Lin,National Taiwan University,https://www.csie.ntu.edu.tw/~cjlin,SLMkts8AAAAJ,0000-0003-4684-8747
 Chih-Tsun Huang,National Tsing Hua University,http://nthucad.cs.nthu.edu.tw/~cthuang,NOSCHOLARPAGE,0000-0000-0000-0000

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -360,7 +360,6 @@ Kathlén Kohn,KTH Royal Inst. of Technology,https://www.kth.se/profile/kathlen,j
 Kathrin Gerling,Karlsruhe Inst. of Technology,https://hci.iar.kit.edu/deutsch/21_59.php,Ujh2RSsAAAAJ,0000-0002-8449-6124
 Kathrin Hanauer,University of Vienna,cs.univie.ac.at/kathrin.hanauer,JCSr8s0AAAAJ,0000-0002-5945-837X
 Kathrin Klamroth,University of Wuppertal,https://www.opt.uni-wuppertal.de/de/ag-opt/mitarbeiter/klamroth.html,8ETjTscAAAAJ,0000-0000-0000-0000
-Kathrin Maria Gerling,KU Leuven,https://iiw.kuleuven.be/onderzoek/emedia/people/gerlingkathrin,Ujh2RSsAAAAJ,0000-0002-8449-6124
 Kathryn E. Jones,Cardiff University,https://www.cardiff.ac.uk/people/view/978504-jones-kathryn,BMZenCsAAAAJ,0000-0001-7939-9314
 Kathryn E. Ringland,Univ. of California - Santa Cruz,https://kateringland.com,g_yas1EAAAAJ,0000-0002-3760-1390
 Kathryn Elizabeth Jones,Cardiff University,https://www.cardiff.ac.uk/people/view/978504-jones-kathryn,BMZenCsAAAAJ,0000-0000-0000-0000
@@ -1044,7 +1043,6 @@ Kuldeep S. Meel,Georgia Institute of Technology,https://www.cs.toronto.edu/~meel
 Kuldeep Singh 0003,University of Delhi,https://cs.du.ac.in/faculty,J0tK1vwAAAAJ,0000-0000-0000-0000
 Kumar Madhukar,IIT Delhi,https://homecse.iitd.ac.in/team/kumar-madhukar,nGl9MI0AAAAJ,0000-0001-5686-9758
 Kumari Nidhi Lal,VNIT Nagpur,https://vnit.ac.in/engineering/cse/dr-nidhi-lal,U2FM-YAAAAAJ,0000-0000-0000-0000
-Kumiko Tanaka,University of Tokyo,http://www.rcast.u-tokyo.ac.jp/research/people/staff-tanaka-ishii_kumiko_en.html,NOSCHOLARPAGE,0000-0003-1752-3951
 Kumiko Tanaka-Ishii,Waseda University,https://ml-waseda.jp,C7eBj4kAAAAJ,0000-0003-1752-3951
 Kun He 0001,HUST,http://faculty.hust.edu.cn/hekun/en/index.htm,YTQnGJsAAAAJ,0000-0001-7627-4604
 Kun He 0011,Renmin University of China,https://scholar.google.com/citations?hl=en&user=Gaw2AbsAAAAJ,Gaw2AbsAAAAJ,0000-0000-0000-0000


### PR DESCRIPTION
The sweep in #14029 / #14031 / #14032 / #14035 keyed on **Google Scholar ID**, which structurally misses any duplicate whose stale row carries `NOSCHOLARPAGE`. Re-running the same analysis keyed on **ORCID** finds those — a side finding from the ORCID backfill in #14036.

## Scope

Of **16,805** rows with a real ORCID, **578** ORCIDs appear on more than one row. Almost all are same-institution alias rows (`Alberto E. Schaeffer Filho` / `Alberto Schaeffer-Filho`, `Anat Paskin` / `Anat Paskin-Cherniavsky`, …), which are expected. Only **3** span different institutions.

## The 3 removals

| Person | Removed | Evidence |
|---|---|---|
| **Luke Ong** | University of Oxford | At [NTU](https://www3.ntu.edu.sg/home/luke.ong/) since **Aug 2022** — Dean, College of Computing and Data Science, and VP Research. Oxford was **1994–2022** (Professor, Fellow of Merton) |
| **Kumiko Tanaka-Ishii** | University of Tokyo | [Professor at Waseda](https://www.cs.waseda.ac.jp/en/teacher/kumiko-tanaka-ishii) since **2023**; Univ. of Tokyo **2016–2023** |
| **Kathrin Gerling** | KU Leuven | Professor of HCI and Accessibility at **KIT** (Institute for Anthropomatics and Robotics); KU Leuven was **2017–2022** as an *Assistant* Professor |

All three retain a row at their current institution.

## Why the first sweep missed two of them

**Luke Ong** and **Kumiko Tanaka-Ishii** both have `NOSCHOLARPAGE` on the stale row, so no shared Scholar ID existed to detect. This is a real blind spot in the earlier method, not bad luck: a Scholar-ID join can only find duplicates where *both* rows have a real Scholar ID.

**Kathrin Gerling** was visible to the Scholar-ID sweep but I held her back in #14035's predecessor as a possible dual appointment, because ORCID lists both institutions as current with no end dates. The dated career history settles it — KU Leuven ended in 2022.

## Note

Luke Ong also has two same-institution rows at NTU (`C.-H. Luke Ong`, `Luke Ong`). That is the ordinary alias pattern and is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)