### PR TITLE
Revert the ORCID assigned to 'Tao Zhang' in #14036

### DIFF
--- a/csrankings-t.csv
+++ b/csrankings-t.csv
@@ -203,7 +203,7 @@ Tao Xie 0001,Peking University,https://taoxiease.github.io,DhhH9J4AAAAJ,0000-000
 Tao Yang 0009,Univ. of California - Santa Barbara,http://www.cs.ucsb.edu/~tyang,NOSCHOLARPAGE,0000-0003-1902-3387
 Tao Yu 0009,University of Hong Kong,https://taoyds.github.io,5_Fn5CIAAAAJ,0000-0001-9939-2216
 Tao Yue 0002,Beihang University,https://scse.buaa.edu.cn/info/1078/10993.htm,zTDRGDcAAAAJ,0000-0003-3262-5577
-Tao Zhang,New York Tech,https://site.nyit.edu/bio/tzhang,9cMiSg4AAAAJ,0009-0008-6521-1702
+Tao Zhang,New York Tech,https://site.nyit.edu/bio/tzhang,9cMiSg4AAAAJ,0000-0000-0000-0000
 Tao Zhang 0001,MUST,https://cszhangtao.github.io,eMfANKoAAAAJ,0000-0002-6272-4069
 Tao Zhou 0001,UESTC,http://www.bigdata-research.org/people/faculty/4.html,MXgWgmEAAAAJ,0000-0003-0561-2316
 Taolue Chen 0001,Birkbeck University of London,https://www.dcs.bbk.ac.uk/about/people/academic-staff/taolue-chen,Qv_-WU4AAAAJ,0000-0002-5993-1665


### PR DESCRIPTION
One-line revert following an audit of the ORCID backfill.

## Why

@emeryberger raised that faculty **with** and **without** ORCIDs are not drawn from the same distribution — so precision measured on a hold-out of people who already have ORCIDs does not transfer to the people who don't. That is correct, and it invalidates the way I justified #14036 / #14038.

Concretely: **every person in that hold-out has an ORCID**, so the hold-out contains zero instances of the error mode that dominates the target set — assigning someone *else's* iD to a person who has none.

## What I measured instead

**Negative control.** Re-ran the hold-out with each person's true ORCID *hidden from the vote*, which simulates "this person has no discoverable iD". The pipeline emitted an iD anyway for 4 of 300 (1.3%). Two of those four were the cases where the stored iD is wrong and the pipeline found the right one, so the genuine false-positive rate is **2/300 = 0.7%**.

Both genuine failures were the same mechanism — surname plus *first initial* only:

| CSRankings name | Emitted iD belongs to |
|---|---|
| Yongfeng Zhang 0003 (Rutgers) | **Yi Zhang**, Professor @ UC Santa Cruz |
| Tien N. Nguyen | **Tung Nguyen**, Texas A&M / Auburn |

The Nguyen case passed with **17 shared publications**, because Tien and Tung Nguyen are frequent co-authors — publication overlap cannot separate collaborators with name-compatible names. That is a real hole in the confirmation step.

**Name-identity audit.** Fetched the registered name for all **1,064** assigned iDs and compared it to the CSRankings name. 1,007 matched exactly; 54 flagged; on inspection **all 54 are legitimate variants** — Konstantinos/Kostas, Evangelos/Vangelis, Jim/James, Jo/Ioanna, Schütze/Schuetze, Wismüller/Wismueller, Lv/Lyu (romanising 吕), `GUO Kehua` name-order, plus two single-letter typos in the ORCID records themselves.

**Zero cases of the Yi-Zhang class in the applied data.** The negative control had to artificially remove the true iD to produce that failure; in the real batches the correct iD wins the vote.

## Residual exposure, and this revert

A name audit cannot catch two *different people sharing the same name*. Screening for that — bare name that DBLP itself disambiguates, plus weakest evidence — leaves **4 of 1,064** rows: `Tao Zhang`, `Jie Li`, `Kun Yang`, `Ziming Liu`. All bare common names, all resting on `dblp-asserted` evidence with no independent confirmation.

`Tao Zhang` is the only one already merged, so this PR reverts it. The other three are dropped from #14038 in `b8c01ff38`.

(`Kun Yang` is also one of the unresolved cross-institution Scholar-ID duplicates from #14032 — Nanjing vs Essex — which is consistent with it being two people.)

## Change to the pipeline for future batches

`compatible()` must require full given-name equality when both names are spelled out, allowing initial-matching only when one side is genuinely an initial, plus a nickname/transliteration allowance. That rejects Yongfeng/Yi and Tien/Tung while keeping Konstantinos/Kostas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)