### PR TITLE
Add a fast path in commit_validation for identifier-only diffs

### DIFF
--- a/test/test_identifier_only_diff.py
+++ b/test/test_identifier_only_diff.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+Tests for the identifier-only fast path in util/validate_commit.py.
+
+A diff that only rewrites the ORCID field of existing rows does not change any
+faculty member's eligibility, so it does not need the per-entry DBLP/homepage/
+Google Scholar lookups or the AI audit. This suite pins down when that fast path
+is taken -- and, more importantly, when it is NOT.
+
+The default must be fail-safe: anything that is not purely an ORCID rewrite has
+to fall back to the full validation.
+
+Run with: pytest test/test_identifier_only_diff.py -v
+"""
+
+import importlib.util
+import io
+import json
+import contextlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _load_validate_commit():
+    """Import util/validate_commit.py with its heavyweight deps stubbed out.
+
+    fuzzysearch/unidecode/openai are only needed on the slow path; stubbing them
+    keeps this suite runnable without the full CI dependency set.
+    """
+    for name in ("fuzzysearch", "unidecode", "openai"):
+        if name not in sys.modules:
+            sys.modules[name] = types.ModuleType(name)
+    sys.modules["fuzzysearch"].find_near_matches = lambda *a, **k: []  # type: ignore[attr-defined]
+    sys.modules["unidecode"].unidecode = lambda s: s  # type: ignore[attr-defined]
+    sys.modules["openai"].OpenAI = object  # type: ignore[attr-defined]
+    spec = importlib.util.spec_from_file_location(
+        "validate_commit", REPO / "util" / "validate_commit.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+vc = _load_validate_commit()
+
+PLACEHOLDER = "0000-0000-0000-0000"
+REAL = "0000-0002-1825-0097"
+OTHER = "0000-0003-1234-5679"
+
+JANE_PLACEHOLDER = f"Jane Doe,MIT,https://x.org,abcdEFGHIJK1,{PLACEHOLDER}"
+JANE_REAL = f"Jane Doe,MIT,https://x.org,abcdEFGHIJK1,{REAL}"
+JOHN_PLACEHOLDER = f"John Roe,CMU,https://y.org,abcdEFGHIJK2,{PLACEHOLDER}"
+JOHN_REAL = f"John Roe,CMU,https://y.org,abcdEFGHIJK2,{REAL}"
+
+
+def _diff(files, tmp_path):
+    """Build a diff.json of the shape generate_diff.py produces."""
+    data = {
+        "files": [
+            {
+                "path": path,
+                "chunks": [
+                    {"changes": [{"type": t, "content": c} for t, c in changes]}
+                ],
+            }
+            for path, changes in files
+        ]
+    }
+    p = tmp_path / "diff.json"
+    p.write_text(json.dumps(data), encoding="utf-8")
+    return str(p)
+
+
+def _classify(files, tmp_path):
+    return vc.classify_identifier_only(_diff(files, tmp_path))
+
+
+def _validate(pairs):
+    """Run the cheap checks, swallowing their progress output."""
+    with contextlib.redirect_stdout(io.StringIO()):
+        return vc.validate_identifier_only(pairs)
+
+
+# --- cases that SHOULD take the fast path -------------------------------------
+
+def test_filling_a_placeholder_takes_fast_path(tmp_path):
+    pairs = _classify(
+        [("csrankings-j.csv", [("DeletedLine", JANE_PLACEHOLDER), ("AddedLine", JANE_REAL)])],
+        tmp_path,
+    )
+    assert pairs is not None
+    assert len(pairs) == 1
+    assert _validate(pairs) is True
+
+
+def test_reverting_to_placeholder_takes_fast_path(tmp_path):
+    """Reverting a bad assignment is also identifier-only."""
+    pairs = _classify(
+        [("csrankings-j.csv", [("DeletedLine", JANE_REAL), ("AddedLine", JANE_PLACEHOLDER)])],
+        tmp_path,
+    )
+    assert pairs is not None
+    assert _validate(pairs) is True
+
+
+def test_old_csv_files_are_allowed(tmp_path):
+    pairs = _classify(
+        [("old/industry.csv", [("DeletedLine", JANE_PLACEHOLDER), ("AddedLine", JANE_REAL)])],
+        tmp_path,
+    )
+    assert pairs is not None
+
+
+def test_many_rows_across_files(tmp_path):
+    pairs = _classify(
+        [
+            ("csrankings-j.csv", [("DeletedLine", JANE_PLACEHOLDER), ("AddedLine", JANE_REAL)]),
+            ("csrankings-r.csv", [("DeletedLine", JOHN_PLACEHOLDER), ("AddedLine", f"John Roe,CMU,https://y.org,abcdEFGHIJK2,{OTHER}")]),
+        ],
+        tmp_path,
+    )
+    assert pairs is not None
+    assert len(pairs) == 2
+    assert _validate(pairs) is True
+
+
+# --- cases the fast path MUST reject (fall back to full validation) -----------
+
+@pytest.mark.parametrize(
+    "label,changes",
+    [
+        # affiliation edited alongside the ORCID
+        ("affiliation changed", [("DeletedLine", JANE_PLACEHOLDER),
+                                 ("AddedLine", f"Jane Doe,CMU,https://x.org,abcdEFGHIJK1,{REAL}")]),
+        # homepage edited alongside the ORCID
+        ("homepage changed", [("DeletedLine", JANE_PLACEHOLDER),
+                              ("AddedLine", f"Jane Doe,MIT,https://z.org,abcdEFGHIJK1,{REAL}")]),
+        # Scholar ID edited alongside the ORCID
+        ("scholar id changed", [("DeletedLine", JANE_PLACEHOLDER),
+                                ("AddedLine", f"Jane Doe,MIT,https://x.org,ZZZZZZZZZZZZ,{REAL}")]),
+        # a genuinely new faculty member
+        ("pure addition", [("AddedLine", JANE_REAL)]),
+        # a removal
+        ("pure deletion", [("DeletedLine", JANE_REAL)]),
+        # nothing actually changed
+        ("no-op", [("DeletedLine", JANE_REAL), ("AddedLine", JANE_REAL)]),
+        # ORCID rewrite mixed with a real addition
+        ("mixed with addition", [("DeletedLine", JANE_PLACEHOLDER), ("AddedLine", JANE_REAL),
+                                 ("AddedLine", JOHN_REAL)]),
+        # wrong column count
+        ("four columns", [("DeletedLine", "Jane Doe,MIT,https://x.org,abcdEFGHIJK1"),
+                          ("AddedLine", JANE_REAL)]),
+    ],
+)
+def test_non_identifier_changes_fall_back(label, changes, tmp_path):
+    assert _classify([("csrankings-j.csv", changes)], tmp_path) is None, label
+
+
+def test_disallowed_file_falls_back(tmp_path):
+    """A source file in the diff must never reach the cheap path."""
+    assert _classify(
+        [("util/evil.py", [("DeletedLine", JANE_PLACEHOLDER), ("AddedLine", JANE_REAL)])],
+        tmp_path,
+    ) is None
+
+
+def test_empty_diff_falls_back(tmp_path):
+    assert _classify([("csrankings-j.csv", [])], tmp_path) is None
+
+
+# --- checks the fast path still enforces --------------------------------------
+
+def test_malformed_orcid_is_rejected(tmp_path):
+    pairs = _classify(
+        [("csrankings-j.csv", [("DeletedLine", JANE_PLACEHOLDER),
+                               ("AddedLine", "Jane Doe,MIT,https://x.org,abcdEFGHIJK1,not-an-orcid")])],
+        tmp_path,
+    )
+    assert pairs is not None
+    assert _validate(pairs) is False
+
+
+def test_same_orcid_across_two_institutions_is_rejected(tmp_path):
+    """One ORCID identifies one person, so it cannot appear at two institutions."""
+    pairs = _classify(
+        [("csrankings-j.csv", [("DeletedLine", JANE_PLACEHOLDER), ("AddedLine", JANE_REAL),
+                               ("DeletedLine", JOHN_PLACEHOLDER), ("AddedLine", JOHN_REAL)])],
+        tmp_path,
+    )
+    assert pairs is not None
+    assert _validate(pairs) is False
+
+
+def test_same_orcid_at_one_institution_is_allowed(tmp_path):
+    """Alias rows for one person at one institution legitimately share an ORCID."""
+    alias_old = f"J. Doe,MIT,https://x.org,abcdEFGHIJK9,{PLACEHOLDER}"
+    alias_new = f"J. Doe,MIT,https://x.org,abcdEFGHIJK9,{REAL}"
+    pairs = _classify(
+        [("csrankings-j.csv", [("DeletedLine", JANE_PLACEHOLDER), ("AddedLine", JANE_REAL),
+                               ("DeletedLine", alias_old), ("AddedLine", alias_new)])],
+        tmp_path,
+    )
+    assert pairs is not None
+    assert _validate(pairs) is True
+
+
+def test_space_after_comma_is_rejected(tmp_path):
+    pairs = _classify(
+        [("csrankings-j.csv", [("DeletedLine", JANE_PLACEHOLDER),
+                               ("AddedLine", f"Jane Doe, MIT,https://x.org,abcdEFGHIJK1,{REAL}")])],
+        tmp_path,
+    )
+    # the space also changes the affiliation field, so this must fall back
+    assert pairs is None

--- a/util/validate_commit.py
+++ b/util/validate_commit.py
@@ -10,7 +10,7 @@ import requests
 import unidecode
 import openai
 
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Tuple
 from pydantic import HttpUrl, BaseModel, ValidationError
 
 ERROR = chr(0x274C)
@@ -414,6 +414,89 @@ def is_valid_file(file: str) -> bool:
     ]
     return re.match(r'.*\.csv$', file) and any(re.match(p, file) for p in allowed_files)
 
+def classify_identifier_only(diff_path: str) -> Optional[List[Tuple[str, str, str]]]:
+    """Detect a diff that ONLY rewrites the ORCID field of existing rows.
+
+    Bulk ORCID backfills change no name, affiliation, homepage or Scholar ID, so the
+    per-entry eligibility lookups (DBLP + homepage + Google Scholar, ~10s/row) and the
+    AI audit re-verify people this PR does not touch. On a 660-row batch that is a
+    ~2-hour CI job; at ~1500 rows it would approach the 6-hour job limit.
+
+    Returns a list of (path, old_line, new_line) when every change is
+    identifier-only, else None (meaning: run the full validation).
+    """
+    with open(diff_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    pairs: List[Tuple[str, str, str]] = []
+    for d in data.get("files", []):
+        path = d.get("path")
+        if not path or not is_valid_file(path):
+            return None
+        added, deleted = [], []
+        for ch in d.get("chunks", []):
+            for c in ch.get("changes", []):
+                if c["type"] == "AddedLine" and c["content"].strip():
+                    added.append(c["content"])
+                elif c["type"] == "DeletedLine" and c["content"].strip():
+                    deleted.append(c["content"])
+        if len(added) != len(deleted) or not added:
+            return None
+        # Pair by the first four fields; only the ORCID may differ.
+        key = lambda L: tuple(L.split(",")[:4])
+        by_old = {}
+        for L in deleted:
+            parts = L.split(",")
+            if len(parts) != 5:
+                return None
+            by_old.setdefault(key(L), []).append(L)
+        for L in added:
+            parts = L.split(",")
+            if len(parts) != 5:
+                return None
+            k = key(L)
+            if k not in by_old or not by_old[k]:
+                return None
+            old = by_old[k].pop()
+            if old.split(",")[4] == parts[4]:
+                return None            # nothing actually changed
+            pairs.append((path, old, L))
+        if any(v for v in by_old.values()):
+            return None
+    return pairs or None
+
+
+def validate_identifier_only(pairs: List[Tuple[str, str, str]]) -> bool:
+    """Cheap, network-free checks sufficient for an identifier-only diff."""
+    valid = True
+    print(f"{INFO}\tIdentifier-only diff: {len(pairs)} row(s) change the ORCID field and nothing else.")
+    print(f"{INFO}\tSkipping per-entry DBLP/homepage/Scholar lookups and the AI audit -- name,")
+    print(f"{INFO}\taffiliation, homepage and Scholar ID are byte-identical on every row, so")
+    print(f"{INFO}\teligibility is unchanged by this PR.")
+    seen = {}
+    for path, old, new in pairs:
+        name, affiliation, _, _, orcid = new.split(",")
+        excel_error = check_excel_corruption(new)
+        if excel_error:
+            print(f"{ERROR}\t{CHECKBOX_REFS['no_excel']} Excel corruption detected: found '{excel_error}' in {name}.")
+            valid = False
+        if re.search(r',\s', new):
+            print(f"{ERROR}\t{CHECKBOX_REFS['csv_format']} Space after comma: {new}")
+            valid = False
+        if not has_valid_orcid(orcid):
+            print(f"{ERROR}\t{CHECKBOX_REFS['orcid']} Invalid ORCID format for {name}: {orcid}")
+            valid = False
+        # An ORCID identifies one person: reject the same iD on two institutions.
+        if orcid != "0000-0000-0000-0000":
+            prev = seen.get(orcid)
+            if prev and prev[1] != affiliation:
+                print(f"{ERROR}\tORCID {orcid} assigned to {name} ({affiliation}) and {prev[0]} ({prev[1]}) -- one iD cannot span two institutions.")
+                valid = False
+            seen.setdefault(orcid, (name, affiliation))
+    if valid:
+        print(f"{INFO}\tAll {len(pairs)} ORCID changes passed format and collision checks.")
+    return valid
+
+
 def process_csv_diff(diff_path: str) -> bool:
     with open("institutions.csv", "r") as f:
         institutions = {row["institution"]: True for row in csv.DictReader(f)}
@@ -609,6 +692,16 @@ if __name__ == "__main__":
     diff_path = sys.argv[2]
 
     pr_metadata_valid = process_pr_metadata(pr_metadata_path)
+
+    # Fast path: a diff that only rewrites ORCID fields needs no eligibility re-check.
+    identifier_only = classify_identifier_only(diff_path)
+    if identifier_only:
+        if validate_identifier_only(identifier_only) and pr_metadata_valid:
+            mark_succeeded()
+            sys.exit(0)
+        mark_failed()
+        sys.exit(-1)
+
     csv_valid = process_csv_diff(diff_path)
 
     # Proceed with the AI audit even when the basic checks fail.


### PR DESCRIPTION
## Problem

`commit_validation` cost scales linearly with changed rows, because `validate_commit.py` does **three network fetches per entry** (DBLP name lookup, homepage fetch, Google Scholar fetch) plus an LLM audit over the whole diff. Measured on recent PRs:

| PR | Rows changed | `commit_validation` |
|---|---|---|
| #14033 / #14037 / #14039 | 1–9 | **~50 seconds** |
| #14036 (ORCID backfill) | 401 | **1h 09m** — passed |
| #14038 (ORCID backfill) | 660 | **~1h 55m** |

At ~10s/row, a ~1,500-row batch would approach the **6-hour job limit**.

## Why it's wasted work on these PRs

#14036 and #14038 change **only the ORCID field**. Name, affiliation, homepage and Scholar ID are byte-identical on every row. So the per-entry lookups and the AI audit re-verify the eligibility of hundreds of people whose eligibility the PR does not touch — at real API and LLM cost, and with a 2-hour feedback loop.

Eligibility depends on department, tenure-track status and PhD advising. None of those can change when the only edited field is an identifier.

## The fast path

`classify_identifier_only()` returns the changed rows **only** when every `AddedLine` pairs with a `DeletedLine` differing solely in the ORCID field. `validate_identifier_only()` then runs the checks that still matter:

- allowed files
- Excel corruption markers
- no space after comma
- well-formed ORCID
- **the same ORCID must not appear at two different institutions** — an ORCID identifies one person (alias rows at a single institution may legitimately share one)

That last check is new, and it is exactly the collision test that caught problems during the backfill.

## Fail-safe by construction

Anything that is not purely an ORCID rewrite takes the slow path: additions, deletions, no-ops, edits to any other field, wrong column counts, mixed diffs, or a file outside the allowed list. The classifier returns `None` on anything it does not fully understand, and `None` means "run the full validation".

## Tests

`test/test_identifier_only_diff.py` — **18 cases**, deliberately weighted towards what must *not* be fast-pathed:

| Must take fast path | Must fall back |
|---|---|
| filling a placeholder | affiliation edited |
| reverting to placeholder | homepage edited |
| `old/*.csv` files | Scholar ID edited |
| many rows across files | pure addition / pure deletion |
| alias rows sharing an ORCID at one institution | no-op |
| | mixed ORCID rewrite + addition |
| | wrong column count |
| | non-CSV file in the diff |

Plus: malformed ORCID rejected, and the same ORCID at two institutions rejected.

```
$ pytest test/test_identifier_only_diff.py -q
18 passed
```

The suite stubs `fuzzysearch` / `unidecode` / `openai` so it runs without the full CI dependency set — those are only needed on the slow path.

## Note

Pyright flags two **pre-existing** issues in `validate_commit.py` that surfaced only because the file was re-analysed: `is_valid_file` returns `Match | None` rather than `bool`, and `homepage_text` may be `None` at line 599. Both predate this change and are left alone to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)