### PR TITLE
Run clean-csrankings in update-dblp-full so csrankings.csv keeps its aliases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,23 +187,23 @@ apply-author-names:
 update-dblp-full:
 	@echo "=== FULLY AUTOMATED DBLP UPDATE ==="
 	@echo ""
-	@echo "Step 1/8: Downloading previous DBLP snapshot (for name change detection)..."
+	@echo "Step 1/9: Downloading previous DBLP snapshot (for name change detection)..."
 	$(MAKE) download-prev-dblp
 	@echo ""
-	@echo "Step 2/8: Backing up to prev-dblp.xml.gz..."
+	@echo "Step 2/9: Backing up to prev-dblp.xml.gz..."
 	$(MAKE) backup-dblp
 	@echo ""
-	@echo "Step 3/8: Downloading new DBLP from $(DBLP)..."
+	@echo "Step 3/9: Downloading new DBLP from $(DBLP)..."
 	$(MAKE) download-dblp
 	@echo ""
-	@echo "Step 4/8: Filtering DBLP to CSRankings venues..."
+	@echo "Step 4/9: Filtering DBLP to CSRankings venues..."
 	$(MAKE) shrink-dblp
 	@echo ""
-	@echo "Step 5/8: Generating DBLP aliases..."
+	@echo "Step 5/9: Generating DBLP aliases..."
 	$(MAKE) faculty-affiliations.csv
 	$(PYTHON) util/generate-aliases.py > dblp-aliases.csv
 	@echo ""
-	@echo "Step 6/8: Detecting and applying author name changes..."
+	@echo "Step 6/9: Detecting and applying author name changes..."
 	@if [ -f prev-dblp.xml.gz ]; then \
 		$(PYTHON) util/new-name-detector.py --old prev-dblp.xml.gz --new dblp-original.xml.gz > name-changes.csv; \
 		CHANGES=$$(wc -l < name-changes.csv | tr -d ' '); \
@@ -217,10 +217,16 @@ update-dblp-full:
 		echo "No previous DBLP backup found. Skipping name change detection."; \
 	fi
 	@echo ""
-	@echo "Step 7/8: Regenerating publication data..."
+	@echo "Step 7/9: Regenerating publication data..."
 	$(MAKE) generated-author-info.csv
 	@echo ""
-	@echo "Step 8/8: Updating DBLP date in index.html..."
+	@echo "Step 8/9: Rebuilding csrankings.csv with DBLP alias expansion..."
+	@# clean-csrankings.py is the only step that expands dblp-aliases.csv into
+	@# csrankings.csv. Without it this target writes an alias-stripped file (~2,100
+	@# rows short), which the next post-merge 'make all' silently puts back.
+	$(MAKE) clean-csrankings
+	@echo ""
+	@echo "Step 9/9: Updating DBLP date in index.html..."
 	$(MAKE) update-dblp-date
 	@echo ""
 	@echo "=== DBLP UPDATE COMPLETE ==="


### PR DESCRIPTION
The real, one-line fix behind the closed #14041.

## The bug

`csrankings.csv` is **not** simply the concatenation of `csrankings-?.csv`. It is those files **plus ~1,900 DBLP alias rows**, and `util/clean-csrankings.py` is the only step that expands `dblp-aliases.csv` into it.

`update-dblp-full` never ran `clean-csrankings`, so the monthly DBLP workflow wrote an **alias-stripped** `csrankings.csv`, roughly 2,100 rows short. The next post-merge `make` — which runs `all`, and `all` runs `clean-csrankings` — silently put them back. So the file oscillated:

| Workflow | Runs `clean-csrankings`? | csrankings.csv |
|---|---|---|
| monthly DBLP (`update-dblp-full`) | **no** | ~32,234 (alias-stripped) |
| post-merge rebuild (`make` → `all`) | yes | ~34,380 (correct) |

Because it self-healed on the next merge, it never surfaced as a visible failure.

## Why aliases matter

They are how publications get matched for faculty whose DBLP name differs from their CSRankings name:

| alias | canonical |
|---|---|
| `A. B. van der Merwe` | Brink van der Merwe |
| `Dingzhu Du` | Ding-Zhu Du |
| `A. Murat Özbayoglu` | A. Murat Ozbayoglu |

Dropping them silently loses publication credit for those people.

## The change

Adds `$(MAKE) clean-csrankings` as a new step after `generated-author-info.csv` — `clean-csrankings.py` reads both `generated-author-info.csv` and `dblp-aliases.csv`, and both exist by that point. Steps renumbered 8 → 9.

## Verified, not assumed

I got the diagnosis backwards the first time (see #14041), so this one is checked empirically:

- Took the alias-stripped file the monthly run actually produces — **32,234** lines.
- Ran `clean-csrankings.py` over it with the real `dblp-aliases.csv`, `generated-author-info.csv` and `institutions.csv`.
- Output is **byte-identical** to the committed `csrankings.csv`: sha256 `21e8305eb51098fc`, 34,380 lines.
- `csrankings-?.csv` left untouched, so the added step is idempotent on current data.
- `make -n update-dblp-full` confirms the new step is reachable and correctly ordered.

## Credit

Found only because @emeryberger challenged a 2,170-row drop instead of accepting my analysis. My original reading — that `csrankings.csv` was stale and the post-merge job was clobbering a correct regeneration — had it exactly backwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)