### PR TITLE
Fix validate_prs.py command reference in VALIDATION.md

### DIFF
--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -233,20 +233,34 @@ The script `util/validate_prs.py` automates the validation workflow:
 # See what needs work
 python3 util/validate_prs.py status         # Full status report
 python3 util/validate_prs.py list           # PRs still needing our validation comment
+python3 util/validate_prs.py check <PR#>    # Does this PR already have our comment?
 
 # Investigate a specific PR
 python3 util/validate_prs.py gather <PR#>   # Diff, data quality checks, red flags
 python3 util/validate_prs.py info <PR#>     # Lighter-weight summary
+python3 util/validate_prs.py gather-all     # Gather all unvalidated PRs -> /tmp/prs_gathered.json
 
 # Post a validation comment from a file
 python3 util/validate_prs.py comment <PR#> <file.md>
 
 # Score and merge
-python3 util/validate_prs.py scores         # Show all scores
-python3 util/validate_prs.py mergeable      # List PRs >= 90% ready to merge
-python3 util/validate_prs.py merge          # Merge all >= 90% (squash, auto-merge)
+python3 util/validate_prs.py scores         # Show all scores; tags those >= 80% [MERGEABLE]
+python3 util/validate_prs.py merge          # Merge ALL PRs >= 80% (squash)
 python3 util/validate_prs.py merge <PR#>    # Merge one specific PR (checks score)
+python3 util/validate_prs.py merge -t 90    # Raise the threshold for this run
+
+# Conflicts and duplicates
+python3 util/validate_prs.py resolve [PR#]  # Auto-resolve conflicts on CSV-only PRs
+python3 util/validate_prs.py duplicates     # Institutions with 2+ open PRs
+python3 util/validate_prs.py close-dupes    # Close dupes, keeping the lowest PR number
+python3 util/validate_prs.py consolidate    # Combine per-institution PRs into one
 ```
+
+> **Careful with bare `merge`.** With no PR argument it merges *every* PR at or
+> above the threshold (default **80%**, not 90%). That will happily merge a PR
+> you flagged as conditionally unsafe — for example, a removal whose replacement
+> entry is still sitting in a separate open PR. When some PRs above the threshold
+> carry caveats, merge them one at a time by number.
 
 The `gather` command performs automated checks including:
 - Institution lookup against `institutions.csv`


### PR DESCRIPTION
The Automation section of `VALIDATION.md` documented the `util/validate_prs.py` interface inaccurately. Three problems, found while using it to validate the current open-PR queue.

## 1. `mergeable` is not a subcommand

```
python3 util/validate_prs.py mergeable      # List PRs >= 90% ready to merge
```

Running it fails:

```
validate_prs.py: error: argument COMMAND: invalid choice: 'mergeable'
(choose from 'status', 'list', 'scores', 'check', 'info', 'gather', 'gather-all',
'comment', 'merge', 'resolve', 'duplicates', 'close-dupes', 'consolidate')
```

`scores` already tags qualifying PRs `[MERGEABLE]`, so it covers the intent.

## 2. The merge threshold is 80%, not 90%

The docs said `merge` merges everything `>= 90%`. The script's own help says **"Default threshold: 80%"**, overridable with `-t/--threshold`.

This is the consequential one. Bare `merge` merges *every* PR at or above 80%, which is a wider net than the docs suggest — and it will happily merge a PR that has been flagged as conditionally unsafe. A concrete case from the current queue: a removal PR scored 88% whose *replacement* entry was still sitting in a separate open PR. Merging it on its own would have silently dropped an active faculty member from CSRankings. The docs gave no reason to expect it to be in scope.

Added a callout to that effect, and documented `-t` so raising the bar for a run is discoverable.

## 3. Six subcommands were undocumented

`check`, `gather-all`, `resolve`, `duplicates`, `close-dupes`, `consolidate` — all real, none mentioned. `resolve` and `consolidate` in particular do non-obvious work (force-pushing rebuilt CSV branches; combining per-institution PRs) and are worth knowing about before reaching for them.

## Verification

Cross-checked every subcommand now listed in the doc against `validate_prs.py --help`: all 13 exist, and no subcommand is left undocumented.

Docs only — no code or data changes.