### PR TITLE
Submit form: detect institution-only changes in update mode

### DIFF
--- a/src/submit.ts
+++ b/src/submit.ts
@@ -1927,14 +1927,17 @@ function updateSubmitButton(): void {
             const updateFieldsValid = Object.values(validationState).every((v: ValidationState) => v.valid);
             let hasChanges = false;
             if (selectedEntry) {
+                const currentInstitution = (document.getElementById('institution') as HTMLInputElement).value.trim();
                 const currentHomepage = (document.getElementById('homepage') as HTMLInputElement).value.trim();
                 const currentScholarid = (document.getElementById('scholarid') as HTMLInputElement).value.trim();
                 const currentOrcid = (document.getElementById('orcid') as HTMLInputElement).value.trim();
                 const currentNewName = (document.getElementById('new-name') as HTMLInputElement)?.value.trim() || '';
+                const originalInstitution = selectedEntry.institution.trim();
                 const originalHomepage = selectedEntry.homepage.trim();
                 const originalScholarid = selectedEntry.scholarid.trim();
                 const originalOrcid = selectedEntry.orcid.trim();
-                hasChanges = currentHomepage !== originalHomepage ||
+                hasChanges = currentInstitution !== originalInstitution ||
+                             currentHomepage !== originalHomepage ||
                              currentScholarid !== originalScholarid ||
                              currentOrcid !== originalOrcid ||
                              (currentNewName !== '' && currentNewName !== selectedEntry.name);

--- a/submit/submit.js
+++ b/submit/submit.js
@@ -1,3 +1,4 @@
+"use strict";
 /**
  * CSRankings Faculty Submission Form
  * Client-side validation and GitHub Issue creation
@@ -1723,14 +1724,17 @@ function updateSubmitButton() {
             const updateFieldsValid = Object.values(validationState).every((v) => v.valid);
             let hasChanges = false;
             if (selectedEntry) {
+                const currentInstitution = document.getElementById('institution').value.trim();
                 const currentHomepage = document.getElementById('homepage').value.trim();
                 const currentScholarid = document.getElementById('scholarid').value.trim();
                 const currentOrcid = document.getElementById('orcid').value.trim();
                 const currentNewName = ((_a = document.getElementById('new-name')) === null || _a === void 0 ? void 0 : _a.value.trim()) || '';
+                const originalInstitution = selectedEntry.institution.trim();
                 const originalHomepage = selectedEntry.homepage.trim();
                 const originalScholarid = selectedEntry.scholarid.trim();
                 const originalOrcid = selectedEntry.orcid.trim();
-                hasChanges = currentHomepage !== originalHomepage ||
+                hasChanges = currentInstitution !== originalInstitution ||
+                    currentHomepage !== originalHomepage ||
                     currentScholarid !== originalScholarid ||
                     currentOrcid !== originalOrcid ||
                     (currentNewName !== '' && currentNewName !== selectedEntry.name);

--- a/submit/submit.js
+++ b/submit/submit.js
@@ -1,4 +1,3 @@
-"use strict";
 /**
  * CSRankings Faculty Submission Form
  * Client-side validation and GitHub Issue creation


### PR DESCRIPTION
Fixes #11733 — the update form would not let you submit a change of institution.

Diagnosis by **@chenxuniu** ([comment](https://github.com/emeryberger/CSrankings/issues/11733#issuecomment-5146849134)), who traced it to `updateSubmitButton()` in `src/submit.ts`. That diagnosis was exactly right; this PR implements it.

## The bug

In the `update` branch of `updateSubmitButton()`, `hasChanges` compared homepage, Scholar ID, ORCID and the optional new name — but never the institution:

```ts
hasChanges = currentHomepage !== originalHomepage ||
             currentScholarid !== originalScholarid ||
             currentOrcid !== originalOrcid ||
             (currentNewName !== "" && currentNewName !== selectedEntry.name);
```

So selecting an entry and changing only its institution left `hasChanges === false`, which disabled the submit button and pinned the label to **"No Changes"**.

## Why it is only one comparison

I checked the rest of the update path before writing the fix, in case the button was masking a deeper problem. It was not:

- `submitForm()` already reads `institution` into the `FacultyEntry` it builds.
- `createUpdateIssueUrl()` already emits `- Institution: {old} → {new}` when the two differ.
- The institution input already re-runs the gate on edit: `validateInstitution()` → `setFieldStatus()` → `updateSubmitButton()`.

Everything downstream was correct and unreachable. Only the gate was wrong, so adding the missing comparison is the complete fix — no other changes needed.

## Verification

Driven against the real form in headless Chrome (full faculty dataset loaded, 33,089 entries), selecting an entry and then changing **only** the institution:

| | submit button | label |
|---|---|---|
| **Before fix** | `disabled` | `No Changes` |
| **After fix** | `enabled` | `Submit Update` |

The "before" row is a real control run against the pre-fix `submit.js`, not an assumption. Baseline behaviour is unchanged: immediately after selecting an entry, with nothing edited, the button is still correctly disabled and reads "No Changes".

## Note on the generated file

`submit/submit.js` is regenerated via `make submit/submit.js` (i.e. `tsc --project tsconfig.submit.json`), and no CI workflow rebuilds it — the committed artifact is what ships. It is included here so the fix actually takes effect.

Building with the local TypeScript (6.0.2) additionally emitted a `"use strict";` prologue that the previously committed `submit.js` lacks. **That line has been stripped** so this PR is exactly the two hunks of the fix.

Two things to be aware of, since this means the committed file no longer matches raw `tsc` output on TS 6.x:

- A future `make submit/submit.js` will reintroduce the prologue as an incidental one-line diff.
- Suppressing it at build level was considered and rejected: the relevant option, `alwaysStrict: false`, is **deprecated**, errors without `ignoreDeprecations: "6.0"`, and **stops functioning in TypeScript 7.0**. Not worth carrying that in `tsconfig.submit.json` for a cosmetic prologue.

The cleaner long-term resolution is probably to accept the newer compiler output in a separate, clearly-labelled commit rather than folding it into a bug fix. Flagging rather than deciding.

The fix was re-verified in headless Chrome *after* stripping the prologue, and `node --check submit/submit.js` passes.

## Testing

There is currently no automated coverage for the submit form (`test/` has `test_incremental.py`, which drives the main rankings page with pytest + Selenium, plus `test_identifier_only_diff.py`). A regression test for this would fit the `test_incremental.py` pattern; I have not added one here to keep the fix reviewable, and have suggested it to @chenxuniu as a follow-up.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)