### PR TITLE
Regenerate submit/submit.js with current TypeScript

### DIFF
--- a/submit/submit.js
+++ b/submit/submit.js
@@ -1,3 +1,4 @@
+"use strict";
 /**
  * CSRankings Faculty Submission Form
  * Client-side validation and GitHub Issue creation


### PR DESCRIPTION
Build-output refresh only. **`src/submit.ts` is untouched**; the diff is one line in the generated file.

Follow-up to the discussion on #14105, split out so a bug fix does not carry a compiler-version change.

## What and why

`submit/submit.js` predates this repo's TypeScript 6.0 migration, so the committed artifact no longer matches what `make submit/submit.js` produces. Current `tsc` emits a `"use strict";` prologue that the committed file lacks.

Concretely, that meant anyone running `make` picked up a stray one-line diff in an unrelated PR — which is exactly what happened on #14105.

**`submit/submit.js` was the only shipped JS bundle missing the prologue.** `csrankings.js` already has it, and this is by design rather than accident — `util/concat-js.py` explicitly emits it, and its docstring spells out why:

> Because each file is emitted independently, tsc inlines its runtime helpers (`"use strict";`, `var __awaiter = ...`) into every file that needs them. This script keeps only the first occurrence of each and hoists the helpers to the top […] so the output matches the single-helper form that `outFile` produced.

The same docstring records that `outFile` "was removed in TypeScript 6.0", i.e. the build already migrated. `submit/submit.js` just was not rebuilt at the time. This PR finishes that migration.

## Scope of the change — measured, not assumed

I rebuilt `gh-pages`'s `src/submit.ts` with tsc 6.0.2 and diffed against the committed `submit/submit.js`. **The prologue is the only difference** — there is no other compiler drift hiding in the file:

```diff
+"use strict";
 /**
  * CSRankings Faculty Submission Form
```

So "regenerate wholesale" turns out to mean one line. After this lands, `make submit/submit.js` is a no-op against the committed artifact.

## Why not suppress it in tsconfig instead

Considered and rejected. The option that suppresses the prologue, `alwaysStrict: false`, is **deprecated in TypeScript 6**, errors without `"ignoreDeprecations": "6.0"`, and **stops functioning entirely in TypeScript 7.0**. Carrying that in `tsconfig.submit.json` to avoid one line is not worth the future breakage — and it would also leave `submit.js` inconsistent with `csrankings.js`.

## Verification

- **Behaviour**: loaded the submission form in headless Chrome against this build — full 33,089-entry dataset loads, entry selection populates fields, and field validation runs normally. No strict-mode breakage.
- **Static**: `node --check submit/submit.js` passes.
- **Hazard scan**: checked for constructs strict mode would break — `with`, octal literals, `arguments.callee`, assignment to undeclared variables. None present. (TypeScript output is strict-compatible by construction; this was a belt-and-braces check.)

## Interaction with #14105

No conflict. This touches line 1; the #14105 fix is around line 1723. Either can merge first — whichever lands second will apply cleanly.

Note that #14105 currently has the prologue **stripped** to keep its diff to the fix itself. Once this PR merges, that strip becomes redundant; if #14105 has not merged by then it can simply be rebased and the prologue left in place.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)