### PR TITLE
Add variables for the volume numbers of the meetings corresponding to TOG in 2025 and 2026

### DIFF
--- a/util/csrankings.py
+++ b/util/csrankings.py
@@ -551,6 +551,8 @@ ISMB_Bioinformatics = {
 # TOG special handling to count only SIGGRAPH proceedings.
 # Assuming all will be in the same issues through 2024.
 TOG_SIGGRAPH_Volume = {
+    2026: (45, 4),
+    2025: (44, 4),
     2024: (43, 4),
     2023: (42, 4),
     2022: (41, 4),
@@ -578,6 +580,8 @@ TOG_SIGGRAPH_Volume = {
 # TOG special handling to count only SIGGRAPH Asia proceedings.
 # Assuming all will be in the same issues through 2024.
 TOG_SIGGRAPH_Asia_Volume = {
+    2026: (45, 6),
+    2025: (44, 6),
     2024: (43, 6),
     2023: (42, 6),
     2022: (41, 6),


### PR DESCRIPTION

I have also submitted an issue, please take a look when you have time, thank you.

The #Pubs for SIGGRAPH and SIGGRAPH Asia in 2025 and 2026 were counted incorrectly.

https://github.com/emeryberger/CSrankings/issues/14231

> **Adding or updating a single faculty member?** Use our [self-service form](https://csrankings.org/submit/) instead — it's faster and validates your entry automatically!

## Required Checklist

Read [CONTRIBUTING.md](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md) and check **all** boxes that apply.
Delete any lines that don't apply to your PR.

### Identity & Format
- [X] My GitHub profile shows my full name[^1]
- [X] PR title is descriptive (not "Update csrankings-x.csv")[^2]
- [X] One PR per institution, all changes combined[^3]
- [X] Only modified `csrankings-[a-z].csv` or `old/industry.csv`[^4]
- [X] Did NOT use Excel[^5]
- [X] No spaces after commas, no missing fields[^6]
- [X] Entries in alphabetical order by full name[^7]

### Data Accuracy
- [X] Name matches [DBLP](https://dblp.org) exactly (including 0001 suffixes)[^8]
- [X] Homepage URL works and shows name + affiliation[^9]
- [X] Google Scholar ID is the 12-character code only[^10]
- [X] Valid ORCID provided (not placeholder zeros)[^16]

### Eligibility
- [X] Faculty is full-time, tenure-track[^11]
- [X] Can **solely** advise CS PhD students[^12]
- [X] If not in CS department: included justification with links[^13]

### New Institutions
- [X] If adding new institution: opened issue first[^14]
- [X] Adding **all** CS faculty (not just one)[^15]

---

[^1]: Anonymous submissions are rejected to ensure accountability. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#non-anonymous)
[^2]: Generic titles make the PR queue difficult to manage. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#pr-title)
[^3]: Multiple PRs for one institution create merge conflicts. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#one-pr)
[^4]: Other files are auto-generated or require maintainer access. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#allowed-files)
[^5]: Excel corrupts Google Scholar IDs by converting them to formulas. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#no-excel)
[^6]: Malformed CSV lines break the data pipeline. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#csv-format)
[^7]: Alphabetical order makes entries easy to find and reduces merge conflicts. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#alphabetical)
[^8]: Publications are matched by exact DBLP name; mismatches = zero papers counted. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#dblp-name)
[^9]: Automated validation fetches homepage to verify affiliation. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#homepage)
[^10]: Full URLs or `&hl=en` suffixes break the Scholar lookup. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#scholar-id)
[^11]: Adjuncts, visitors, and part-time faculty are excluded. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#tenure-track)
[^12]: Faculty who can only co-advise don't meet inclusion criteria. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#sole-advising)
[^13]: E.g., courtesy appointment in CS, or graduate program membership. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#non-cs-dept)
[^14]: Institution must be added to `institutions.csv` first by maintainer. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#new-institution)
[^15]: Partial departments skew rankings; all-or-nothing ensures fairness. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#entire-dept)
[^16]: ORCID is required for all new and updated entries. [Register for an ORCID iD](https://support.orcid.org/hc/en-us/articles/360006897454-How-do-I-register-for-an-ORCID-ID) if you don't have one. [more info](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#orcid)
