### PR TITLE
Vanderbilt University: 2026 faculty update (11 additions, 2 affiliation changes, 1 removal, ORCID backfill)

### DIFF
--- a/csrankings-a.csv
+++ b/csrankings-a.csv
@@ -567,7 +567,7 @@ Alan J. Hu,University of British Columbia,http://www.cs.ubc.ca/~ajh,6-JE5-cAAAAJ
 Alan K. Mackworth,University of British Columbia,http://www.cs.ubc.ca/~mack,6Jf5GeYAAAAJ,0000-0000-0000-0000
 Alan Kaminsky,Rochester Inst. of Technology,https://www.cs.rit.edu/~ark,NOSCHOLARPAGE,0000-0000-0000-0000
 Alan Kuhnle,Texas A&M University,http://www.alankuhnle.com,-zrlrKgAAAAJ,0000-0001-6506-1902
-Alan Kuntz,University of Utah,http://www.cs.utah.edu/~adk,7uZPiGoAAAAJ,0000-0003-0017-3932
+Alan Kuntz,Vanderbilt University,https://www.vanderbilt.edu/vise/people/alan-kuntz/,7uZPiGoAAAAJ,0000-0003-0017-3932
 Alan L. Cox,Rice University,https://www.cs.rice.edu/~alc,z28ApZkAAAAJ,0000-0000-0000-0000
 Alan L. Yuille,Johns Hopkins University,http://www.cs.jhu.edu/~ayuille,FJ-huxgAAAAJ,0000-0001-5207-9249
 Alan Loddon Yuille,Johns Hopkins University,http://www.cs.jhu.edu/~ayuille,FJ-huxgAAAAJ,0000-0000-0000-0000
@@ -1204,7 +1204,7 @@ Alwen Tiu,Australian National University,https://cecs.anu.edu.au/people/alwen-ti
 Aly E. Fathy,University of Tennessee,http://web.eecs.utk.edu/~fathy,D_b0_TYAAAAJ,0000-0002-7855-5546
 Alyosha A. Efros,Univ. of California - Berkeley,http://www.eecs.berkeley.edu/~efros,d97bGd8AAAAJ,0000-0000-0000-0000
 Alyson K. Fletcher,Univ. of California - Los Angeles,http://www.stat.ucla.edu/~akfletcher,MCClSvsAAAAJ,0000-0000-0000-0000
-Alyssa Friend Wise,Vanderbilt University,https://lab.vanderbilt.edu/live/person/alyssa-wise,oJK9RqEAAAAJ,0000-0000-0000-0000
+Alyssa Friend Wise,Vanderbilt University,https://lab.vanderbilt.edu/live/person/alyssa-wise,oJK9RqEAAAAJ,0000-0002-4043-6808
 Alysson Bessani,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/anbessani,-mFXT_oAAAAJ,0000-0002-8386-1628
 Alysson Neves Bessani,Universidade de Lisboa,https://ciencias.ulisboa.pt/perfil/anbessani,-mFXT_oAAAAJ,0000-0002-8386-1628
 Amal Ahmed 0001,Northeastern University,http://www.ccs.neu.edu/home/amal,Y1C007wAAAAJ,0000-0001-7424-572X
@@ -2648,7 +2648,7 @@ Atul Mantri,Virginia Tech,https://website.cs.vt.edu/people/faculty/atul-mantri.h
 Atul Prakash 0001,University of Michigan,http://web.eecs.umich.edu/~aprakash,kIkHa2IAAAAJ,0000-0002-4907-3687
 Audrey Durand,Université Laval,https://audur2.ift.ulaval.ca,Qdm6sEwAAAAJ,0000-0000-0000-0000
 Audrey Girouard,Carleton University,https://cil.csit.carleton.ca,wP7xkUEAAAAJ,0000-0003-3223-105X
-Audrey K. Bowden,Vanderbilt University,https://lab.vanderbilt.edu/bowdenlab,NOSCHOLARPAGE,0000-0000-0000-0000
+Audrey K. Bowden,Vanderbilt University,https://lab.vanderbilt.edu/bowdenlab,NOSCHOLARPAGE,0000-0002-5412-3976
 Audris Kalnins,University of Latvia,https://www.linkedin.com/in/audris-kalnins-33b3b0,NOSCHOLARPAGE,0000-0003-0907-7496
 Audris Mockus,University of Tennessee,http://mockus.us,ZGvnVQUAAAAJ,0000-0002-7987-7598
 August-Wilhelm Scheer,TU Munich,http://www.tum-ias.de/people/members/tum-august-wilhelm-scheer-visiting-professors.html,JeUi9iEAAAAJ,0000-0000-0000-0000

--- a/csrankings-b.csv
+++ b/csrankings-b.csv
@@ -335,7 +335,7 @@ Benjamin W. Wah,Chinese University of Hong Kong,https://wah.cse.cuhk.edu.hk,WL8i
 Benjamin Wan-Sang Wah,Chinese University of Hong Kong,https://wah.cse.cuhk.edu.hk,WL8igVEAAAAJ,0000-0000-0000-0000
 Benjamin Watson 0001,North Carolina State University,https://www.csc.ncsu.edu/people/bwatson,yfYYAMQAAAAJ,0000-0002-3758-7357
 Benjamin Weyers,University of Trier,https://www.uni-trier.de/index.php?id=68465,L7JClToAAAAJ,0000-0003-4785-708X
-Bennett A. Landman,Vanderbilt University,https://engineering.vanderbilt.edu/bio/?pid=bennett-landman,tmTcH0QAAAAJ,0000-0000-0000-0000
+Bennett A. Landman,Vanderbilt University,https://engineering.vanderbilt.edu/bio/?pid=bennett-landman,tmTcH0QAAAAJ,0000-0001-5733-2127
 Benno Stabernack,University of Potsdam,https://www.uni-potsdam.de/de/aess/mitarbeiter/mitarbeiter,NOSCHOLARPAGE,0000-0000-0000-0000
 Benno Stein 0001,Bauhaus University Weimar,https://www.uni-weimar.de/en/media/chairs/computer-science-department/webis/people/stein,NOSCHOLARPAGE,0000-0001-9033-2217
 Benny Akesson,University of Amsterdam,https://akesson.nl,pQC-OOkAAAAJ,0000-0003-2949-2080
@@ -347,7 +347,7 @@ Benny Van Houdt,University of Antwerp,https://www.uantwerpen.be/en/staff/benny-v
 Benoit Baudry,KTH Royal Inst. of Technology,https://www.kth.se/profile/baudry,oP4UxPkAAAAJ,0000-0002-4015-4640
 Benoît Baudry,KTH Royal Inst. of Technology,https://www.kth.se/profile/baudry,oP4UxPkAAAAJ,0000-0000-0000-0000
 Benoît Libert,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/benoit.libert,kRpKU4IAAAAJ,0000-0002-6914-1616
-Benoit M. Dawant,Vanderbilt University,http://engineering.vanderbilt.edu/bio/benoit-dawant,I_N__-QAAAAJ,0000-0000-0000-0000
+Benoit M. Dawant,Vanderbilt University,http://engineering.vanderbilt.edu/bio/benoit-dawant,I_N__-QAAAAJ,0000-0002-3804-8400
 Bent Flyvbjerg,IT University of Copenhagen,https://pure.itu.dk/portal/en/persons/bent-flyvbjerg(598de448-af84-43c8-9147-6134a63c9b3c).html,79htA7gAAAAJ,0000-0000-0000-0000
 Bent Thomsen,Aalborg University,http://people.cs.aau.dk/~bt,mhyMmZoAAAAJ,0000-0002-5853-7973
 Bentley Oakes,Polytechnique Montreal,https://bentleyjoakes.github.io,x9H9H4QAAAAJ,0000-0001-7558-1434

--- a/csrankings-c.csv
+++ b/csrankings-c.csv
@@ -153,6 +153,7 @@ Carlos Eduardo Ferreira,USP,http://www.ime.usp.br/~cef,cp2Bft4AAAAJ,0000-0003-48
 Carlos Eduardo Pedreira,UFRJ,http://www.cos.ufrj.br/~pedreira,Dg3fjRgAAAAJ,0000-0000-0000-0000
 Carlos Eduardo R. Lopes,UFU,http://www.facom.ufu.br/~crlopes,NOSCHOLARPAGE,0000-0000-0000-0000
 Carlos Fernandez-Lozano,University of A Coruña,https://cafernandezlo.github.io/es_github_cafernandezlo,gE-7NE4AAAAJ,0000-0003-0413-5677
+Carlos G. Oliver,Vanderbilt University,https://carlosoliver.co,UnTr7qIAAAAJ,0000-0001-8742-8795
 Carlos Gómez-Rodríguez,University of A Coruña,http://www.grupolys.org/~cgomezr,BeNhySQAAAAJ,0000-0003-0752-8812
 Carlos Gustavo López Pombo,University of Buenos Aires,https://www.dc.uba.ar/~clpombo,DGmfF8QAAAAJ,0000-0000-0000-0000
 Carlos H. Morimoto,USP,http://www.ime.usp.br/~hitoshi,ylIa7EoAAAAJ,0000-0003-4679-2827
@@ -821,6 +822,7 @@ Chris J. Price,Aberystwyth University,https://www.aber.ac.uk/en/cs/staff-profile
 Chris Jermaine,Rice University,https://www.cs.rice.edu/~cmj4,D2P2B0MAAAAJ,0000-0000-0000-0000
 Chris Kanan,University of Rochester,http://www.chriskanan.com,jMxZjBoAAAAJ,0000-0000-0000-0000
 Chris Kanich,University of Illinois at Chicago,https://www.cs.uic.edu/~ckanich,Zy1b3UAAAAAJ,0000-0002-3836-2168
+Chris Kapulkin,Vanderbilt University,https://kkapulkin.github.io/,0Wkji3IAAAAJ,0000-0002-8141-2554
 Chris Leckie,University of Melbourne,http://findanexpert.unimelb.edu.au/display/person6335,wUsI0cAAAAAJ,0000-0000-0000-0000
 Chris Lehnert,Queensland Univ. of Technology,https://research.qut.edu.au/qcr/people/chris-lehnert,PN4ITysAAAAJ,0000-0002-4230-8068
 Chris Lucas 0001,University of Edinburgh,http://www.christopherglucas.com,KS4uI1sAAAAJ,0000-0000-0000-0000
@@ -1494,6 +1496,7 @@ Congyi Zhang 0005,University of Texas at Dallas,https://cong-yi.github.io,-Ke6AG
 Connie White,University of Southern Mississippi,https://www.usm.edu/computing,NOSCHOLARPAGE,0000-0000-0000-0000
 Conor J. Houghton,University of Bristol,https://conorhoughton.github.io,VoP4kDQAAAAJ,0000-0000-0000-0000
 Conor McBride,University of Strathclyde,https://personal.cis.strath.ac.uk/conor.mcbride,vO7qGKwAAAAJ,0000-0003-1487-0886
+Conrad Borchers,Vanderbilt University,https://cborchers.com,v5yiJVAAAAAJ,0000-0003-3437-8979
 Conrad Watt,Nanyang Technological University,https://conrad-watt.github.io,SVU1RU8AAAAJ,0000-0002-0596-877X
 Conrado R. Ruiz Jr.,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32742689520&command=GETPROFILE,y91psfsAAAAJ,0000-0002-0956-7201
 Constandinos X. Mavromoustakis,University of Nicosia,https://www.unic.ac.cy/mavromoustakis-constandinos,b095UrEAAAAJ,0000-0000-0000-0000

--- a/csrankings-d.csv
+++ b/csrankings-d.csv
@@ -137,7 +137,7 @@ Dan Klein 0001,Univ. of California - Berkeley,https://www2.eecs.berkeley.edu/Fac
 Dan Knights,University of Minnesota,http://www.knightslab.org,zTkLS_gAAAAJ,0000-0000-0000-0000
 Dan Li 0001,Tsinghua University,https://nasp.cs.tsinghua.edu.cn/lidan.html,NOSCHOLARPAGE,0000-0002-7581-8865
 Dan Li 0016,Sun Yat-sen University,http://sse.sysu.edu.cn/teacher/209,YYig2NUAAAAJ,0000-0002-3787-1673
-Dan Lin 0001,Vanderbilt University,https://engineering.vanderbilt.edu/bio/?pid=dan-lin,6GB4dDYAAAAJ,0000-0000-0000-0000
+Dan Lin 0001,Vanderbilt University,https://engineering.vanderbilt.edu/bio/?pid=dan-lin,6GB4dDYAAAAJ,0000-0003-1521-1452
 Dan McQuillan,Goldsmiths University of London,https://www.gold.ac.uk/computing/staff/d-mcquillan,7e1W_LcAAAAJ,0000-0000-0000-0000
 Dan Miranker,University of Texas at Austin,https://www.cs.utexas.edu/~miranker,NOSCHOLARPAGE,0000-0000-0000-0000
 Dan Negrut,University of Wisconsin - Madison,https://sbel.wisc.edu,Olsi_owAAAAJ,0000-0003-1565-2784
@@ -335,7 +335,7 @@ Daniel Massey,University of Colorado Boulder,https://www.colorado.edu/cs/daniel-
 Daniel Mauricio Romero,University of Michigan,http://www.dromero.org,c4M3MQoAAAAJ,0000-0000-0000-0000
 Daniel McQuillan,Goldsmiths University of London,https://www.gold.ac.uk/computing/staff/d-mcquillan,7e1W_LcAAAAJ,0000-0000-0000-0000
 Daniel Mossé,University of Pittsburgh,https://www.cs.pitt.edu/~mosse,O1FZe5EAAAAJ,0000-0000-0000-0000
-Daniel Moyer,Vanderbilt University,https://dcmoyer.github.io,sKmoxSMAAAAJ,0000-0000-0000-0000
+Daniel Moyer,Vanderbilt University,https://dcmoyer.github.io,sKmoxSMAAAAJ,0000-0003-4428-5012
 Daniel Mueller 0001,TU Wien,https://informatics.tuwien.ac.at/people/daniel-mueller-gritschneder,uIy75_wAAAAJ,0000-0003-0903-631X
 Daniel Mueller-Gritschneder,TU Wien,https://informatics.tuwien.ac.at/people/daniel-mueller-gritschneder,uIy75_wAAAAJ,0000-0003-0903-631X
 Daniel Müller-Gritschneder,TU Wien,https://informatics.tuwien.ac.at/people/daniel-mueller-gritschneder,uIy75_wAAAAJ,0000-0003-0903-631X
@@ -494,7 +494,7 @@ Darío Correal,Universidad de los Andes,https://profesores.virtual.uniandes.edu.
 Dario D. Salvucci,Drexel University,http://www.mcs.drexel.edu/~salvucci,i1VJMhgAAAAJ,0000-0001-8812-4996
 Darío Ernesto Correal Torres,Universidad de los Andes,https://profesores.virtual.uniandes.edu.co/dcorreal/es/inicio,Bo4lXDAtq9QC,0000-0000-0000-0000
 Dario Fiore 0001,IMDEA Software Institute,http://www.dariofiore.it,RiIDoKQAAAAJ,0000-0001-7274-6600
-Dario J. Englot,Vanderbilt University,https://www.vanderbilt.edu/vise/visepeople/dario-j-englot,xTp_8_AAAAAJ,0000-0000-0000-0000
+Dario J. Englot,Vanderbilt University,https://www.vanderbilt.edu/vise/visepeople/dario-j-englot,xTp_8_AAAAAJ,0000-0001-8373-690X
 Dario Landa Silva,University of Nottingham,https://www.nottingham.ac.uk/computerscience/people/dario.landasilva,T8jdVWwAAAAJ,0000-0000-0000-0000
 Dario Landa-Silva,University of Nottingham,https://www.nottingham.ac.uk/computerscience/people/dario.landasilva,T8jdVWwAAAAJ,0000-0002-9499-6827
 Dario Paccagnan,Imperial College London,https://www.doc.ic.ac.uk/~dp414,Y7wBGG8AAAAJ,0000-0002-8541-6966

--- a/csrankings-f.csv
+++ b/csrankings-f.csv
@@ -503,7 +503,7 @@ Fnu Suya,University of Tennessee,https://eecs.utk.edu/people/fnu-suya,OmLIG8EAAA
 Foad Hamidi,Univ. of Maryland - Baltimore County,http://www.foadhamidi.com,FItnzEoAAAAJ,0000-0003-1991-6062
 Fons J. Verbeek,Leiden University,https://liacs.leidenuniv.nl/~verbeekfj,J3RNQesAAAAJ,0000-0000-0000-0000
 Forest Agostinelli,University of South Carolina,https://cse.sc.edu/~foresta,R3ru5X8AAAAJ,0000-0003-1392-3667
-Forrest J. Laine,Vanderbilt University,https://forrestlaine.github.io,raa7w5YAAAAJ,0000-0000-0000-0000
+Forrest J. Laine,Vanderbilt University,https://forrestlaine.github.io,raa7w5YAAAAJ,0000-0003-3982-3920
 Forrest Laine,Vanderbilt University,https://4estlaine.github.io,raa7w5YAAAAJ,0000-0003-3982-3920
 Forrest Sheng Bao,Iowa State University,https://www.cs.iastate.edu/people/forrest-sheng-bao,XWpFf0IAAAAJ,0000-0000-0000-0000
 Foster J. Provost,New York University,https://fosterprovost.com,-Km63D4AAAAJ,0000-0000-0000-0000

--- a/csrankings-g.csv
+++ b/csrankings-g.csv
@@ -673,7 +673,7 @@ Göksel Biricik,Yıldız Technical University,https://www.ce.yildiz.edu.tr/perso
 Göktürk Üçoluk,Middle East Technical University,http://user.ceng.metu.edu.tr/~ucoluk,kV5zQBkAAAAJ,0000-0000-0000-0000
 Gokul Subramanian Ravi,University of Michigan,https://gsravi.engin.umich.edu,fFtGasEAAAAJ,0000-0002-2334-2682
 Golden G. Richard III,Louisiana State University,http://cct.lsu.edu/~golden,gq8-LJ8AAAAJ,0000-0000-0000-0000
-Golnaz Arastoopour Irgens,Vanderbilt University,https://lab.vanderbilt.edu/live/person/golnaz-arastoopour-irgens,5bJ9ABkAAAAJ,0000-0000-0000-0000
+Golnaz Arastoopour Irgens,Vanderbilt University,https://lab.vanderbilt.edu/live/person/golnaz-arastoopour-irgens,5bJ9ABkAAAAJ,0000-0002-5308-3925
 Golnaz Badkobeh,Goldsmiths University of London,https://www.gold.ac.uk/computing/people/badkobeh-golnaz,m4IC_BgAAAAJ,0000-0001-5550-7149
 Golnaz Habibi,University of Oklahoma,https://www.ou.edu/coe/cs/people/faculty/golnaz-habibi,hU-LeNEAAAAJ,0000-0002-9130-9323
 Golnoush Abaei,RMIT University,https://www.rmit.edu.au/contact/staff-contacts/academic-staff/a/abaei-dr-golnoush,0OjUid0AAAAJ,0000-0002-8916-759X

--- a/csrankings-h.csv
+++ b/csrankings-h.csv
@@ -1,7 +1,7 @@
 name,affiliation,homepage,scholarid,orcid
 H. Altay Güvenir,Bilkent University,http://www.cs.bilkent.edu.tr/~guvenir,zRvIRVUAAAAJ,0000-0000-0000-0000
 H. Andrés Neyem,UC Chile,http://www.andresneyem.cl,xPEdf1wAAAAJ,0000-0000-0000-0000
-H. Andrew Schwartz,Vanderbilt University,https://haschwartz.com,Na16PsUAAAAJ,0000-0000-0000-0000
+H. Andrew Schwartz,Vanderbilt University,https://haschwartz.com,Na16PsUAAAAJ,0000-0002-6383-3339
 H. Anitha,Manipal Academy of Higher Education,https://www.manipal.edu/mit/department-faculty/faculty-list/anitha-h/_jcr_content.html,8f9mZtQAAAAJ,0000-0001-5898-4442
 H. Birkan Yilmaz,Boğaziçi University,https://sites.google.com/site/birkanyilmazacademic,Eg_wBXUAAAAJ,0000-0002-4773-2028
 H. Dieter Rombach,TU Kaiserslautern,http://wwwagse.informatik.uni-kl.de/staff/rombach,OpsrHLAAAAAJ,0000-0000-0000-0000
@@ -326,7 +326,7 @@ Hans-Ulrich Prokosch,University of Erlangen–Nuremberg,https://www.imi.med.fau.
 Hans-Werner Gellersen,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/people/hans-gellersen,wmpvU_YAAAAJ,0000-0003-2233-2121
 Hans-Werner Güsgen,Massey University,http://seat.massey.ac.nz/h.w.guesgen,QwXZ99YAAAAJ,0000-0000-0000-0000
 Hans-Wolfgang Loidl,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/hans-wolfgang-loidl.htm,lwb1Va0AAAAJ,0000-0001-6318-1732
-Hansen Andrew Schwartz,Vanderbilt University,https://haschwartz.com,Na16PsUAAAAJ,0000-0000-0000-0000
+Hansen Andrew Schwartz,Vanderbilt University,https://haschwartz.com,Na16PsUAAAAJ,0000-0002-6383-3339
 Hansenclever de F. Bassani,UFPE,https://www.cin.ufpe.br/~hfb,s14pJ00AAAAJ,0000-0000-0000-0000
 Hansenclever F. Bassani,UFPE,https://www.cin.ufpe.br/~hfb,s14pJ00AAAAJ,0000-0000-0000-0000
 Hanseok Ko,Korea University,http://ispl.korea.ac.kr,G9v28v4AAAAJ,0000-0002-8744-4514
@@ -1244,6 +1244,7 @@ Huseyin Levent Akin,Boğaziçi University,https://www.cmpe.boun.edu.tr/~akin,61a
 Husheng Li,University of Tennessee,http://web.eecs.utk.edu/~husheng,pM3wc_YAAAAJ,0000-0000-0000-0000
 Hüsnü Yenigün,Sabancı University,http://people.sabanciuniv.edu/yenigun,VaDb-YYAAAAJ,0000-0003-0947-8150
 Hussam Amrouch,TU Munich,https://campus.tum.de/tumonline/ee/ui/ca2/app/desktop/#/pl/ui/$ctx/visitenkarte.show_vcard?$ctx=design=ca2;header=max;lang=de&pPersonenGruppe=3&pPersonenId=894A6D4391C7631E,63J6zas48moC,0000-0002-5649-3102
+Hussam Mahmoud,Vanderbilt University,https://engineering.vanderbilt.edu/bio/hussam-mahmoud/,K7bi2GgAAAAJ,0000-0002-3106-6067
 Hussein M. Alnuweiri,Texas A&M at Qatar,https://www.qatar.tamu.edu/programs/ecen/faculty-and-staff/duplicate-of-dr.-patrick-linke,NOSCHOLARPAGE,0000-0000-0000-0000
 Hussein Sibai,Washington University in St. Louis,https://engineering.washu.edu/faculty/Hussein-Sibai.html,St5uCSwAAAAJ,0000-0002-6053-1001
 Hussein Suleman,University of Cape Town,http://www.husseinsspace.com,7efxJWkAAAAJ,0000-0002-4196-1444

--- a/csrankings-i.csv
+++ b/csrankings-i.csv
@@ -430,7 +430,7 @@ Ivana Konvalinka,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE,0000-0000-
 Ivano Malavolta,VU Amsterdam,http://www.ivanomalavolta.com,ya3htIoAAAAJ,0000-0001-5773-8346
 Ivano Salvo,Sapienza University of Rome,http://wwwusers.di.uniroma1.it/~salvo,YwCGzIcAAAAJ,0000-0000-0000-0000
 Ivar Farup,NTNU,https://www.ntnu.edu/employees/ivar.farup,Fly9iXMAAAAJ,0000-0000-0000-0000
-Ivelin Georgiev,Vanderbilt University,https://www.vanderbilt.edu/evolution/person/ivelin-georgiev,igzamsYAAAAJ,0000-0000-0000-0000
+Ivelin Georgiev,Vanderbilt University,https://www.vanderbilt.edu/evolution/person/ivelin-georgiev,igzamsYAAAAJ,0000-0002-6312-7696
 Ivica Crnkovic,Chalmers/GU,https://www.chalmers.se/en/staff/Pages/crnkovic.aspx,yewx0GgAAAAJ,0000-0002-5278-755X
 Ivo F. Sbalzarini,TU Dresden,http://mosaic.mpi-cbg.de/?q=people/ivo_sbalzarini,KPdbUktu0hkC,0000-0003-4414-4340
 Ivo Grosse,University of Halle-Wittenberg,https://www.informatik.uni-halle.de/arbeitsgruppen/bioinformatik/mitarbeiterinnen/grosse,9885qDUAAAAJ,0000-0001-5318-4825

--- a/csrankings-j.csv
+++ b/csrankings-j.csv
@@ -66,7 +66,7 @@ Jack C. Wileden,Univ. of Massachusetts Amherst,https://people.cs.umass.edu/~jack
 Jack Doerner,University of Virginia,https://jackdoerner.net,QMbCDtEAAAAJ,0009-0007-0409-2132
 Jack Dongarra,University of Tennessee,http://www.netlib.org/utk/people/JackDongarra,X4SbSTAAAAAJ,0000-0003-3247-1782
 Jack H. Lutz,Iowa State University,http://www.cs.iastate.edu/~lutz,mxv3BeAAAAAJ,0000-0000-0000-0000
-Jack H. Noble,Vanderbilt University,https://my.vanderbilt.edu/jacknoble,xrsieAkAAAAJ,0000-0000-0000-0000
+Jack H. Noble,Vanderbilt University,https://my.vanderbilt.edu/jacknoble,xrsieAkAAAAJ,0000-0002-0973-505X
 Jack J. Dongarra,University of Tennessee,http://www.netlib.org/utk/people/JackDongarra,X4SbSTAAAAAJ,0000-0003-3247-1782
 Jack Jansen,CWI,http://homepages.cwi.nl/~jack,qHiBTg0AAAAJ,0000-0000-0000-0000
 Jack Lange,University of Pittsburgh,https://www.cs.pitt.edu/~jacklange,47I8TqkAAAAJ,0000-0000-0000-0000
@@ -2101,6 +2101,7 @@ Jonathan Edward Fieldsend,University of Exeter,http://emps.exeter.ac.uk/computer
 Jonathan F. Gemmell,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=494,RIhZrvIAAAAJ,0000-0000-0000-0000
 Jonathan Gaudreault,Université Laval,https://www.ift.ulaval.ca/departement-et-professeurs/professeurs-et-personnel/professeurs-reguliers/fiche/show/gaudreault-jonathan,g7YxejsAAAAJ,0000-0001-5493-8836
 Jonathan Gemmell,DePaul University,http://www.cdm.depaul.edu/about/Pages/People/facultyinfo.aspx?fid=494,RIhZrvIAAAAJ,0009-0002-8764-8792
+Jonathan Gratch,Vanderbilt University,https://computing.vanderbilt.edu/person/jonathan-gratch/,HF448PMAAAAJ,0000-0002-5959-809X
 Jonathan Gryak,CUNY,https://www.gc.cuny.edu/people/jonathan-gryak,llkzRAYAAAAJ,0000-0002-5125-7741
 Jonathan H. Huggins,Boston University,http://jhhuggins.org,x1mbRloAAAAJ,0000-0000-0000-0000
 Jonathan Herbert Schaeffer,University of Alberta,https://webdocs.cs.ualberta.ca/~jonathan,W6WwvbQAAAAJ,0000-0000-0000-0000
@@ -2579,7 +2580,7 @@ Jukka K. Nurminen,University of Helsinki,https://researchportal.helsinki.fi/en/p
 Jukka Kalevi Nurminen,University of Helsinki,https://researchportal.helsinki.fi/en/persons/jukka-k-nurminen,cmftgn4AAAAJ,0000-0000-0000-0000
 Jukka Matthias Krisp,University of Augsburg,https://www.uni-augsburg.de/en/fakultaet/fai/geo/prof/geoagi/geoagi-team/j-krisp,NOSCHOLARPAGE,0000-0000-0000-0000
 Jukka Suomela,Aalto University,https://jukkasuomela.fi,hTZOWl8AAAAJ,0000-0001-6117-8089
-Jules White,Vanderbilt University,https://engineering.vanderbilt.edu/bio/?pid=jules-white,10HSX90AAAAJ,0000-0000-0000-0000
+Jules White,Vanderbilt University,https://computing.vanderbilt.edu/person/jules-white/,10HSX90AAAAJ,0000-0002-6331-2365
 Julia Chuzhoy,TTI Chicago,http://ttic.uchicago.edu/~cjulia,ikn-xhYAAAAJ,0000-0001-7839-751X
 Julia E. Hodges,Mississippi State University,http://www.cse.msstate.edu/people/faculty/julia-hodges,NOSCHOLARPAGE,0000-0000-0000-0000
 Julia Fukuyama,Indiana University,https://luddy.indiana.edu/contact/profile/index.html?Julia_Fukuyama,BhazhScAAAAJ,0000-0000-0000-0000

--- a/csrankings-k.csv
+++ b/csrankings-k.csv
@@ -508,7 +508,7 @@ Keith Vertanen,Michigan Technological University,https://www.mtu.edu/cs/departme
 Keith W. Cheverst,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/people/keith-cheverst,XElVSIEAAAAJ,0000-0000-0000-0000
 Keith W. Ross,NYU Abu Dhabi,https://nyuad.nyu.edu/en/academics/divisions/science/faculty/keith-ross.html,RhUcYmQAAAAJ,0000-0000-0000-0000
 Keith Winstein,Stanford University,https://cs.stanford.edu/~keithw,S5sz8gIAAAAJ,0000-0003-2305-8048
-Keivan G. Stassun,Vanderbilt University,https://as.vanderbilt.edu/physics-astronomy/bio/keivan-stassun,nQ_TNGwAAAAJ,0000-0000-0000-0000
+Keivan G. Stassun,Vanderbilt University,https://as.vanderbilt.edu/physics-astronomy/bio/keivan-stassun,nQ_TNGwAAAAJ,0000-0002-3481-9052
 Keivan Navaie,Lancaster University,https://www.lancaster.ac.uk/scc/about-us/people/keivan-navaie,bWDRdFoAAAAJ,0000-0002-4399-6472
 Keizo Oyama,National Inst. of Informatics,http://research.nii.ac.jp/~oyama/index_en.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Kejiang Ye,Chinese Academy of Sciences,https://people.ucas.edu.cn/~kejiang?language=en,8SFhg9AAAAAJ,0000-0002-3947-6183
@@ -1016,6 +1016,7 @@ Krzysztof J. Cios,Virginia Commonwealth University,http://cioslab.vcu.edu/index.
 Krzysztof J. Geras,New York University,https://cs.nyu.edu/~kgeras,ZMCGp48AAAAJ,0000-0000-0000-0000
 Krzysztof J. Kochut,University of Georgia,http://cobweb.cs.uga.edu/~kochut,NOSCHOLARPAGE,0000-0000-0000-0000
 Krzysztof Jozef Cios,Virginia Commonwealth University,http://cioslab.vcu.edu/index.html,hrWVmoAAAAAJ,0000-0000-0000-0000
+Krzysztof Kapulkin,Vanderbilt University,https://kkapulkin.github.io/,0Wkji3IAAAAJ,0000-0002-8141-2554
 Krzysztof Kuchcinski,Lund University,http://cs.lth.se/krzysztof_kuchcinski,NOSCHOLARPAGE,0000-0001-8941-459X
 Krzysztof Lorys,University of Wroclaw,http://www.ii.uni.wroc.pl/~lorys,NOSCHOLARPAGE,0000-0002-3553-3443
 Krzysztof Onak,Boston University,https://onak.pl,68eoKg4AAAAJ,0000-0003-0226-7449

--- a/csrankings-m.csv
+++ b/csrankings-m.csv
@@ -1970,7 +1970,7 @@ Michael Hübner,Brandenburg Univ. of Technology,https://www.b-tu.de/en/fg-techni
 Michael Huth 0001,Imperial College London,http://www.doc.ic.ac.uk/~mrh,ZBlUaIAAAAAJ,0000-0001-9229-3055
 Michael I. Jordan,INRIA,http://www.cs.berkeley.edu/~jordan,yxUduqMAAAAJ,0000-0001-8935-817X
 Michael I. Mandel,CUNY,http://www.brooklyn.cuny.edu/web/academics/faculty/faculty_profile.jsp?faculty=1264,0v1-axgAAAAJ,0000-0000-0000-0000
-Michael I. Miga,Vanderbilt University,https://migalab.org,q2ThJtAAAAAJ,0000-0000-0000-0000
+Michael I. Miga,Vanderbilt University,https://migalab.org,q2ThJtAAAAAJ,0000-0002-0694-9765
 Michael I. Miller,Johns Hopkins University,https://www.bme.jhu.edu/people/faculty/michael-i-miller,Ui8pnoIAAAAJ,0000-0000-0000-0000
 Michael I. Shamos,Carnegie Mellon University,http://euro.ecom.cmu.edu/shamos.html,PswI6pYAAAAJ,0000-0000-0000-0000
 Michael Ian Shamos,Carnegie Mellon University,http://euro.ecom.cmu.edu/shamos.html,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -2315,7 +2315,7 @@ Mikaël Salson,CRIStAL,http://cristal.univ-lille.fr/~salson,NOSCHOLARPAGE,0000-0
 Mikael Sjödin,Mälardalen University,https://www.es.mdh.se/staff/63-Mikael_Sjodin,K8v5JfgAAAAJ,0000-0000-0000-0000
 Mikael Vejdemo-Johansson,CUNY,https://www.math.csi.cuny.edu/~mvj,XJN1TGIAAAAJ,0000-0001-6322-7542
 Mikaela Keller,CRIStAL,https://www.cristal.univ-lille.fr/profil/kellerm,BbxquKkAAAAJ,0000-0000-0000-0000
-Mikail Rubinov,Vanderbilt University,https://www.rubinovlab.net,-HLPnzIAAAAJ,0000-0000-0000-0000
+Mikail Rubinov,Vanderbilt University,https://www.rubinovlab.net,-HLPnzIAAAAJ,0000-0002-4787-7075
 Mike Bailey,Oregon State University,http://eecs.oregonstate.edu/people/bailey-mike,rHKC-kAAAAAJ,0000-0000-0000-0000
 Mike Barley,University of Auckland,https://www.cs.auckland.ac.nz/people/m-barley,QwAxKoEAAAAJ,0000-0000-0000-0000
 Mike Brooks,Adelaide University,http://www.adelaide.edu.au/directory/michael.brooks,IRsRrroAAAAJ,0000-0000-0000-0000

--- a/csrankings-p.csv
+++ b/csrankings-p.csv
@@ -977,6 +977,7 @@ Philippe Cudré-Mauroux,University of Fribourg,https://exascale.info/phil,NpccCX
 Philippe Devienne,CRIStAL,https://www.cristal.univ-lille.fr/profil/devienne,NOSCHOLARPAGE,0000-0000-0000-0000
 Philippe Ezequel,Université Jean Monnet,http://perso.univ-st-etienne.fr/ezequel,NOSCHOLARPAGE,0000-0000-0000-0000
 Philippe Fournier-Viger,Shenzhen University,https://csse.szu.edu.cn/en/pages/user/index?id=1205,QG_7KjoAAAAJ,0000-0000-0000-0000
+Philippe G. Schyns,Vanderbilt University,https://computing.vanderbilt.edu/person/philippe-schyns/,cwgW51EAAAAJ,0000-0002-8542-7489
 Philippe Giguère,Université Laval,http://www2.ift.ulaval.ca/~pgiguere,tgZPkzkAAAAJ,0000-0002-7520-8290
 Philippe Langlais,University of Montreal,http://www.iro.umontreal.ca/~felipe,NOSCHOLARPAGE,0000-0000-0000-0000
 Philippe Marquet,CRIStAL,https://www.cristal.univ-lille.fr/profil/marquet,IeTyR8gAAAAJ,0000-0000-0000-0000

--- a/csrankings-r.csv
+++ b/csrankings-r.csv
@@ -37,6 +37,7 @@ Raanan Fattal,Hebrew University of Jerusalem,http://www.cs.huji.ac.il/~raananf,9
 Raaz Dwivedi [Tech],Cornell University,https://raazdwivedi.github.io,9ehX_58AAAAJ,0000-0000-0000-0000
 Rabi N. Mahapatra,Texas A&M University,http://codesign.cs.tamu.edu/people/director,PHGvd5cAAAAJ,0000-0000-0000-0000
 Rabie Ben Atitallah,Galatasaray University,https://cv.gsu.edu.tr/tr/CV/rabie-ben-atitallah,EkBJrH4AAAAJ,0000-0000-0000-0000
+Rachael Jack,Vanderbilt University,https://computing.vanderbilt.edu/person/rachael-jack/,gO2daQsAAAAJ,0000-0003-3687-0799
 Rachee Singh,Cornell University,https://www.racheesingh.com,GKja_-QAAAAJ,0000-0002-8118-3026
 Rachel Blagojevic,Massey University,https://www.massey.ac.nz/massey/learning/colleges/college-of-sciences/staff-profile.cfm?stref=380350,22gHgyAAAAAJ,0000-0000-0000-0000
 Rachel Cardell-Oliver,University of Western Australia,http://uwa.edu.au/people/rachel.cardell-oliver,2vXqE0wAAAAJ,0000-0003-0590-1003
@@ -966,7 +967,7 @@ Robert Dabrowski,University of Warsaw,https://www.facebook.com/public/Robert-Dab
 Robert Duncan Macredie,Brunel University London,https://www.brunel.ac.uk/people/robert-macredie,jdB84x8AAAAJ,0000-0000-0000-0000
 Robert Dyer,University of Nebraska,https://go.unl.edu/rdyer,-tLiAa8AAAAJ,0000-0000-0000-0000
 Robert Dyer 0001,University of Nebraska,https://go.unl.edu/rdyer,-tLiAa8AAAAJ,0000-0001-9571-5567
-Robert E. Bodenheimer,Vanderbilt University,http://www.vuse.vanderbilt.edu/~bobbyb,hI4XguUAAAAJ,0000-0000-0000-0000
+Robert E. Bodenheimer,Vanderbilt University,https://computing.vanderbilt.edu/person/robert-bodenheimer/,hI4XguUAAAAJ,0000-0002-0616-5936
 Robert E. Fields,Middlesex University,http://www.cs.mdx.ac.uk/people/bob-fields,DrLWtAYAAAAJ,0000-0000-0000-0000
 Robert E. Hiromoto,University of Idaho,http://www.uidaho.edu/engr/departments/cs/our-people/faculty/robert-hiromoto,NOSCHOLARPAGE,0000-0000-0000-0000
 Robert E. Kinicki,Worcester Polytechnic Institute,http://www.cs.wpi.edu/~rek,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -1011,6 +1012,7 @@ Robert J. Renka,University of North Texas,http://www.cse.unt.edu/~renka,XzNYtXMA
 Robert J. Stewart,Heriot-Watt University,https://www.hw.ac.uk/staff/uk/macs/robert-stewart.htm,ArZWHf4AAAAJ,0000-0000-0000-0000
 Robert J. Walker,University of Calgary,http://lsmr.org/walker,lvXu4XcAAAAJ,0000-0002-0953-6907
 Robert J. Walls,Worcester Polytechnic Institute,http://rjwalls.github.io,7yHU8hMAAAAJ,0000-0002-1338-6403
+Robert J. Webster III,Vanderbilt University,https://www.medicalengineeringlab.com/,fxYQWPAAAAAJ,0000-0003-1389-224X
 Robert Jenssen,UiT The Arctic Univ. of Norway,https://uit.no/ansatte/robert.jenssen,HiviXjIAAAAJ,0000-0000-0000-0000
 Robert K. Harle,University of Cambridge,https://www.cl.cam.ac.uk/~rkh23,MUWnoZIAAAAJ,0000-0000-0000-0000
 Robert Karam,University of South Florida,https://cse.usf.edu/~rkaram,8m6uKm0AAAAJ,0000-0000-0000-0000
@@ -1628,7 +1630,9 @@ Ryan K. L. Ko,University of Queensland,https://researchers.uq.edu.au/researcher/
 Ryan Kastner,Univ. of California - San Diego,http://kastner.ucsd.edu,lfLiQmcAAAAJ,0000-0001-9062-5570
 Ryan Kelly 0001,RMIT University,https://www.rmit.edu.au/profiles/k/ryan-kelly,qmM84tIAAAAJ,0000-0002-8773-6656
 Ryan Kok Leong Ko,University of Queensland,https://researchers.uq.edu.au/researcher/23784,doBtsCkAAAAJ,0000-0000-0000-0000
+Ryan L. Boyd,Vanderbilt University,https://computing.vanderbilt.edu/person/ryan-boyd/,dfQrLLUAAAAJ,0000-0002-1876-6050
 Ryan Layer,University of Colorado Boulder,http://layerlab.org,AXnmFTIAAAAJ,0000-0000-0000-0000
+Ryan Louie,Vanderbilt University,https://computing.vanderbilt.edu/person/ryan-louie/,KSH-VIcAAAAJ,0000-0001-7266-3688
 Ryan M. Layer,University of Colorado Boulder,http://layerlab.org,AXnmFTIAAAAJ,0000-0000-0000-0000
 Ryan Marcus,University of Pennsylvania,https://rmarcus.info,vPOl-IwAAAAJ,0000-0002-1279-1124
 Ryan O'Donnell,Carnegie Mellon University,http://www.cs.cmu.edu/~odonnell,Z8U0BwcAAAAJ,0000-0001-7608-1458

--- a/csrankings-s.csv
+++ b/csrankings-s.csv
@@ -1688,7 +1688,7 @@ Siqi Sun,Fudan University,https://intersun.github.io,2dyg3WgAAAAJ,0000-0001-7240
 Siqiang Luo,Nanyang Technological University,https://siqiangluo.wixsite.com/homepage,ZDwbMg4AAAAJ,0000-0001-8197-0903
 Sirma Yavuz,Yıldız Technical University,https://www.ce.yildiz.edu.tr/personal/sirma?lang=en,fmbg4lsAAAAJ,0000-0000-0000-0000
 Sirong Lin,University of Massachusetts Lowell,https://www.uml.edu/Sciences/computer-science/faculty/Lin-Sirong.aspx,NOSCHOLARPAGE,0000-0000-0000-0000
-Siru Liu,Vanderbilt University,https://www.vumc.org/dbmi/person/siru-liu-phd,JKXOENIAAAAJ,0000-0000-0000-0000
+Siru Liu,Vanderbilt University,https://www.vumc.org/dbmi/person/siru-liu-phd,JKXOENIAAAAJ,0000-0002-5003-5354
 Sishuai Gong,University of North Carolina,https://sishuaigong.github.io,mlSsYHwAAAAJ,0000-0002-2784-2617
 Sitan Chen,Harvard University,https://seas.harvard.edu/person/sitan-chen,YnJVsp4AAAAJ,0000-0002-9450-3332
 Sitao Huang,Univ. of California - Irvine,http://sitaohuang.com,KduOKeMAAAAJ,0000-0001-7669-1467
@@ -2191,7 +2191,7 @@ Stéphane Julia,UFU,http://www.ppgco.facom.ufu.br/pt-br/pessoas/stephane-julia,N
 Stéphane Mallat,Ecole Normale Superieure,https://www.di.ens.fr/~mallat,g_YTmSgAAAAJ,0000-0000-0000-0000
 Stéphane S. Somé,University of Ottawa,http://www.site.uottawa.ca/~ssome,gZvSWooAAAAJ,0000-0000-0000-0000
 Stéphane Sotèg Somé,University of Ottawa,http://www.site.uottawa.ca/~ssome,gZvSWooAAAAJ,0000-0000-0000-0000
-Stephanie A. Wankowicz,Vanderbilt University,https://medschool.vanderbilt.edu/mpb/person/stephanie-wankowicz,WJ9lxYMAAAAJ,0000-0000-0000-0000
+Stephanie A. Wankowicz,Vanderbilt University,https://wankowiczlab.com,WJ9lxYMAAAAJ,0000-0002-4225-7459
 Stephanie Balzer,Carnegie Mellon University,https://www.cs.cmu.edu/~balzers,xZXNqqYAAAAJ,0000-0002-8347-3529
 Stephanie Brandl,University of Copenhagen,https://researchprofiles.ku.dk/en/persons/stephanie-brandl,eCDiVTMAAAAJ,0000-0000-0000-0000
 Stephanie C. Weirich,University of Pennsylvania,https://www.cis.upenn.edu/~sweirich,NOSCHOLARPAGE,0000-0000-0000-0000

--- a/csrankings-t.csv
+++ b/csrankings-t.csv
@@ -29,7 +29,7 @@ Tadashi Okoshi,Keio University,https://k-ris.keio.ac.jp/html/100011927_en.html,9
 Tadayoshi Kohno,University of Washington,http://homes.cs.washington.edu/~yoshi,s_YDrrgAAAAJ,0000-0002-4899-226X
 Tae H. Oh,Rochester Inst. of Technology,https://www.rit.edu/gccis/computingsecurity/people/tom-oh,ugbZoXwAAAAJ,0000-0000-0000-0000
 Tae Hee Han,Sungkyunkwan University,https://sites.google.com/view/idealab400525/home,4m_r2psAAAAJ,0000-0001-8508-7536
-Tae Hyun Hwang,Vanderbilt University,https://www.hwanglab.org,YCgx9yUAAAAJ,0000-0000-0000-0000
+Tae Hyun Hwang,Vanderbilt University,https://www.hwanglab.org,YCgx9yUAAAAJ,0000-0002-6668-7269
 Tae Hyun Kim 0006,Hanyang University,https://sites.google.com/site/lliger9/home,NOSCHOLARPAGE,0000-0000-0000-0000
 Tae Hyun Oh,KAIST,https://ami.kaist.ac.kr,dMCBjeIAAAAJ,0000-0003-0468-1571
 Tae-Eui Kam,Korea University,http://mailab.korea.ac.kr,y7B2OsUAAAAJ,0000-0000-0000-0000
@@ -262,11 +262,11 @@ Tatsuya Akutsu,Kyoto University,http://www.bic.kyoto-u.ac.jp/takutsu/members/tak
 Tatsuya Harada,University of Tokyo,http://www.mi.t.u-tokyo.ac.jp/harada,k8rlJ8AAAAAJ,0000-0002-3712-3691
 Tatsuya Kawahara,Kyoto University,http://sap.ist.i.kyoto-u.ac.jp/members/kawahara,o3AmlFYAAAAJ,0000-0002-2686-2296
 Tauhidur Rahman,Univ. of California - San Diego,https://www.tauhidurrahman.com,mc9BzYwAAAAJ,0000-0003-1981-6395
-Tawanna Dillahunt,University of Michigan,http://www.tawannadillahunt.com,qPpuKe4AAAAJ,0000-0000-0000-0000
-Tawanna R. Dillahunt,University of Michigan,http://www.tawannadillahunt.com,qPpuKe4AAAAJ,0000-0002-1155-8507
+Tawanna Dillahunt,Vanderbilt University,https://computing.vanderbilt.edu/person/tawanna-ruth-dillahunt/,qPpuKe4AAAAJ,0000-0002-1155-8507
+Tawanna R. Dillahunt,Vanderbilt University,https://computing.vanderbilt.edu/person/tawanna-ruth-dillahunt/,qPpuKe4AAAAJ,0000-0002-1155-8507
 Taylan Cemgil,Boğaziçi University,https://www.cmpe.boun.edu.tr/~cemgil,X3ZFZ7AAAAAJ,0000-0000-0000-0000
 Taylor Berg-Kirkpatrick,Univ. of California - San Diego,http://cseweb.ucsd.edu/~tberg,mN6_BKAAAAAJ,0000-0002-1283-4075
-Taylor Johnson,Vanderbilt University,http://www.TaylorTJohnson.com,MdTkXNYAAAAJ,0000-0000-0000-0000
+Taylor Johnson,Vanderbilt University,http://www.TaylorTJohnson.com,MdTkXNYAAAAJ,0000-0001-8021-9923
 Taylor T. Johnson,Vanderbilt University,http://www.TaylorTJohnson.com,MdTkXNYAAAAJ,0000-0001-8021-9923
 Te Taka Keegan,University of Waikato,http://www.cms.waikato.ac.nz/people/tetaka,qo3DLSkAAAAJ,0000-0000-0000-0000
 Te-Yen Wu,Florida State University,http://teyenwu.com,TMrlaiUAAAAJ,0000-0003-3977-9093
@@ -419,7 +419,7 @@ Thierry Massart,Université libre de Bruxelles,http://www.ulb.ac.be/di/verif/tma
 Thierry Peynot,Queensland Univ. of Technology,https://research.qut.edu.au/qcr/people/thierry-peynot,S47ydIgAAAAJ,0000-0000-0000-0000
 Thieu Vo,University of Bath,https://researchportal.bath.ac.uk/en/persons/thieu-vo,CM2qJSoAAAAJ,0000-0001-7957-5648
 Thijs van Ede,University of Twente,https://research.utwente.nl/en/persons/349c2ece-aa67-4897-8f72-ff608db33c85,tb8_7jEAAAAJ,0000-0000-0000-0000
-Thilo Womelsdorf,Vanderbilt University,https://accl.psy.vanderbilt.edu/people/team,iIofoscAAAAJ,0000-0000-0000-0000
+Thilo Womelsdorf,Vanderbilt University,https://accl.psy.vanderbilt.edu/people/team,iIofoscAAAAJ,0000-0001-6921-4187
 Thinh Nguyen,Oregon State University,http://eecs.oregonstate.edu/people/nguyen-thinh,9flSED8AAAAJ,0000-0000-0000-0000
 Thirimachos Bourlai,West Virginia University,https://www.statler.wvu.edu/faculty-staff/faculty/thirimachos-bourlai,vBn6I3sAAAAJ,0000-0000-0000-0000
 Thivya Kandappu,Singapore Management University,https://scis.smu.edu.sg/faculty/profile/541/thivya-kandappu,M3gdduIAAAAJ,0000-0002-4279-2830
@@ -428,14 +428,14 @@ Thomas A. DeFanti,University of Illinois at Chicago,https://www.cs.uic.edu/~tom,
 Thomas A. Goldstein,Univ. of Maryland - College Park,https://www.cs.umd.edu/~tomg,KmSuVtgAAAAJ,0000-0000-0000-0000
 Thomas A. Henzinger,IST Austria,http://pub.ist.ac.at/~tah,jpgplxUAAAAJ,0000-0002-2985-7724
 Thomas A. Horan,Claremont Graduate University,https://www.redlands.edu/study/schools-and-centers/business/staff/thomas-horan,2aFmaaAAAAAJ,0000-0000-0000-0000
-Thomas A. Lasko,Vanderbilt University,https://www.vumc.org/dbmi/person/thomas-lasko-md-phd,Ibzfs-kAAAAJ,0000-0000-0000-0000
+Thomas A. Lasko,Vanderbilt University,https://www.vumc.org/dbmi/person/thomas-lasko-md-phd,Ibzfs-kAAAAJ,0000-0003-2300-9529
 Thomas A. Runkler,TU Munich,https://www7.in.tum.de/~runkler,9ulZrB8AAAAJ,0000-0002-5465-198X
 Thomas Abeel,TU Delft,http://www.abeel.be,eCS5_oAAAAAJ,0000-0002-7205-7431
 Thomas Andreas Meyer,University of Cape Town,https://people.cs.uct.ac.za/~tmeyer,Ua2MNSoAAAAJ,0000-0003-2204-6969
 Thomas B. Schön,Uppsala University,http://user.it.uu.se/~thosc112/index.html,NOSCHOLARPAGE,0000-0001-5183-234X
 Thomas Bäck,Leiden University,https://www.universiteitleiden.nl/en/staffmembers/thomas-back#tab-2,x7LEID0AAAAJ,0000-0001-6768-1478
 Thomas Bauschert,TU Chemnitz,https://www.tu-chemnitz.de/etit/kn/kn.php,NOSCHOLARPAGE,0000-0000-0000-0000
-Thomas Beckers 0001,Vanderbilt University,https://engineering.vanderbilt.edu/bio/?pid=thomas-beckers,WBA4xBcAAAAJ,0000-0000-0000-0000
+Thomas Beckers 0001,Vanderbilt University,https://engineering.vanderbilt.edu/bio/?pid=thomas-beckers,WBA4xBcAAAAJ,0000-0003-1718-0338
 Thomas Begin,Ecole Normale Superieure de Lyon,http://perso.ens-lyon.fr/thomas.begin,YJS1hw0AAAAJ,0000-0000-0000-0000
 Thomas Berlage,RWTH Aachen University,https://dbis.rwth-aachen.de/dbis/index.php/user/berlage,NOSCHOLARPAGE,0000-0000-0000-0000
 Thomas Bewley,Univ. of California - San Diego,http://fccr.ucsd.edu/Bewley.html,NOSCHOLARPAGE,0000-0000-0000-0000
@@ -492,7 +492,7 @@ Thomas Huckle,TU Munich,http://www5.in.tum.de/wiki/index.php/Univ.-Prof._Dr._Tho
 Thomas Hupperich,University of Münster,https://www.wi.uni-muenster.de/de/institut/it-security/personen/thomas-hupperich,p5c2P1MAAAAJ,0000-0002-4981-9522
 Thomas Hurtut,Polytechnique Montreal,http://www.professeurs.polymtl.ca/thomas.hurtut,uMNNCawAAAAJ,0000-0000-0000-0000
 Thomas J. Naughton,Maynooth University,https://www.maynoothuniversity.ie/faculty-science-engineering/our-people/thomas-naughton,A3S71cAAAAAJ,0000-0000-0000-0000
-Thomas J. Palmeri,Vanderbilt University,https://www.vanderbilt.edu/psychological_sciences/bio/thomas-palmeri,HWF8o_kAAAAJ,0000-0000-0000-0000
+Thomas J. Palmeri,Vanderbilt University,https://www.vanderbilt.edu/psychological_sciences/bio/thomas-palmeri,HWF8o_kAAAAJ,0000-0001-7617-9797
 Thomas Jaki,University of Regensburg,https://www.uni-regensburg.de/informatik-data-science/computational-statistics/startseite/index.html,hg4yUCoAAAAJ,0000-0000-0000-0000
 Thomas James Z. Tiam-Lee,De La Salle University,https://www.dlsu.edu.ph/colleges/ccs/faculty-profile/single/?id=32665788831&command=GETPROFILE,_LmluKUAAAAJ,0000-0000-0000-0000
 Thomas Jansen 0001,Aberystwyth University,https://www.aber.ac.uk/en/cs/staff-profiles/listing/profile/thj10,eXdrAtQAAAAJ,0000-0000-0000-0000

--- a/csrankings-v.csv
+++ b/csrankings-v.csv
@@ -436,7 +436,7 @@ Vishal M. Patel,Johns Hopkins University,https://engineering.jhu.edu/faculty/vis
 Vishal Misra,Columbia University,http://www.cs.columbia.edu/~misra,9hPnkXsAAAAJ,0000-0000-0000-0000
 Vishal Patel 0001,Johns Hopkins University,https://engineering.jhu.edu/faculty/vishal-patel,AkEXTbIAAAAJ,0000-0000-0000-0000
 Vishesh Jain,University of Illinois at Chicago,https://jainvishesh.github.io,oCw8EScAAAAJ,0000-0000-0000-0000
-Vishesh Kumar,Vanderbilt University,https://lab.vanderbilt.edu/live/person/vishesh-kumar,udPfphwAAAAJ,0000-0000-0000-0000
+Vishesh Kumar,Vanderbilt University,https://lab.vanderbilt.edu/live/person/vishesh-kumar,udPfphwAAAAJ,0000-0001-5097-7678
 Vishnu Boddeti,Michigan State University,http://vishnu.boddeti.net,JKcrO9IAAAAJ,0000-0000-0000-0000
 Vishnu Chalavadi,IIT Tirupati,https://vish9u.github.io,2a-8giwAAAAJ,0000-0000-0000-0000
 Vishnu Monn Baskaran,Monash University Malaysia,https://research.monash.edu/en/persons/vishnu-monn,hvF0DWkAAAAJ,0000-0001-6809-5817

--- a/csrankings-w.csv
+++ b/csrankings-w.csv
@@ -212,7 +212,7 @@ Wei-Ming Lu 0001,Zhejiang University,http://mypage.zju.edu.cn/lwm,NOSCHOLARPAGE,
 Wei-ming Lu 0001,Zhejiang University,http://mypage.zju.edu.cn/lwm,NOSCHOLARPAGE,0000-0000-0000-0000
 Wei-Nan Zhang 0003,Harbin Institute of Technology,http://ir.hit.edu.cn/~wnzhang,DBLdEf4AAAAJ,0000-0000-0000-0000
 Wei-Ngan Chin,National University of Singapore,https://www.comp.nus.edu.sg/~chinwn,DO2x-J0AAAAJ,0000-0002-9660-5682
-Wei-Qi Wei,Vanderbilt University,https://www.vumc.org/dbmi/person/wei-qi-wei-md-phd-famia,xuw6dakAAAAJ,0000-0000-0000-0000
+Wei-Qi Wei,Vanderbilt University,https://www.vumc.org/dbmi/person/wei-qi-wei-md-phd-famia,xuw6dakAAAAJ,0000-0003-4985-056X
 Wei-Shi Zheng 0001,Sun Yat-sen University,http://www.isee-ai.cn/~zhwshi,AwqDDGoAAAAJ,0000-0001-8327-0003
 Wei-Shinn Ku,Auburn University,http://www.eng.auburn.edu/~weishinn,ZQ87sO4AAAAJ,0000-0001-8636-4689
 Wei-Ta Chu,National Cheng Kung University,http://www.csie.ncku.edu.tw/ncku_csie/depmember/teacherdetail/id/82,DcltNjQAAAAJ,0000-0001-5722-7239
@@ -357,7 +357,7 @@ Wendy Hall 0001,University of Southampton,https://www.ecs.soton.ac.uk/people/wh,
 Wendy Hui Wang,Stevens Institute of Technology,http://www.cs.stevens.edu/~hwang4,3pXvHPUAAAAJ,0000-0002-3913-815X
 Wendy Ju [Tech],Cornell University,https://wendyju.com,kjYhZYwAAAAJ,0000-0000-0000-0000
 Wendy K. Ivins,Cardiff University,https://www.cardiff.ac.uk/people/view/118135-ivins-wendy,NOSCHOLARPAGE,0000-0000-0000-0000
-Wendy K. Tam Cho,Vanderbilt University,https://tam.cas.vanderbilt.edu,NOSCHOLARPAGE,0000-0000-0000-0000
+Wendy K. Tam Cho,Vanderbilt University,https://tam.cas.vanderbilt.edu,NOSCHOLARPAGE,0000-0003-3042-8983
 Wendy Moncur,University of Strathclyde,https://pureportal.strath.ac.uk/en/persons/wendy-moncur/publications,YlZFhnsAAAAJ,0000-0002-1485-4723
 Wenfei Fan,University of Edinburgh,http://homepages.inf.ed.ac.uk/wenfei,u0S6ofAAAAAJ,0000-0001-5149-2656
 Wenfei Wu,Peking University,http://wenfei-wu.github.io,PQsb1ZwAAAAJ,0000-0002-1357-3137

--- a/csrankings-x.csv
+++ b/csrankings-x.csv
@@ -13,7 +13,7 @@ Xavier P. V. Maldague,Université Laval,http://w3.gel.ulaval.ca/~maldagx,NOSCHOL
 Xavier Rival,Ecole Normale Superieure,http://www.di.ens.fr/~rival,YGy_zroAAAAJ,0000-0002-2875-6171
 Xavier Tricoche,Purdue University,https://www.cs.purdue.edu/homes/xmt,iL-hxJoAAAAJ,0000-0002-1688-3106
 Xenofon Fafoutis,DTU,https://www.compute.dtu.dk/english,NOSCHOLARPAGE,0000-0000-0000-0000
-Xenofon Koutsoukos,Vanderbilt University,https://engineering.vanderbilt.edu/bio/?pid=xenofon-koutsoukos,NHZdlVkAAAAJ,0000-0000-0000-0000
+Xenofon Koutsoukos,Vanderbilt University,https://computing.vanderbilt.edu/person/xenofon-koutsoukos/,NHZdlVkAAAAJ,0000-0002-0923-6293
 Xenofontas A. Dimitropoulos,University of Crete,http://www.inspire.edu.gr/~fontas,pWyNwcMAAAAJ,0000-0003-2600-7633
 Xi Chen 0001,Columbia University,http://www.cs.columbia.edu/~xichen/Homepage/Welcome.html,P_UgxSYAAAAJ,0000-0001-5661-515X
 Xi Chen 0010,New York University,https://www.stern.nyu.edu/faculty/bio/xi-chen,qjJg6akAAAAJ,0000-0002-9049-9452

--- a/csrankings-y.csv
+++ b/csrankings-y.csv
@@ -880,7 +880,7 @@ Yossi Gilad,Hebrew University of Jerusalem,https://www.cs.huji.ac.il/~yossigi,J2
 Yossi Matias,Tel Aviv University,http://www.math.tau.ac.il/~matias,IwSe1-MAAAAJ,0000-0003-3960-6002
 Yossi Oren,Ben-Gurion University of the Negev,https://iss.oy.ne.ro,_V9NAX8AAAAJ,0000-0002-0423-802X
 Yotam I. Gingold,George Mason University,https://cragl.cs.gmu.edu,lFh34ncAAAAJ,0000-0002-5381-2104
-You Chen 0001,Vanderbilt University,https://www.vumc.org/dbmi/person/you-chen-phd-famia,c-pOkPEAAAAJ,0000-0000-0000-0000
+You Chen 0001,Vanderbilt University,https://www.vumc.org/dbmi/person/you-chen-phd-famia,c-pOkPEAAAAJ,0000-0001-8232-8840
 You Zhou 0008,Jilin University,https://ccst.jlu.edu.cn/info/1367/19089.htm,e50RgX4AAAAJ,0000-0003-0013-1281
 You-Jin Kim,University of Nebraska,https://computing.unl.edu/person/you-jin-kim,U6_SdvMAAAAJ,0000-0003-0903-8999
 Youcef Saad,University of Minnesota,http://www-users.cs.umn.edu/~saad,90qiDCwAAAAJ,0000-0000-0000-0000

--- a/csrankings-z.csv
+++ b/csrankings-z.csv
@@ -88,7 +88,6 @@ Zhaodan Kong,Univ. of California - Davis,https://cs.ucdavis.edu/directory/zhaoda
 Zhaofei Yu,Peking University,https://yuzhaofei.github.io,qaUgD50AAAAJ,0000-0000-0000-0000
 Zhaoguo Wang,Shanghai Jiao Tong University,https://ipads.se.sjtu.edu.cn/zhaoguo_wang,7y3lixMAAAAJ,0009-0005-7344-3210
 Zhaohan Xi,Binghamton University,https://www.binghamton.edu/computer-science/people/profile.html?id=zxi1,wQgnjMIAAAAJ,0000-0000-0000-0000
-Zhaohua Ding,Vanderbilt University,https://www.vumc.org/vuiis/person/zhaohua-ding-phd,-NEYu_IAAAAJ,0000-0000-0000-0000
 Zhaohui Luo,Royal Holloway Univ. of London,https://pure.royalholloway.ac.uk/portal/en/persons/zhaohui-luo_217b224d-b244-464d-a29b-16e05b764ce7.html,NOSCHOLARPAGE,0000-0000-0000-0000
 Zhaohui Peng,Shandong University,http://www.cs.sdu.edu.cn/info/1090/2342.htm,NOSCHOLARPAGE,0000-0000-0000-0000
 Zhaohui S. Qin,Emory University,https://www.sph.emory.edu/faculty/profile/index.php?FID=8697,9F-Jk74AAAAJ,0000-0002-1583-146X


### PR DESCRIPTION
## Required Checklist

Read [CONTRIBUTING.md](https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md) and check **all** boxes that apply.

### Identity & Format
- [X] My GitHub profile shows my full name[^1]
- [X] PR title is descriptive (not "Update csrankings-x.csv")[^2]
- [X] One PR per institution, all changes combined[^3]
- [X] Only modified `csrankings-[a-z].csv` or `old/industry.csv`[^4]
- [X] Did NOT use Excel[^5]
- [X] No spaces after commas, no missing fields[^6]
- [X] Entries in alphabetical order by full name[^7]

### Data Accuracy
- [X] Name matches [DBLP](https://dblp.org) exactly (including 0001 suffixes)[^8]
- [X] Homepage URL works and shows name + affiliation[^9] — **two documented exceptions, see [Homepage notes](#homepage-notes)**
- [X] Google Scholar ID is the 12-character code only[^10]
- [X] Valid ORCID provided (not placeholder zeros)[^16]

### Eligibility
- [X] Faculty is full-time, tenure-track[^11]
- [X] Can **solely** advise CS PhD students[^12]
- [X] If not in CS department: included justification with links[^13]

---

## Summary

Annual Vanderbilt University update:

| Change | Rows | People |
|---|---|---|
| Added | 11 | 10 |
| Moved to Vanderbilt from a previous institution | 3 | 2 |
| Removed | 1 | 1 |
| Placeholder ORCID replaced with a real one | 32 | — |
| Dead / non-rendering homepage repaired | 4 | — |

As Director of Graduate Studies for Computer Science and Associate Dean for
Graduate Education in Vanderbilt's College of Connected Computing (CCC), I
confirm that every person added below is full-time tenure-track and can
**solely** advise Computer Science PhD students at Vanderbilt.

Appointments were verified against the **Vanderbilt Faculty Registry**, the
university's system of record for faculty appointments, which is published
publicly and requires no login:

> https://public.tableau.com/app/profile/virg.reporting/viz/FacultyRegistry/FacultySearch

Filtering that view by last name reproduces every appointment row quoted below
(fields: Appointment Type, Full Name, School Name, Title, Graduate Faculty).
Titles were cross-checked against the Office of Faculty Affairs'
[2026 new faculty list](https://www.vanderbilt.edu/faculty-affairs/2026-new-faculty/).

### Additions

| Name | Title | Source |
|---|---|---|
| Jonathan Gratch | Professor, College of Connected Computing | [CCC](https://computing.vanderbilt.edu/person/jonathan-gratch/) · [Faculty Affairs 2026](https://www.vanderbilt.edu/faculty-affairs/2026-new-faculty/) |
| Rachael Jack | Professor; Area Lead, Computational Social Science | [CCC](https://computing.vanderbilt.edu/person/rachael-jack/) · [Faculty Affairs 2026](https://www.vanderbilt.edu/faculty-affairs/2026-new-faculty/) |
| Philippe G. Schyns | Professor, College of Connected Computing | [CCC](https://computing.vanderbilt.edu/person/philippe-schyns/) · [Faculty Affairs 2026](https://www.vanderbilt.edu/faculty-affairs/2026-new-faculty/) |
| Ryan L. Boyd | Assistant Professor, College of Connected Computing | [CCC](https://computing.vanderbilt.edu/person/ryan-boyd/) · [Faculty Affairs 2026](https://www.vanderbilt.edu/faculty-affairs/2026-new-faculty/) |
| Ryan Louie | Assistant Professor of Computer Science | [CCC](https://computing.vanderbilt.edu/person/ryan-louie/) · [Faculty Affairs 2026](https://www.vanderbilt.edu/faculty-affairs/2026-new-faculty/) |
| Chris Kapulkin / Krzysztof Kapulkin | Professor of Computer Science (dual appointment in Mathematics) | [homepage](https://kkapulkin.github.io/) · [CCC](https://computing.vanderbilt.edu/person/krzysztof-kapulkin/) |
| Conrad Borchers | Assistant Professor of Artificial Intelligence | [Faculty Affairs 2026](https://www.vanderbilt.edu/faculty-affairs/2026-new-faculty/) · [homepage](https://cborchers.com) |
| Carlos G. Oliver | Assistant Professor of Computer Science | [homepage](https://carlosoliver.co) |

**Two DBLP records for one person — Kapulkin.** DBLP holds two distinct author
records for this person, with disjoint publication sets:
[Chris Kapulkin](https://dblp.org/pid/283/7642) (13 records) and
[Krzysztof Kapulkin](https://dblp.org/pid/24/9730) (11 records). Per
CONTRIBUTING ("If DBLP has multiple entries for this person, *all of them need
to be listed*"), both are included, sharing one homepage, Scholar ID and ORCID.
This is not the "same record under two name forms" pattern — neither record is
an alias of the other, and neither carries a disambiguation suffix. The shared
Google Scholar ID across these two rows is therefore intentional.

**Non-CS primary appointment — Conrad Borchers.** His primary appointment is in
Peabody College (Assistant Professor of Artificial Intelligence), with an
appointment in the College of Connected Computing, where he is listed in the
"AI and Education" research area. He can solely advise Computer Science PhD
students at Vanderbilt.

**Carlos G. Oliver** was approved in PR #9430 (November 2025) but was not
applied when that PR was resolved manually, and is currently absent from
CSrankings entirely. He remains an Assistant Professor of Computer Science at
Vanderbilt. Note his DBLP entry is
[Carlos G. Oliver](https://dblp.org/pid/205/3100), not the separate
"Carlos Oliver" record.

### Additions with a College of Connected Computing secondary appointment

Both hold a **Professor of Computer Science** appointment in the College of
Connected Computing alongside a primary appointment elsewhere at Vanderbilt,
and both carry Graduate Faculty status. Verbatim rows from the Faculty
Registry:

**Robert J. Webster III**

```
Secondary,"Webster, Robert J.",College of Connected Computing,Professor of Computer Science,Yes
Primary,"Webster, Robert J.",School of Engineering,Professor of Mechanical Engineering,Yes
```

He directs the Medical Engineering and Discovery (MED) Lab and publishes in
ICRA, IROS and IEEE T-RO. His lab's
[people page](https://www.medicalengineeringlab.com/people) lists ten current
PhD students, including **Kang Zhang, "PhD Student, Computer Science"** —
direct evidence of Computer Science doctoral supervision in practice, not
merely eligibility for it.

**Hussam Mahmoud**

```
Secondary,"Mahmoud, Hussam",College of Connected Computing,Professor of Computer Science,Yes
Primary,"Mahmoud, Hussam",School of Engineering,Professor of Civil & Environmental Engineering,Yes
Primary-Other,"Mahmoud, Hussam",School of Engineering,Craig E. Philip Chair,Yes
```

He holds the Craig E. Philip Chair of Engineering. His CCC appointment is a
full Professor of Computer Science appointment carrying Graduate Faculty
status, which at Vanderbilt confers the right to serve as sole dissertation
advisor.

### Affiliation changes

| Name | From | To |
|---|---|---|
| Tawanna Dillahunt / Tawanna R. Dillahunt | University of Michigan | Vanderbilt University |
| Alan Kuntz | University of Utah | Vanderbilt University |

**Two DBLP records for one person — Dillahunt.** As with Kapulkin, DBLP holds
two author records for this person, under "Tawanna Dillahunt" and
"Tawanna R. Dillahunt". **Both rows already existed upstream as separate
University of Michigan entries before this PR** — this PR does not introduce
the duplication, it only updates both rows to Vanderbilt so they stay
consistent with one another. They share one homepage, Scholar ID and ORCID;
that shared Google Scholar ID is likewise pre-existing upstream and is not
introduced here.

She is Professor, Associate Dean for Special Initiatives, and Area Head for
Human-Computer Interaction in the CCC
([page](https://computing.vanderbilt.edu/person/tawanna-ruth-dillahunt/)).

Alan Kuntz is Assistant Professor of Electrical and Computer Engineering **and**
Assistant Professor of Computer Science
([Faculty Affairs 2026](https://www.vanderbilt.edu/faculty-affairs/2026-new-faculty/),
[VISE](https://www.vanderbilt.edu/vise/people/alan-kuntz/)).

### Removal

**Zhaohua Ding** — his appointments are all Research Professor titles (Computer
Science, Electrical and Computer Engineering, Biomedical Engineering). Research
track, not tenure-track, so he does not meet the inclusion criteria.

### ORCID backfill and homepage repairs

32 Vanderbilt rows carried the `0000-0000-0000-0000` placeholder and now carry
a real ORCID. Each was resolved against the ORCID public API and cross-checked
against publication metadata and institutional affiliation; every row that
already had a real ORCID resolved to the same identifier, and rows sharing a
Google Scholar ID (DBLP alias pairs) were checked to carry matching ORCIDs.
**After this change every one of the 83 Vanderbilt University rows in
CSrankings carries a real ORCID**; none retain the placeholder.

Row count reconciliation, for anyone checking: `gh-pages` has 70 rows whose
affiliation is exactly `Vanderbilt University`. This PR adds 11, moves 3 in
from other institutions (counted as modifications, not additions, since the
name already existed upstream), and removes 1 — leaving **70 + 11 + 3 − 1 =
83**. The 32 ORCID replacements include Tawanna Dillahunt, whose row is both
an affiliation move and a placeholder-to-real ORCID change; she should be
counted once, not twice.

Four homepages that no longer resolve, or that no longer render the person's
name, are repaired in the same change since those rows are being touched anyway:

| Name | Old | New |
|---|---|---|
| Robert E. Bodenheimer | `http://www.vuse.vanderbilt.edu/~bobbyb` (dead) | https://computing.vanderbilt.edu/person/robert-bodenheimer/ |
| Stephanie A. Wankowicz | old URL returns HTTP 404 | https://wankowiczlab.com |
| Jules White | `engineering.vanderbilt.edu/bio/?pid=jules-white` | https://computing.vanderbilt.edu/person/jules-white/ |
| Xenofon Koutsoukos | `engineering.vanderbilt.edu/bio/?pid=xenofon-koutsoukos` | https://computing.vanderbilt.edu/person/xenofon-koutsoukos/ |

### Homepage notes

Two rows will report a homepage name-match warning, both for known and benign
reasons. Flagging them here rather than leaving them to be discovered:

1. **Krzysztof Kapulkin** — he goes by "Chris", so his homepage
   (https://kkapulkin.github.io/) reads *Chris Kapulkin*. The `Chris Kapulkin`
   row matches; the `Krzysztof Kapulkin` row, required by the all-DBLP-records
   rule, cannot.
2. **Hussam Mahmoud** — his Vanderbilt School of Engineering bio page is
   client-side rendered, so his name is absent from the HTML a plain
   `requests.get()` receives, though it displays correctly in a browser. I could
   not find an alternative Vanderbilt URL that renders server-side. The Faculty
   Registry rows quoted above are the primary evidence for this entry.

Several Vanderbilt rows already in CSrankings have the same client-side
rendering issue and will warn for the same reason now that the ORCID backfill
touches their rows (Wise, Bowden, Landman, Dawant, Arastoopour Irgens, Miga,
Rubinov, Beckers, Kumar). Their homepages are **unchanged** by this PR; they
were simply never validated before, because CI only checks modified lines.

### A note on Google Scholar rate limiting in CI

This PR touches 45 rows, which makes the validator perform **43 live Google
Scholar profile fetches** in a single run. Google rate-limits the Actions
runner intermittently, and when the fetch fails at the HTTP layer the validator
reports `Invalid Google Scholar ID` and fails the run.

That happened once here, on `raa7w5YAAAAJ` (Forrest J. Laine) and
`JKXOENIAAAAJ` (Siru Liu). Both IDs are unchanged by this PR, both are correct,
and both passed in three earlier runs of this same diff. They are pre-existing
rows pulled into validation only because the ORCID backfill touches them.

Worth noting for the validator itself: `validate_commit.py` already tolerates
Google's bot-detection *page* (it checks for "your computer or network may be
sending automated queries"), but that branch is only reached when the fetch
succeeds. An HTTP-level 429 falls through to a hard failure instead. Treating a
failed fetch as "unverified" rather than "invalid" — the way the DBLP check
already does — would remove this class of false negative.

### Deferred to a follow-up PR

**Daniel J. Gervais** (Professor of College of Connected Computing, secondary;
primary appointment Vanderbilt Law School) holds Graduate Faculty status in the
Registry, but no available URL renders his name server-side, so the homepage
criterion cannot be satisfied today. He is held for a later PR rather than
submitted with a homepage that cannot be verified.

**Erin Calipari**, **Laura Stark** and **Jennifer L. Davis** hold CCC secondary
appointments with Graduate Faculty status but have no unambiguous DBLP author
record, so per CONTRIBUTING ("If the faculty entry is currently ambiguous,
please do not include them") they are omitted pending DBLP disambiguation.

[^1]: https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#non-anonymous
[^2]: https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#pr-title
[^3]: https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#one-pr
[^4]: https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#allowed-files
[^5]: https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#no-excel
[^6]: https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#csv-format
[^7]: https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#alphabetical
[^8]: https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#dblp-name
[^9]: https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#homepage
[^10]: https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#scholar-id
[^11]: https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#tenure-track
[^12]: https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#sole-advising
[^13]: https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#non-cs-dept
[^16]: https://github.com/emeryberger/CSrankings/blob/gh-pages/CONTRIBUTING.md#orcid

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzR6awkYTYrQ6dgi1vYEEm
